### PR TITLE
Move Options to Document Sidebar

### DIFF
--- a/src/editor/index.js
+++ b/src/editor/index.js
@@ -9,24 +9,9 @@ import { __ } from '@wordpress/i18n';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 import { Component, render, Fragment } from '@wordpress/element';
-import {
-	PanelBody,
-	Path,
-	RangeControl,
-	RadioControl,
-	SelectControl,
-	SVG,
-} from '@wordpress/components';
+import { Path, RangeControl, RadioControl, SelectControl, SVG } from '@wordpress/components';
 import { registerPlugin } from '@wordpress/plugins';
-import { PluginSidebar, PluginSidebarMoreMenuItem } from '@wordpress/editPost';
-
-import './style.scss';
-
-const icon = (
-	<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
-		<Path d="M11.99 18.54l-7.37-5.73L3 14.07l9 7 9-7-1.63-1.27-7.38 5.74zM12 16l7.36-5.73L21 9l-9-7-9 7 1.63 1.27L12 16z" />
-	</SVG>
-);
+import { PluginDocumentSettingPanel } from '@wordpress/editPost';
 
 class PopupSidebar extends Component {
 	/**
@@ -43,68 +28,61 @@ class PopupSidebar extends Component {
 		} = this.props;
 		return (
 			<Fragment>
-				<PluginSidebarMoreMenuItem target="sidebar-name">
-					{ __( 'Popup Settings' ) }
-				</PluginSidebarMoreMenuItem>
-				<PluginSidebar name="sidebar-name" title={ __( 'Popup Settings' ) }>
-					<PanelBody title={ __( 'Popup Triggers' ) } initialOpen={ true }>
-						<RadioControl
-							label={ __( 'Trigger' ) }
-							help={ __( 'The event to trigger the popup' ) }
-							selected={ trigger_type }
-							options={ [
-								{ label: __( 'Timer' ), value: 'time' },
-								{ label: __( 'Scroll Progress' ), value: 'scroll' },
-							] }
-							onChange={ value => onMetaFieldChange( 'trigger_type', value ) }
-						/>
-						{ 'time' === trigger_type && (
-							<RangeControl
-								label={ __( 'Delay (seconds)' ) }
-								value={ trigger_delay }
-								onChange={ value => onMetaFieldChange( 'trigger_delay', value ) }
-								min={ 0 }
-								max={ 60 }
-							/>
-						) }
-						{ 'scroll' === trigger_type && (
-							<RangeControl
-								label={ __( 'Scroll Progress (percent) ' ) }
-								value={ trigger_scroll_progress }
-								onChange={ value => onMetaFieldChange( 'trigger_scroll_progress', value ) }
-								min={ 1 }
-								max={ 100 }
-							/>
-						) }
-						<SelectControl
-							label={ __( 'Frequency' ) }
-							value={ frequency }
-							onChange={ value => onMetaFieldChange( 'frequency', value ) }
-							options={ [
-								{ value: 0, label: __( 'Once per user' ) },
-								{ value: 5, label: __( 'Every 5 page views' ) },
-								{ value: 25, label: __( 'Every 25 page views' ) },
-								{ value: 100, label: __( 'Every 100 page views' ) },
-							] }
-						/>
-						<SelectControl
-							label={ __( 'Placement' ) }
-							value={ placement }
-							onChange={ value => onMetaFieldChange( 'placement', value ) }
-							options={ [
-								{ value: 'center', label: __( 'Center' ) },
-								{ value: 'top', label: __( 'Top' ) },
-								{ value: 'bottom', label: __( 'Bottom' ) },
-							] }
-						/>
-					</PanelBody>
-				</PluginSidebar>
+				<RadioControl
+					label={ __( 'Trigger' ) }
+					help={ __( 'The event to trigger the popup' ) }
+					selected={ trigger_type }
+					options={ [
+						{ label: __( 'Timer' ), value: 'time' },
+						{ label: __( 'Scroll Progress' ), value: 'scroll' },
+					] }
+					onChange={ value => onMetaFieldChange( 'trigger_type', value ) }
+				/>
+				{ 'time' === trigger_type && (
+					<RangeControl
+						label={ __( 'Delay (seconds)' ) }
+						value={ trigger_delay }
+						onChange={ value => onMetaFieldChange( 'trigger_delay', value ) }
+						min={ 0 }
+						max={ 60 }
+					/>
+				) }
+				{ 'scroll' === trigger_type && (
+					<RangeControl
+						label={ __( 'Scroll Progress (percent) ' ) }
+						value={ trigger_scroll_progress }
+						onChange={ value => onMetaFieldChange( 'trigger_scroll_progress', value ) }
+						min={ 1 }
+						max={ 100 }
+					/>
+				) }
+				<SelectControl
+					label={ __( 'Frequency' ) }
+					value={ frequency }
+					onChange={ value => onMetaFieldChange( 'frequency', value ) }
+					options={ [
+						{ value: 0, label: __( 'Once per user' ) },
+						{ value: 5, label: __( 'Every 5 page views' ) },
+						{ value: 25, label: __( 'Every 25 page views' ) },
+						{ value: 100, label: __( 'Every 100 page views' ) },
+					] }
+				/>
+				<SelectControl
+					label={ __( 'Placement' ) }
+					value={ placement }
+					onChange={ value => onMetaFieldChange( 'placement', value ) }
+					options={ [
+						{ value: 'center', label: __( 'Center' ) },
+						{ value: 'top', label: __( 'Top' ) },
+						{ value: 'bottom', label: __( 'Bottom' ) },
+					] }
+				/>
 			</Fragment>
 		);
 	}
 }
 
-const popupSidebar = compose( [
+const PopupSidebarWithData = compose( [
 	withSelect( select => {
 		const { getEditedPostAttribute } = select( 'core/editor' );
 		const meta = getEditedPostAttribute( 'meta' );
@@ -127,7 +105,12 @@ const popupSidebar = compose( [
 	} ),
 ] )( PopupSidebar );
 
+const PluginDocumentSettingPanelDemo = () => (
+	<PluginDocumentSettingPanel name="popup-settings-panel" title="Popup Settings">
+		<PopupSidebarWithData />
+	</PluginDocumentSettingPanel>
+);
 registerPlugin( 'newspack-popups', {
-	icon,
-	render: popupSidebar,
+	render: PluginDocumentSettingPanelDemo,
+	icon: null,
 } );

--- a/src/editor/index.js
+++ b/src/editor/index.js
@@ -106,7 +106,7 @@ const PopupSidebarWithData = compose( [
 ] )( PopupSidebar );
 
 const PluginDocumentSettingPanelDemo = () => (
-	<PluginDocumentSettingPanel name="popup-settings-panel" title="Popup Settings">
+	<PluginDocumentSettingPanel name="popup-settings-panel" title={ __(' Pop-up Settings' ) }>
 		<PopupSidebarWithData />
 	</PluginDocumentSettingPanel>
 );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This branch moves the popup CPT options to the Document sidebar. Previously they were located in a sidebar specifically for the post type, which led to discoverability problems.

<img width="1690" alt="Screen Shot 2019-11-03 at 11 19 09 AM" src="https://user-images.githubusercontent.com/1477002/68089183-df9a7000-fe2b-11e9-8ffb-9435aef3388a.png">

### How to test the changes in this Pull Request:

1. Check out the branch, run `npm run build:webpack`
2. Click `Pop-ups` in the admin navigation and create a new Popup.
3. Open the Document sidebar (if it isn't open already), and verify it  has a Pop-up Settings panel, with Trigger, Frequency, and Placement options.
4. Make changes to the settings, save the post, and verify the changes stick.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
