### PR TITLE
Include style file so it gets compiled

### DIFF
--- a/src/editor/index.js
+++ b/src/editor/index.js
@@ -20,6 +20,8 @@ import {
 import { registerPlugin } from '@wordpress/plugins';
 import { PluginSidebar, PluginSidebarMoreMenuItem } from '@wordpress/editPost';
 
+import './style.scss';
+
 const icon = (
 	<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
 		<Path d="M11.99 18.54l-7.37-5.73L3 14.07l9 7 9-7-1.63-1.27-7.38 5.74zM12 16l7.36-5.73L21 9l-9-7-9 7 1.63 1.27L12 16z" />


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

I was getting missing file errors [because the editor css file wasn't getting built](https://github.com/Automattic/newspack-popups/blob/2b0652007d304e1bfd7191d9346b2bf0105da42a/includes/class-newspack-popups.php#L147). It's an empty file, but I assumed we'd probably add some CSS at some point, so I didn't just remove it.

### How to test the changes in this Pull Request:

1. Before checking this PR out, `npm run clean && npm run build`. Observe missing file error when trying to create a pop up and missing file in `dist` folder.
2. Check PR out, repeat above process, observe error goes away and file exists.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
