### PR TITLE
Improvements To Custom Post Type Definition

### DIFF
--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -12,7 +12,7 @@ defined( 'ABSPATH' ) || exit;
  */
 final class Newspack_Popups {
 
-	const NEWSPACK_PLUGINS_CPT = 'newspack_plugins_cpt';
+	const NEWSPACK_PLUGINS_CPT = 'newspack_popups_cpt';
 
 	/**
 	 * The single instance of the class.
@@ -58,8 +58,25 @@ final class Newspack_Popups {
 	 * Register the custom post type.
 	 */
 	public static function register_cpt() {
+		$labels = [
+			'name'               => _x( 'Pop-ups', 'post type general name', 'newspack-popups' ),
+			'singular_name'      => _x( 'Pop-up', 'post type singular name', 'newspack-popups' ),
+			'menu_name'          => _x( 'Pop-ups', 'admin menu', 'newspack-popups' ),
+			'name_admin_bar'     => _x( 'Pop-up', 'add new on admin bar', 'newspack-popups' ),
+			'add_new'            => _x( 'Add New', 'popup', 'newspack-popups' ),
+			'add_new_item'       => __( 'Add New Pop-up', 'newspack-popups' ),
+			'new_item'           => __( 'New Pop-up', 'newspack-popups' ),
+			'edit_item'          => __( 'Edit Pop-up', 'newspack-popups' ),
+			'view_item'          => __( 'View Pop-up', 'newspack-popups' ),
+			'all_items'          => __( 'All Pop-ups', 'newspack-popups' ),
+			'search_items'       => __( 'Search Pop-ups', 'newspack-popups' ),
+			'parent_item_colon'  => __( 'Parent Pop-ups:', 'newspack-popups' ),
+			'not_found'          => __( 'No pop-ups found.', 'newspack-popups' ),
+			'not_found_in_trash' => __( 'No pop-ups found in Trash.', 'newspack-popups' ),
+		];
+
 		$cpt_args = [
-			'label'        => __( 'Pop-ups' ),
+			'labels'       => $labels,
 			'public'       => false,
 			'show_ui'      => true,
 			'show_in_rest' => true,
@@ -137,7 +154,7 @@ final class Newspack_Popups {
 	 */
 	public static function enqueue_block_editor_assets() {
 		$screen = get_current_screen();
-		if ( 'newspack_plugins_cpt' !== $screen->post_type ) {
+		if ( self::NEWSPACK_PLUGINS_CPT !== $screen->post_type ) {
 			return;
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This  changes the `$post_type` to a more description  string: `newspack_popups_cpt`. The CPT labels are all included as well, so there should no longer be any references to  "Post" on Pop-up  edit pages.

Closes https://github.com/Automattic/newspack-popups/issues/13.

### How to test the changes in this Pull Request:

1. Verify pop-ups can be created and work properly in the front end. (Note that any existing Pop-ups will be lost after switching to this branch)
2. Verify that all text referring to Pop-ups shows the word "pop-up" rather than  "post." For example, page title when editing  a Pop-up, "No pop-ups found", "Search pop-ups" button, etc.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
