### PR TITLE
Category Filtering

### DIFF
--- a/includes/class-newspack-popups-api.php
+++ b/includes/class-newspack-popups-api.php
@@ -51,7 +51,7 @@ final class Newspack_Popups_API {
 	 */
 	public function reader_get_endpoint( $request ) {
 		$popup_id = isset( $request['popup_id'] ) ? $request['popup_id'] : false;
-		$popup    = Newspack_Popups_Inserter::retrieve_popup( $popup_id );
+		$popup    = Newspack_Popups_Inserter::retrieve_popup_by_id( $popup_id );
 		$response = [
 			'currentViews' => 0,
 			'displayPopup' => false,
@@ -111,10 +111,10 @@ final class Newspack_Popups_API {
 	 * @return string Transient id.
 	 */
 	public function get_transient_name( $request ) {
-		$reader_id = isset( $request['rid'] ) ? sanitize_title( $request['rid'] ) : false;
+		$reader_id = isset( $request['rid'] ) ? esc_attr( $request['rid'] ) : false;
 		// TODO: Is retrieving the amp-access cookie the best way to get READER_ID outside the context of amp-access?
 		if ( ! $reader_id ) {
-			$reader_id = isset( $_COOKIE['amp-access'] ) ? sanitize_text_field( $_COOKIE['amp-access'] ) : false; // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
+			$reader_id = isset( $_COOKIE['amp-access'] ) ? esc_attr( $_COOKIE['amp-access'] ) : false; // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		}
 		$popup_id = isset( $request['popup_id'] ) ? $request['popup_id'] : false;
 		$url      = isset( $request['url'] ) ? esc_url_raw( urldecode( $request['url'] ) ) : false;

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -135,12 +135,12 @@ final class Newspack_Popups_Inserter {
 		if ( count( $category_ids ) ) {
 			$args['category__in'] = $category_ids;
 		} else {
-			$args['category__not_in'] = get_terms(
-				'category',
+			$args['tax_query'] = [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
 				[
-					'fields' => 'ids',
-				]
-			);
+					'taxonomy' => 'category',
+					'operator' => 'NOT EXISTS',
+				],
+			];
 		}
 		return self::retrieve_popup_with_query( new WP_Query( $args ) );
 	}

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -114,6 +114,7 @@ final class Newspack_Popups_Inserter {
 	/**
 	 * Retrieve popup CPT post.
 	 *
+	 * @param array $categories An array of categories to match.
 	 * @return object Popup object
 	 */
 	public static function retrieve_popup( $categories = [] ) {
@@ -141,7 +142,36 @@ final class Newspack_Popups_Inserter {
 				]
 			);
 		}
-		$query = new WP_Query( $args );
+		return self::retrieve_popup_with_query( new WP_Query( $args ) );
+	}
+
+	/**
+	 * Retrieve popup CPT post by ID.
+	 *
+	 * @param string $post_id An array of categories to match.
+	 * @return object Popup object
+	 */
+	public static function retrieve_popup_by_id( $post_id ) {
+		$popup = null;
+
+		$args = [
+			'post_type'      => Newspack_Popups::NEWSPACK_PLUGINS_CPT,
+			'post_status'    => 'publish',
+			'posts_per_page' => 1,
+			'p'              => $post_id,
+		];
+
+		return self::retrieve_popup_with_query( new WP_Query( $args ) );
+	}
+
+	/**
+	 * Retrieve popup CPT post.
+	 *
+	 * @param WP_Query $query The query to use.
+	 * @return object Popup object
+	 */
+	protected static function retrieve_popup_with_query( WP_Query $query ) {
+		$popup = null;
 		while ( $query->have_posts() ) {
 			$query->the_post();
 			$blocks = parse_blocks( get_the_content() );

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -126,8 +126,8 @@ final class Newspack_Popups_Inserter {
 		];
 
 		$category_ids = array_map(
-			function( $cagegory ) {
-				return $cagegory->term_id;
+			function( $category ) {
+				return $category->term_id;
 			},
 			$categories
 		);

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -42,7 +42,7 @@ final class Newspack_Popups_Inserter {
 	 * Constructor.
 	 */
 	public function __construct() {
-		add_action( 'the_content', [ $this, 'popup' ] );
+		add_filter( 'the_content', [ $this, 'popup' ] );
 		add_action( 'wp_head', [ __CLASS__, 'popup_access' ] );
 	}
 

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -195,6 +195,14 @@ final class Newspack_Popups {
 					'post_type'        => self::NEWSPACK_PLUGINS_CPT,
 					'post_status'      => 'publish',
 					'posts_per_page'   => 1,
+					'tax_query'        => [ //phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
+						[
+							'taxonomy' => 'category',
+							'operator' => 'NOT EXISTS',
+						],
+					],
+
+
 					'category__not_in' => get_terms(
 						'category',
 						[

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -81,6 +81,7 @@ final class Newspack_Popups {
 			'show_ui'      => true,
 			'show_in_rest' => true,
 			'supports'     => [ 'editor', 'title', 'custom-fields' ],
+			'taxonomies'   => [ 'category' ],
 			'menu_icon'    => 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0Ij48cGF0aCBmaWxsPSIjYTBhNWFhIiBkPSJNMTEuOTkgMTguNTRsLTcuMzctNS43M0wzIDE0LjA3bDkgNyA5LTctMS42My0xLjI3LTcuMzggNS43NHpNMTIgMTZsNy4zNi01LjczTDIxIDlsLTktNy05IDcgMS42MyAxLjI3TDEyIDE2eiIvPjwvc3ZnPgo=',
 		];
 		\register_post_type( self::NEWSPACK_PLUGINS_CPT, $cpt_args );
@@ -191,9 +192,15 @@ final class Newspack_Popups {
 
 			$query = new WP_Query(
 				[
-					'post_type'      => self::NEWSPACK_PLUGINS_CPT,
-					'post_status'    => 'publish',
-					'posts_per_page' => 1,
+					'post_type'        => self::NEWSPACK_PLUGINS_CPT,
+					'post_status'      => 'publish',
+					'posts_per_page'   => 1,
+					'category__not_in' => get_terms(
+						'category',
+						[
+							'fields' => 'ids',
+						]
+					),
 				]
 			);
 			if ( $query->have_posts() ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds category filtering to Pop-ups. The Pop-up CPT  now allows category selection, and these will be used to determine the rules for which pop-ups appear on which posts. 

- If a post has one or more categories assigned, the most recent Pop-up with any of those categories will be shown. 
- If no Pop-ups have the same categories as  the post, the most recent Pop-up with no categories will be shown. This is called the "Sitewide" pop-up.

Two questions:

1) To query for Pop-ups with no  categories I've used this logic:

```
$args['category__not_in'] = get_terms(
	'category',
		[
			'fields' => 'ids',
		]
);
```

This may be inefficient if there are a large number of categories. Is there a better way to structure this query?

2) In working on this, I noticed that the `the_content` hook fires twice. Is this problematic, and should anything be done to make sure the `popup()` function only executes once?

Closes https://github.com/Automattic/newspack-popups/issues/1.

### How to test the changes in this Pull Request:

1. Create a few pop-ups, some with multiple categories, some with one category, some with none.  To ease testing I suggest setting  the titles to describe their categories, and using a frequency of "Every page view."
2. In an incognito window, view  the site. Visit various pages with different categories and verify the filtering rules described above.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
