### PR TITLE
utm_source Pop-up Suppression

### DIFF
--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -44,6 +44,7 @@ final class Newspack_Popups_Inserter {
 	public function __construct() {
 		add_filter( 'the_content', [ $this, 'popup' ] );
 		add_action( 'wp_head', [ __CLASS__, 'popup_access' ] );
+		add_action( 'wp_head', [ __CLASS__, 'popup_access' ] );
 	}
 
 	/**
@@ -190,6 +191,7 @@ final class Newspack_Popups_Inserter {
 						'trigger_type'            => get_post_meta( get_the_ID(), 'trigger_type', true ),
 						'trigger_delay'           => get_post_meta( get_the_ID(), 'trigger_delay', true ),
 						'trigger_scroll_progress' => get_post_meta( get_the_ID(), 'trigger_scroll_progress', true ),
+						'utm_suppression'         => get_post_meta( get_the_ID(), 'utm_suppression', true ),
 					],
 					[
 						'placement'               => 'center',
@@ -197,6 +199,7 @@ final class Newspack_Popups_Inserter {
 						'trigger_type'            => 'time',
 						'trigger_delay'           => 0,
 						'trigger_scroll_progress' => 0,
+						'utm_suppression'         => null,
 					]
 				),
 			];

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -148,6 +148,18 @@ final class Newspack_Popups {
 				'auth_callback'  => '__return_true',
 			]
 		);
+
+		\register_meta(
+			'post',
+			'utm_suppression',
+			[
+				'object_subtype' => self::NEWSPACK_PLUGINS_CPT,
+				'show_in_rest'   => true,
+				'type'           => 'string',
+				'single'         => true,
+				'auth_callback'  => '__return_true',
+			]
+		);
 	}
 
 	/**

--- a/src/editor/index.js
+++ b/src/editor/index.js
@@ -9,7 +9,7 @@ import { __ } from '@wordpress/i18n';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 import { Component, render, Fragment } from '@wordpress/element';
-import { Path, RangeControl, RadioControl, SelectControl, SVG } from '@wordpress/components';
+import { Path, RangeControl, RadioControl, SelectControl, TextControl, SVG } from '@wordpress/components';
 import { registerPlugin } from '@wordpress/plugins';
 import { PluginDocumentSettingPanel } from '@wordpress/editPost';
 
@@ -25,6 +25,7 @@ class PopupSidebar extends Component {
 			trigger_scroll_progress,
 			trigger_delay,
 			trigger_type,
+			utm_suppression,
 		} = this.props;
 		return (
 			<Fragment>
@@ -77,6 +78,12 @@ class PopupSidebar extends Component {
 						{ value: 'bottom', label: __( 'Bottom' ) },
 					] }
 				/>
+				<TextControl
+					label={ __( 'UTM Suppression' ) }
+					help={  __( 'Users arriving at the site from URLs with this utm_source will never be shown the pop-up.' ) }
+					value={ utm_suppression }
+					onChange={ value => onMetaFieldChange( 'utm_suppression', value ) }
+				/>
 			</Fragment>
 		);
 	}
@@ -86,7 +93,7 @@ const PopupSidebarWithData = compose( [
 	withSelect( select => {
 		const { getEditedPostAttribute } = select( 'core/editor' );
 		const meta = getEditedPostAttribute( 'meta' );
-		const { frequency, placement, trigger_scroll_progress, trigger_delay, trigger_type } =
+		const { frequency, placement, trigger_scroll_progress, trigger_delay, trigger_type, utm_suppression } =
 			meta || {};
 		return {
 			frequency,
@@ -94,6 +101,7 @@ const PopupSidebarWithData = compose( [
 			trigger_scroll_progress,
 			trigger_delay,
 			trigger_type,
+			utm_suppression,
 		};
 	} ),
 	withDispatch( dispatch => {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Newsletter links often have a `utm_source` query parameter to track the source of the traffic. Based on this parameter we can make the assumption that a site visitor is already a newsletter subscriber, and suppress all pop-ups to avoid annoying the user with a call to action they have already taken. In the Pop-up settings pane there is a new `UTM Suppression` text field. When a request contains the `utm_source` param, a transient is updated that links the value to the user by their AMP Reader ID. The `amp-access` API call checks to see if  the current Pop-up has UTM Suppression defined, and if so if the current user came in through that code. If a match is found, the user will never be shown the pop-up. 

<img width="1582" alt="Screen Shot 2019-11-06 at 4 35 22 PM" src="https://user-images.githubusercontent.com/1477002/68340155-dfaca100-00b3-11ea-8459-8ad6f95313db.png">

cc: @tristanloper 

### How to test the changes in this Pull Request:

1. Create a Pop-up. Trigger by Scroll Progress, set Scroll Progress to a low number, Frequency "Every Page View." Set UTM Suppression to an arbitrary value such as "newsletter."
2. Visit a page in incognito mode. You should see the popup. Visit another page, and you should see it again.
3. Append `?utm_source=newsletter` to the URL. You should not see the pop-up, and if you visit any other page (with or without the query parameter) you should still not see the pop-up.
4. In wp-admin, remove the UTM Suppression field and republish the Pop-up.
5. Visit any page and you should get the pop-up. 

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
