### PR TITLE
Overlay Improvements

### DIFF
--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -301,7 +301,8 @@ final class Newspack_Popups_Inserter {
 							"selector": ".newspack-lightbox",
 							"delay": "<?php echo intval( $popup['options']['trigger_delay'] ) * 1000 + 500; ?>",
 							"keyframes": {
-								"opacity": ["0", "1"]
+								"opacity": ["0", "1"],
+								"visibility": ["hidden", "visible"]
 							}
 						},
 						{

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -187,6 +187,7 @@ final class Newspack_Popups_Inserter {
 				'options' => wp_parse_args(
 					[
 						'frequency'               => get_post_meta( get_the_ID(), 'frequency', true ),
+						'overlay_opacity'         => get_post_meta( get_the_ID(), 'overlay_opacity', true ),
 						'placement'               => get_post_meta( get_the_ID(), 'placement', true ),
 						'trigger_type'            => get_post_meta( get_the_ID(), 'trigger_type', true ),
 						'trigger_delay'           => get_post_meta( get_the_ID(), 'trigger_delay', true ),
@@ -194,8 +195,9 @@ final class Newspack_Popups_Inserter {
 						'utm_suppression'         => get_post_meta( get_the_ID(), 'utm_suppression', true ),
 					],
 					[
-						'placement'               => 'center',
 						'frequency'               => 0,
+						'overlay_opacity'         => 30,
+						'placement'               => 'center',
 						'trigger_type'            => 'time',
 						'trigger_delay'           => 0,
 						'trigger_scroll_progress' => 0,
@@ -229,9 +231,10 @@ final class Newspack_Popups_Inserter {
 	 * @return string The generated markup.
 	 */
 	public static function generate_popup( $popup ) {
-		$element_id = 'lightbox' . rand(); // phpcs:ignore WordPress.WP.AlternativeFunctions.rand_rand
-		$endpoint   = str_replace( 'http://', '//', get_rest_url( null, 'newspack-popups/v1/reader' ) );
-		$classes    = [ 'newspack-lightbox', 'newspack-lightbox-placement-' . $popup['options']['placement'] ];
+		$element_id      = 'lightbox' . rand(); // phpcs:ignore WordPress.WP.AlternativeFunctions.rand_rand
+		$endpoint        = str_replace( 'http://', '//', get_rest_url( null, 'newspack-popups/v1/reader' ) );
+		$classes         = [ 'newspack-lightbox', 'newspack-lightbox-placement-' . $popup['options']['placement'] ];
+		$overlay_opacity = absint( $popup['options']['overlay_opacity'] ) / 100;
 		ob_start();
 		?>
 		<div amp-access="displayPopup" amp-access-hide class="<?php echo esc_attr( implode( ' ', $classes ) ); ?>" role="button" tabindex="0" id="<?php echo esc_attr( $element_id ); ?>">
@@ -277,7 +280,7 @@ final class Newspack_Popups_Inserter {
 					type="hidden"
 					value="<?php echo ( esc_attr( $popup['id'] ) ); ?>"
 				/>
-				<button class="newspack-lightbox-shim" on="tap:<?php echo esc_attr( $element_id ); ?>.hide"></button>
+				<button style="opacity: <?php echo floatval( $overlay_opacity ); ?>" class="newspack-lightbox-shim" on="tap:<?php echo esc_attr( $element_id ); ?>.hide"></button>
 			</form>
 		</div>
 		<div id="newspack-lightbox-marker">

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -187,6 +187,7 @@ final class Newspack_Popups_Inserter {
 				'options' => wp_parse_args(
 					[
 						'frequency'               => get_post_meta( get_the_ID(), 'frequency', true ),
+						'overlay_color'           => get_post_meta( get_the_ID(), 'overlay_color', true ),
 						'overlay_opacity'         => get_post_meta( get_the_ID(), 'overlay_opacity', true ),
 						'placement'               => get_post_meta( get_the_ID(), 'placement', true ),
 						'trigger_type'            => get_post_meta( get_the_ID(), 'trigger_type', true ),
@@ -196,6 +197,7 @@ final class Newspack_Popups_Inserter {
 					],
 					[
 						'frequency'               => 0,
+						'overlay_color'           => '#000000',
 						'overlay_opacity'         => 30,
 						'placement'               => 'center',
 						'trigger_type'            => 'time',
@@ -235,6 +237,7 @@ final class Newspack_Popups_Inserter {
 		$endpoint        = str_replace( 'http://', '//', get_rest_url( null, 'newspack-popups/v1/reader' ) );
 		$classes         = [ 'newspack-lightbox', 'newspack-lightbox-placement-' . $popup['options']['placement'] ];
 		$overlay_opacity = absint( $popup['options']['overlay_opacity'] ) / 100;
+		$overlay_color   = $popup['options']['overlay_color'];
 		ob_start();
 		?>
 		<div amp-access="displayPopup" amp-access-hide class="<?php echo esc_attr( implode( ' ', $classes ) ); ?>" role="button" tabindex="0" id="<?php echo esc_attr( $element_id ); ?>">
@@ -280,7 +283,7 @@ final class Newspack_Popups_Inserter {
 					type="hidden"
 					value="<?php echo ( esc_attr( $popup['id'] ) ); ?>"
 				/>
-				<button style="opacity: <?php echo floatval( $overlay_opacity ); ?>" class="newspack-lightbox-shim" on="tap:<?php echo esc_attr( $element_id ); ?>.hide"></button>
+				<button style="opacity: <?php echo floatval( $overlay_opacity ); ?>;background-color:<?php echo esc_attr( $overlay_color ); ?>;" class="newspack-lightbox-shim" on="tap:<?php echo esc_attr( $element_id ); ?>.hide"></button>
 			</form>
 		</div>
 		<div id="newspack-lightbox-marker">

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -262,6 +262,23 @@ final class Newspack_Popups_Inserter {
 					</form>
 				</div>
 			</div>
+			<form class="popup-dismiss-form"
+				method="POST"
+				action-xhr="<?php echo esc_url( $endpoint ); ?>"
+				target="_top">
+				<input
+					name="url"
+					type="hidden"
+					value="CANONICAL_URL"
+					data-amp-replace="CANONICAL_URL"
+				/>
+				<input
+					name="popup_id"
+					type="hidden"
+					value="<?php echo ( esc_attr( $popup['id'] ) ); ?>"
+				/>
+				<button class="newspack-lightbox-shim" on="tap:<?php echo esc_attr( $element_id ); ?>.hide"></button>
+			</form>
 		</div>
 		<div id="newspack-lightbox-marker">
 			<amp-position-observer on="enter:showAnim.start;" once layout="nodisplay" />

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -160,6 +160,18 @@ final class Newspack_Popups {
 				'auth_callback'  => '__return_true',
 			]
 		);
+
+		\register_meta(
+			'post',
+			'overlay_opacity',
+			[
+				'object_subtype' => self::NEWSPACK_PLUGINS_CPT,
+				'show_in_rest'   => true,
+				'type'           => 'integer',
+				'single'         => true,
+				'auth_callback'  => '__return_true',
+			]
+		);
 	}
 
 	/**

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -163,6 +163,18 @@ final class Newspack_Popups {
 
 		\register_meta(
 			'post',
+			'overlay_color',
+			[
+				'object_subtype' => self::NEWSPACK_PLUGINS_CPT,
+				'show_in_rest'   => true,
+				'type'           => 'string',
+				'single'         => true,
+				'auth_callback'  => '__return_true',
+			]
+		);
+
+		\register_meta(
+			'post',
 			'overlay_opacity',
 			[
 				'object_subtype' => self::NEWSPACK_PLUGINS_CPT,

--- a/src/editor/index.js
+++ b/src/editor/index.js
@@ -19,6 +19,7 @@ import {
 } from '@wordpress/components';
 import { registerPlugin } from '@wordpress/plugins';
 import { PluginDocumentSettingPanel } from '@wordpress/editPost';
+import { ColorPaletteControl } from '@wordpress/block-editor';
 
 class PopupSidebar extends Component {
 	/**
@@ -29,6 +30,7 @@ class PopupSidebar extends Component {
 			frequency,
 			onMetaFieldChange,
 			overlay_opacity,
+			overlay_color,
 			placement,
 			trigger_scroll_progress,
 			trigger_delay,
@@ -94,6 +96,11 @@ class PopupSidebar extends Component {
 					value={ utm_suppression }
 					onChange={ value => onMetaFieldChange( 'utm_suppression', value ) }
 				/>
+				<ColorPaletteControl
+					value={ overlay_color }
+					onChange={ value => onMetaFieldChange( 'overlay_color', value ) }
+					label={ __( 'Overlay Color' ) }
+				/>
 				<RangeControl
 					label={ __( 'Overlay opacity' ) }
 					value={ overlay_opacity }
@@ -112,6 +119,7 @@ const PopupSidebarWithData = compose( [
 		const meta = getEditedPostAttribute( 'meta' );
 		const {
 			frequency,
+			overlay_color,
 			overlay_opacity,
 			placement,
 			trigger_scroll_progress,
@@ -121,6 +129,7 @@ const PopupSidebarWithData = compose( [
 		} = meta || {};
 		return {
 			frequency,
+			overlay_color,
 			overlay_opacity,
 			placement,
 			trigger_scroll_progress,

--- a/src/editor/index.js
+++ b/src/editor/index.js
@@ -9,7 +9,14 @@ import { __ } from '@wordpress/i18n';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 import { Component, render, Fragment } from '@wordpress/element';
-import { Path, RangeControl, RadioControl, SelectControl, TextControl, SVG } from '@wordpress/components';
+import {
+	Path,
+	RangeControl,
+	RadioControl,
+	SelectControl,
+	TextControl,
+	SVG,
+} from '@wordpress/components';
 import { registerPlugin } from '@wordpress/plugins';
 import { PluginDocumentSettingPanel } from '@wordpress/editPost';
 
@@ -20,8 +27,9 @@ class PopupSidebar extends Component {
 	render() {
 		const {
 			frequency,
-			placement,
 			onMetaFieldChange,
+			overlay_opacity,
+			placement,
 			trigger_scroll_progress,
 			trigger_delay,
 			trigger_type,
@@ -80,9 +88,18 @@ class PopupSidebar extends Component {
 				/>
 				<TextControl
 					label={ __( 'UTM Suppression' ) }
-					help={  __( 'Users arriving at the site from URLs with this utm_source will never be shown the pop-up.' ) }
+					help={ __(
+						'Users arriving at the site from URLs with this utm_source will never be shown the pop-up.'
+					) }
 					value={ utm_suppression }
 					onChange={ value => onMetaFieldChange( 'utm_suppression', value ) }
+				/>
+				<RangeControl
+					label={ __( 'Overlay opacity' ) }
+					value={ overlay_opacity }
+					onChange={ value => onMetaFieldChange( 'overlay_opacity', value ) }
+					min={ 0 }
+					max={ 100 }
 				/>
 			</Fragment>
 		);
@@ -93,10 +110,18 @@ const PopupSidebarWithData = compose( [
 	withSelect( select => {
 		const { getEditedPostAttribute } = select( 'core/editor' );
 		const meta = getEditedPostAttribute( 'meta' );
-		const { frequency, placement, trigger_scroll_progress, trigger_delay, trigger_type, utm_suppression } =
-			meta || {};
+		const {
+			frequency,
+			overlay_opacity,
+			placement,
+			trigger_scroll_progress,
+			trigger_delay,
+			trigger_type,
+			utm_suppression,
+		} = meta || {};
 		return {
 			frequency,
+			overlay_opacity,
 			placement,
 			trigger_scroll_progress,
 			trigger_delay,
@@ -114,7 +139,7 @@ const PopupSidebarWithData = compose( [
 ] )( PopupSidebar );
 
 const PluginDocumentSettingPanelDemo = () => (
-	<PluginDocumentSettingPanel name="popup-settings-panel" title={ __(' Pop-up Settings' ) }>
+	<PluginDocumentSettingPanel name="popup-settings-panel" title={ __( ' Pop-up Settings' ) }>
 		<PopupSidebarWithData />
 	</PluginDocumentSettingPanel>
 );

--- a/src/view/style.scss
+++ b/src/view/style.scss
@@ -1,6 +1,5 @@
 .newspack-lightbox {
 	align-items: center;
-	background: rgba( black, 0.5 );
 	display: flex;
 	height: 100%;
 	justify-content: center;
@@ -13,7 +12,7 @@
 	z-index: 99999;
 
 	.newspack-lightbox-shim {
-		background: transparent;
+		background: black;
 		height: 100%;
 		left: 0;
 		position: absolute;

--- a/src/view/style.scss
+++ b/src/view/style.scss
@@ -12,9 +12,20 @@
 	width: 100%;
 	z-index: 99999;
 
+	.newspack-lightbox-shim {
+		background: transparent;
+		height: 100%;
+		left: 0;
+		position: absolute;
+		top: 0;
+		width: 100%;
+		z-index: 0;
+	}
+
 	.newspack-popup-wrapper {
 		background: white;
 		position: relative;
+		z-index: 1;
 	}
 
 	.newspack-popup {

--- a/src/view/style.scss
+++ b/src/view/style.scss
@@ -13,8 +13,12 @@
 
 	.newspack-lightbox-shim {
 		background: black;
+		border: 0;
+		border-radius: 0;
 		height: 100%;
 		left: 0;
+		margin: 0;
+		padding: 0;
 		position: absolute;
 		top: 0;
 		width: 100%;

--- a/src/view/style.scss
+++ b/src/view/style.scss
@@ -8,6 +8,7 @@
 	opacity: 0;
 	position: fixed;
 	top: 0;
+	visibility: hidden;
 	width: 100%;
 	z-index: 99999;
 

--- a/src/view/style.scss
+++ b/src/view/style.scss
@@ -28,6 +28,7 @@
 
 	.newspack-popup-wrapper {
 		background: white;
+		overflow-x: hidden;
 		position: relative;
 		z-index: 1;
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The Overlay is now clickable/dismiss-able in addition to the close button. Clicking the overlay behind the pop-up should have exactly the same  effect as clicking the close button - the popup is dismissed, and the `newspack-popups/v1/reader` API is called. There is also an overlay opacity range control, which can be set from 0-100.

<img width="1582" alt="Screen Shot 2019-11-06 at 6 46 19 PM" src="https://user-images.githubusercontent.com/1477002/68347986-aa5d7e80-00c6-11ea-94ef-1fd0dd076aca.png">

cc: @tristanloper 

### How to test the changes in this Pull Request:

1. Create a pop-up with Frequency=Every Page View, Trigger=Scroll Progress, Scroll Progress=20. 
2. View the site in an incognito window, and navigate to any single post. The popup should appear as you scroll down.
3. Click the background and verify the Pop-up is dismissed.
4. Alter the overlay opacity setting, and verify the change.
5. Change the Frequency to "Once A Day."
6. View a post, the popup should appear. Click the overlay to dismiss.
7. View another post, the popup should not appear (demonstrating that the  API call was made when the overlay was clicked.)
8. Verify the close button continues to work as before.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
