### PR TITLE
Dismiss Button

### DIFF
--- a/includes/class-newspack-popups-api.php
+++ b/includes/class-newspack-popups-api.php
@@ -68,9 +68,10 @@ final class Newspack_Popups_API {
 		$response['currentViews'] = (int) $data['count'];
 
 		$frequency             = $popup['options']['frequency'];
-		$utm_suppression       = $popup['options']['utm_suppression'];
-		$current_views         = (int) $response['currentViews'];
-		$last_view             = (int) $data['time'];
+		$utm_suppression       = ! empty( $popup['options']['utm_suppression'] ) ? $popup['options']['utm_suppression'] : null;
+		$current_views         = ! empty( $response['currentViews'] ) ? (int) $response['currentViews'] : 0;
+		$suppress_forever      = ! empty( $data['suppress_forever'] ) ? (int) $data['suppress_forever'] : false;
+		$last_view             = ! empty( $data['time'] ) ? (int) $data['time'] : 0;
 		$response['frequency'] = $frequency;
 		switch ( $frequency ) {
 			case 'daily':
@@ -94,6 +95,9 @@ final class Newspack_Popups_API {
 				$response['displayPopup'] = false;
 			}
 		}
+		if ( $suppress_forever ) {
+			$response['displayPopup'] = false;
+		}
 		return rest_ensure_response( $response );
 	}
 
@@ -109,6 +113,9 @@ final class Newspack_Popups_API {
 			$data          = get_transient( $transient_name );
 			$data['count'] = (int) $data['count'] + 1;
 			$data['time']  = time();
+			if ( $request['suppress_forever'] ) {
+				$data['suppress_forever'] = true;
+			}
 			set_transient( $transient_name, $data, 0 );
 		}
 		return $this->reader_get_endpoint( $request );

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -184,6 +184,19 @@ final class Newspack_Popups {
 				'auth_callback'  => '__return_true',
 			]
 		);
+
+		\register_meta(
+			'post',
+			'dismiss_text',
+			[
+				'object_subtype' => self::NEWSPACK_PLUGINS_CPT,
+				'show_in_rest'   => true,
+				'type'           => 'string',
+				'single'         => true,
+				'auth_callback'  => '__return_true',
+			]
+		);
+
 	}
 
 	/**

--- a/src/editor/index.js
+++ b/src/editor/index.js
@@ -27,6 +27,7 @@ class PopupSidebar extends Component {
 	 */
 	render() {
 		const {
+			dismiss_text,
 			frequency,
 			onMetaFieldChange,
 			overlay_opacity,
@@ -108,6 +109,11 @@ class PopupSidebar extends Component {
 					min={ 0 }
 					max={ 100 }
 				/>
+				<TextControl
+					label={ __( 'Text for "Not Interested" button' ) }
+					value={ dismiss_text }
+					onChange={ value => onMetaFieldChange( 'dismiss_text', value ) }
+				/>
 			</Fragment>
 		);
 	}
@@ -119,6 +125,7 @@ const PopupSidebarWithData = compose( [
 		const meta = getEditedPostAttribute( 'meta' );
 		const {
 			frequency,
+			dismiss_text,
 			overlay_color,
 			overlay_opacity,
 			placement,
@@ -128,6 +135,7 @@ const PopupSidebarWithData = compose( [
 			utm_suppression,
 		} = meta || {};
 		return {
+			dismiss_text,
 			frequency,
 			overlay_color,
 			overlay_opacity,

--- a/src/view/style.scss
+++ b/src/view/style.scss
@@ -1,3 +1,7 @@
+// Secondary Color based on Newspack Theme
+$color__secondary: #555;
+$color__secondary-variation: darken( $color__secondary, 10% );
+
 .newspack-lightbox {
 	align-items: center;
 	display: flex;
@@ -63,16 +67,25 @@
 	}
 
 	.popup-not-interested-form {
+		font-size: 0.7em;
 		text-align: center;
+
 		button {
 			background: transparent;
-			border: none;
-			padding: 0;
+			border: 0;
+			border-radius: 0;
+			color: $color__secondary;
+			font-size: 1em;
+			font-weight: normal;
 			margin: 0;
-			font-weight: lighter;
-			color: lightgray;
+			padding: 0;
+
+
+			&:active,
+			&:focus,
 			&:hover {
-				color: darkgray;
+				color: $color__secondary-variation;
+				outline: 0;
 			}
 		}
 	}

--- a/src/view/style.scss
+++ b/src/view/style.scss
@@ -62,6 +62,21 @@
 		width: 36px;
 	}
 
+	.popup-not-interested-form {
+		text-align: center;
+		button {
+			background: transparent;
+			border: none;
+			padding: 0;
+			margin: 0;
+			font-weight: lighter;
+			color: lightgray;
+			&:hover {
+				color: darkgray;
+			}
+		}
+	}
+
 	/* Placements */
 	&.newspack-lightbox-placement-center {
 		.newspack-popup-wrapper {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds an optional button that dismisses the pop-up forever. When editing the Pop-up the document sidebar now has a `Text for "Not Interested" button`  field. If  this is populated, there will be a light button at the bottom of the popup with that text. Clicking the button dismisses the popup with a special `dismiss_forever` flag that will cause it to never be shown again to the current user.

<img width="1582" alt="Screen Shot 2019-11-06 at 7 37 44 PM" src="https://user-images.githubusercontent.com/1477002/68350166-789be600-00cd-11ea-9cc6-7b8c90b55543.png">

<img width="1582" alt="Screen Shot 2019-11-06 at 7 38 14 PM" src="https://user-images.githubusercontent.com/1477002/68350171-7cc80380-00cd-11ea-8079-26513151adbb.png">

cc: @tristanloper 

### How to test the changes in this Pull Request:

1. Create a popup with Trigger=Scroll, Scroll Progress=20%, Frequency=Every Page View, Text for "Not Interested" button="I'm not interested."
2. View the site incognito, navigate to a Post, scroll down until you see the popup. 
3. Verify the button at the bottom of the popup.
4. Click the button. Verify popup is dismissed.
5. Navigate to any other page, verify the popup does not show again.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
