### PR TITLE
Add a class the the `h1` title so it can easily be targeted by a theme

### DIFF
--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -235,7 +235,7 @@ final class Newspack_Popups_Inserter {
 			<div class="newspack-popup-wrapper">
 				<div class="newspack-popup">
 					<?php if ( ! empty( $popup['title'] ) ) : ?>
-						<h1><?php echo esc_html( $popup['title'] ); ?></h1>
+						<h1 class="newspack-popup-title"><?php echo esc_html( $popup['title'] ); ?></h1>
 					<?php endif; ?>
 					<?php echo ( $popup['body'] ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 					<form class="popup-dismiss-form"


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This is a simple one...

It just adds a class of `newspack-popup-title` to the `h1` used for the title.

![Screenshot 2019-11-07 at 17 18 01](https://user-images.githubusercontent.com/177929/68411581-98d9ac80-0182-11ea-8e02-ae7cbe6b5f32.png)

### How to test the changes in this Pull Request:

1. Switch to this branch
2. Load a post with the pop-up and inspect the title. Does it have the class?

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
