### PR TITLE
Fix the margin bottom/top of the elements within the `.newspack-popup`

### DIFF
--- a/src/view/style.scss
+++ b/src/view/style.scss
@@ -27,8 +27,18 @@
 			margin-top: 0;
 		}
 
-		& > *:last-child {
+		& > *:nth-last-child(2) { // Last child being .popup-dismiss-form
 			margin-bottom: 0;
+		}
+
+		.wp-block-column {
+			& > *:first-child {
+				margin-top: 0;
+			}
+
+			& > *:last-child {
+				margin-bottom: 0;
+			}
 		}
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Reset the margins of the elements inside the pop-up.

__Before__

![1 before](https://user-images.githubusercontent.com/177929/68412827-e5be8280-0184-11ea-933f-788cd5cb995d.png)

__After__

![2 after](https://user-images.githubusercontent.com/177929/68412797-d2abb280-0184-11ea-9db6-f4bcf6ce997a.png)


### How to test the changes in this Pull Request:

1. Check a post with the pop-up
2. switch to this branch and run `npm run build`
3. refresh your post and notice the slight difference

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
