### PR TITLE
Add a very subtle box-shadow to `.newspack-popup-wrapper`

### DIFF
--- a/src/view/style.scss
+++ b/src/view/style.scss
@@ -14,6 +14,7 @@
 
 	.newspack-popup-wrapper {
 		background: white;
+		box-shadow: 0 0 1em 0.5em rgba( black, 0.1 );
 		position: relative;
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

In order to differentiate the pop-up from the content, I added a very subtle shadow to the wrapper. It's the most noticeable when the overlay opacity is set to 0.

__Before:__

![1 before](https://user-images.githubusercontent.com/177929/68414225-b0fffa80-0187-11ea-89dd-2594b1400d79.png)

__After:__

![2 after](https://user-images.githubusercontent.com/177929/68414239-b78e7200-0187-11ea-95c0-e87aca7ce3c7.png)

### How to test the changes in this Pull Request:

1. load a post with the popup
2. switch to this branch and run `npm run build`
3. reload the post, do you notice the shadow?

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
