### PR TITLE
Support For Non-AMP Requests

### DIFF
--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -73,8 +73,6 @@ final class Newspack_Popups_Inserter {
 		);
 		\wp_style_add_data( 'newspack-popups-view', 'rtl', 'replace' );
 		\wp_enqueue_style( 'newspack-popups-view' );
-		wp_enqueue_script( 'amp-animation' );
-		wp_enqueue_script( 'amp-position-observer' );
 		return $content;
 	}
 
@@ -376,7 +374,38 @@ final class Newspack_Popups_Inserter {
 			}
 		</script>
 		<?php
-		wp_enqueue_script( 'amp-access' );
+		static::register_amp_scripts();
+	}
+
+	/**
+	 * Register and enqueue all required AMP scripts, if needed.
+	 */
+	public static function register_amp_scripts() {
+		if ( ! wp_script_is( 'amp-runtime', 'registered' ) ) {
+		// phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion
+			wp_register_script(
+				'amp-runtime',
+				'https://cdn.ampproject.org/v0.js',
+				null,
+				null,
+				true
+			);
+		}
+		$scripts = [ 'amp-access', 'amp-animation', 'amp-form', 'amp-bind', 'amp-position-observer' ];
+		foreach ( $scripts as $script ) {
+			if ( ! wp_script_is( $script, 'registered' ) ) {
+				$path = "https://cdn.ampproject.org/v0/{$script}-latest.js";
+				// phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion
+				wp_register_script(
+					$script,
+					$path,
+					array( 'amp-runtime' ),
+					null,
+					true
+				);
+			}
+			wp_enqueue_script( $script );
+		}
 	}
 }
 $newspack_popups_inserter = new Newspack_Popups_Inserter();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR registers and enqueues the AMP scripts so that they will be loaded in  non-AMP requests, even if the AMP plugin is not installed.

### How to test the changes in this Pull Request:

1. Create a Pop-Up, in an incognito window verify that it reveals and behaves normally in an AMP request.
2. Switch AMP mode to Transitional, test that behavior is identical in AMP and non-AMP requests.
3. Do the same in Reader Mode.
4. Disable the AMP plugin, then re-test a page. It should behave just like the AMP version.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
