### PR TITLE
Suppress Popups After Mailchimp Signup

### DIFF
--- a/includes/class-newspack-popups-api.php
+++ b/includes/class-newspack-popups-api.php
@@ -71,6 +71,7 @@ final class Newspack_Popups_API {
 		$utm_suppression       = ! empty( $popup['options']['utm_suppression'] ) ? $popup['options']['utm_suppression'] : null;
 		$current_views         = ! empty( $response['currentViews'] ) ? (int) $response['currentViews'] : 0;
 		$suppress_forever      = ! empty( $data['suppress_forever'] ) ? (int) $data['suppress_forever'] : false;
+		$mailing_list_status   = ! empty( $data['mailing_list_status'] ) ? (int) $data['mailing_list_status'] : false;
 		$last_view             = ! empty( $data['time'] ) ? (int) $data['time'] : 0;
 		$response['frequency'] = $frequency;
 		switch ( $frequency ) {
@@ -95,7 +96,7 @@ final class Newspack_Popups_API {
 				$response['displayPopup'] = false;
 			}
 		}
-		if ( $suppress_forever ) {
+		if ( $suppress_forever || $mailing_list_status ) {
 			$response['displayPopup'] = false;
 		}
 		return rest_ensure_response( $response );
@@ -115,6 +116,9 @@ final class Newspack_Popups_API {
 			$data['time']  = time();
 			if ( $request['suppress_forever'] ) {
 				$data['suppress_forever'] = true;
+			}
+			if ( $request['mailing_list_status'] && 'subscribed' === $request['mailing_list_status'] ) {
+				$data['mailing_list_status'] = true;
 			}
 			set_transient( $transient_name, $data, 0 );
 		}

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -241,6 +241,28 @@ final class Newspack_Popups_Inserter {
 		$dismiss_text    = ! empty( $popup['options']['dismiss_text'] ) && strlen( trim( $popup['options']['dismiss_text'] ) ) > 0 ? $popup['options']['dismiss_text'] : null;
 		$overlay_opacity = absint( $popup['options']['overlay_opacity'] ) / 100;
 		$overlay_color   = $popup['options']['overlay_color'];
+
+		ob_start();
+		?>
+		<input
+			name="url"
+			type="hidden"
+			value="CANONICAL_URL"
+			data-amp-replace="CANONICAL_URL"
+		/>
+		<input
+			name="popup_id"
+			type="hidden"
+			value="<?php echo ( esc_attr( $popup['id'] ) ); ?>"
+		/>
+		<input
+			name="mailing_list_status"
+			type="hidden"
+			[value]="mailing_list_status"
+		/>
+		<?php
+		$hidden_fields = ob_get_clean();
+
 		ob_start();
 		?>
 		<div amp-access="displayPopup" amp-access-hide class="<?php echo esc_attr( implode( ' ', $classes ) ); ?>" role="button" tabindex="0" id="<?php echo esc_attr( $element_id ); ?>">
@@ -255,17 +277,7 @@ final class Newspack_Popups_Inserter {
 						method="POST"
 						action-xhr="<?php echo esc_url( $endpoint ); ?>"
 						target="_top">
-						<input
-							name="url"
-							type="hidden"
-							value="CANONICAL_URL"
-							data-amp-replace="CANONICAL_URL"
-						/>
-						<input
-							name="popup_id"
-							type="hidden"
-							value="<?php echo ( esc_attr( $popup['id'] ) ); ?>"
-						/>
+						<?php echo $hidden_fields; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 						<input
 							name="suppress_forever"
 							type="hidden"
@@ -278,17 +290,7 @@ final class Newspack_Popups_Inserter {
 						method="POST"
 						action-xhr="<?php echo esc_url( $endpoint ); ?>"
 						target="_top">
-						<input
-							name="url"
-							type="hidden"
-							value="CANONICAL_URL"
-							data-amp-replace="CANONICAL_URL"
-						/>
-						<input
-							name="popup_id"
-							type="hidden"
-							value="<?php echo ( esc_attr( $popup['id'] ) ); ?>"
-						/>
+						<?php echo $hidden_fields; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 						<button on="tap:<?php echo esc_attr( $element_id ); ?>.hide" class="newspack-lightbox__close" aria-label="<?php esc_html_e( 'Close Pop-up', 'newspack-popups' ); ?>">
 							<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" role="img" aria-hidden="true" focusable="false"><path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12 19 6.41z"/></svg>
 						</button>
@@ -299,17 +301,7 @@ final class Newspack_Popups_Inserter {
 				method="POST"
 				action-xhr="<?php echo esc_url( $endpoint ); ?>"
 				target="_top">
-				<input
-					name="url"
-					type="hidden"
-					value="CANONICAL_URL"
-					data-amp-replace="CANONICAL_URL"
-				/>
-				<input
-					name="popup_id"
-					type="hidden"
-					value="<?php echo ( esc_attr( $popup['id'] ) ); ?>"
-				/>
+				<?php echo $hidden_fields; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 				<button style="opacity: <?php echo floatval( $overlay_opacity ); ?>;background-color:<?php echo esc_attr( $overlay_color ); ?>;" class="newspack-lightbox-shim" on="tap:<?php echo esc_attr( $element_id ); ?>.hide"></button>
 			</form>
 		</div>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

After a successful Mailchimp signup, popups should not be shown again. This PR, combined with [recent additions to the Jetpack Mailchimp Block](https://github.com/Automattic/jetpack/pull/14050), will respond to a successful signup and suppress future popups. 

This is done using `amp-state` as follows:
- Upon successful form submission from the JP Mailchimp block, AMP state is updated: https://github.com/Automattic/jetpack/blob/master/extensions/blocks/mailchimp/mailchimp.php#L92
- `AMP.state.mailing_list_status` is reflected in hidden form elements in all of the forms associated with the popup.
- When the popup is hidden, the form is submitted and the API endpoint understands `mailing_list_status` to mean this user should never see a popup again. 

This functionality requires the most recent version of Jetpack (8.0), and will only work in AMP requests.

### How to test the changes in this Pull Request:

1. Activate Jetpack 8.0 and AMP plugins, set AMP to Standard mode. 
2. Create a Pop-Up, and insert the Jetpack Mailchimp block. If necessary, follow flow to connect site to Mailchimp account. Set popup to appear on Every Page View. Set Trigger to Timer and Delay very low.
3. In incognito window, view a  post. The Pop-up should appear. 
4. Inspect the page. `<form/>` elements in the popup markup should contain a hidden form input with name `mailing_list_status`.
5. Subscribe to the mailing list.
6. Observe the hidden inputs' value changes to  `subscribed`.
7. Close the popup in any way (click X, click overlay)
8. Navigate to another post. 
9. Observe the pop-up does not appear.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
