### PR TITLE
Popups  On Non-Posts

### DIFF
--- a/includes/class-newspack-popups-api.php
+++ b/includes/class-newspack-popups-api.php
@@ -139,10 +139,7 @@ final class Newspack_Popups_API {
 		$popup_id = isset( $request['popup_id'] ) ? $request['popup_id'] : false;
 		$url      = isset( $request['url'] ) ? esc_url_raw( urldecode( $request['url'] ) ) : false;
 		if ( $reader_id && $url && $popup_id ) {
-			$post_id = url_to_postid( $url ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.url_to_postid_url_to_postid
-			if ( $post_id && 'post' === get_post_type( $post_id ) ) {
-				return $reader_id . '-' . $popup_id . '-popup';
-			}
+			return $reader_id . '-' . $popup_id . '-popup';
 		}
 		return false;
 	}

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -43,12 +43,12 @@ final class Newspack_Popups_Inserter {
 	 */
 	public function __construct() {
 		add_filter( 'the_content', [ $this, 'popup' ] );
-		add_action( 'wp_head', [ __CLASS__, 'popup_access' ] );
+		add_action( 'after_header', [ $this, 'popup_after_header' ] ); // This is a Newspack theme hook. When used with other themes, popups won't be inserted on archive pages.
 		add_action( 'wp_head', [ __CLASS__, 'popup_access' ] );
 	}
 
 	/**
-	 * Process popup and insert into content if needed.
+	 * Process popup and insert into post and page ontent if needed.
 	 *
 	 * @param string $content The content of the post.
 	 * @return string The content with popup inserted.
@@ -79,6 +79,29 @@ final class Newspack_Popups_Inserter {
 		\wp_style_add_data( 'newspack-popups-view', 'rtl', 'replace' );
 		\wp_enqueue_style( 'newspack-popups-view' );
 		return $content;
+	}
+
+	/**
+	 * Process popup and insert into archive pages if needed. Applies to Newspack Theme only.
+	 */
+	public static function popup_after_header() {
+		/* Posts and pages are covered by the_content hook */
+		if ( is_user_logged_in() || is_single() || is_page() ) {
+			return;
+		}
+
+		$popup = self::popup_for_post();
+
+		if ( ! $popup ) {
+			return;
+		}
+
+		// Pop-ups triggered by scroll position can only appear on Posts.
+		if ( 'scroll' === $popup['options']['trigger_type'] ) {
+			return;
+		}
+
+		echo $popup['markup']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
 
 	/**

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -55,12 +55,17 @@ final class Newspack_Popups_Inserter {
 	 */
 	public static function popup( $content = '' ) {
 		/* From https://github.com/Automattic/newspack-blocks/pull/115 */
-		if ( is_user_logged_in() || ! is_single() ) {
+		if ( is_user_logged_in() ) {
 			return $content;
 		}
 		$popup = self::popup_for_post();
 
 		if ( ! $popup ) {
+			return $content;
+		}
+
+		// Pop-ups triggered by scroll position can only appear on Posts.
+		if ( 'scroll' === $popup['options']['trigger_type'] && ! is_single() ) {
 			return $content;
 		}
 
@@ -347,11 +352,15 @@ final class Newspack_Popups_Inserter {
 	 * Add amp-access header code.
 	 */
 	public static function popup_access() {
-		if ( is_user_logged_in() || ! is_single() ) {
+		if ( is_user_logged_in() ) {
 			return;
 		}
 		$popup = self::popup_for_post();
 		if ( ! $popup ) {
+			return;
+		}
+		// Pop-ups triggered by scroll position can only appear on Posts.
+		if ( 'scroll' === $popup['options']['trigger_type'] && ! is_single() ) {
 			return;
 		}
 		$endpoint = str_replace( 'http://', '//', get_rest_url( null, 'newspack-popups/v1/reader' ) );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR places Timed Pop-ups on non-posts, including Homepage, Pages, Category Archives, Author Archives, and Search Results. The hook used to place on Archive pages is specific to Newspack Theme, so for the moment, popups  will only appear on those pages if Newspack is the active theme. The  new logic applies only to Pop-ups with a timer trigger. Scroll triggers only work in posts, because the trigger point placement is calculated based on normal paragraph-based content.

### How to test the changes in this Pull Request:

1. With Newspack as the theme, create  a Pop-up, set Trigger: Timer, Delay: 1s, Frequency: Every Page View. 
2. In an incognito window, view homepage,  another page, a  category archive, an author archive, search results, and a post. The popup should appear on all of these.
3. Change the popup's Trigger to "Scroll Progress." Test on all of the above  again. It should appear only on the post.
4, Change theme to something other than Newspack, and set  the Trigger back to Timer. Re-check the above. Only the Post should work.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
