### PR TITLE
Remove "Every Page View" Frequency Option

### DIFF
--- a/includes/class-newspack-popups-api.php
+++ b/includes/class-newspack-popups-api.php
@@ -81,9 +81,6 @@ final class Newspack_Popups_API {
 			case 'once':
 				$response['displayPopup'] = $current_views < 1;
 				break;
-			case 'always':
-				$response['displayPopup'] = true;
-				break;
 			case 'never':
 			default:
 				$response['displayPopup'] = false;

--- a/src/editor/index.js
+++ b/src/editor/index.js
@@ -75,7 +75,6 @@ class PopupSidebar extends Component {
 					options={ [
 						{ value: 'never', label: __( 'Never' ) },
 						{ value: 'once', label: __( 'Once' ) },
-						{ value: 'always', label: __( 'Every page view' ) },
 						{ value: 'daily', label: __( 'Once a day' ) },
 					] }
 				/>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The "Every Page View" Frequency option was included to make testing easier while the plugin was in development. In real-world situations it enables aggressive overuse of popups which we want to avoid. In this PR the option is removed.

### How to test the changes in this Pull Request:

Build the plugin, verify the "Every Page View" Frequency option is no longer available. View several pages incognito and verify that any Pop-up appears at most once a day.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
