### PR TITLE
Fix: default values

### DIFF
--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -85,7 +85,7 @@ final class Newspack_Popups_Model {
 				'title'   => get_the_title(),
 				'body'    => $body,
 				'options' => wp_parse_args(
-					[
+					array_filter([
 						'dismiss_text'            => get_post_meta( get_the_ID(), 'dismiss_text', true ),
 						'frequency'               => get_post_meta( get_the_ID(), 'frequency', true ),
 						'overlay_color'           => get_post_meta( get_the_ID(), 'overlay_color', true ),
@@ -95,10 +95,10 @@ final class Newspack_Popups_Model {
 						'trigger_delay'           => get_post_meta( get_the_ID(), 'trigger_delay', true ),
 						'trigger_scroll_progress' => get_post_meta( get_the_ID(), 'trigger_scroll_progress', true ),
 						'utm_suppression'         => get_post_meta( get_the_ID(), 'utm_suppression', true ),
-					],
+					]),
 					[
 						'dismiss_text'            => '',
-						'frequency'               => 0,
+						'frequency'               => 'test',
 						'overlay_color'           => '#000000',
 						'overlay_opacity'         => 30,
 						'placement'               => 'center',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

After creating a new popup, all values were set to empty strings.

### How to test the changes in this Pull Request:

1. create a new popup
2. it should have `'test'` frequency by default, so it should appear right away without updating popup settings

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
