### PR TITLE
Update default style with more generic buttons and rely on current theme

### DIFF
--- a/src/view/style.scss
+++ b/src/view/style.scss
@@ -4,16 +4,18 @@ $color__secondary-variation: darken( $color__secondary, 10% );
 
 .newspack-lightbox {
 	align-items: center;
+	bottom: 0;
 	display: flex;
-	height: 100%;
 	justify-content: center;
 	left: 0;
 	margin: 0 !important;
+	max-width: 100% !important;
 	opacity: 0;
 	position: fixed;
+	right: 0;
 	top: 0;
 	visibility: hidden;
-	width: 100%;
+	width: 100% !important;
 	z-index: 99999;
 
 	.newspack-lightbox-shim {
@@ -65,39 +67,49 @@ $color__secondary-variation: darken( $color__secondary, 10% );
 	}
 
 	.newspack-lightbox__close {
-		border-radius: 50%;
+		align-items: center;
 		box-shadow: none;
 		cursor: pointer;
+		display: flex;
 		font-size: inherit;
 		height: 36px;
+		justify-content: center;
 		margin: 0;
 		padding: 6px;
 		position: absolute;
 		right: 0.25em;
 		top: 0.25em;
 		width: 36px;
+
+		svg {
+			fill: currentcolor;
+			flex: 0 0 24px;
+		}
 	}
 
 	.popup-not-interested-form {
-		font-size: 0.7em;
-		text-align: center;
+		display: flex;
+		justify-content: center;
+		margin-top: 1.5em;
 
 		button {
 			background: transparent;
 			border: 0;
 			border-radius: 0;
 			color: $color__secondary;
-			font-size: 1em;
+			font-size: 0.7em;
 			font-weight: normal;
+			line-height: 1;
 			margin: 0;
 			padding: 0;
-
+			text-decoration: underline;
 
 			&:active,
 			&:focus,
 			&:hover {
 				color: $color__secondary-variation;
-				outline: 0;
+				outline-offset: 2px;
+				text-decoration: none;
 			}
 		}
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Simplify the CSS for the buttons so the style will rely on the active theme. Also making sure some properties are not being overridden by the theme.

Closes #37  .

### How to test the changes in this Pull Request:

1. Switch to this branch
2. Try different themes
3. Does the pop-up look ok?

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
