### PR TITLE
Add padding to the pop-up when admin bar is available

### DIFF
--- a/src/view/style.scss
+++ b/src/view/style.scss
@@ -16,6 +16,16 @@ $color__secondary-variation: darken( $color__secondary, 10% );
 	width: 100%;
 	z-index: 99999;
 
+	.admin-bar & {
+		@media only screen and (min-width: 601px) {
+			padding-top: 46px !important;
+		}
+
+		@media only screen and (min-width: 783px) {
+			padding-top: 32px !important;
+		}
+	}
+
 	.newspack-lightbox-shim {
 		background: black;
 		border: 0;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

By adding a padding-top we avoid having the top part of the pop-up being behind the admin bar. 

Closes #38.

### How to test the changes in this Pull Request:

1. Make sure you're logged in. Use a Pop-up in Test mode.
2. You can either: use the top placement, or have a pop-up with lots of content
3. Check a post. The pop-up should be displayed behind the admin bar at the top.
4. Switch to this branch.
5. Refresh your post. It should now be below the admin bar.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
