### PR TITLE
Refactor Sitewide Default

### DIFF
--- a/includes/class-newspack-popups-api.php
+++ b/includes/class-newspack-popups-api.php
@@ -43,6 +43,56 @@ final class Newspack_Popups_API {
 				'callback' => [ $this, 'reader_post_endpoint' ],
 			]
 		);
+		\register_rest_route(
+			'newspack-popups/v1/',
+			'sitewide_default/(?P<id>\d+)',
+			[
+				'methods'             => \WP_REST_Server::EDITABLE,
+				'callback'            => [ $this, 'set_sitewide_default_endpoint' ],
+				'permission_callback' => function() {
+					if ( ! current_user_can( 'manage_options' ) ) {
+						return new \WP_Error(
+							'newspack_rest_forbidden',
+							esc_html__( 'You cannot use this resource.', 'newspack' ),
+							[
+								'status' => 403,
+							]
+						);
+					}
+					return true;
+				},
+				'args'                => [
+					'id' => [
+						'sanitize_callback' => 'absint',
+					],
+				],
+			]
+		);
+		\register_rest_route(
+			'newspack-popups/v1/',
+			'sitewide_default/(?P<id>\d+)',
+			[
+				'methods'             => \WP_REST_Server::DELETABLE,
+				'callback'            => [ $this, 'unset_sitewide_default_endpoint' ],
+				'permission_callback' => function() {
+					if ( ! current_user_can( 'manage_options' ) ) {
+						return new \WP_Error(
+							'newspack_rest_forbidden',
+							esc_html__( 'You cannot use this resource.', 'newspack' ),
+							[
+								'status' => 403,
+							]
+						);
+					}
+					return true;
+				},
+				'args'                => [
+					'id' => [
+						'sanitize_callback' => 'absint',
+					],
+				],
+			]
+		);
 	}
 
 	/**
@@ -144,6 +194,26 @@ final class Newspack_Popups_API {
 			set_transient( $transient_name, $data, 0 );
 		}
 		return $this->reader_get_endpoint( $request );
+	}
+
+	/**
+	 * Set sitewide default Popup
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 */
+	public function set_sitewide_default_endpoint( $request ) {
+		$response = Newspack_Popups_Model::set_sitewide_popup( $request['id'] );
+		return is_wp_error( $response ) ? $response : [ 'success' => true ];
+	}
+
+	/**
+	 * Unset sitewide default Popup (if it is the specified post)
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 */
+	public function unset_sitewide_default_endpoint( $request ) {
+		$response = Newspack_Popups_Model::unset_sitewide_popup( $request['id'] );
+		return is_wp_error( $response ) ? $response : [ 'success' => true ];
 	}
 
 	/**

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -47,6 +47,9 @@ final class Newspack_Popups_Inserter {
 		$sitewide_default = get_option( Newspack_Popups::NEWSPACK_POPUPS_SITEWIDE_DEFAULT, null );
 		if ( $sitewide_default ) {
 			self::$popup = Newspack_Popups_Model::retrieve_popup_by_id( $sitewide_default );
+			if ( self::$popup ) {
+				return self::$popup;
+			}
 		}
 		return null;
 	}

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -35,13 +35,20 @@ final class Newspack_Popups_Inserter {
 		}
 
 		// Then try for pop-up with category filtering.
-		self::$popup = Newspack_Popups_Model::retrieve_popup( get_the_category() );
+		$categories = get_the_category();
+		if ( $categories && count( $categories ) ) {
+			self::$popup = Newspack_Popups_Model::retrieve_popup( get_the_category() );
+			if ( self::$popup ) {
+				return self::$popup;
+			}
+		}
 
 		// If nothing found, try for sitewide pop-up.
-		if ( ! self::$popup ) {
-			self::$popup = Newspack_Popups_Model::retrieve_popup();
+		$sitewide_default = get_option( Newspack_Popups::NEWSPACK_POPUPS_SITEWIDE_DEFAULT, null );
+		if ( $sitewide_default ) {
+			self::$popup = Newspack_Popups_Model::retrieve_popup_by_id( $sitewide_default );
 		}
-		return self::$popup;
+		return null;
 	}
 
 	/**

--- a/src/editor/index.js
+++ b/src/editor/index.js
@@ -31,6 +31,25 @@ import { optionsFieldsSelector } from './utils';
 import PopupPreview from './PopupPreview';
 
 class PopupSidebar extends Component {
+	state = {
+		isSiteWideDefault: undefined,
+	};
+	componentDidMount() {
+		this.setState( {
+			isSiteWideDefault: this.props.newspack_popups_is_sitewide_default,
+		} );
+	}
+	componentDidUpdate( prevProps ) {
+		const { isSavingPost, id } = this.props;
+		const { isSiteWideDefault } = this.state;
+		if ( ! prevProps.isSavingPost && isSavingPost ) {
+			const params = {
+				path: '/newspack-popups/v1/sitewide_default/' + id,
+				method: isSiteWideDefault ? 'POST' : 'DELETE',
+			};
+			apiFetch( params );
+		}
+	}
 	/**
 	 * Render
 	 */
@@ -39,9 +58,7 @@ class PopupSidebar extends Component {
 			dismiss_text,
 			display_title,
 			frequency,
-			id,
 			onMetaFieldChange,
-			onSitewideDefaultChange,
 			overlay_opacity,
 			overlay_color,
 			placement,
@@ -50,21 +67,24 @@ class PopupSidebar extends Component {
 			trigger_delay,
 			trigger_type,
 			utm_suppression,
+			onSitewideDefaultChange,
+			isCurrentPostPublished,
 		} = this.props;
+		const { isSiteWideDefault } = this.state;
 		return (
 			<Fragment>
-				<CheckboxControl
-					label={ __( 'Sitewide Default', 'newspack-popups' ) }
-					checked={ newspack_popups_is_sitewide_default }
-					onChange={ value => {
-						const params = {
-							path: '/newspack-popups/v1/sitewide_default/' + id,
-							method: value ? 'POST' : 'DELETE',
-						};
-						onSitewideDefaultChange( value );
-						apiFetch( params );
-					} }
-				/>
+				{ isCurrentPostPublished && isSiteWideDefault !== undefined && (
+					<CheckboxControl
+						label={ __( 'Sitewide Default', 'newspack-popups' ) }
+						checked={ isSiteWideDefault }
+						onChange={ isSiteWideDefault => {
+							this.setState( { isSiteWideDefault } );
+							// an ugly hack to update the post attribute, just to make the editor aware of a change,
+							// so that "update" button becomes enabled
+							onSitewideDefaultChange( Math.random() );
+						} }
+					/>
+				) }
 				<RadioControl
 					label={ __( 'Trigger' ) }
 					help={ __( 'The event to trigger the popup' ) }

--- a/src/editor/index.js
+++ b/src/editor/index.js
@@ -32,13 +32,8 @@ import PopupPreview from './PopupPreview';
 
 class PopupSidebar extends Component {
 	state = {
-		isSiteWideDefault: undefined,
+		isSiteWideDefault: this.props.newspack_popups_is_sitewide_default,
 	};
-	componentDidMount() {
-		this.setState( {
-			isSiteWideDefault: this.props.newspack_popups_is_sitewide_default,
-		} );
-	}
 	componentDidUpdate( prevProps ) {
 		const { isSavingPost, id } = this.props;
 		const { isSiteWideDefault } = this.state;
@@ -73,7 +68,7 @@ class PopupSidebar extends Component {
 		const { isSiteWideDefault } = this.state;
 		return (
 			<Fragment>
-				{ isCurrentPostPublished && isSiteWideDefault !== undefined && (
+				{ isCurrentPostPublished && (
 					<CheckboxControl
 						label={ __( 'Sitewide Default', 'newspack-popups' ) }
 						checked={ isSiteWideDefault }

--- a/src/editor/index.js
+++ b/src/editor/index.js
@@ -6,10 +6,12 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+import apiFetch from '@wordpress/api-fetch';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 import { Component, render, Fragment } from '@wordpress/element';
 import {
+	CheckboxControl,
 	Path,
 	RangeControl,
 	RadioControl,
@@ -37,10 +39,13 @@ class PopupSidebar extends Component {
 			dismiss_text,
 			display_title,
 			frequency,
+			id,
 			onMetaFieldChange,
+			onSitewideDefaultChange,
 			overlay_opacity,
 			overlay_color,
 			placement,
+			newspack_popups_is_sitewide_default,
 			trigger_scroll_progress,
 			trigger_delay,
 			trigger_type,
@@ -48,6 +53,18 @@ class PopupSidebar extends Component {
 		} = this.props;
 		return (
 			<Fragment>
+				<CheckboxControl
+					label={ __( 'Sitewide Default', 'newspack-popups' ) }
+					checked={ newspack_popups_is_sitewide_default }
+					onChange={ value => {
+						const params = {
+							path: '/newspack-popups/v1/sitewide_default/' + id,
+							method: value ? 'POST' : 'DELETE',
+						};
+						onSitewideDefaultChange( value );
+						apiFetch( params );
+					} }
+				/>
 				<RadioControl
 					label={ __( 'Trigger' ) }
 					help={ __( 'The event to trigger the popup' ) }
@@ -142,6 +159,9 @@ const PopupSidebarWithData = compose( [
 		return {
 			onMetaFieldChange: ( key, value ) => {
 				dispatch( 'core/editor' ).editPost( { meta: { [ key ]: value } } );
+			},
+			onSitewideDefaultChange: value => {
+				dispatch( 'core/editor' ).editPost( { newspack_popups_is_sitewide_default: value } );
 			},
 		};
 	} ),

--- a/src/editor/utils.js
+++ b/src/editor/utils.js
@@ -2,7 +2,7 @@
  * Data selector for popup options (stored in post meta)
  */
 export const optionsFieldsSelector = select => {
-	const { getEditedPostAttribute } = select( 'core/editor' );
+	const { getEditedPostAttribute, getCurrentPostId } = select( 'core/editor' );
 	const meta = getEditedPostAttribute( 'meta' );
 	const {
 		frequency,
@@ -20,8 +20,12 @@ export const optionsFieldsSelector = select => {
 		dismiss_text,
 		display_title,
 		frequency,
+		id: getCurrentPostId(),
 		overlay_color,
 		overlay_opacity,
+		newspack_popups_is_sitewide_default: getEditedPostAttribute(
+			'newspack_popups_is_sitewide_default'
+		),
 		placement,
 		trigger_scroll_progress,
 		trigger_delay,

--- a/src/editor/utils.js
+++ b/src/editor/utils.js
@@ -2,7 +2,9 @@
  * Data selector for popup options (stored in post meta)
  */
 export const optionsFieldsSelector = select => {
-	const { getEditedPostAttribute, getCurrentPostId } = select( 'core/editor' );
+	const { getEditedPostAttribute, getCurrentPostId, isSavingPost, isCurrentPostPublished } = select(
+		'core/editor'
+	);
 	const meta = getEditedPostAttribute( 'meta' );
 	const {
 		frequency,
@@ -31,5 +33,7 @@ export const optionsFieldsSelector = select => {
 		trigger_delay,
 		trigger_type,
 		utm_suppression,
+		isSavingPost: isSavingPost(),
+		isCurrentPostPublished: isCurrentPostPublished(),
 	};
 };


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

"Sitewide Default" refers to the Pop-up that is shown on any page, assuming there is no better match based on category filters. Currently this will be the newest published Pop-up with no category assignments. This logic is awkward:

- Sometimes it is unclear why a particular Pop-up has this status. 
- Setting a different sitewide default requires changing the published date of the post, which is a bit janky. 
- As the display logic becomes richer (e.g. [referrer filters](https://github.com/Automattic/newspack-popups/issues/48)) this approach will quickly become untenable. 
- The current approach is effectively a blocker on https://github.com/Automattic/newspack-plugin/pull/409, and this change frees that work to proceed.

This PR clarifies this logic by storing the ID of the sitewide default Pop-up in a single option, rather than relying on post newness and category assignment. The editor explicitly picks which Pop-up is the sitewide default, which is a much more understandable and deliberate approach.

At the top of the Pop-up Settings panel there is a Sitewide Default checkbox. Checking this causes the current Pop-up to immediately become sitewide default, replacing any other that might have been previously. Unchecking will cause there to be no sitewide default at all. 

<img width="1685" alt="Screen Shot 2020-02-02 at 6 11 04 PM" src="https://user-images.githubusercontent.com/1477002/73617005-6bb56280-45e8-11ea-8bc9-8bd506cb6965.png">

Closes https://github.com/Automattic/newspack-popups/issues/47

### How to test the changes in this Pull Request:

1. Create at least three Pop-ups. Two should have no category assignments. Set the Trigger to Timer with a short Delay. Frequency should be Test Mode.
2. Edit one of the category-less ones, and check Sitewide Default. 
3. Return to the Pop-ups post list page, and observe that this post now has "Sitewide Default" after it's name. 
4. In a normal (not incognito) window, open the homepage of the site. Observe the Sitewide Default Pop-up appears.
5. Edit the other category-less one, and check Sitewide Default.
6. On the Pop-ups list page the new one should say Sitewide Default.
7. Refresh the homepage and you should be shown the new one.
8. Visit a page with a category matching the category chosen in the third Pop-up. Observe that this Pop-up is shown.
9. Edit the current sitewide default and uncheck the checkbox. 
10. Return to the Pop-ups list and observe no Pop-ups have Sitewide Default text.
11. Visit the homepage and observe that no Pop-up is shown.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
