### PR TITLE
Toggle Pop-up Title Display

### DIFF
--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -162,6 +162,7 @@ final class Newspack_Popups_Model {
 				'options' => wp_parse_args(
 					array_filter([
 						'dismiss_text'            => get_post_meta( get_the_ID(), 'dismiss_text', true ),
+						'display_title'           => get_post_meta( get_the_ID(), 'display_title', true ),
 						'frequency'               => get_post_meta( get_the_ID(), 'frequency', true ),
 						'overlay_color'           => get_post_meta( get_the_ID(), 'overlay_color', true ),
 						'overlay_opacity'         => get_post_meta( get_the_ID(), 'overlay_opacity', true ),
@@ -172,6 +173,7 @@ final class Newspack_Popups_Model {
 						'utm_suppression'         => get_post_meta( get_the_ID(), 'utm_suppression', true ),
 					]),
 					[
+						'display_title'           => false,
 						'dismiss_text'            => '',
 						'frequency'               => 'test',
 						'overlay_color'           => '#000000',
@@ -219,6 +221,7 @@ final class Newspack_Popups_Model {
 		$endpoint        = str_replace( 'http://', '//', get_rest_url( null, 'newspack-popups/v1/reader' ) );
 		$classes         = [ 'newspack-lightbox', 'newspack-lightbox-placement-' . $popup['options']['placement'] ];
 		$dismiss_text    = ! empty( $popup['options']['dismiss_text'] ) && strlen( trim( $popup['options']['dismiss_text'] ) ) > 0 ? $popup['options']['dismiss_text'] : null;
+		$display_title   = $popup['options']['display_title'];
 		$overlay_opacity = absint( $popup['options']['overlay_opacity'] ) / 100;
 		$overlay_color   = $popup['options']['overlay_color'];
 
@@ -248,7 +251,7 @@ final class Newspack_Popups_Model {
 		<div amp-access="displayPopup" amp-access-hide class="<?php echo esc_attr( implode( ' ', $classes ) ); ?>" role="button" tabindex="0" id="<?php echo esc_attr( $element_id ); ?>">
 			<div class="newspack-popup-wrapper">
 				<div class="newspack-popup">
-					<?php if ( ! empty( $popup['title'] ) ) : ?>
+					<?php if ( ! empty( $popup['title'] ) && $display_title ) : ?>
 						<h1 class="newspack-popup-title"><?php echo esc_html( $popup['title'] ); ?></h1>
 					<?php endif; ?>
 					<?php echo ( $popup['body'] ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -198,6 +198,18 @@ final class Newspack_Popups {
 			]
 		);
 
+		\register_meta(
+			'post',
+			'display_title',
+			[
+				'object_subtype' => self::NEWSPACK_PLUGINS_CPT,
+				'show_in_rest'   => true,
+				'type'           => 'boolean',
+				'single'         => true,
+				'auth_callback'  => '__return_true',
+			]
+		);
+
 	}
 
 	/**

--- a/src/editor/index.js
+++ b/src/editor/index.js
@@ -10,12 +10,12 @@ import { withSelect, withDispatch } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 import { Component, render, Fragment } from '@wordpress/element';
 import {
-	CheckboxControl,
 	Path,
 	RangeControl,
 	RadioControl,
 	SelectControl,
 	TextControl,
+	ToggleControl,
 	SVG,
 } from '@wordpress/components';
 import { registerPlugin } from '@wordpress/plugins';
@@ -115,7 +115,7 @@ class PopupSidebar extends Component {
 					min={ 0 }
 					max={ 100 }
 				/>
-				<CheckboxControl
+				<ToggleControl
 					label={ __( 'Display Pop-up title', 'newspack-popups' ) }
 					checked={ display_title }
         			onChange={ value => onMetaFieldChange( 'display_title', value ) }

--- a/src/editor/index.js
+++ b/src/editor/index.js
@@ -10,6 +10,7 @@ import { withSelect, withDispatch } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 import { Component, render, Fragment } from '@wordpress/element';
 import {
+	CheckboxControl,
 	Path,
 	RangeControl,
 	RadioControl,
@@ -28,6 +29,7 @@ class PopupSidebar extends Component {
 	render() {
 		const {
 			dismiss_text,
+			display_title,
 			frequency,
 			onMetaFieldChange,
 			overlay_opacity,
@@ -113,6 +115,11 @@ class PopupSidebar extends Component {
 					min={ 0 }
 					max={ 100 }
 				/>
+				<CheckboxControl
+					label={ __( 'Display Pop-up title', 'newspack-popups' ) }
+					checked={ display_title }
+        			onChange={ value => onMetaFieldChange( 'display_title', value ) }
+				/>
 				<TextControl
 					label={ __( 'Text for "Not Interested" button' ) }
 					value={ dismiss_text }
@@ -129,6 +136,7 @@ const PopupSidebarWithData = compose( [
 		const meta = getEditedPostAttribute( 'meta' );
 		const {
 			frequency,
+			display_title,
 			dismiss_text,
 			overlay_color,
 			overlay_opacity,
@@ -139,6 +147,7 @@ const PopupSidebarWithData = compose( [
 			utm_suppression,
 		} = meta || {};
 		return {
+			display_title,
 			dismiss_text,
 			frequency,
 			overlay_color,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds a checkbox to determine if Pop-up title is displayed. 

<img width="1685" alt="Screen Shot 2020-02-03 at 12 30 05 AM" src="https://user-images.githubusercontent.com/1477002/73627883-66720b00-461c-11ea-96b5-ad2f50dd6227.png">

<img width="1685" alt="Screen Shot 2020-02-03 at 12 31 40 AM" src="https://user-images.githubusercontent.com/1477002/73627930-94574f80-461c-11ea-99d8-600457af4fe3.png">

Closes https://github.com/Automattic/newspack-popups/issues/40

### How to test the changes in this Pull Request:

1. Create one Pop-up, Trigger=Timer, Delay=1, Frequency=Test Mode.
2. Open the site homepage, verify it appears without the title.
3. Edit the Pop-up and check `Display Pop-up Title`.
4. Open the site homepage again, verify the Pop-up appears with the title.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
