### PR TITLE
Pop-up Background Color Control

### DIFF
--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -314,8 +314,8 @@ final class Newspack_Popups_Model {
 		ob_start();
 		?>
 		<div amp-access="displayPopup" amp-access-hide class="<?php echo esc_attr( implode( ' ', $classes ) ); ?>" role="button" tabindex="0" id="<?php echo esc_attr( $element_id ); ?>">
-			<div class="newspack-popup-wrapper">
-				<div class="newspack-popup" style="background-color:<?php echo esc_attr( $background_color ); ?>;">
+			<div class="newspack-popup-wrapper" style="background-color:<?php echo esc_attr( $background_color ); ?>;">
+				<div class="newspack-popup">
 					<?php if ( ! empty( $popup['title'] ) && $display_title ) : ?>
 						<h1 class="newspack-popup-title"><?php echo esc_html( $popup['title'] ); ?></h1>
 					<?php endif; ?>

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -219,6 +219,7 @@ final class Newspack_Popups_Model {
 		$id = $post->ID;
 
 		$post_options = isset( $options ) ? $options : [
+			'background_color'        => get_post_meta( get_the_ID(), 'background_color', true ),
 			'dismiss_text'            => get_post_meta( $id, 'dismiss_text', true ),
 			'display_title'           => get_post_meta( $id, 'display_title', true ),
 			'frequency'               => get_post_meta( $id, 'frequency', true ),
@@ -238,6 +239,7 @@ final class Newspack_Popups_Model {
 			'options' => wp_parse_args(
 				array_filter( $post_options ),
 				[
+					'background_color'        => '#FFFFFF',
 					'display_title'           => false,
 					'dismiss_text'            => '',
 					'frequency'               => 'test',
@@ -279,13 +281,14 @@ final class Newspack_Popups_Model {
 	 * @return string The generated markup.
 	 */
 	public static function generate_popup( $popup ) {
-		$element_id      = 'lightbox' . rand(); // phpcs:ignore WordPress.WP.AlternativeFunctions.rand_rand
-		$endpoint        = str_replace( 'http://', '//', get_rest_url( null, 'newspack-popups/v1/reader' ) );
-		$classes         = [ 'newspack-lightbox', 'newspack-lightbox-placement-' . $popup['options']['placement'] ];
-		$dismiss_text    = ! empty( $popup['options']['dismiss_text'] ) && strlen( trim( $popup['options']['dismiss_text'] ) ) > 0 ? $popup['options']['dismiss_text'] : null;
-		$display_title   = $popup['options']['display_title'];
-		$overlay_opacity = absint( $popup['options']['overlay_opacity'] ) / 100;
-		$overlay_color   = $popup['options']['overlay_color'];
+		$element_id       = 'lightbox' . rand(); // phpcs:ignore WordPress.WP.AlternativeFunctions.rand_rand
+		$endpoint         = str_replace( 'http://', '//', get_rest_url( null, 'newspack-popups/v1/reader' ) );
+		$classes          = [ 'newspack-lightbox', 'newspack-lightbox-placement-' . $popup['options']['placement'] ];
+		$dismiss_text     = ! empty( $popup['options']['dismiss_text'] ) && strlen( trim( $popup['options']['dismiss_text'] ) ) > 0 ? $popup['options']['dismiss_text'] : null;
+		$display_title    = $popup['options']['display_title'];
+		$overlay_opacity  = absint( $popup['options']['overlay_opacity'] ) / 100;
+		$overlay_color    = $popup['options']['overlay_color'];
+		$background_color = $popup['options']['background_color'];
 
 		ob_start();
 		?>
@@ -312,7 +315,7 @@ final class Newspack_Popups_Model {
 		?>
 		<div amp-access="displayPopup" amp-access-hide class="<?php echo esc_attr( implode( ' ', $classes ) ); ?>" role="button" tabindex="0" id="<?php echo esc_attr( $element_id ); ?>">
 			<div class="newspack-popup-wrapper">
-				<div class="newspack-popup">
+				<div class="newspack-popup" style="background-color:<?php echo esc_attr( $background_color ); ?>;">
 					<?php if ( ! empty( $popup['title'] ) && $display_title ) : ?>
 						<h1 class="newspack-popup-title"><?php echo esc_html( $popup['title'] ); ?></h1>
 					<?php endif; ?>

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -150,6 +150,7 @@ final class Newspack_Popups_Model {
 			$autosave ? $autosave : get_post( $post_id ),
 			false,
 			[
+				'background_color'        => filter_input( INPUT_GET, 'background_color', FILTER_SANITIZE_STRING ),
 				'display_title'           => filter_input( INPUT_GET, 'display_title', FILTER_VALIDATE_BOOLEAN ),
 				'dismiss_text'            => filter_input( INPUT_GET, 'dismiss_text', FILTER_SANITIZE_STRING ),
 				'frequency'               => filter_input( INPUT_GET, 'frequency', FILTER_SANITIZE_STRING ),

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -162,6 +162,18 @@ final class Newspack_Popups {
 
 		\register_meta(
 			'post',
+			'background_color',
+			[
+				'object_subtype' => self::NEWSPACK_PLUGINS_CPT,
+				'show_in_rest'   => true,
+				'type'           => 'string',
+				'single'         => true,
+				'auth_callback'  => '__return_true',
+			]
+		);
+
+		\register_meta(
+			'post',
 			'overlay_color',
 			[
 				'object_subtype' => self::NEWSPACK_PLUGINS_CPT,

--- a/src/editor/index.js
+++ b/src/editor/index.js
@@ -27,15 +27,19 @@ import { ColorPaletteControl } from '@wordpress/block-editor';
 /**
  * Internal dependencies
  */
-import { optionsFieldsSelector } from './utils';
+import { optionsFieldsSelector, updateEditorColors } from './utils';
 import PopupPreview from './PopupPreview';
 
 class PopupSidebar extends Component {
 	state = {
 		isSiteWideDefault: this.props.newspack_popups_is_sitewide_default,
 	};
+	componentDidMount() {
+		const { background_color } = this.props;
+		updateEditorColors( background_color );
+	}
 	componentDidUpdate( prevProps ) {
-		const { isSavingPost, id } = this.props;
+		const { background_color, isSavingPost, id } = this.props;
 		const { isSiteWideDefault } = this.state;
 		if ( ! prevProps.isSavingPost && isSavingPost ) {
 			const params = {
@@ -43,6 +47,9 @@ class PopupSidebar extends Component {
 				method: isSiteWideDefault ? 'POST' : 'DELETE',
 			};
 			apiFetch( params );
+		}
+		if ( background_color !== prevProps.background_color ) {
+			updateEditorColors( background_color );
 		}
 	}
 	/**

--- a/src/editor/index.js
+++ b/src/editor/index.js
@@ -50,6 +50,7 @@ class PopupSidebar extends Component {
 	 */
 	render() {
 		const {
+			background_color,
 			dismiss_text,
 			display_title,
 			frequency,
@@ -140,6 +141,11 @@ class PopupSidebar extends Component {
 					) }
 					value={ utm_suppression }
 					onChange={ value => onMetaFieldChange( 'utm_suppression', value ) }
+				/>
+				<ColorPaletteControl
+					value={ background_color }
+					onChange={ value => onMetaFieldChange( 'background_color', value ) }
+					label={ __( 'Background Color' ) }
 				/>
 				<ColorPaletteControl
 					value={ overlay_color }

--- a/src/editor/utils.js
+++ b/src/editor/utils.js
@@ -67,12 +67,12 @@ export const updateEditorColors = backgroundColor => {
 
 	const l1 =
 		0.2126 * Math.pow( backgroundColorRGB[0] / 255, 2.2 ) +
-		0.7152 * Math.pow( backgroundColorRGB[2] / 255, 2.2 ) +
-		0.0722 * Math.pow( backgroundColorRGB[1] / 255, 2.2 );
+		0.7152 * Math.pow( backgroundColorRGB[1] / 255, 2.2 ) +
+		0.0722 * Math.pow( backgroundColorRGB[2] / 255, 2.2 );
 	const l2 =
 		0.2126 * Math.pow( blackRGB[0] / 255, 2.2 ) +
-		0.7152 * Math.pow( blackRGB[2] / 255, 2.2 ) +
-		0.0722 * Math.pow( blackRGB[1] / 255, 2.2 );
+		0.7152 * Math.pow( blackRGB[1] / 255, 2.2 ) +
+		0.0722 * Math.pow( blackRGB[2] / 255, 2.2 );
 
 	const contrastRatio =
 		l1 > l2 ? parseInt( ( l1 + 0.05 ) / ( l2 + 0.05 ) ) : parseInt( ( l2 + 0.05 ) / ( l1 + 0.05 ) );

--- a/src/editor/utils.js
+++ b/src/editor/utils.js
@@ -7,6 +7,7 @@ export const optionsFieldsSelector = select => {
 	);
 	const meta = getEditedPostAttribute( 'meta' );
 	const {
+		background_color,
 		frequency,
 		dismiss_text,
 		display_title,
@@ -19,6 +20,7 @@ export const optionsFieldsSelector = select => {
 		utm_suppression,
 	} = meta || {};
 	return {
+		background_color,
 		dismiss_text,
 		display_title,
 		frequency,

--- a/src/editor/utils.js
+++ b/src/editor/utils.js
@@ -39,3 +39,62 @@ export const optionsFieldsSelector = select => {
 		isCurrentPostPublished: isCurrentPostPublished(),
 	};
 };
+
+/**
+ * Convert hex color to RGB.
+ * From https://stackoverflow.com/questions/5623838/rgb-to-hex-and-hex-to-rgb
+ */
+const hexToRGB = hex =>
+	hex
+		.replace( /^#?([a-f\d])([a-f\d])([a-f\d])$/i, ( m, r, g, b ) => '#' + r + r + g + g + b + b )
+		.substring( 1 )
+		.match( /.{2}/g )
+		.map( x => parseInt( x, 16 ) );
+
+/**
+ * Set the background color meta field.
+ * Based on https://github.com/Automattic/newspack-theme/blob/master/newspack-theme/inc/template-functions.php#L401-L431
+ */
+export const updateEditorColors = backgroundColor => {
+	if ( ! backgroundColor ) {
+		return;
+	}
+	const blackColor = '#000';
+	const whiteColor = '#fff';
+
+	const backgroundColorRGB = hexToRGB( backgroundColor );
+	const blackRGB = hexToRGB( blackColor );
+
+	const l1 =
+		0.2126 * Math.pow( backgroundColorRGB[0] / 255, 2.2 ) +
+		0.7152 * Math.pow( backgroundColorRGB[2] / 255, 2.2 ) +
+		0.0722 * Math.pow( backgroundColorRGB[1] / 255, 2.2 );
+	const l2 =
+		0.2126 * Math.pow( blackRGB[0] / 255, 2.2 ) +
+		0.7152 * Math.pow( blackRGB[2] / 255, 2.2 ) +
+		0.0722 * Math.pow( blackRGB[1] / 255, 2.2 );
+
+	const contrastRatio =
+		l1 > l2 ? parseInt( ( l1 + 0.05 ) / ( l2 + 0.05 ) ) : parseInt( ( l2 + 0.05 ) / ( l1 + 0.05 ) );
+
+	const foregroundColor = contrastRatio > 5 ? blackColor : whiteColor;
+
+	const editorStylesEl = document.querySelector( '.edit-post-visual-editor.editor-styles-wrapper' );
+	const editorPostTitleEl = document.querySelector(
+		'.wp-block.editor-post-title__block .editor-post-title__input'
+	);
+	const editorPostTitlePlaceholderEl = document.querySelector(
+		'.wp-block.editor-post-title__block .editor-post-title__input::placeholder'
+	);
+
+	if ( editorStylesEl ) {
+		editorStylesEl.style[ 'backgroundColor' ] = backgroundColor;
+		editorStylesEl.style[ 'color' ] = foregroundColor;
+	}
+	if ( editorPostTitleEl ) {
+		editorPostTitleEl.style[ 'color' ] = foregroundColor;
+	}
+	if ( editorPostTitlePlaceholderEl ) {
+		editorPostTitlePlaceholderEl.style[ 'color' ] = foregroundColor;
+	}
+};

--- a/src/view/style.scss
+++ b/src/view/style.scss
@@ -45,6 +45,7 @@ $color__secondary-variation: darken( $color__secondary, 10% );
 
 	.newspack-popup-wrapper {
 		background: white;
+		border: none;
 		box-shadow: 0 0 1em 0.5em rgba( black, 0.1 );
 		overflow-x: hidden;
 		position: relative;
@@ -52,7 +53,7 @@ $color__secondary-variation: darken( $color__secondary, 10% );
 	}
 
 	.newspack-popup {
-		background: white;
+		background: transparent;
 		margin: 0 auto;
 		max-width: 780px;
 		padding: 1.5em;


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds a background color picker for Pop-ups, with a default of white.

Closes https://github.com/Automattic/newspack-popups/issues/49

<img width="1685" alt="Screen Shot 2020-02-03 at 12 42 34 AM" src="https://user-images.githubusercontent.com/1477002/73628460-59eeb200-461e-11ea-9e20-cc47ae0d87e5.png">

<img width="1685" alt="Screen Shot 2020-02-03 at 12 42 48 AM" src="https://user-images.githubusercontent.com/1477002/73628468-5f4bfc80-461e-11ea-9888-2924dc8d5ecc.png">

### Design Questions:

- Will this feature make it too easy to produce unattractive Pop-ups? Should there be any restrictions on it?
- There is a border around Pop-up that I'm having trouble tracking down. Is this problematic? 
- I moved the background color from `newspack-popup` to `newspack-popup-wrapper`. Any issue with this?

### How to test the changes in this Pull Request:

1. Create a Pop-up, Trigger=Timer, Delay=1, Frequency=Test Mode, Placement=Center. Leave Background Image untouched.
2. Open site homepage, verify the Pop-up appears and looks exactly like it did previously.
3. Edit the Pop-up and set a background color. 
4. Open homepage again, verify Pop-up appears with correctly colored background.
5. Try all Placement options.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
