### PR TITLE
save sitewide_default on component update

### DIFF
--- a/src/editor/index.js
+++ b/src/editor/index.js
@@ -25,13 +25,8 @@ import { ColorPaletteControl } from '@wordpress/block-editor';
 
 class PopupSidebar extends Component {
 	state = {
-		isSiteWideDefault: undefined,
+		isSiteWideDefault: this.props.newspack_popups_is_sitewide_default,
 	};
-	componentDidMount() {
-		this.setState( {
-			isSiteWideDefault: this.props.newspack_popups_is_sitewide_default,
-		} );
-	}
 	componentDidUpdate( prevProps ) {
 		const { isSavingPost, id } = this.props;
 		const { isSiteWideDefault } = this.state;
@@ -65,7 +60,7 @@ class PopupSidebar extends Component {
 		const { isSiteWideDefault } = this.state;
 		return (
 			<Fragment>
-				{ isCurrentPostPublished && isSiteWideDefault !== undefined && (
+				{ isCurrentPostPublished && (
 					<CheckboxControl
 						label={ __( 'Sitewide Default', 'newspack-popups' ) }
 						checked={ isSiteWideDefault }


### PR DESCRIPTION
Problem: the `newspack_popups_is_sitewide_default` on a post should be updated on save, like a meta field.  
How it works here - on save:
- the request is sent to `/sitewide_default/:id` endpoint
- post is saved

But `newspack_popups_is_sitewide_default` value in post save payload is ignored, so the response has stale value of `newspack_popups_is_sitewide_default`. Before, post save always happened after `/sitewide_default/:id` request has completed, so there was not such problem.