### PR TITLE
Update close button style to remove background colour and inherit text colour

### DIFF
--- a/src/view/style.scss
+++ b/src/view/style.scss
@@ -78,7 +78,11 @@ $color__secondary-variation: darken( $color__secondary, 10% );
 
 	.newspack-lightbox__close {
 		align-items: center;
+		background: transparent;
+		border: none;
+		border-radius: 0;
 		box-shadow: none;
+		color: inherit;
 		cursor: pointer;
 		display: flex;
 		font-size: inherit;
@@ -87,13 +91,23 @@ $color__secondary-variation: darken( $color__secondary, 10% );
 		margin: 0;
 		padding: 6px;
 		position: absolute;
-		right: 0.25em;
-		top: 0.25em;
+		right: 0;
+		top: 0;
 		width: 36px;
 
 		svg {
 			fill: currentcolor;
 			flex: 0 0 24px;
+		}
+
+		&:active,
+		&:hover {
+			opacity: 0.6;
+		}
+
+		&:focus {
+			outline: 1px solid;
+			outline-offset: -1px;
 		}
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

I'm overwriting the style of the `newspack-lightbox__close` button to make sure it blends in nicely with the rest of the content.

This allows to apply a background/text colour to `newspack-popup` and the button will inherit it.

![Screenshot 2020-02-04 at 09 42 20](https://user-images.githubusercontent.com/177929/73732935-f73b0a80-4732-11ea-85e2-9b8263675790.png)


### How to test the changes in this Pull Request:

1. On the front-end, try changing the background/text colour of `newspack-popup`
2. The close button shouldn't change
3. Switch to this branch
4. Play with the colours once again.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
