### PR TITLE
Fix Sitewide Default Setting In Pop-up List

### DIFF
--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -28,7 +28,7 @@ final class Newspack_Popups_Model {
 
 		$popups = self::retrieve_popup_with_query( new WP_Query( $args ), true );
 		foreach ( $popups as &$popup ) {
-			$popup['sitewide_default'] = $sitewide_default_id === $popup['id'];
+			$popup['sitewide_default'] = absint( $sitewide_default_id ) === absint( $popup['id'] );
 		}
 		return $popups;
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Quick fix needed to properly rendering the Popups UI in https://github.com/Automattic/newspack-plugin/pull/409. 

### How to test the changes in this Pull Request:

This is difficult to test. It could be tested by:

- Create a Popup, check the box to make it Sitewide Default, Publish.
- In any of the PHP files add this to the bottom:
```
add_action( 'init', function() {
	var_dump( Newspack_Popups_Model::retrieve_popups() );
	die();
} );
```
- Load a page, inspect the output, verify that `sitewide_default` is `true` for the correct Pop-up.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
