### PR TITLE
Dont inject popups into feeds

### DIFF
--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -70,7 +70,7 @@ final class Newspack_Popups_Inserter {
 	 * @return string The content with popup inserted.
 	 */
 	public static function popup( $content = '' ) {
-		if ( is_admin() ) {
+		if ( is_admin() || is_feed() ) {
 			return $content;
 		}
 		$popup = self::popup_for_post();

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -70,7 +70,7 @@ final class Newspack_Popups_Inserter {
 	 * @return string The content with popup inserted.
 	 */
 	public static function popup( $content = '' ) {
-		if ( is_admin() || is_feed() ) {
+		if ( is_admin() || ! is_singular() ) {
 			return $content;
 		}
 		$popup = self::popup_for_post();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR fixes an issue where popup content was getting injected into the feeds, so the first line of each item in a site's RSS feed would be the popup content.

### How to test the changes in this Pull Request:

1. Before applying this patch, create a popup:
<img width="419" alt="Screen Shot 2020-02-12 at 2 21 01 PM" src="https://user-images.githubusercontent.com/7317227/74383212-a6b35500-4da3-11ea-96e0-c2e4193c1d04.png">

2. Visit `/feed` on your site. Observe the pop up content is in the description for each item:
<img width="1662" alt="Screen Shot 2020-02-12 at 2 21 10 PM" src="https://user-images.githubusercontent.com/7317227/74383285-c34f8d00-4da3-11ea-8d1b-a7ec0c89a37e.png">

3. Apply this patch. Refresh. Observe the pop up content is not in the description for each item:
<img width="1673" alt="Screen Shot 2020-02-12 at 2 22 44 PM" src="https://user-images.githubusercontent.com/7317227/74383293-c6e31400-4da3-11ea-9e5b-97c5460c982a.png">

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
