### PR TITLE
Load popup styles on archives

### DIFF
--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -124,6 +124,15 @@ final class Newspack_Popups_Inserter {
 			return;
 		}
 
+		\wp_register_style(
+			'newspack-popups-view',
+			plugins_url( '../dist/view.css', __FILE__ ),
+			null,
+			filemtime( dirname( NEWSPACK_POPUPS_PLUGIN_FILE ) . '/dist/view.css' )
+		);
+		\wp_style_add_data( 'newspack-popups-view', 'rtl', 'replace' );
+		\wp_enqueue_style( 'newspack-popups-view' );
+
 		echo $popup['markup']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This is a fix for a bug uncovered by https://github.com/Automattic/newspack-popups/pull/59. Since the popups aren't getting injected into excerpts on archives any more, the styles are not getting loaded on archives. Previously they were enqueued by the popup injecting itself into excerpts, disguising the bug.

### How to test the changes in this Pull Request:

1. Before applying this PR, create a popup and view it on an archive:
<img width="1086" alt="Screen Shot 2020-02-13 at 11 16 43 AM" src="https://user-images.githubusercontent.com/7317227/74469946-71197500-4e52-11ea-9273-83dd838826ef.png">

2. Apply this PR and view the popup again:
<img width="896" alt="Screen Shot 2020-02-13 at 11 16 57 AM" src="https://user-images.githubusercontent.com/7317227/74469973-7e366400-4e52-11ea-9293-8b5376cbd49c.png">

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
