### PR TITLE
Pre-populate New Pop-ups with Defaults

### DIFF
--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -47,6 +47,7 @@ final class Newspack_Popups {
 		add_filter( 'display_post_states', [ __CLASS__, 'display_post_states' ], 10, 2 );
 		add_filter( 'show_admin_bar', [ __CLASS__, 'hide_admin_bar_for_preview' ], 10, 2 );
 		add_action( 'rest_api_init', [ __CLASS__, 'rest_api_init' ] );
+		add_action( 'save_post_newspack_popups_cpt', [ __CLASS__, 'popup_default_fields' ], 10, 3 );
 
 		include_once dirname( __FILE__ ) . '/class-newspack-popups-model.php';
 		include_once dirname( __FILE__ ) . '/class-newspack-popups-inserter.php';
@@ -311,6 +312,32 @@ final class Newspack_Popups {
 				],
 			]
 		);
+	}
+
+
+	/**
+	 * Set default fields when Pop-up is created.
+	 *
+	 * @param int     $post_id ID of post being saved.
+	 * @param WP_POST $post The post being saved.
+	 * @param bool    $update True if this is an update, false if a newly created post.
+	 */
+	public static function popup_default_fields( $post_id, $post, $update ) {
+		// Set meta only if this is a newly created post.
+		if ( $update ) {
+			return;
+		}
+		update_post_meta( $post_id, 'background_color', '#FFFFFF' );
+		update_post_meta( $post_id, 'display_title', false );
+		update_post_meta( $post_id, 'dismiss_text', __( "I'm not interested", 'newspack' ) );
+		update_post_meta( $post_id, 'frequency', 'test' );
+		update_post_meta( $post_id, 'overlay_color', '#000000' );
+		update_post_meta( $post_id, 'overlay_opacity', 30 );
+		update_post_meta( $post_id, 'placement', 'center' );
+		update_post_meta( $post_id, 'trigger_type', 'time' );
+		update_post_meta( $post_id, 'trigger_delay', 3 );
+		update_post_meta( $post_id, 'trigger_scroll_progress', 30 );
+		update_post_meta( $post_id, 'utm_suppression', '' );
 	}
 }
 Newspack_Popups::instance();


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR sets up default values for a new pop-up when it is created. 

Closes #46 

### How to test the changes in this Pull Request:

1. Create a new Pop-up. 
2. Verify sidebar values match these https://github.com/Automattic/newspack-popups/compare/add/new-popup-defaults?expand=1#diff-5ceb977074740266ec972c731b1544ccR330-R340.
3. Save post and verify the values are intact.
4. Verify changes can be made to all values.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
