### PR TITLE
Inline Placement

### DIFF
--- a/includes/class-newspack-popups-api.php
+++ b/includes/class-newspack-popups-api.php
@@ -229,6 +229,11 @@ final class Newspack_Popups_API {
 		}
 		$popup_id = isset( $request['popup_id'] ) ? $request['popup_id'] : false;
 		$url      = isset( $request['url'] ) ? esc_url_raw( urldecode( $request['url'] ) ) : false;
+		if ( ! $popup_id && ! $url ) {
+			$body     = json_decode( $request->get_body(), true );
+			$popup_id = isset( $body['popup_id'] ) ? $body['popup_id'] : false;
+			$url      = isset( $body['url'] ) ? esc_url_raw( urldecode( $body['url'] ) ) : false;
+		}
 		if ( $reader_id && $url && $popup_id ) {
 			return $reader_id . '-' . $popup_id . '-popup';
 		}

--- a/includes/class-newspack-popups-api.php
+++ b/includes/class-newspack-popups-api.php
@@ -188,7 +188,7 @@ final class Newspack_Popups_API {
 			if ( $request['suppress_forever'] ) {
 				$data['suppress_forever'] = true;
 			}
-			if ( $request['mailing_list_status'] && 'subscribed' === $request['mailing_list_status'] ) {
+			if ( $this->get_mailing_list_status( $request ) ) {
 				$data['mailing_list_status'] = true;
 			}
 			set_transient( $transient_name, $data, 0 );
@@ -238,6 +238,21 @@ final class Newspack_Popups_API {
 			return $reader_id . '-' . $popup_id . '-popup';
 		}
 		return false;
+	}
+
+	/**
+	 * Get mailing list status.
+	 *
+	 * @param WP_REST_Request $request amp-access request.
+	 * @return string Mailing list status.
+	 */
+	public function get_mailing_list_status( $request ) {
+		$mailing_list_status = isset( $request['mailing_list_status'] ) ? esc_attr( $request['mailing_list_status'] ) : false;
+		if ( ! $mailing_list_status ) {
+			$body                = json_decode( $request->get_body(), true );
+			$mailing_list_status = isset( $body['mailing_list_status'] ) ? $body['mailing_list_status'] : false;
+		}
+		return 'subscribed' === $mailing_list_status;
 	}
 
 	/**

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -315,6 +315,16 @@ final class Newspack_Popups_Model {
 									"popup_id": "<?php echo ( esc_attr( $popup['id'] ) ); ?>",
 									"url": "<?php echo esc_url( home_url( $wp->request ) ); ?>"
 								}
+							},
+							"formSubmitSuccess": {
+								"on": "amp-form-submit-success",
+								"request": "event",
+								"selector": "#mailchimp_form",
+								"extraUrlParams": {
+									"popup_id": "<?php echo ( esc_attr( $popup['id'] ) ); ?>",
+									"url": "<?php echo esc_url( home_url( $wp->request ) ); ?>",
+									"mailing_list_status": "subscribed"
+								}
 							}
 						},
 						"transport": {

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -286,6 +286,7 @@ final class Newspack_Popups_Model {
 	 * @return string The generated markup.
 	 */
 	public static function generate_inline_popup( $popup ) {
+		global $wp;
 		$element_id    = 'lightbox' . rand(); // phpcs:ignore WordPress.WP.AlternativeFunctions.rand_rand
 		$classes       = [ 'newspack-inline-popup' ];
 		$endpoint      = self::get_dismiss_endpoint();
@@ -294,7 +295,38 @@ final class Newspack_Popups_Model {
 		$dismiss_text  = ! empty( $popup['options']['dismiss_text'] ) && strlen( trim( $popup['options']['dismiss_text'] ) ) > 0 ? $popup['options']['dismiss_text'] : null;
 		ob_start();
 		?>
-			<div amp-access="displayPopup" amp-access-hide class="<?php echo esc_attr( implode( ' ', $classes ) ); ?>" role="button" tabindex="0" style="<?php echo esc_attr( self::container_style( $popup ) ); ?>" id="<?php echo esc_attr( $element_id ); ?>">
+			<amp-analytics>
+				<script type="application/json">
+					{
+						"requests": {
+							"event": "<?php echo esc_url( $endpoint ); ?>"
+						},
+						"triggers": {
+							"trackPageview": {
+								"on": "visible",
+								"request": "event",
+								"visibilitySpec": {
+									"selector": "#<?php echo esc_attr( $element_id ); ?>",
+									"visiblePercentageMin": 90,
+									"totalTimeMin": 500,
+									"continuousTimeMin": 200
+								},
+								"extraUrlParams": {
+									"popup_id": "<?php echo ( esc_attr( $popup['id'] ) ); ?>",
+									"url": "<?php echo esc_url( home_url( $wp->request ) ); ?>"
+								}
+							}
+						},
+						"transport": {
+							"beacon": true,
+							"xhrpost": true,
+							"useBody": true,
+							"image": false
+						}
+					}
+				</script>
+			</amp-analytics>
+			<amp-layout amp-access="displayPopup" amp-access-hide class="<?php echo esc_attr( implode( ' ', $classes ) ); ?>" role="button" tabindex="0" style="<?php echo esc_attr( self::container_style( $popup ) ); ?>" id="<?php echo esc_attr( $element_id ); ?>">
 				<?php if ( ! empty( $popup['title'] ) && $display_title ) : ?>
 					<h1 class="newspack-popup-title"><?php echo esc_html( $popup['title'] ); ?></h1>
 				<?php endif; ?>
@@ -313,7 +345,7 @@ final class Newspack_Popups_Model {
 						<button on="tap:<?php echo esc_attr( $element_id ); ?>.hide" aria-label="<?php esc_attr( $dismiss_text ); ?>"><?php echo esc_attr( $dismiss_text ); ?></button>
 					</form>
 				<?php endif; ?>
-			</div>
+			</amp-layout>
 		<?php
 		return ob_get_clean();
 	}

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -258,6 +258,11 @@ final class Newspack_Popups_Model {
 			$popup['categories'] = get_the_category( $id );
 		}
 
+		if ( 'inline' === $popup['options']['placement'] ) {
+			$popup['markup'] = self::generate_inline_popup( $popup );
+			return $popup;
+		}
+
 		switch ( $popup['options']['trigger_type'] ) {
 			case 'scroll':
 				$popup['options']['trigger_delay'] = 0;
@@ -271,8 +276,46 @@ final class Newspack_Popups_Model {
 			$popup['options']['placement'] = 'center';
 		}
 		$popup['markup'] = self::generate_popup( $popup );
-
 		return $popup;
+	}
+
+	/**
+	 * Generate markup inline popup.
+	 *
+	 * @param string $popup The popup object.
+	 * @return string The generated markup.
+	 */
+	public static function generate_inline_popup( $popup ) {
+		$element_id    = 'lightbox' . rand(); // phpcs:ignore WordPress.WP.AlternativeFunctions.rand_rand
+		$classes       = [ 'newspack-inline-popup' ];
+		$endpoint      = self::get_dismiss_endpoint();
+		$display_title = $popup['options']['display_title'];
+		$hidden_fields = self::get_hidden_fields( $popup );
+		$dismiss_text  = ! empty( $popup['options']['dismiss_text'] ) && strlen( trim( $popup['options']['dismiss_text'] ) ) > 0 ? $popup['options']['dismiss_text'] : null;
+		ob_start();
+		?>
+			<div amp-access="displayPopup" amp-access-hide class="<?php echo esc_attr( implode( ' ', $classes ) ); ?>" role="button" tabindex="0" style="<?php echo esc_attr( self::container_style( $popup ) ); ?>" id="<?php echo esc_attr( $element_id ); ?>">
+				<?php if ( ! empty( $popup['title'] ) && $display_title ) : ?>
+					<h1 class="newspack-popup-title"><?php echo esc_html( $popup['title'] ); ?></h1>
+				<?php endif; ?>
+				<?php echo ( $popup['body'] ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+				<?php if ( $dismiss_text ) : ?>
+					<form class="popup-not-interested-form"
+						method="POST"
+						action-xhr="<?php echo esc_url( $endpoint ); ?>"
+						target="_top">
+						<?php echo $hidden_fields; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+						<input
+							name="suppress_forever"
+							type="hidden"
+							value="1"
+						/>
+						<button on="tap:<?php echo esc_attr( $element_id ); ?>.hide" aria-label="<?php esc_attr( $dismiss_text ); ?>"><?php echo esc_attr( $dismiss_text ); ?></button>
+					</form>
+				<?php endif; ?>
+			</div>
+		<?php
+		return ob_get_clean();
 	}
 
 	/**
@@ -282,41 +325,19 @@ final class Newspack_Popups_Model {
 	 * @return string The generated markup.
 	 */
 	public static function generate_popup( $popup ) {
-		$element_id       = 'lightbox' . rand(); // phpcs:ignore WordPress.WP.AlternativeFunctions.rand_rand
-		$endpoint         = str_replace( 'http://', '//', get_rest_url( null, 'newspack-popups/v1/reader' ) );
-		$classes          = [ 'newspack-lightbox', 'newspack-lightbox-placement-' . $popup['options']['placement'] ];
-		$dismiss_text     = ! empty( $popup['options']['dismiss_text'] ) && strlen( trim( $popup['options']['dismiss_text'] ) ) > 0 ? $popup['options']['dismiss_text'] : null;
-		$display_title    = $popup['options']['display_title'];
-		$overlay_opacity  = absint( $popup['options']['overlay_opacity'] ) / 100;
-		$overlay_color    = $popup['options']['overlay_color'];
-		$background_color = $popup['options']['background_color'];
-		$foreground_color = self::foreground_color_for_background( $background_color );
-
-		ob_start();
-		?>
-		<input
-			name="url"
-			type="hidden"
-			value="CANONICAL_URL"
-			data-amp-replace="CANONICAL_URL"
-		/>
-		<input
-			name="popup_id"
-			type="hidden"
-			value="<?php echo ( esc_attr( $popup['id'] ) ); ?>"
-		/>
-		<input
-			name="mailing_list_status"
-			type="hidden"
-			[value]="mailing_list_status"
-		/>
-		<?php
-		$hidden_fields = ob_get_clean();
+		$element_id      = 'lightbox' . rand(); // phpcs:ignore WordPress.WP.AlternativeFunctions.rand_rand
+		$endpoint        = self::get_dismiss_endpoint();
+		$classes         = [ 'newspack-lightbox', 'newspack-lightbox-placement-' . $popup['options']['placement'] ];
+		$dismiss_text    = ! empty( $popup['options']['dismiss_text'] ) && strlen( trim( $popup['options']['dismiss_text'] ) ) > 0 ? $popup['options']['dismiss_text'] : null;
+		$display_title   = $popup['options']['display_title'];
+		$overlay_opacity = absint( $popup['options']['overlay_opacity'] ) / 100;
+		$overlay_color   = $popup['options']['overlay_color'];
+		$hidden_fields   = self::get_hidden_fields( $popup );
 
 		ob_start();
 		?>
 		<div amp-access="displayPopup" amp-access-hide class="<?php echo esc_attr( implode( ' ', $classes ) ); ?>" role="button" tabindex="0" id="<?php echo esc_attr( $element_id ); ?>">
-			<div class="newspack-popup-wrapper" style="background-color:<?php echo esc_attr( $background_color ); ?>;color: <?php echo esc_attr( $foreground_color ); ?>">
+			<div class="newspack-popup-wrapper" style="<?php echo esc_attr( self::container_style( $popup ) ); ?>">
 				<div class="newspack-popup">
 					<?php if ( ! empty( $popup['title'] ) && $display_title ) : ?>
 						<h1 class="newspack-popup-title"><?php echo esc_html( $popup['title'] ); ?></h1>
@@ -434,5 +455,55 @@ final class Newspack_Popups_Model {
 			// if not, return white color.
 			return '#fff';
 		}
+	}
+
+	/**
+	 * Generate inline styles for Popup element.
+	 *
+	 * @param  object $popup A Pop-up object.
+	 * @return string Inline styles attribute.
+	 */
+	public static function container_style( $popup ) {
+		$background_color = $popup['options']['background_color'];
+		$foreground_color = self::foreground_color_for_background( $background_color );
+		return 'background-color:' . $background_color . ';color:' . $foreground_color;
+	}
+
+	/**
+	 * Endpoint to dismiss Pop-up.
+	 *
+	 * @return string Endpoint URL.
+	 */
+	public static function get_dismiss_endpoint() {
+		return str_replace( 'http://', '//', get_rest_url( null, 'newspack-popups/v1/reader' ) );
+	}
+
+	/**
+	 * Generate hidden fields to be used in all dismiss FORMs.
+	 *
+	 * @param  object $popup A Pop-up object.
+	 * @return string Hidden fields markup.
+	 */
+	public static function get_hidden_fields( $popup ) {
+		ob_start();
+		?>
+		<input
+			name="url"
+			type="hidden"
+			value="CANONICAL_URL"
+			data-amp-replace="CANONICAL_URL"
+		/>
+		<input
+			name="popup_id"
+			type="hidden"
+			value="<?php echo ( esc_attr( $popup['id'] ) ); ?>"
+		/>
+		<input
+			name="mailing_list_status"
+			type="hidden"
+			[value]="mailing_list_status"
+		/>
+		<?php
+		return ob_get_clean();
 	}
 }

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -239,6 +239,22 @@ final class Newspack_Popups {
 			filemtime( dirname( NEWSPACK_POPUPS_PLUGIN_FILE ) . '/dist/editor.js' ),
 			true
 		);
+		$recent_posts = wp_get_recent_posts(
+			[
+				'numberposts' => 1,
+				'post_status' => 'publish',
+			],
+			OBJECT
+		);
+		$preview_post = count( $recent_posts ) > 0 ? get_the_permalink( $recent_posts[0] ) : '';
+
+		\wp_localize_script(
+			'newspack-popups',
+			'newspack_popups_data',
+			[
+				'preview_post' => $preview_post,
+			]
+		);
 		\wp_enqueue_style(
 			'newspack-popups-editor',
 			plugins_url( '../dist/editor.css', __FILE__ ),

--- a/src/editor/PopupPreview.js
+++ b/src/editor/PopupPreview.js
@@ -19,9 +19,15 @@ const PopupPreviewSetting = ( { autosavePost, isSavingPost, postId, metaFields }
 		...metaFields,
 	} );
 
+	// For inline placements, use most recent post to preview. For anything else, use the home.
+	const previewURL =
+		'inline' === metaFields.placement
+			? window && window.newspack_popups_data && window.newspack_popups_data.preview_post
+			: '/';
+
 	return (
 		<WebPreview
-			url={ `/?${ query }` }
+			url={ `${ previewURL }?${ query }` }
 			renderButton={ ( { showPreview } ) => (
 				<Button
 					isPrimary

--- a/src/editor/index.js
+++ b/src/editor/index.js
@@ -74,6 +74,7 @@ class PopupSidebar extends Component {
 			isCurrentPostPublished,
 		} = this.props;
 		const { isSiteWideDefault } = this.state;
+		const isInline = 'inline' === placement;
 		return (
 			<Fragment>
 				{ isCurrentPostPublished && (
@@ -88,28 +89,52 @@ class PopupSidebar extends Component {
 						} }
 					/>
 				) }
-				<RadioControl
-					label={ __( 'Trigger' ) }
-					help={ __( 'The event to trigger the popup' ) }
-					selected={ trigger_type }
+				<SelectControl
+					label={ __( 'Placement' ) }
+					value={ placement }
+					onChange={ value => onMetaFieldChange( 'placement', value ) }
 					options={ [
-						{ label: __( 'Timer' ), value: 'time' },
-						{ label: __( 'Scroll Progress' ), value: 'scroll' },
+						{ value: 'center', label: __( 'Center' ) },
+						{ value: 'top', label: __( 'Top' ) },
+						{ value: 'bottom', label: __( 'Bottom' ) },
+						{ value: 'inline', label: __( 'Inline' ) },
 					] }
-					onChange={ value => onMetaFieldChange( 'trigger_type', value ) }
 				/>
-				{ 'time' === trigger_type && (
-					<RangeControl
-						label={ __( 'Delay (seconds)' ) }
-						value={ trigger_delay }
-						onChange={ value => onMetaFieldChange( 'trigger_delay', value ) }
-						min={ 0 }
-						max={ 60 }
-					/>
+				{ ! isInline && (
+					<Fragment>
+						<RadioControl
+							label={ __( 'Trigger' ) }
+							help={ __( 'The event to trigger the popup' ) }
+							selected={ trigger_type }
+							options={ [
+								{ label: __( 'Timer' ), value: 'time' },
+								{ label: __( 'Scroll Progress' ), value: 'scroll' },
+							] }
+							onChange={ value => onMetaFieldChange( 'trigger_type', value ) }
+						/>
+						{ 'time' === trigger_type && (
+							<RangeControl
+								label={ __( 'Delay (seconds)' ) }
+								value={ trigger_delay }
+								onChange={ value => onMetaFieldChange( 'trigger_delay', value ) }
+								min={ 0 }
+								max={ 60 }
+							/>
+						) }
+						{ 'scroll' === trigger_type && (
+							<RangeControl
+								label={ __( 'Scroll Progress (percent) ' ) }
+								value={ trigger_scroll_progress }
+								onChange={ value => onMetaFieldChange( 'trigger_scroll_progress', value ) }
+								min={ 1 }
+								max={ 100 }
+							/>
+						) }
+					</Fragment>
 				) }
-				{ 'scroll' === trigger_type && (
+				{ isInline && (
 					<RangeControl
-						label={ __( 'Scroll Progress (percent) ' ) }
+						label={ __( 'Approximate position (in percent)' ) }
 						value={ trigger_scroll_progress }
 						onChange={ value => onMetaFieldChange( 'trigger_scroll_progress', value ) }
 						min={ 1 }
@@ -131,16 +156,6 @@ class PopupSidebar extends Component {
 						'newspack-popups'
 					) }
 				/>
-				<SelectControl
-					label={ __( 'Placement' ) }
-					value={ placement }
-					onChange={ value => onMetaFieldChange( 'placement', value ) }
-					options={ [
-						{ value: 'center', label: __( 'Center' ) },
-						{ value: 'top', label: __( 'Top' ) },
-						{ value: 'bottom', label: __( 'Bottom' ) },
-					] }
-				/>
 				<TextControl
 					label={ __( 'UTM Suppression' ) }
 					help={ __(
@@ -154,18 +169,22 @@ class PopupSidebar extends Component {
 					onChange={ value => onMetaFieldChange( 'background_color', value ) }
 					label={ __( 'Background Color' ) }
 				/>
-				<ColorPaletteControl
-					value={ overlay_color }
-					onChange={ value => onMetaFieldChange( 'overlay_color', value ) }
-					label={ __( 'Overlay Color' ) }
-				/>
-				<RangeControl
-					label={ __( 'Overlay opacity' ) }
-					value={ overlay_opacity }
-					onChange={ value => onMetaFieldChange( 'overlay_opacity', value ) }
-					min={ 0 }
-					max={ 100 }
-				/>
+				{ ! isInline && (
+					<Fragment>
+						<ColorPaletteControl
+							value={ overlay_color }
+							onChange={ value => onMetaFieldChange( 'overlay_color', value ) }
+							label={ __( 'Overlay Color' ) }
+						/>
+						<RangeControl
+							label={ __( 'Overlay opacity' ) }
+							value={ overlay_opacity }
+							onChange={ value => onMetaFieldChange( 'overlay_opacity', value ) }
+							min={ 0 }
+							max={ 100 }
+						/>
+					</Fragment>
+				) }
 				<ToggleControl
 					label={ __( 'Display Pop-up title', 'newspack-popups' ) }
 					checked={ display_title }

--- a/src/view/style.scss
+++ b/src/view/style.scss
@@ -62,7 +62,8 @@ $color__secondary-variation: darken( $color__secondary, 10% );
 			margin-top: 0;
 		}
 
-		& > *:nth-last-child(3) { // Last 2 child being .popup-dismiss-form and .popup-not-interested-form
+		& > *:nth-last-child( 3 ) {
+			// Last 2 child being .popup-dismiss-form and .popup-not-interested-form
 			margin-bottom: 0;
 		}
 
@@ -112,42 +113,15 @@ $color__secondary-variation: darken( $color__secondary, 10% );
 		}
 	}
 
-	.popup-not-interested-form {
-		display: flex;
-		justify-content: center;
-		margin-top: 1.5em;
-
-		button {
-			background: transparent;
-			border: 0;
-			border-radius: 0;
-			color: $color__secondary;
-			font-size: 0.7em;
-			font-weight: normal;
-			line-height: 1;
-			margin: 0;
-			padding: 0;
-			text-decoration: underline;
-
-			&:active,
-			&:focus,
-			&:hover {
-				color: $color__secondary-variation;
-				outline-offset: 2px;
-				text-decoration: none;
-			}
-		}
-	}
-
 	/* Placements */
 	&.newspack-lightbox-placement-center {
 		.newspack-popup-wrapper {
 			max-height: 90%;
-			max-height: calc(100% - 1.5em);
+			max-height: calc( 100% - 1.5em );
 			min-width: 100%;
 			overflow-y: auto;
 
-			@media only screen and (min-width: 780px) {
+			@media only screen and ( min-width: 780px ) {
 				min-width: 780px;
 			}
 		}
@@ -190,12 +164,12 @@ $color__secondary-variation: darken( $color__secondary, 10% );
 				padding-left: 0;
 				padding-right: 0;
 
-				@media only screen and (min-width: 600px) {
+				@media only screen and ( min-width: 600px ) {
 					&.wp-block-columns {
 						margin-left: -16px;
 						margin-right: -16px;
-						max-width: calc(100% + 32px);
-						width: calc(100% + 32px);
+						max-width: calc( 100% + 32px );
+						width: calc( 100% + 32px );
 					}
 				}
 
@@ -206,13 +180,46 @@ $color__secondary-variation: darken( $color__secondary, 10% );
 				}
 			}
 
-			@media only screen and (min-width: 600px) {
+			@media only screen and ( min-width: 600px ) {
 				.alignfull.wp-block-columns {
 					margin-left: -16px;
 					margin-right: -16px;
-					max-width: calc(100% + 32px);
-					width: calc(100% + 32px);
+					max-width: calc( 100% + 32px );
+					width: calc( 100% + 32px );
 				}
+			}
+		}
+	}
+}
+
+.newspack-inline-popup {
+	padding: 1em;
+}
+.newspack-lightbox,
+.newspack-inline-popup {
+	.popup-not-interested-form {
+		display: flex;
+		justify-content: center;
+		margin-top: 1.5em;
+
+		button {
+			background: transparent;
+			border: 0;
+			border-radius: 0;
+			color: $color__secondary;
+			font-size: 0.7em;
+			font-weight: normal;
+			line-height: 1;
+			margin: 0;
+			padding: 0;
+			text-decoration: underline;
+
+			&:active,
+			&:focus,
+			&:hover {
+				color: $color__secondary-variation;
+				outline-offset: 2px;
+				text-decoration: none;
 			}
 		}
 	}

--- a/src/view/style.scss
+++ b/src/view/style.scss
@@ -194,6 +194,7 @@ $color__secondary-variation: darken( $color__secondary, 10% );
 
 .newspack-inline-popup {
 	padding: 1em;
+	border: 1px solid rgba( $color__secondary, 0.25 );
 }
 .newspack-lightbox,
 .newspack-inline-popup {

--- a/src/view/style.scss
+++ b/src/view/style.scss
@@ -193,9 +193,14 @@ $color__secondary-variation: darken( $color__secondary, 10% );
 }
 
 .newspack-inline-popup {
-	padding: 1em;
-	border: 1px solid rgba( $color__secondary, 0.25 );
+	padding: 0.75em;
+	border: 1px solid rgba( black, 0.2 );
+
+	&:focus {
+		outline: none;
+	}
 }
+
 .newspack-lightbox,
 .newspack-inline-popup {
 	.popup-not-interested-form {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR creates a new placement option: inline. When selected, the content is inserted inline in posts as opposed to being displayed in an overlay. For inline pop-ups the `trigger_scroll_progress` field is repurposed to determine the placement of the content.  

Unresolved issues (now resolved):

- [x] For overlays, clicking the close button is the event that records the campaign has been viewed. Inline campaigns don't need a close button, so we'll need an alternate approach.
- [x] How should inline campaigns be styled? cc: @thomasguillot 
- [x] Should inline campaigns use the same visibility rules as overlays (sitewide default, categories, etc)? 
- [x] Does it make sense to treat "inline" as a placement option? If this doesn't feel like a logical fit, there could be a new "type" control with options `overlay|inline`. Placement options would be shown only when overlay is selected.

Closes https://github.com/Automattic/newspack-popups/issues/65.

<img width="1411" alt="Screen Shot 2020-03-09 at 4 57 11 PM" src="https://user-images.githubusercontent.com/1477002/76256901-109a0f80-6227-11ea-8ec6-ebddd0ce2211.png">

### Testing Instructions

- Create a new Pop-up, add Mailchimp block. Set Placement to "Inline," and Frequency to "Test Mode."
- Preview the block, verify it appears inline. Note that the Preview for inline blocks will be the most recent Post, since Inline Pop-ups cannot be inserted on the Homepage.
- Try different Position settings. Note that the Pop-up will be placed immediately after the paragraph that appears closest to the position specified, so setting the value to 1% should place the block just after the first paragraph.
- Change Frequency to "Once."
- View a post in Incognito mode. Verify the Pop-up appears.
- Go to another post, and verify the Pop-up does not appear. 

After successful Mailchimp subscription, the Pop-up should never be shown again to the same user. This is difficult to test, though, since it would require waiting 24 hours and trying again. Here's how it can be tested:

- Clear the Database of all popup transients by executing this query: `DELETE FROM wp_options WHERE option_name LIKE '%amp%-popup'`
- View the Pop-up incognito, subscribe successfully.
- Query for the transient: `SELECT * FROM wp_options WHERE option_name LIKE '%amp%-popup'`
- Verify the `option_value` contains `mailing_list_status` with a value of 1.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
