### PR TITLE
Fix popup blocks alignment (full-width and wide)

### DIFF
--- a/src/view/style.scss
+++ b/src/view/style.scss
@@ -62,7 +62,7 @@ $color__secondary-variation: darken( $color__secondary, 10% );
 			margin-top: 0;
 		}
 
-		& > *:nth-last-child(2) { // Last child being .popup-dismiss-form
+		& > *:nth-last-child(3) { // Last 2 child being .popup-dismiss-form and .popup-not-interested-form
 			margin-bottom: 0;
 		}
 
@@ -175,5 +175,45 @@ $color__secondary-variation: darken( $color__secondary, 10% );
 
 	&.newspack-lightbox-placement-top {
 		align-items: flex-start;
+	}
+}
+
+// Alignment
+.entry-content {
+	.newspack-lightbox {
+		.newspack-popup {
+			.alignfull,
+			.alignwide {
+				margin-left: 0;
+				margin-right: 0;
+				max-width: 100%;
+				padding-left: 0;
+				padding-right: 0;
+
+				@media only screen and (min-width: 600px) {
+					&.wp-block-columns {
+						margin-left: -16px;
+						margin-right: -16px;
+						max-width: calc(100% + 32px);
+						width: calc(100% + 32px);
+					}
+				}
+
+				&.wp-block-columns,
+				&.wp-block-columns .wp-block-column {
+					padding-left: 0;
+					padding-right: 0;
+				}
+			}
+
+			@media only screen and (min-width: 600px) {
+				.alignfull.wp-block-columns {
+					margin-left: -16px;
+					margin-right: -16px;
+					max-width: calc(100% + 32px);
+					width: calc(100% + 32px);
+				}
+			}
+		}
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Make sure full-width and wide blocks don't overflow the pop-up wrapper.

### How to test the changes in this Pull Request:

1. In a new pop-up CPT, add a bunch of wide and full-width blocks
2. Check the front-end, they should overflow (check front page, posts)
3. Switch to this branch.
4. Re-check the front-end

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
