### PR TITLE
Add event tracking

### DIFF
--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -64,7 +64,7 @@ final class Newspack_Popups_Inserter {
 	}
 
 	/**
-	 * Process popup and insert into post and page ontent if needed.
+	 * Process popup and insert into post and page content if needed.
 	 *
 	 * @param string $content The content of the post.
 	 * @return string The content with popup inserted.

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -304,8 +304,8 @@ final class Newspack_Popups_Model {
 			return '';
 		}
 
-		$event_category = 'Newspack Popup';
-		$event_label    = 'Newspack Popup: ' . $popup['title'];
+		$event_category = 'Newspack Announcement';
+		$event_label    = 'Newspack Announcement: ' . $popup['title'];
 
 		$has_link                = preg_match( '/<a\s/', $popup['body'] ) !== 0;
 		$has_form                = preg_match( '/<form\s/', $popup['body'] ) !== 0;
@@ -329,7 +329,7 @@ final class Newspack_Popups_Model {
 							"on": "click",
 							"request": "event",
 							"vars": {
-								"event_name": "<?php echo esc_html__( 'Popup link clicked' ); ?>",
+								"event_name": "<?php echo esc_html__( 'Link Click', 'newspack-popups' ); ?>",
 								"event_label": "<?php echo esc_attr( $event_label ); ?>",
 								"event_category": "<?php echo esc_attr( $event_category ); ?>"
 							}
@@ -341,7 +341,7 @@ final class Newspack_Popups_Model {
 								"request": "event",
 								"selector": "#<?php echo esc_attr( $element_id ); ?> form:not(.popup-action-form)",
 								"vars": {
-									"event_name": "<?php echo esc_html__( 'Popup form submitted' ); ?>",
+									"event_name": "<?php echo esc_html__( 'Form Submission', 'newspack-popups' ); ?>",
 									"event_label": "<?php echo esc_attr( $event_label ); ?>",
 									"event_category": "<?php echo esc_attr( $event_category ); ?>"
 								}
@@ -353,7 +353,7 @@ final class Newspack_Popups_Model {
 								"request": "event",
 								"selector": "#<?php echo esc_attr( $element_id ); ?> form.popup-dismiss-form",
 								"vars": {
-									"event_name": "<?php echo esc_html__( 'Popup dismissed' ); ?>",
+									"event_name": "<?php echo esc_html__( 'Dismissal', 'newspack-popups' ); ?>",
 									"event_label": "<?php echo esc_attr( $event_label ); ?>",
 									"event_category": "<?php echo esc_attr( $event_category ); ?>"
 								}
@@ -365,7 +365,7 @@ final class Newspack_Popups_Model {
 							"request": "event",
 							"selector": "#<?php echo esc_attr( $element_id ); ?> form.popup-not-interested-form",
 							"vars": {
-								"event_name": "<?php echo esc_html__( 'Popup not interesting' ); ?>",
+								"event_name": "<?php echo esc_html__( 'Permanent Dismissal', 'newspack-popups' ); ?>",
 								"event_label": "<?php echo esc_attr( $event_label ); ?>",
 								"event_category": "<?php echo esc_attr( $event_category ); ?>"
 							}
@@ -376,7 +376,7 @@ final class Newspack_Popups_Model {
 							"request": "event",
 							"selector": "#<?php echo esc_attr( $element_id ); ?>",
 							"vars": {
-								"event_name": "<?php echo esc_html__( 'Popup seen' ); ?>",
+								"event_name": "<?php echo esc_html__( 'Seen', 'newspack-popups' ); ?>",
 								"event_label": "<?php echo esc_attr( $event_label ); ?>",
 								"event_category": "<?php echo esc_attr( $event_category ); ?>"
 							}

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -293,7 +293,7 @@ final class Newspack_Popups_Model {
 	 * Get the popup delay in milliseconds.
 	 *
 	 * @param object $popup The popup object.
-	 * @return number|null Delay in milliseconds.
+	 * @return number Delay in milliseconds.
 	 */
 	protected static function get_delay( $popup ) {
 		return intval( $popup['options']['trigger_delay'] ) * 1000 + 500;

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -418,12 +418,13 @@ final class Newspack_Popups_Model {
 	 */
 	public static function generate_inline_popup( $popup ) {
 		global $wp;
-		$element_id    = 'lightbox' . rand(); // phpcs:ignore WordPress.WP.AlternativeFunctions.rand_rand
-		$classes       = [ 'newspack-inline-popup' ];
-		$endpoint      = self::get_dismiss_endpoint();
-		$display_title = $popup['options']['display_title'];
-		$hidden_fields = self::get_hidden_fields( $popup );
-		$dismiss_text  = self::get_dismiss_text( $popup );
+		$element_id         = 'lightbox' . rand(); // phpcs:ignore WordPress.WP.AlternativeFunctions.rand_rand
+		$classes            = [ 'newspack-inline-popup' ];
+		$endpoint           = self::get_dismiss_endpoint();
+		$display_title      = $popup['options']['display_title'];
+		$hidden_fields      = self::get_hidden_fields( $popup );
+		$dismiss_text       = self::get_dismiss_text( $popup );
+		$has_mailchimp_form = preg_match( '/mailchimp_form/', $popup['body'] ) !== 0;
 		ob_start();
 		?>
 			<amp-analytics>
@@ -446,8 +447,9 @@ final class Newspack_Popups_Model {
 									"popup_id": "<?php echo ( esc_attr( $popup['id'] ) ); ?>",
 									"url": "<?php echo esc_url( home_url( $wp->request ) ); ?>"
 								}
-							},
-							"formSubmitSuccess": {
+							}
+							<?php if ( $has_mailchimp_form ) : ?>
+							,"formSubmitSuccess": {
 								"on": "amp-form-submit-success",
 								"request": "event",
 								"selector": "#mailchimp_form",
@@ -457,6 +459,7 @@ final class Newspack_Popups_Model {
 									"mailing_list_status": "subscribed"
 								}
 							}
+							<?php endif; ?>
 						},
 						"transport": {
 							"beacon": true,

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -290,6 +290,16 @@ final class Newspack_Popups_Model {
 	}
 
 	/**
+	 * Get the popup delay in milliseconds.
+	 *
+	 * @param object $popup The popup object.
+	 * @return number|null Delay in milliseconds.
+	 */
+	protected static function get_delay( $popup ) {
+		return intval( $popup['options']['trigger_delay'] ) * 1000 + 500;
+	}
+
+	/**
 	 * Insert analytics tracking code.
 	 *
 	 * @param object $popup The popup object.
@@ -375,6 +385,9 @@ final class Newspack_Popups_Model {
 							"on": "visible",
 							"request": "event",
 							"selector": "#<?php echo esc_attr( $element_id ); ?>",
+							"visibilitySpec": {
+								"totalTimeMin": "500"
+							},
 							"vars": {
 								"event_name": "<?php echo esc_html__( 'Seen', 'newspack-popups' ); ?>",
 								"event_label": "<?php echo esc_attr( $event_label ); ?>",
@@ -550,10 +563,17 @@ final class Newspack_Popups_Model {
 					"animations": [
 						{
 							"selector": ".newspack-lightbox",
-							"delay": "<?php echo intval( $popup['options']['trigger_delay'] ) * 1000 + 500; ?>",
+							"delay": "<?php echo esc_html( self::get_delay( $popup ) ); ?>",
 							"keyframes": {
 								"opacity": ["0", "1"],
 								"visibility": ["hidden", "visible"]
+							}
+						},
+						{
+							"selector": ".newspack-lightbox",
+							"delay": "<?php echo esc_html( self::get_delay( $popup ) - 500 ); ?>",
+							"keyframes": {
+								"transform": ["translateY(100vh)", "translateY(0vh)"]
 							}
 						},
 						{

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -396,6 +396,7 @@ final class Newspack_Popups_Model {
 						},
 						"popupPageLoaded": {
 							"on": "ini-load",
+							"selector": "#<?php echo esc_attr( $element_id ); ?>",
 							"request": "event",
 							"vars": {
 								"event_name": "<?php echo esc_html__( 'Load', 'newspack-popups' ); ?>",

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -305,7 +305,7 @@ final class Newspack_Popups_Model {
 		}
 
 		$event_category = 'Newspack Announcement';
-		$event_label    = 'Newspack Announcement: ' . $popup['title'];
+		$event_label    = 'Newspack Announcement: ' . $popup['title'] . ' (' . $popup['id'] . ')';
 
 		$has_link                = preg_match( '/<a\s/', $popup['body'] ) !== 0;
 		$has_form                = preg_match( '/<form\s/', $popup['body'] ) !== 0;
@@ -377,6 +377,15 @@ final class Newspack_Popups_Model {
 							"selector": "#<?php echo esc_attr( $element_id ); ?>",
 							"vars": {
 								"event_name": "<?php echo esc_html__( 'Seen', 'newspack-popups' ); ?>",
+								"event_label": "<?php echo esc_attr( $event_label ); ?>",
+								"event_category": "<?php echo esc_attr( $event_category ); ?>"
+							}
+						},
+						"popupPageLoaded": {
+							"on": "ini-load",
+							"request": "event",
+							"vars": {
+								"event_name": "<?php echo esc_html__( 'Load', 'newspack-popups' ); ?>",
 								"event_label": "<?php echo esc_attr( $event_label ); ?>",
 								"event_category": "<?php echo esc_attr( $event_category ); ?>"
 							}

--- a/src/view/style.scss
+++ b/src/view/style.scss
@@ -14,6 +14,9 @@ $color__secondary-variation: darken( $color__secondary, 10% );
 	position: fixed;
 	right: 0;
 	top: 0;
+	// Popup needs to be initially out of the viewport,
+	// so that analytics work when checking visibility.
+	transform: translateY( 100vh );
 	visibility: hidden;
 	width: 100% !important;
 	z-index: 99999;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds event tracking via Google Analytics. If Site Kit is installed and has analytics configured, every popup will report custom events:

1. Seen
1. Dismissed - by clicking on close button
1. Dismissed - by clicking on "not interested" text
1. Any link click in popup
1. Any form submission in popup

GA custom events have three properties: `Category`, `Action`, `Label`. This PR proposes the following use:

| Category | Action    | Label     |
| :------------- | :------------- | :------------- |
| `Newspack Popup` | `Popup (link clicked \| form submitted \| not interesting \| dismissed \| seen)`       | `Newspack Popup: <popup title>`       |

Closes #64.

### How to test the changes in this Pull Request:

1. Make sure Site Kit is connected to Analytics
1. Create a popup with a link and a form (e.g. Button block and Mailchimp block)
1. Visit site with a popup and open devtools network tab. Filter `google-analytics`.
1. Trigger and observe reported events being sent:
    1. Seen
    1. Dismissed - by clicking on close button
    1. Dismissed - by clicking on "not interested" text
    1. Any link click in popup
    1. Any form submission in popup
1. Visit your [GA dashboard](https://analytics.google.com/analytics/web), navigate to "Behavior"->"Events"->"Overview" in the sidebar menu
1. Observe that the events are inspectable there
1. Try with both inline and regular popup

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
