### PR TITLE
Super Cool Ad Inserter Collisions With Newspack Popups

### DIFF
--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -85,6 +85,13 @@ final class Newspack_Popups_Inserter {
 
 		$is_inline = 'inline' === $popup['options']['placement'];
 
+		// In order to prevent the SCAIP ad being inserted mid-popup, let's insert the ads
+		// manually. SCAI begins by checking if there are any ads already inserted and bails
+		// if there are, to allow for manual ads placement.
+		if ( $is_inline ) {
+			$content = scaip_maybe_insert_shortcode( $content );
+		}
+
 		if ( $is_inline && ! is_single() ) {
 			// Inline Pop-ups can only appear in Posts.
 			return $content;

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -88,7 +88,7 @@ final class Newspack_Popups_Inserter {
 		// In order to prevent the SCAIP ad being inserted mid-popup, let's insert the ads
 		// manually. SCAI begins by checking if there are any ads already inserted and bails
 		// if there are, to allow for manual ads placement.
-		if ( $is_inline ) {
+		if ( function_exists( 'scaip_maybe_insert_shortcode' ) && $is_inline ) {
 			$content = scaip_maybe_insert_shortcode( $content );
 		}
 

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -58,7 +58,7 @@ final class Newspack_Popups_Inserter {
 	 * Constructor.
 	 */
 	public function __construct() {
-		add_filter( 'the_content', [ $this, 'popup' ], 100 );
+		add_filter( 'the_content', [ $this, 'popup' ], 1 );
 		add_action( 'after_header', [ $this, 'popup_after_header' ] ); // This is a Newspack theme hook. When used with other themes, popups won't be inserted on archive pages.
 		add_action( 'wp_head', [ __CLASS__, 'popup_access' ] );
 	}

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -58,7 +58,7 @@ final class Newspack_Popups_Inserter {
 	 * Constructor.
 	 */
 	public function __construct() {
-		add_filter( 'the_content', [ $this, 'popup' ] );
+		add_filter( 'the_content', [ $this, 'popup' ], 100 );
 		add_action( 'after_header', [ $this, 'popup_after_header' ] ); // This is a Newspack theme hook. When used with other themes, popups won't be inserted on archive pages.
 		add_action( 'wp_head', [ __CLASS__, 'popup_access' ] );
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This branch addresses a conflict with Super Cool Ad Inserter, where under certain circumstances SCAI may place an ad within the markup of an inline popup. [This issue ](https://github.com/Automattic/newspack-popups/issues/85) demonstrates the problem that occurs when this happens. This branch resolves the problem by setting the priority of Pop-up insertion to be later, thus occurring after Super Cool Ad Inserter has already finished insertions.

Closes https://github.com/Automattic/newspack-popups/issues/85. Closes https://github.com/Automattic/newspack-popups/issues/84.

### How to test the changes in this Pull Request:

_This one is difficult to test!_

1. Install Super Cool Ad Inserter. In `/wp-admin/options-general.php?page=scaip` set values to 6/2/6.
2. Navigate to Newspack->Advertising and create a Google Ad Manager Unit. 
3. Navigate to Appearance->Widgets. Add Newspack Ad Unit to Inserted Ad Position 1. In Newspack Ad Unit set the Ad Unit to the one created in the previous step.
4. Create a Pop-up and populate it with the Subscribe->Style 1 pattern. Set Frequency to "Test Mode," Placement to "Inline, Approximate Position to "50%", and Sitewide Default to checked.
5. Create a post with exactly 7 paragraphs.  
6. On `master` test this out. The Newsletter popup should have a SCAI unit inserted within it, between the input field and the button.
7. Switch to this branch and reload. The Newspack Popup should display cleanly, and the SCAI unit should appear elsewhere in the content.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
