### PR TITLE
Clear floats when using inline popup

### DIFF
--- a/src/view/style.scss
+++ b/src/view/style.scss
@@ -196,8 +196,9 @@ $color__secondary-variation: darken( $color__secondary, 10% );
 }
 
 .newspack-inline-popup {
-	padding: 0.75em;
 	border: 1px solid rgba( black, 0.2 );
+	clear: both;
+	padding: 0.75em;
 
 	&:focus {
 		outline: none;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Make sure the floats are being cleared when inserting an inline pop-up.

### How to test the changes in this Pull Request:

1. In a post, add some paragraphs and a floated image
2. Add an inline pop-up to it (make sure that it's being inserted after your image)
3. Check the post -- it should look slightly broken
4. Switch to this branch
5. Check the post again...

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
