### PR TITLE
Handle multiple popups

### DIFF
--- a/includes/class-newspack-popups-api.php
+++ b/includes/class-newspack-popups-api.php
@@ -162,7 +162,7 @@ final class Newspack_Popups_API {
 			$response['displayPopup'] = false;
 		}
 
-		if ( $this->is_preview_request( $request ) || $frequency === 'test' ) {
+		if ( $this->is_preview_request( $request ) || 'test' === $frequency ) {
 			$response['displayPopup'] = true;
 		};
 

--- a/includes/class-newspack-popups-api.php
+++ b/includes/class-newspack-popups-api.php
@@ -162,7 +162,7 @@ final class Newspack_Popups_API {
 			$response['displayPopup'] = false;
 		}
 
-		if ( $this->is_preview_request( $request ) ) {
+		if ( $this->is_preview_request( $request ) || $frequency === 'test' ) {
 			$response['displayPopup'] = true;
 		};
 

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -66,7 +66,7 @@ final class Newspack_Popups_Inserter {
 
 		$popups_to_display = array_filter(
 			$popups_to_maybe_display,
-			[ 'self', 'should_display' ]
+			[ __CLASS__, 'should_display' ]
 		);
 		if ( ! empty( $popups_to_display ) ) {
 			return $popups_to_display;
@@ -211,10 +211,13 @@ final class Newspack_Popups_Inserter {
 	 */
 	public static function popup_shortcode( $atts = array() ) {
 		$previewed_popup_id = Newspack_Popups::previewed_popup_id();
-		if ($previewed_popup_id) {
-			return Newspack_Popups_Model::retrieve_preview_popup( $previewed_popup_id )['markup'];
-		} else {
-			return Newspack_Popups_Model::retrieve_popup_by_id( $atts['id'] )['markup'];
+		if ( $previewed_popup_id ) {
+			$found_popup = Newspack_Popups_Model::retrieve_preview_popup( $previewed_popup_id );
+		} elseif ( isset( $atts['id'] ) ) {
+			$found_popup = Newspack_Popups_Model::retrieve_popup_by_id( $atts['id'] );
+		}
+		if ( isset( $found_popup['markup'] ) ) {
+			return $found_popup['markup'];
 		}
 	}
 

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -34,25 +34,35 @@ final class Newspack_Popups_Inserter {
 			return [ Newspack_Popups_Model::retrieve_preview_popup( Newspack_Popups::previewed_popup_id() ) ];
 		}
 
-		// Get all inline popups in there first.
+		// 1. Get all inline popups in there first.
 		$popups_to_display = Newspack_Popups_Model::retrieve_inline_popups();
 
-		// Get the sitewide pop-up.
-		$sitewide_default = get_option( Newspack_Popups::NEWSPACK_POPUPS_SITEWIDE_DEFAULT, null );
-		if ( $sitewide_default ) {
-			$found_popup = Newspack_Popups_Model::retrieve_popup_by_id( $sitewide_default );
-			if (
-				$found_popup &&
-				// Prevent inline sitewide default from being added - all inline popups are there.
-				'inline' !== $found_popup['options']['placement']
-			) {
-				array_push(
-					$popups_to_display,
-					$found_popup
-				);
+		// 2. Get the overlay popup.
+
+		// Check if there's an overlay popup with matching category.
+		$category_overlay_popup = Newspack_Popups_Model::retrieve_category_overlay_popup();
+		if ( $category_overlay_popup ) {
+			array_push(
+				$popups_to_display,
+				$category_overlay_popup
+			);
+		} else {
+			// If there's no category-matching popup, get the sitewide pop-up.
+			$sitewide_default = get_option( Newspack_Popups::NEWSPACK_POPUPS_SITEWIDE_DEFAULT, null );
+			if ( $sitewide_default ) {
+				$found_popup = Newspack_Popups_Model::retrieve_popup_by_id( $sitewide_default );
+				if (
+					$found_popup &&
+					// Prevent inline sitewide default from being added - all inline popups are there.
+					'inline' !== $found_popup['options']['placement']
+				) {
+					array_push(
+						$popups_to_display,
+						$found_popup
+					);
+				}
 			}
 		}
-
 
 		if ( ! empty( $popups_to_display ) ) {
 			return $popups_to_display;

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -25,7 +25,7 @@ final class Newspack_Popups_Inserter {
 	 * @return array Popup objects.
 	 */
 	public static function popups_for_post() {
-		if ( !empty(self::$popups) ) {
+		if ( ! empty( self::$popups ) ) {
 			return self::$popups;
 		}
 
@@ -36,9 +36,9 @@ final class Newspack_Popups_Inserter {
 			return [ Newspack_Popups_Model::retrieve_preview_popup( Newspack_Popups::previewed_popup_id() ) ];
 		}
 
-		// Get all inline popups
+		// Get all inline popups.
 		$inline_popups = Newspack_Popups_Model::retrieve_inline_popups();
-		if (!empty($inline_popups)) {
+		if ( ! empty( $inline_popups ) ) {
 			$found_popups = array_merge(
 				$found_popups,
 				$inline_popups
@@ -62,7 +62,7 @@ final class Newspack_Popups_Inserter {
 		}
 
 
-		if ( !empty($found_popups) ) {
+		if ( ! empty( $found_popups ) ) {
 			return $found_popups;
 		}
 
@@ -74,7 +74,7 @@ final class Newspack_Popups_Inserter {
 	 */
 	public function __construct() {
 		add_filter( 'the_content', [ $this, 'insert_popups_in_content' ], 1 );
-		add_shortcode( 'newspack-popup', [$this, 'popup_shortcode'] );
+		add_shortcode( 'newspack-popup', [ $this, 'popup_shortcode' ] );
 		add_action( 'after_header', [ $this, 'insert_popups_after_header' ] ); // This is a Newspack theme hook. When used with other themes, popups won't be inserted on archive pages.
 		add_action( 'wp_head', [ __CLASS__, 'insert_popups_access' ] );
 	}
@@ -91,14 +91,14 @@ final class Newspack_Popups_Inserter {
 
 		$popups = self::popups_for_post();
 
-		if (empty($popups)) {
+		if ( empty( $popups ) ) {
 			return $content;
 		}
 
 		$has_an_inline_popup = false;
 
 		// First needs to check if there any inline popups, to handle SCAIP.
-		foreach($popups as $popup) {
+		foreach ( $popups as $popup ) {
 			if (
 				static::should_display( $popup ) &&
 				'inline' === $popup['options']['placement']
@@ -107,7 +107,7 @@ final class Newspack_Popups_Inserter {
 			}
 		}
 
-		if ($has_an_inline_popup && function_exists( 'scaip_maybe_insert_shortcode' )) {
+		if ( $has_an_inline_popup && function_exists( 'scaip_maybe_insert_shortcode' ) ) {
 			// Prevent default SCAIP insertion.
 			remove_filter( 'the_content', 'scaip_maybe_insert_shortcode', 10 );
 
@@ -118,9 +118,9 @@ final class Newspack_Popups_Inserter {
 		}
 
 		// Now insert the popups.
-		foreach($popups as $popup) {
+		foreach ( $popups as $popup ) {
 			if ( static::should_display( $popup ) ) {
-				$content = self::insert_single_popup_in_content($content, $popup);
+				$content = self::insert_single_popup_in_content( $content, $popup );
 			}
 		}
 
@@ -133,8 +133,8 @@ final class Newspack_Popups_Inserter {
 	/**
 	 * Insert popup into post and page content.
 	 *
-	 * @param object $popup The popup to be inserted.
 	 * @param string $content The content of the post.
+	 * @param object $popup The popup to be inserted.
 	 * @return string The content with popup inserted.
 	 */
 	public static function insert_single_popup_in_content( $content = '', $popup = [] ) {
@@ -163,9 +163,9 @@ final class Newspack_Popups_Inserter {
 
 		$popups = self::popups_for_post();
 
-		if (!empty($popups)) {
-			foreach($popups as $popup) {
-				self::insert_single_popup_after_header($popup);
+		if ( ! empty( $popups ) ) {
+			foreach ( $popups as $popup ) {
+				self::insert_single_popup_after_header( $popup );
 			}
 			self::enqueue_popup_assets();
 		}
@@ -176,7 +176,7 @@ final class Newspack_Popups_Inserter {
 	 *
 	 * @param object $popup The popup to be inserted.
 	 */
-	public static function insert_single_popup_after_header($popup) {
+	public static function insert_single_popup_after_header( $popup ) {
 		if (
 			! $popup ||
 			! static::should_display( $popup ) ||
@@ -290,9 +290,9 @@ final class Newspack_Popups_Inserter {
 
 		$popups = self::popups_for_post();
 
-		if (!empty($popups)) {
-			foreach($popups as $popup) {
-				self::insert_single_popup_amp_access($popup);
+		if ( ! empty( $popups ) ) {
+			foreach ( $popups as $popup ) {
+				self::insert_single_popup_amp_access( $popup );
 			}
 			static::register_amp_scripts();
 		}
@@ -303,7 +303,7 @@ final class Newspack_Popups_Inserter {
 	 *
 	 * @param object $popup The popup object to insert.
 	 */
-	public static function insert_single_popup_amp_access($popup) {
+	public static function insert_single_popup_amp_access( $popup ) {
 		if (
 			! static::should_display( $popup ) ||
 			// Pop-ups triggered by scroll position can only appear on Posts.
@@ -394,12 +394,12 @@ final class Newspack_Popups_Inserter {
 	 * @return bool Should popup be shown based on categories it has.
 	 */
 	public static function assess_categories_filter( $popup ) {
-		$post_categories = get_the_category();
-		$popup_categories = get_the_category($popup['id']);
+		$post_categories  = get_the_category();
+		$popup_categories = get_the_category( $popup['id'] );
 		if ( $popup_categories && count( $popup_categories ) ) {
 			return array_intersect(
-				array_column($post_categories, 'term_id'),
-				array_column($popup_categories, 'term_id')
+				array_column( $post_categories, 'term_id' ),
+				array_column( $popup_categories, 'term_id' )
 			);
 		}
 		return true;
@@ -412,7 +412,7 @@ final class Newspack_Popups_Inserter {
 	 * @return bool Should popup be shown.
 	 */
 	public static function should_display( $popup ) {
-		return self::assess_test_mode($popup) && self::assess_categories_filter($popup);
+		return self::assess_test_mode( $popup ) && self::assess_categories_filter( $popup );
 	}
 }
 $newspack_popups_inserter = new Newspack_Popups_Inserter();

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -121,8 +121,7 @@ final class Newspack_Popups_Inserter {
 
 		// Now insert the popups.
 		foreach ( $popups as $popup ) {
-			$is_inline = 'inline' === $popup['options']['placement'];
-			$content   = $is_inline ? self::insert_inline_popup_shortcode( $content, $popup ) : self::insert_popup( $content, $popup );
+			$content = self::insert_popup( $content, $popup );
 		}
 
 		self::enqueue_popup_assets();
@@ -168,11 +167,14 @@ final class Newspack_Popups_Inserter {
 	 *
 	 * @param string $content The content of the post.
 	 * @param object $popup The popup object to insert.
-	 * @return string The content with popup inserted.
+	 * @return string The content with popup markup inserted.
 	 */
 	public static function insert_popup( $content = '', $popup = [] ) {
-		if ( 0 === $popup['options']['trigger_scroll_progress'] || Newspack_Popups::previewed_popup_id() ) {
-			return $popup['markup'] . $content;
+		$is_inline    = 'inline' === $popup['options']['placement'];
+		$popup_markup = $is_inline ? '[newspack-popup id="' . $popup['id'] . '"]' : $popup['markup'];
+
+		if ( ! $is_inline && 0 === $popup['options']['trigger_scroll_progress'] ) {
+			return $popup_markup . $content;
 		}
 
 		$position  = 0;
@@ -194,37 +196,8 @@ final class Newspack_Popups_Inserter {
 		}
 		$before_popup = substr( $content, 0, $insertion_position );
 		$after_popup  = substr( $content, $insertion_position );
-		return $before_popup . $popup['markup'] . $after_popup;
-	}
 
-	/**
-	 * Insert inline Popup shortcode into content.
-	 *
-	 * @param string $content The content of the post.
-	 * @param object $popup The popup object to insert.
-	 * @return string The content with popup shortcode inserted.
-	 */
-	public static function insert_inline_popup_shortcode( $content = '', $popup = [] ) {
-		$position  = 0;
-		$positions = [];
-		$close_tag = '</p>';
-		while ( stripos( $content, $close_tag, $position ) !== false ) {
-			$position    = stripos( $content, '</p>', $position ) + strlen( $close_tag );
-			$positions[] = $position;
-		}
-		$total_length       = strlen( $content );
-		$percentage         = intval( $popup['options']['trigger_scroll_progress'] ) / 100;
-		$precise_position   = $total_length * $percentage;
-		$insertion_position = $total_length;
-		foreach ( $positions as $position ) {
-			if ( $position >= $precise_position ) {
-				$insertion_position = $position;
-				break;
-			}
-		}
-		$before_popup = substr( $content, 0, $insertion_position );
-		$after_popup  = substr( $content, $insertion_position );
-		return $before_popup . '[newspack-popup id="' . $popup['id'] . '"]' . $after_popup;
+		return $before_popup . $popup_markup . $after_popup;
 	}
 
 	/**

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -180,28 +180,26 @@ final class Newspack_Popups_Inserter {
 			return $popup_markup . $content;
 		}
 
-		$percentage       = intval( $popup['options']['trigger_scroll_progress'] ) / 100;
-		$total_length     = strlen( $content );
-		$precise_position = $total_length * $percentage;
-
-		$blocks = [];
-		// Match block closing comment.
-		$block_close_pattern = '/<!-- \/wp:[\w-\/]* -->/';
-		// Minus 2 to account for '/' chars.
-		$pattern_string_length = strlen( $block_close_pattern ) - 2;
-		preg_match_all( $block_close_pattern, $content, $blocks, PREG_OFFSET_CAPTURE );
+		$position  = 0;
+		$positions = [];
+		$close_tag = '</p>';
+		while ( stripos( $content, $close_tag, $position ) !== false ) {
+			$position    = stripos( $content, '</p>', $position ) + strlen( $close_tag );
+			$positions[] = $position;
+		}
+		$total_length       = strlen( $content );
+		$percentage         = intval( $popup['options']['trigger_scroll_progress'] ) / 100;
+		$precise_position   = $total_length * $percentage;
 		$insertion_position = $total_length;
-		foreach ( $blocks[0] as $index => $block ) {
-			$block_offest = $block[1];
-			$offset       = $block_offest + $pattern_string_length;
-			if ( $offset >= $precise_position ) {
-				$insertion_position = $offset;
+		foreach ( $positions as $position ) {
+			if ( $position >= $precise_position ) {
+				$insertion_position = $position;
 				break;
 			}
 		}
-
 		$before_popup = substr( $content, 0, $insertion_position );
 		$after_popup  = substr( $content, $insertion_position );
+
 		return $before_popup . $popup_markup . $after_popup;
 	}
 
@@ -213,7 +211,7 @@ final class Newspack_Popups_Inserter {
 	 */
 	public static function popup_shortcode( $atts = array() ) {
 		$previewed_popup_id = Newspack_Popups::previewed_popup_id();
-		if ( $previewed_popup_id ) {
+		if ($previewed_popup_id) {
 			return Newspack_Popups_Model::retrieve_preview_popup( $previewed_popup_id )['markup'];
 		} else {
 			return Newspack_Popups_Model::retrieve_popup_by_id( $atts['id'] )['markup'];

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -35,15 +35,15 @@ final class Newspack_Popups_Inserter {
 		}
 
 		// 1. Get all inline popups in there first.
-		$popups_to_display = Newspack_Popups_Model::retrieve_inline_popups();
+		$popups_to_maybe_display = Newspack_Popups_Model::retrieve_inline_popups();
 
 		// 2. Get the overlay popup.
 
 		// Check if there's an overlay popup with matching category.
 		$category_overlay_popup = Newspack_Popups_Model::retrieve_category_overlay_popup();
-		if ( $category_overlay_popup && static::should_display( $category_overlay_popup ) ) {
+		if ( $category_overlay_popup ) {
 			array_push(
-				$popups_to_display,
+				$popups_to_maybe_display,
 				$category_overlay_popup
 			);
 		} else {
@@ -53,23 +53,26 @@ final class Newspack_Popups_Inserter {
 				$found_popup = Newspack_Popups_Model::retrieve_popup_by_id( $sitewide_default );
 				if (
 					$found_popup &&
-					static::should_display( $found_popup ) &&
 					// Prevent inline sitewide default from being added - all inline popups are there.
 					'inline' !== $found_popup['options']['placement']
 				) {
 					array_push(
-						$popups_to_display,
+						$popups_to_maybe_display,
 						$found_popup
 					);
 				}
 			}
 		}
 
+		$popups_to_display = array_filter(
+			$popups_to_maybe_display,
+			[ 'self', 'should_display' ]
+		);
 		if ( ! empty( $popups_to_display ) ) {
 			return $popups_to_display;
 		}
 
-		return null;
+		return [];
 	}
 
 	/**

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -180,26 +180,28 @@ final class Newspack_Popups_Inserter {
 			return $popup_markup . $content;
 		}
 
-		$position  = 0;
-		$positions = [];
-		$close_tag = '</p>';
-		while ( stripos( $content, $close_tag, $position ) !== false ) {
-			$position    = stripos( $content, '</p>', $position ) + strlen( $close_tag );
-			$positions[] = $position;
-		}
-		$total_length       = strlen( $content );
-		$percentage         = intval( $popup['options']['trigger_scroll_progress'] ) / 100;
-		$precise_position   = $total_length * $percentage;
+		$percentage       = intval( $popup['options']['trigger_scroll_progress'] ) / 100;
+		$total_length     = strlen( $content );
+		$precise_position = $total_length * $percentage;
+
+		$blocks = [];
+		// Match block closing comment.
+		$block_close_pattern = '/<!-- \/wp:[\w-\/]* -->/';
+		// Minus 2 to account for '/' chars.
+		$pattern_string_length = strlen( $block_close_pattern ) - 2;
+		preg_match_all( $block_close_pattern, $content, $blocks, PREG_OFFSET_CAPTURE );
 		$insertion_position = $total_length;
-		foreach ( $positions as $position ) {
-			if ( $position >= $precise_position ) {
-				$insertion_position = $position;
+		foreach ( $blocks[0] as $index => $block ) {
+			$block_offest = $block[1];
+			$offset       = $block_offest + $pattern_string_length;
+			if ( $offset >= $precise_position ) {
+				$insertion_position = $offset;
 				break;
 			}
 		}
+
 		$before_popup = substr( $content, 0, $insertion_position );
 		$after_popup  = substr( $content, $insertion_position );
-
 		return $before_popup . $popup_markup . $after_popup;
 	}
 
@@ -211,7 +213,7 @@ final class Newspack_Popups_Inserter {
 	 */
 	public static function popup_shortcode( $atts = array() ) {
 		$previewed_popup_id = Newspack_Popups::previewed_popup_id();
-		if ($previewed_popup_id) {
+		if ( $previewed_popup_id ) {
 			return Newspack_Popups_Model::retrieve_preview_popup( $previewed_popup_id )['markup'];
 		} else {
 			return Newspack_Popups_Model::retrieve_popup_by_id( $atts['id'] )['markup'];

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -29,21 +29,13 @@ final class Newspack_Popups_Inserter {
 			return self::$popups;
 		}
 
-		$found_popups = [];
-
 		// Get the previewed popup and return early if there's one.
 		if ( Newspack_Popups::previewed_popup_id() ) {
 			return [ Newspack_Popups_Model::retrieve_preview_popup( Newspack_Popups::previewed_popup_id() ) ];
 		}
 
-		// Get all inline popups.
-		$inline_popups = Newspack_Popups_Model::retrieve_inline_popups();
-		if ( ! empty( $inline_popups ) ) {
-			$found_popups = array_merge(
-				$found_popups,
-				$inline_popups
-			);
-		}
+		// Get all inline popups in there first.
+		$popups_to_display = Newspack_Popups_Model::retrieve_inline_popups();
 
 		// Get the sitewide pop-up.
 		$sitewide_default = get_option( Newspack_Popups::NEWSPACK_POPUPS_SITEWIDE_DEFAULT, null );
@@ -55,15 +47,15 @@ final class Newspack_Popups_Inserter {
 				'inline' !== $found_popup['options']['placement']
 			) {
 				array_push(
-					$found_popups,
+					$popups_to_display,
 					$found_popup
 				);
 			}
 		}
 
 
-		if ( ! empty( $found_popups ) ) {
-			return $found_popups;
+		if ( ! empty( $popups_to_display ) ) {
+			return $popups_to_display;
 		}
 
 		return null;

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -210,7 +210,12 @@ final class Newspack_Popups_Inserter {
 	 * @return HTML
 	 */
 	public static function popup_shortcode( $atts = array() ) {
-		return Newspack_Popups_Model::retrieve_popup_by_id( $atts['id'] )['markup'];
+		$previewed_popup_id = Newspack_Popups::previewed_popup_id();
+		if ($previewed_popup_id) {
+			return Newspack_Popups_Model::retrieve_preview_popup( $previewed_popup_id )['markup'];
+		} else {
+			return Newspack_Popups_Model::retrieve_popup_by_id( $atts['id'] )['markup'];
+		}
 	}
 
 	/**

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -74,6 +74,7 @@ final class Newspack_Popups_Inserter {
 	 */
 	public function __construct() {
 		add_filter( 'the_content', [ $this, 'insert_popups_in_content' ], 1 );
+		add_shortcode( 'newspack-popup', [$this, 'popup_shortcode'] );
 		add_action( 'after_header', [ $this, 'insert_popups_after_header' ] ); // This is a Newspack theme hook. When used with other themes, popups won't be inserted on archive pages.
 		add_action( 'wp_head', [ __CLASS__, 'insert_popups_access' ] );
 	}
@@ -147,7 +148,7 @@ final class Newspack_Popups_Inserter {
 			return $content;
 		}
 
-		$content = $is_inline ? self::insert_inline_popup( $content, $popup ) : self::insert_popup( $content, $popup );
+		$content = $is_inline ? self::insert_inline_popup_shortcode( $content, $popup ) : self::insert_popup( $content, $popup );
 		return $content;
 	}
 
@@ -240,13 +241,13 @@ final class Newspack_Popups_Inserter {
 	}
 
 	/**
-	 * Insert inline Popup markup into content
+	 * Insert inline Popup shortcode into content.
 	 *
 	 * @param string $content The content of the post.
 	 * @param object $popup The popup object to insert.
-	 * @return string The content with popup inserted.
+	 * @return string The content with popup shortcode inserted.
 	 */
-	public static function insert_inline_popup( $content = '', $popup = [] ) {
+	public static function insert_inline_popup_shortcode( $content = '', $popup = [] ) {
 		$position  = 0;
 		$positions = [];
 		$close_tag = '</p>';
@@ -266,7 +267,17 @@ final class Newspack_Popups_Inserter {
 		}
 		$before_popup = substr( $content, 0, $insertion_position );
 		$after_popup  = substr( $content, $insertion_position );
-		return $before_popup . $popup['markup'] . $after_popup;
+		return $before_popup . '[newspack-popup id="' . $popup['id'] . '"]' . $after_popup;
+	}
+
+	/**
+	 * The popup shortcode function.
+	 *
+	 * @param array $atts Shortcode attributes.
+	 * @return HTML
+	 */
+	public static function popup_shortcode( $atts = array() ) {
+		return Newspack_Popups_Model::retrieve_popup_by_id( $atts['id'] )['markup'];
 	}
 
 	/**

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -26,7 +26,7 @@ final class Newspack_Popups_Model {
 
 		$sitewide_default_id = get_option( Newspack_Popups::NEWSPACK_POPUPS_SITEWIDE_DEFAULT, null );
 
-		$popups = self::retrieve_popup_with_query( new WP_Query( $args ), true );
+		$popups = self::retrieve_popups_with_query( new WP_Query( $args ), true );
 		foreach ( $popups as &$popup ) {
 			$popup['sitewide_default'] = absint( $sitewide_default_id ) === absint( $popup['id'] );
 		}
@@ -132,7 +132,7 @@ final class Newspack_Popups_Model {
 			];
 		}
 
-		$popups = self::retrieve_popup_with_query( new WP_Query( $args ) );
+		$popups = self::retrieve_popups_with_query( new WP_Query( $args ) );
 		return count( $popups ) > 0 ? $popups[0] : null;
 	}
 
@@ -179,7 +179,7 @@ final class Newspack_Popups_Model {
 			'p'              => $post_id,
 		];
 
-		$popups = self::retrieve_popup_with_query( new WP_Query( $args ) );
+		$popups = self::retrieve_popups_with_query( new WP_Query( $args ) );
 		return count( $popups ) > 0 ? $popups[0] : null;
 	}
 
@@ -190,7 +190,7 @@ final class Newspack_Popups_Model {
 	 * @param boolean  $include_categories If true, returned objects will include assigned categories.
 	 * @return array Popup objects array
 	 */
-	protected static function retrieve_popup_with_query( WP_Query $query, $include_categories = false ) {
+	protected static function retrieve_popups_with_query( WP_Query $query, $include_categories = false ) {
 		$popups = [];
 		while ( $query->have_posts() ) {
 			$query->the_post();

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -30,7 +30,7 @@ final class Newspack_Popups_Model {
 		foreach ( $popups as &$popup ) {
 			// UI will not allow for setting inline as sitewide default, but there may be
 			// legacy popups from before this update.
-			if ('inline' !== $popup['options']['placement']) {
+			if ( 'inline' !== $popup['options']['placement'] ) {
 				$popup['sitewide_default'] = absint( $sitewide_default_id ) === absint( $popup['id'] );
 			}
 		}
@@ -56,7 +56,7 @@ final class Newspack_Popups_Model {
 		}
 
 		// Such update will not be permitted by the UI, but it's handled just to be explicit about it.
-		if ('inline' === $popup['options']['placement']) {
+		if ( 'inline' === $popup['options']['placement'] ) {
 			return new \WP_Error(
 				'newspack_popups_inline_sitewide',
 				esc_html__( 'An inline popup cannot be a sitewide default.', 'newspack-popups' ),
@@ -123,12 +123,13 @@ final class Newspack_Popups_Model {
 	 *
 	 * @return array Inline popup objects.
 	 */
-	public static function retrieve_inline_popups( $categories = [] ) {
+	public static function retrieve_inline_popups() {
 		$args = [
-			'post_type'      => Newspack_Popups::NEWSPACK_PLUGINS_CPT,
-			'post_status'    => 'publish',
-			'meta_key' => 'placement',
-			'meta_value' => 'inline',
+			'post_type'   => Newspack_Popups::NEWSPACK_PLUGINS_CPT,
+			'post_status' => 'publish',
+			'meta_key'    => 'placement',
+			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+			'meta_value'  => 'inline',
 		];
 
 		return self::retrieve_popups_with_query( new WP_Query( $args ) );

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -136,6 +136,35 @@ final class Newspack_Popups_Model {
 	}
 
 	/**
+	 * Retrieve first overlay popup matching post categries.
+	 *
+	 * @return object|null Popup object.
+	 */
+	public static function retrieve_category_overlay_popup() {
+		$post_categories = get_the_category();
+
+		if ( empty( $post_categories ) ) {
+			return null;
+		}
+
+		$args = [
+			'post_type'      => Newspack_Popups::NEWSPACK_PLUGINS_CPT,
+			'posts_per_page' => 1,
+			'post_status'    => 'publish',
+			'category__in'   => array_column( $post_categories, 'term_id' ),
+			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+			'meta_query'     => array(
+				'key'     => 'placement',
+				'value'   => 'inline',
+				'compare' => '!=',
+			),
+		];
+
+		$popups = self::retrieve_popups_with_query( new WP_Query( $args ) );
+		return count( $popups ) > 0 ? $popups[0] : null;
+	}
+
+	/**
 	 * Retrieve popup preview CPT post.
 	 *
 	 * @param string $post_id Post id.
@@ -182,7 +211,7 @@ final class Newspack_Popups_Model {
 	}
 
 	/**
-	 * Retrieve popup CPT post.
+	 * Retrieve popup CPT posts.
 	 *
 	 * @param WP_Query $query The query to use.
 	 * @param boolean  $include_categories If true, returned objects will include assigned categories.

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -152,12 +152,10 @@ final class Newspack_Popups_Model {
 			'posts_per_page' => 1,
 			'post_status'    => 'publish',
 			'category__in'   => array_column( $post_categories, 'term_id' ),
-			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
-			'meta_query'     => array(
-				'key'     => 'placement',
-				'value'   => 'inline',
-				'compare' => '!=',
-			),
+			'meta_key'       => 'placement',
+			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+			'meta_value'     => 'inline',
+			'meta_compare'   => '!=',
 		];
 
 		$popups = self::retrieve_popups_with_query( new WP_Query( $args ) );

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -152,7 +152,7 @@ final class Newspack_Popups_Model {
 			'posts_per_page' => 1,
 			'post_status'    => 'publish',
 			'category__in'   => array_column( $post_categories, 'term_id' ),
-			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 			'meta_query'     => array(
 				'key'     => 'placement',
 				'value'   => 'inline',
@@ -541,7 +541,7 @@ final class Newspack_Popups_Model {
 		ob_start();
 		?>
 			<?php self::insert_event_tracking( $popup, $element_id ); ?>
-			<amp-layout amp-access="displayPopup" amp-access-hide class="<?php echo esc_attr( implode( ' ', $classes ) ); ?>" role="button" tabindex="0" style="<?php echo esc_attr( self::container_style( $popup ) ); ?>" id="<?php echo esc_attr( $element_id ); ?>">
+			<amp-layout amp-access="popup_<?php echo esc_attr( $popup['id'] ); ?>.displayPopup" amp-access-hide class="<?php echo esc_attr( implode( ' ', $classes ) ); ?>" role="button" tabindex="0" style="<?php echo esc_attr( self::container_style( $popup ) ); ?>" id="<?php echo esc_attr( $element_id ); ?>">
 				<?php if ( ! empty( $popup['title'] ) && $display_title ) : ?>
 					<h1 class="newspack-popup-title"><?php echo esc_html( $popup['title'] ); ?></h1>
 				<?php endif; ?>
@@ -583,7 +583,7 @@ final class Newspack_Popups_Model {
 
 		ob_start();
 		?>
-		<amp-layout amp-access="displayPopup" amp-access-hide class="<?php echo esc_attr( implode( ' ', $classes ) ); ?>" role="button" tabindex="0" id="<?php echo esc_attr( $element_id ); ?>">
+		<amp-layout amp-access="popup_<?php echo esc_attr( $popup['id'] ); ?>.displayPopup" amp-access-hide class="<?php echo esc_attr( implode( ' ', $classes ) ); ?>" role="button" tabindex="0" id="<?php echo esc_attr( $element_id ); ?>">
 			<div class="newspack-popup-wrapper" style="<?php echo esc_attr( self::container_style( $popup ) ); ?>">
 				<div class="newspack-popup">
 					<?php if ( ! empty( $popup['title'] ) && $display_title ) : ?>

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -473,7 +473,7 @@ final class Newspack_Popups_Model {
 							"formSubmitSuccess": {
 								"on": "<?php echo esc_attr( $custom_form_submit_event ); ?>",
 								"request": "event",
-								"selector": ".wp-block-jetpack-mailchimp form",
+								"selector": "#<?php echo esc_attr( $element_id ); ?> .wp-block-jetpack-mailchimp form",
 								"extraUrlParams": {
 									"popup_id": "<?php echo ( esc_attr( $popup['id'] ) ); ?>",
 									"url": "<?php echo esc_url( home_url( $wp->request ) ); ?>",

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -171,10 +171,14 @@ final class Newspack_Popups_Model {
 	 * @return object Popup object.
 	 */
 	public static function retrieve_preview_popup( $post_id ) {
-		// A preview is stored in an autosave.
-		$autosave = wp_get_post_autosave( $post_id );
+		// Up-to-date post data is stored in an autosave.
+		$autosave    = wp_get_post_autosave( $post_id );
+		$post_object = $autosave ? $autosave : get_post( $post_id );
+		// Setting proper id for correct API calls.
+		$post_object->ID = $post_id;
+
 		return self::create_popup_object(
-			$autosave ? $autosave : get_post( $post_id ),
+			$post_object,
 			false,
 			[
 				'background_color'        => filter_input( INPUT_GET, 'background_color', FILTER_SANITIZE_STRING ),

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -274,10 +274,10 @@ final class Newspack_Popups {
 			return $post_states;
 		}
 		$post_status_object = get_post_status_object( $post->post_status );
-		$is_inline = get_post_meta( $post->ID, 'placement', true ) == 'inline';
-		if ($is_inline) {
+		$is_inline          = get_post_meta( $post->ID, 'placement', true ) == 'inline';
+		if ( $is_inline ) {
 			$post_states[ $post_status_object->name ] = __( 'Inline', 'newspack-popups' );
-		} else if ( absint( get_option( self::NEWSPACK_POPUPS_SITEWIDE_DEFAULT, null ) ) === absint( $post->ID ) ) {
+		} elseif ( absint( get_option( self::NEWSPACK_POPUPS_SITEWIDE_DEFAULT, null ) ) === absint( $post->ID ) ) {
 			$post_states[ $post_status_object->name ] = __( 'Sitewide Default', 'newspack-popups' );
 		}
 		return $post_states;

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -264,7 +264,7 @@ final class Newspack_Popups {
 	}
 
 	/**
-	 * Display 'Sitewide Default' state by the appropriate pop-up.
+	 * Display popup states by the pop-ups.
 	 *
 	 * @param array   $post_states An array of post display states.
 	 * @param WP_Post $post        The current post object.
@@ -273,8 +273,12 @@ final class Newspack_Popups {
 		if ( self::NEWSPACK_PLUGINS_CPT !== $post->post_type ) {
 			return $post_states;
 		}
-		if ( absint( get_option( self::NEWSPACK_POPUPS_SITEWIDE_DEFAULT, null ) ) === absint( $post->ID ) ) {
-			$post_states['newspack_popups_sitewide_default'] = __( 'Sitewide Default', 'newspack-popups' );
+		$post_status_object = get_post_status_object( $post->post_status );
+		$is_inline = get_post_meta( $post->ID, 'placement', true ) == 'inline';
+		if ($is_inline) {
+			$post_states[ $post_status_object->name ] = __( 'Inline', 'newspack-popups' );
+		} else if ( absint( get_option( self::NEWSPACK_POPUPS_SITEWIDE_DEFAULT, null ) ) === absint( $post->ID ) ) {
+			$post_states[ $post_status_object->name ] = __( 'Sitewide Default', 'newspack-popups' );
 		}
 		return $post_states;
 	}

--- a/src/editor/PopupPreview.js
+++ b/src/editor/PopupPreview.js
@@ -19,11 +19,12 @@ const PopupPreviewSetting = ( { autosavePost, isSavingPost, postId, metaFields }
 		...metaFields,
 	} );
 
-	// For inline placements, use most recent post to preview. For anything else, use the home.
-	const previewURL =
-		'inline' === metaFields.placement
-			? window && window.newspack_popups_data && window.newspack_popups_data.preview_post
-			: '/';
+	// For inline and scroll-triggered popups, use most recent post to preview. For anything else, use the home.
+	const shouldDisplayOnPost =
+		'inline' === metaFields.placement || 'scroll' === metaFields.trigger_type;
+	const previewURL = shouldDisplayOnPost
+		? window && window.newspack_popups_data && window.newspack_popups_data.preview_post
+		: '/';
 
 	return (
 		<WebPreview

--- a/src/editor/index.js
+++ b/src/editor/index.js
@@ -84,9 +84,13 @@ class PopupSidebar extends Component {
 		} = this.props;
 		const { isSiteWideDefault } = this.state;
 		const isInline = 'inline' === placement;
+
+		// The sitewide default option is for overlay popups only.
+		const canBeSiteWideDefault = ! isInline && isCurrentPostPublished;
+
 		return (
 			<Fragment>
-				{ isCurrentPostPublished && (
+				{ canBeSiteWideDefault && (
 					<CheckboxControl
 						label={ __( 'Sitewide Default', 'newspack-popups' ) }
 						checked={ isSiteWideDefault }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

A couple of changes to the logic and architecture, which result in the possibility of having multiple inline popups, and at most one overlaid popup:

- In editor, the "Sitewide Default" switch will be disabled if "inline" is chosen as placement.
- Some checks on the backend will prevent an inline popup from being marked as "sitewide default".
- Inline popups are inserted as shortcodes. This prevents an inline popup ending up inside another inline popup.
- All inline popups will be inserted into a post, unless there's category filtering. Any popup with a set category will only appear on a post with matching category.
- A non-inline popup will be displayed only if it's sitewide default, as it were (unless there's category filtering)
-  In admin's popup list view, a post state of "Inline" is added next to inline popups.

Closes #77 

### How to test the changes in this Pull Request:

1. Create a lot of popups - both inline and overlaid. Go wild.
2. Browse the site - all inline popups should be visible on posts.
3. Mark one of overlay (non-inline) popups as "Sitewide default".
4. Browse the site - apart from the inline popups, the overlaid sitewide popup should be displayed.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
