### PR TITLE
fix: correct query reset that can reset the loop

### DIFF
--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -192,14 +192,16 @@ final class Newspack_Popups_Model {
 	 */
 	protected static function retrieve_popup_with_query( WP_Query $query, $include_categories = false ) {
 		$popups = [];
-		while ( $query->have_posts() ) {
-			$query->the_post();
-			$popups[] = self::create_popup_object(
-				get_post( get_the_ID() ),
-				$include_categories
-			);
+		if ( $query->have_posts() ) {
+			while ( $query->have_posts() ) {
+				$query->the_post();
+				$popups[] = self::create_popup_object(
+					get_post( get_the_ID() ),
+					$include_categories
+				);
+			}
+			wp_reset_postdata();
 		}
-		wp_reset_postdata();
 		return $popups;
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fixes a bug that can cause the loop to reset, which manifests in incorrect pub dates in the Newspack Blocks Homepage Posts block. h/t @philipjohn for finding this and @claudiulodro for the fix.

Closes https://github.com/Automattic/newspack-popups/issues/90

### How to test the changes in this Pull Request:

1. With Newspack Popups on `master`, create a few normal Posts and publish them.
2. If there are any Pop-ups, delete them all.
3. Create a Page. Add a Homepage Posts block, with **Excerpt** and **Show Date** enabled. 
4. Set the publish date to several months in the past, then publish the Page.
5. View the published page. The dates shown for posts in the block should be the date of the Page, not the date of the posts.
6. Switch to this branch, observe the correct dates are displayed.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
