### PR TITLE
Add style to subscribe pattern 1

### DIFF
--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -532,7 +532,7 @@ final class Newspack_Popups_Model {
 							type="hidden"
 							value="1"
 						/>
-						<button on="tap:<?php echo esc_attr( $element_id ); ?>.hide" aria-label="<?php esc_attr( $dismiss_text ); ?>"><?php echo esc_attr( $dismiss_text ); ?></button>
+						<button on="tap:<?php echo esc_attr( $element_id ); ?>.hide" aria-label="<?php esc_attr( $dismiss_text ); ?>" style="<?php echo esc_attr( self::container_style( $popup ) ); ?>"><?php echo esc_attr( $dismiss_text ); ?></button>
 					</form>
 				<?php endif; ?>
 			</amp-layout>
@@ -576,7 +576,7 @@ final class Newspack_Popups_Model {
 							type="hidden"
 							value="1"
 						/>
-						<button on="tap:<?php echo esc_attr( $element_id ); ?>.hide" aria-label="<?php esc_attr( $dismiss_text ); ?>"><?php echo esc_attr( $dismiss_text ); ?></button>
+						<button on="tap:<?php echo esc_attr( $element_id ); ?>.hide" aria-label="<?php esc_attr( $dismiss_text ); ?>" style="<?php echo esc_attr( self::container_style( $popup ) ); ?>"><?php echo esc_attr( $dismiss_text ); ?></button>
 					</form>
 					<?php endif; ?>
 					<form class="popup-dismiss-form popup-action-form"
@@ -584,7 +584,7 @@ final class Newspack_Popups_Model {
 						action-xhr="<?php echo esc_url( $endpoint ); ?>"
 						target="_top">
 						<?php echo $hidden_fields; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
-						<button on="tap:<?php echo esc_attr( $element_id ); ?>.hide" class="newspack-lightbox__close" aria-label="<?php esc_html_e( 'Close Pop-up', 'newspack-popups' ); ?>">
+						<button on="tap:<?php echo esc_attr( $element_id ); ?>.hide" class="newspack-lightbox__close" aria-label="<?php esc_html_e( 'Close Pop-up', 'newspack-popups' ); ?>" style="<?php echo esc_attr( self::container_style( $popup ) ); ?>">
 							<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" role="img" aria-hidden="true" focusable="false"><path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12 19 6.41z"/></svg>
 						</button>
 					</form>

--- a/src/view/index.js
+++ b/src/view/index.js
@@ -1,1 +1,2 @@
 import './style.scss';
+import './patterns.scss';

--- a/src/view/patterns.scss
+++ b/src/view/patterns.scss
@@ -12,7 +12,7 @@
 				margin-bottom: 0.75em;
 			}
 
-			& + .popup-not-interested-form {
+			+ .popup-not-interested-form {
 				margin-top: 0.75rem;
 			}
 		}
@@ -20,7 +20,7 @@
 		.newspack-lightbox-placement-center & {
 			margin: -1.5em -1.5em 0;
 
-			& + .popup-not-interested-form {
+			+ .popup-not-interested-form {
 				margin-bottom: -0.75rem;
 			}
 		}

--- a/src/view/patterns.scss
+++ b/src/view/patterns.scss
@@ -1,0 +1,28 @@
+.newspack-pattern {
+	&.subscribe__style-1 {
+		.newspack-inline-popup &,
+		.newspack-lightbox-placement-center & {
+			margin: -0.75em -0.75em 0;
+
+			p:empty {
+				display: none;
+			}
+
+			.wp-block-group__inner-container > * {
+				margin-bottom: 0.75em;
+			}
+
+			& + .popup-not-interested-form {
+				margin-top: 0.75rem;
+			}
+		}
+
+		.newspack-lightbox-placement-center & {
+			margin: -1.5em -1.5em 0;
+
+			& + .popup-not-interested-form {
+				margin-bottom: -0.75rem;
+			}
+		}
+	}
+}

--- a/src/view/style.scss
+++ b/src/view/style.scss
@@ -83,7 +83,7 @@ $color__secondary-variation: darken( $color__secondary, 10% );
 
 	.newspack-lightbox__close {
 		align-items: center;
-		background: transparent;
+		background: white;
 		border: none;
 		border-radius: 0;
 		box-shadow: none;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

If a pop-up has the Subscribe Pattern Style 1 then the pop-up add some extra CSS to it, removing the margin on both sides when centred and inline.

![Screenshot 2020-03-30 at 17 57 18](https://user-images.githubusercontent.com/177929/77940018-ee3c6480-72af-11ea-88c1-4792c878da97.png)

### How to test the changes in this Pull Request:

1. Create a new pop-up and insert the Subscribe Pattern Style 1
2. Preview -- you should have the "borders" around the pattern
3. Switch to this branch.
4. Refresh the preview -- you should see something similar to the screenshot above.
5. Test with inline placement as well.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
