### PR TITLE
fix: popup insertion logic

### DIFF
--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -184,23 +184,21 @@ final class Newspack_Popups_Inserter {
 		$total_length     = strlen( $content );
 		$precise_position = $total_length * $percentage;
 
-		$blocks = [];
-		// Match block closing comment.
-		// hyphens have to be escaped for some PHP versions: https://stackoverflow.com/a/55606868/3772847.
-		$block_close_pattern = '/<!\-\- \/wp:[\w\-\/]* \-\->/';
-		preg_match_all( $block_close_pattern, $content, $blocks, PREG_OFFSET_CAPTURE );
-		$insertion_position = $total_length;
-		foreach ( $blocks[0] as $index => $block ) {
-			$block_offest = $block[1];
-			if ( $block_offest >= $precise_position ) {
-				$insertion_position = $block_offest;
-				break;
+		$blocks      = parse_blocks( $content );
+		$pos         = 0;
+		$output      = '';
+		$is_inserted = false;
+		foreach ( $blocks as $block ) {
+			$block_content = render_block( $block );
+			$pos          += strlen( $block_content );
+			if ( ! $is_inserted && $pos >= $precise_position ) {
+				$output     .= '<!-- wp:shortcode -->' . $popup_markup . '<!-- /wp:shortcode -->';
+				$is_inserted = true;
 			}
+			$output .= $block_content;
 		}
 
-		$before_popup = substr( $content, 0, $insertion_position );
-		$after_popup  = substr( $content, $insertion_position );
-		return $before_popup . $popup_markup . $after_popup;
+		return $output;
 	}
 
 	/**

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -174,16 +174,14 @@ final class Newspack_Popups_Inserter {
 
 		$blocks = [];
 		// Match block closing comment.
-		$block_close_pattern = '/<!-- \/wp:[\w-\/]* -->/';
-		// Minus 2 to account for '/' chars.
-		$pattern_string_length = strlen( $block_close_pattern ) - 2;
+		// hyphens have to be escaped for some PHP versions: https://stackoverflow.com/a/55606868/3772847.
+		$block_close_pattern = '/<!\-\- \/wp:[\w\-\/]* \-\->/';
 		preg_match_all( $block_close_pattern, $content, $blocks, PREG_OFFSET_CAPTURE );
 		$insertion_position = $total_length;
 		foreach ( $blocks[0] as $index => $block ) {
 			$block_offest = $block[1];
-			$offset       = $block_offest + $pattern_string_length;
-			if ( $offset >= $precise_position ) {
-				$insertion_position = $offset;
+			if ( $block_offest >= $precise_position ) {
+				$insertion_position = $block_offest;
 				break;
 			}
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

By matching block end comments instead of paragraph end tags, the popup will always be inserted between blocks, and not inside of a block (which might have paragraphs inside).

Resolves #92

### How to test the changes in this Pull Request:

1. On `master`
1. Add a quote block to a post
2. Add an inline popup and try to set the "Approximate position" so that the popup placed is where the quote is
2. Observe in preview that the inline popup in inserted into the quote block
3. Switch to this branch
4. Observe in preview that the inline popup and quote block are not conjoined

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
