### PR TITLE
Add class to pop-up if display title is enabled

### DIFF
--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -545,11 +545,12 @@ final class Newspack_Popups_Model {
 	public static function generate_inline_popup( $popup ) {
 		global $wp;
 		$element_id    = 'lightbox' . rand(); // phpcs:ignore WordPress.WP.AlternativeFunctions.rand_rand
-		$classes       = [ 'newspack-inline-popup' ];
 		$endpoint      = self::get_dismiss_endpoint();
 		$display_title = $popup['options']['display_title'];
 		$hidden_fields = self::get_hidden_fields( $popup );
 		$dismiss_text  = self::get_dismiss_text( $popup );
+		$classes       = [ 'newspack-inline-popup' ];
+		$classes[]     = ( ! empty( $popup['title'] ) && $display_title ) ? 'newspack-lightbox-has-title' : null;
 		ob_start();
 		?>
 			<?php self::insert_event_tracking( $popup, $element_id ); ?>
@@ -586,12 +587,13 @@ final class Newspack_Popups_Model {
 	public static function generate_popup( $popup ) {
 		$element_id      = 'lightbox' . rand(); // phpcs:ignore WordPress.WP.AlternativeFunctions.rand_rand
 		$endpoint        = self::get_dismiss_endpoint();
-		$classes         = [ 'newspack-lightbox', 'newspack-lightbox-placement-' . $popup['options']['placement'] ];
 		$dismiss_text    = self::get_dismiss_text( $popup );
 		$display_title   = $popup['options']['display_title'];
 		$overlay_opacity = absint( $popup['options']['overlay_opacity'] ) / 100;
 		$overlay_color   = $popup['options']['overlay_color'];
 		$hidden_fields   = self::get_hidden_fields( $popup );
+		$classes         = [ 'newspack-lightbox', 'newspack-lightbox-placement-' . $popup['options']['placement'] ];
+		$classes[]       = ( ! empty( $popup['title'] ) && $display_title ) ? 'newspack-lightbox-has-title' : null;
 
 		ob_start();
 		?>

--- a/src/view/patterns.scss
+++ b/src/view/patterns.scss
@@ -24,5 +24,10 @@
 				margin-bottom: -0.75rem;
 			}
 		}
+
+		.newspack-lightbox-has-title.newspack-inline-popup &,
+		.newspack-lightbox-has-title.newspack-lightbox-placement-center & {
+			margin-top: 0;
+		}
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This allows patterns to style pop-ups differently whether they display the title or not.

This PR also fixes issue when pop-up is using the subscribe pattern 1 and displays the title.

### How to test the changes in this Pull Request:

1. Create a new pop-up, inline or centred.
2. Add subscribe pattern 1
3. Display the pop-up title
4. Preview (the title should be right above the subscribe box with no margin)
5. Preview inline && centred.
6. Switch to this branch.
7. Preview again (you should see a margin between the subscribe box and the title)
8. Check the source and look for `.newspack-lightbox-has-title`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
