### PR TITLE
[wip] Add popup analytics to Site Kit analytics config.

### DIFF
--- a/includes/class-newspack-popups-analytics.php
+++ b/includes/class-newspack-popups-analytics.php
@@ -13,28 +13,12 @@ defined( 'ABSPATH' ) || exit;
 final class Newspack_Popups_Analytics {
 
 	/**
-	 * Popups to add analytics for.
-	 *
-	 * @var array $popups An array of format 'element ID => popup object'.
-	 */
-	protected static $popups = [];
-
-	/**
 	 * Constructor.
 	 */
 	public function __construct() {
 		add_filter( 'googlesitekit_amp_gtag_opt', [ $this, 'insert_analytics' ] );
-		add_filter( 'googlesitekit_gtag_opt', [ $this, 'insert_analytics' ] ); // @todo should this be here?
+		add_filter( 'googlesitekit_gtag_opt', [ $this, 'insert_analytics' ] );
 		add_action( 'wp_footer', [ $this, 'print_extra_analytics' ] );
-	}
-
-	/**
-	 * Add GA event tracking to a popup.
-	 *
-	 * @param object $popup A popup object.
-	 */
-	public static function add_event_tracking( $popup ) {
-		self::$popups[ $popup['id'] ] = $popup;
 	}
 
 	/**
@@ -53,7 +37,7 @@ final class Newspack_Popups_Analytics {
 		$custom_form_submit_event = ( function_exists( 'is_amp_endpoint' ) && is_amp_endpoint() ) ? 'amp-form-submit-success' : 'amp-form-submit';
 		$event_category           = __( 'Newspack Announcement', 'newspack-popups' );
 
-		foreach ( self::$popups as $popup ) {
+		foreach ( Newspack_Popups_Inserter::popups_for_post() as $popup ) {
 			$element_id = 'lightbox-popup-' . $popup['id'];
 			/* translators: %$1s: popup title %2$d popup ID */
 			$event_label             = sprintf( __( 'Newspack Announcement: %1$s (%2$d)', 'newspack-popups' ), $popup['title'], $popup['id'] );
@@ -160,7 +144,7 @@ final class Newspack_Popups_Analytics {
 			return;
 		}
 
-		foreach ( self::$popups as $popup ) {
+		foreach ( Newspack_Popups_Inserter::popups_for_post() as $popup ) {
 			if ( Newspack_Popups_Model::get_mailchimp_form_selector( $popup ) ) {
 				self::print_extra_mailchimp_analytics( $popup );
 			}

--- a/includes/class-newspack-popups-analytics.php
+++ b/includes/class-newspack-popups-analytics.php
@@ -1,0 +1,263 @@
+<?php
+/**
+ * Newspack Popups Analytics
+ *
+ * @package Newspack
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Analytics for popups.
+ */
+final class Newspack_Popups_Analytics {
+
+	/**
+	 * Popups to add analytics for.
+	 *
+	 * @var array $popups An array of format 'element ID => popup object'.
+	 */
+	protected static $popups = [];
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		add_filter( 'googlesitekit_amp_gtag_opt', [ $this, 'insert_analytics' ] );
+		add_filter( 'googlesitekit_gtag_opt', [ $this, 'insert_analytics' ] ); // @todo should this be here?
+		add_action( 'wp_footer', [ $this, 'print_extra_analytics' ] );
+	}
+
+	/**
+	 * Add GA event tracking to a popup.
+	 *
+	 * @param object $popup A popup object.
+	 */
+	public static function add_event_tracking( $popup ) {
+		self::$popups[ $popup['id'] ] = $popup;
+	}
+
+	/**
+	 * Add analytics for all popups registered with this class.
+	 *
+	 * @param array $analytics GA config.
+	 * @return array Modified $analytics.
+	 */
+	public static function insert_analytics( $analytics ) {
+		if ( Newspack_Popups::previewed_popup_id() ) {
+			return $analytics;
+		}
+
+		// For non-AMP forms, the *-success handler is not fired (maybe because of missing action-xhr attribute?).
+		// This might result in some false-positives, though (event fired when form not submitted successfully).
+		$custom_form_submit_event = ( function_exists( 'is_amp_endpoint' ) && is_amp_endpoint() ) ? 'amp-form-submit-success' : 'amp-form-submit';
+		$event_category           = __( 'Newspack Announcement', 'newspack-popups' );
+
+		foreach ( self::$popups as $popup ) {
+			$element_id = 'lightbox-popup-' . $popup['id'];
+			/* translators: %$1s: popup title %2$d popup ID */
+			$event_label             = sprintf( __( 'Newspack Announcement: %1$s (%2$d)', 'newspack-popups' ), $popup['title'], $popup['id'] );
+			$has_link                = preg_match( '/<a\s/', $popup['body'] ) !== 0;
+			$has_form                = preg_match( '/<form\s/', $popup['body'] ) !== 0;
+			$has_dismiss_form        = 'inline' !== $popup['options']['placement'];
+			$has_not_interested_form = Newspack_Popups_Model::get_dismiss_text( $popup );
+			$is_inline               = Newspack_Popups_Model::is_inline( $popup );
+
+			if ( ! isset( $analytics['triggers'] ) ) {
+				$analytics['triggers'] = [];
+			}
+
+			$analytics['triggers'][ 'popupVisible' . ( $is_inline ? 'Inline' : 'Modal' ) ] = [
+				'on'             => 'visible',
+				'request'        => 'event',
+				'selector'       => esc_attr( '#' . $element_id ),
+				'visibilitySpec' => [
+					'totalTimeMin' => 500,
+				],
+				'vars'           => [
+					'event_name'     => esc_html__( 'Seen', 'newspack-popups' ),
+					'event_label'    => esc_html( $event_label ),
+					'event_category' => esc_html( $event_category ),
+				],
+			];
+
+			$analytics['triggers'][ 'popupPageLoaded' . ( $is_inline ? 'Inline' : 'Modal' ) ] = [
+				'on'       => 'ini-load',
+				'selector' => esc_attr( '#' . $element_id ),
+				'request'  => 'event',
+				'vars'     => [
+					'event_name'     => esc_html__( 'Load', 'newspack-popups' ),
+					'event_label'    => esc_html( $event_label ),
+					'event_category' => esc_html( $event_category ),
+				],
+			];
+
+			if ( $has_link ) {
+				$trigger_id                           = 'popupAnchorClicks' . ( $is_inline ? 'Inline' : 'Modal' );
+				$analytics['triggers'][ $trigger_id ] = [
+					'selector' => esc_attr( '#' . $element_id ),
+					'on'       => 'click',
+					'request'  => 'event',
+					'vars'     => [
+						'event_name'     => esc_html__( 'Link Click', 'newspack-popups' ),
+						'event_label'    => esc_html( $event_label ),
+						'event_category' => esc_html( $event_category ),
+					],
+				];
+			}
+
+			if ( $has_form ) {
+				$trigger_id                           = 'popupFormSubmitSuccess' . ( $is_inline ? 'Inline' : 'Modal' );
+				$analytics['triggers'][ $trigger_id ] = [
+					'on'       => $custom_form_submit_event,
+					'request'  => 'event',
+					'selector' => esc_attr( '#' . $element_id . ' form:not(.popup-action-form)' ),
+					'vars'     => [
+						'event_name'     => esc_html__( 'Form Submission', 'newspack-popups' ),
+						'event_label'    => esc_html( $event_label ),
+						'event_category' => esc_html( $event_category ),
+					],
+				];
+			}
+
+			if ( $has_dismiss_form ) {
+				$trigger_id                           = 'popupDismissed' . ( $is_inline ? 'Inline' : 'Modal' );
+				$analytics['triggers'][ $trigger_id ] = [
+					'on'        => 'amp-form-submit-success', // @todo Should this use $custom_form_submit_event?
+					'request'   => 'event',
+					'selectors' => esc_attr( '#' . $element_id . ' form.popup-dismiss-form' ),
+					'vars'      => [
+						'event_name'     => esc_html__( 'Dismissal', 'newspack-popups' ),
+						'event_label'    => esc_html( $event_label ),
+						'event_category' => esc_html( $event_category ),
+					],
+				];
+			}
+
+			if ( $has_not_interested_form ) {
+				$trigger_id                           = 'popupNotInterested' . ( $is_inline ? 'Inline' : 'Modal' );
+				$analytics['triggers'][ $trigger_id ] = [
+					'on'       => 'amp-form-submit-success',
+					'request'  => 'event',
+					'selector' => esc_attr( '#' . $element_id . ' form.popup-not-interested-form' ),
+					'vars'     => [
+						'event_name'     => esc_html__( 'Permanent Dismissal', 'newspack-popups' ),
+						'event_label'    => esc_html( $event_label ),
+						'event_category' => esc_html( $event_category ),
+					],
+				];
+			}
+		}
+
+		return $analytics;
+	}
+
+	/**
+	 * Add extra stand-alone analytics listeners.
+	 */
+	public static function print_extra_analytics() {
+		if ( Newspack_Popups::previewed_popup_id() ) {
+			return;
+		}
+
+		foreach ( self::$popups as $popup ) {
+			if ( Newspack_Popups_Model::get_mailchimp_form_selector( $popup ) ) {
+				self::print_extra_mailchimp_analytics( $popup );
+			}
+
+			if ( Newspack_Popups_Model::is_inline( $popup ) ) {
+				self::print_extra_inline_analytics( $popup );
+			}
+		}
+	}
+
+	/**
+	 * Print extra analytics for popups containing MailChimp forms.
+	 *
+	 * @param object $popup Popup object.
+	 */
+	protected static function print_extra_mailchimp_analytics( $popup ) {
+		global $wp;
+
+		$element_id = 'lightbox-popup-' . $popup['id'];
+
+		// For non-AMP forms, the *-success handler is not fired (maybe because of missing action-xhr attribute?).
+		// This might result in some false-positives, though (event fired when form not submitted successfully).
+		$custom_form_submit_event = ( function_exists( 'is_amp_endpoint' ) && is_amp_endpoint() ) ? 'amp-form-submit-success' : 'amp-form-submit';
+		?>
+		<amp-analytics>
+			<script type="application/json">
+				{
+					"requests": {
+						"event": "<?php echo esc_url( Newspack_Popups_Model::get_dismiss_endpoint() ); ?>"
+					},
+					"triggers": {
+						"formSubmitSuccess": {
+							"on": "<?php echo esc_attr( $custom_form_submit_event ); ?>",
+							"request": "event",
+							"selector": "<?php echo esc_attr( '#' . $element_id . ' ' . Newspack_Popups_Model::get_mailchimp_form_selector( $popup ) ); ?>",
+							"extraUrlParams": {
+								"popup_id": "<?php echo esc_attr( $popup['id'] ); ?>",
+								"url": "<?php echo esc_url( home_url( $wp->request ) ); ?>",
+								"mailing_list_status": "subscribed"
+							}
+						}
+					},
+					"transport": {
+						"beacon": true,
+						"xhrpost": true,
+						"useBody": true,
+						"image": false
+					}
+				}
+			</script>
+		</amp-analytics>
+		<?php
+	}
+
+	/**
+	 * Print extra analytics for inline popups.
+	 *
+	 * @param object $popup Popup object.
+	 */
+	protected static function print_extra_inline_analytics( $popup ) {
+		global $wp;
+
+		$element_id = 'lightbox-popup-' . $popup['id'];
+
+		?>
+		<amp-analytics>
+			<script type="application/json">
+				{
+					"requests": {
+						"event": "<?php echo esc_url( Newspack_Popups_Model::get_dismiss_endpoint() ); ?>"
+					},
+					"triggers": {
+						"trackPageview": {
+							"on": "visible",
+							"request": "event",
+							"visibilitySpec": {
+								"selector": "<?php echo esc_attr( '#' . $element_id ); ?>",
+								"visiblePercentageMin": 90,
+								"totalTimeMin": 500,
+								"continuousTimeMin": 200
+							},
+							"extraUrlParams": {
+								"popup_id": "<?php echo ( esc_attr( $popup['id'] ) ); ?>",
+								"url": "<?php echo esc_url( home_url( $wp->request ) ); ?>"
+							}
+						}
+					},
+					"transport": {
+						"beacon": true,
+						"xhrpost": true,
+						"useBody": true,
+						"image": false
+					}
+				}
+			</script>
+		</amp-analytics>	
+		<?php
+	}
+}
+$newspack_popups_api = new Newspack_Popups_Analytics();

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -372,7 +372,6 @@ final class Newspack_Popups_Model {
 		$dismiss_text  = self::get_dismiss_text( $popup );
 		$classes       = [ 'newspack-inline-popup' ];
 		$classes[]     = ( ! empty( $popup['title'] ) && $display_title ) ? 'newspack-lightbox-has-title' : null;
-		Newspack_Popups_Analytics::add_event_tracking( $popup );
 		ob_start();
 		?>
 			<amp-layout amp-access="popup_<?php echo esc_attr( $popup['id'] ); ?>.displayPopup" amp-access-hide class="<?php echo esc_attr( implode( ' ', $classes ) ); ?>" role="button" tabindex="0" style="<?php echo esc_attr( self::container_style( $popup ) ); ?>" id="<?php echo esc_attr( $element_id ); ?>">
@@ -502,7 +501,6 @@ final class Newspack_Popups_Model {
 			</script>
 		</amp-animation>
 		<?php
-		Newspack_Popups_Analytics::add_event_tracking( $popup );
 		return ob_get_clean();
 	}
 

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -52,6 +52,7 @@ final class Newspack_Popups {
 		include_once dirname( __FILE__ ) . '/class-newspack-popups-model.php';
 		include_once dirname( __FILE__ ) . '/class-newspack-popups-inserter.php';
 		include_once dirname( __FILE__ ) . '/class-newspack-popups-api.php';
+		include_once dirname( __FILE__ ) . '/class-newspack-popups-analytics.php';
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #102.

This PR solves the problem with multiple counting of pageviews by adding the popup analytics to the GA config that Site Kit outputs. It does this by using the [filters available for those sorts of purposes](https://github.com/google/site-kit-wp/blob/ff2efcc4e4f4ee00317c1f10f43eb6575db9cb52/includes/Modules/Analytics.php#L398-L406). 

A couple other notable changes in this PR:
- Instead of having the trigger be named e.g. `popupVisible`, it will be named `popupVisibleInline` or `popupVisibleModal`. Previously there would have been two triggers named `popupVisible` (one for modal and one for inline popups), so the second one would probably override the first. GA is sort-of a black box so it's hard to tell, but I think this change is good either way.
- I've changed the popup element IDs from e.g. `lightbox123662133` to the more predictable `'lightbox-popup-' . $popup['id']`. This will let us do things with the popup more easily because the randomly-generated ID doesn't need to be passed around. The new version should still prevent element ID collisions nicely.

### How to test the changes in this Pull Request:

1. Connect Site Kit and Analytics.
2. Create an inline and modal popup. Possibly add a MailChimp signup form to either/both.
3. Inspect the source code of a page. You should see the analytics events in the **one** `<amp-analytics type="gtag" .../>` element that should exist.
3. Interact with the popups. In GA's real-time view, verify analytics events are working correctly and only one page view is counted per page viewed:
<img width="1405" alt="Screen Shot 2020-04-10 at 12 29 17 PM" src="https://user-images.githubusercontent.com/7317227/79018303-56990a80-7b28-11ea-8659-438626fcf7cb.png">

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
