### PR TITLE
Suppress pageview logging in popups analytics.

### DIFF
--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -393,7 +393,7 @@ final class Newspack_Popups_Model {
 					"vars" : {
 						"gtag_id": "<?php echo esc_attr( $google_analytics_id ); ?>",
 						"config" : {
-							"<?php echo esc_attr( $google_analytics_id ); ?>": { "groups": "default" }
+							"<?php echo esc_attr( $google_analytics_id ); ?>": { "groups": "default", "send_page_view": false }
 						}
 					},
 					"triggers": {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #102.

I think the work going on in #103 is probably a good idea if we can make it work nicely on AMP and non-AMP modes, but I've stumbled across an easy solution directly for #102 . [There is a config param mentioned that suppresses the initial pageview logged in GA](https://developers.google.com/analytics/devguides/collection/gtagjs#disable_pageview_measurment). I did some testing, and was able to make it work in `amp-analytics`! 

This PR patches the immediate issue of the multiple pageviews.

### How to test the changes in this Pull Request:

1. Connect Site Kit. Create an inline and a modal popup.
2. Visit a post that has both popups. Observe 3 pageviews in Google Analytics real time view from the one page visit.
3. Apply patch. Visit a post that has both popups. Observe 1 pageview in Google Analytics real time view.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
