### PR TITLE
Enable disabling popups for specific posts and pages

### DIFF
--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -84,6 +84,13 @@ final class Newspack_Popups_Inserter {
 		add_action( 'after_header', [ $this, 'insert_popups_after_header' ] ); // This is a Newspack theme hook. When used with other themes, popups won't be inserted on archive pages.
 		add_action( 'wp_head', [ $this, 'insert_popups_amp_access' ] );
 		add_action( 'wp_head', [ $this, 'register_amp_scripts' ] );
+
+		add_filter(
+			'newspack_newsletters_assess_has_disabled_popups',
+			function () {
+				return get_post_meta( get_the_ID(), 'newspack_popups_has_disabled_popups', true );
+			}
+		);
 	}
 
 	/**
@@ -274,7 +281,7 @@ final class Newspack_Popups_Inserter {
 	 * @return bool True if popups should be disabled for current page.
 	 */
 	public static function assess_has_disabled_popups() {
-		return get_post_meta( get_the_ID(), 'newspack_popups_has_disabled_popups', true );
+		return apply_filters( 'newspack_newsletters_assess_has_disabled_popups', [] );
 	}
 
 	/**

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -92,7 +92,7 @@ final class Newspack_Popups_Inserter {
 	 * @param string $content The content of the post.
 	 */
 	public static function insert_popups_in_content( $content = '' ) {
-		if ( self::assess_amp_form_issue( $content ) ) {
+		if ( self::assess_has_disabled_popups( $content ) ) {
 			return $content;
 		}
 
@@ -273,32 +273,19 @@ final class Newspack_Popups_Inserter {
 	}
 
 	/**
-	 * Disable popups on non-AMP pages with a form with POST method.
-	 * More context: https://github.com/ampproject/amphtml/issues/27638.
+	 * Disable popups on posts and pages which have newspack_popups_has_disabled_popups.
 	 *
-	 * @param string $content The content of the post.
 	 * @return bool True if popups should be disabled for current page.
 	 */
-	public static function assess_amp_form_issue( $content = false ) {
-		if ( is_admin() || ! is_singular() ) {
-			return false;
-		}
-		if ( ! $content ) {
-			$content = get_the_content();
-		}
-		$is_amp = function_exists( 'is_amp_endpoint' ) && is_amp_endpoint();
-
-		if ( ! $is_amp ) {
-			return preg_match( "/<form.*method=[\"']post[\"']/", $content );
-		}
-		return false;
+	public static function assess_has_disabled_popups() {
+		return get_post_meta( get_the_ID(), 'newspack_popups_has_disabled_popups', true );
 	}
 
 	/**
 	 * Register and enqueue all required AMP scripts, if needed.
 	 */
 	public static function register_amp_scripts() {
-		if ( self::assess_amp_form_issue() ) {
+		if ( self::assess_has_disabled_popups() ) {
 			return;
 		}
 		if ( ! is_admin() && ! wp_script_is( 'amp-runtime', 'registered' ) ) {

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -92,11 +92,7 @@ final class Newspack_Popups_Inserter {
 	 * @param string $content The content of the post.
 	 */
 	public static function insert_popups_in_content( $content = '' ) {
-		if ( self::assess_has_disabled_popups( $content ) ) {
-			return $content;
-		}
-
-		if ( is_admin() || ! is_singular() ) {
+		if ( is_admin() || ! is_singular() || self::assess_has_disabled_popups( $content ) ) {
 			return $content;
 		}
 
@@ -231,7 +227,7 @@ final class Newspack_Popups_Inserter {
 	 * @param object $popups The popup objects to handle.
 	 */
 	public static function insert_popups_amp_access( $popups ) {
-		if ( is_admin() ) {
+		if ( is_admin() || self::assess_has_disabled_popups() ) {
 			return;
 		}
 

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -241,14 +241,16 @@ final class Newspack_Popups {
 		$screen = get_current_screen();
 
 		if ( self::NEWSPACK_PLUGINS_CPT !== $screen->post_type ) {
-			// Script for global settings.
-			\wp_enqueue_script(
-				'newspack-popups',
-				plugins_url( '../dist/documentSettings.js', __FILE__ ),
-				[],
-				filemtime( dirname( NEWSPACK_POPUPS_PLUGIN_FILE ) . '/dist/documentSettings.js' ),
-				true
-			);
+			if ( 'page' !== $screen->post_type || 'post' !== $screen->post_type ) {
+				// Script for global settings.
+				\wp_enqueue_script(
+					'newspack-popups',
+					plugins_url( '../dist/documentSettings.js', __FILE__ ),
+					[],
+					filemtime( dirname( NEWSPACK_POPUPS_PLUGIN_FILE ) . '/dist/documentSettings.js' ),
+					true
+				);
+			}
 
 			return;
 		}

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -221,6 +221,17 @@ final class Newspack_Popups {
 			]
 		);
 
+		// Meta field for all post types.
+		\register_meta(
+			'post',
+			'newspack_popups_has_disabled_popups',
+			[
+				'show_in_rest'  => true,
+				'type'          => 'boolean',
+				'single'        => true,
+				'auth_callback' => '__return_true',
+			]
+		);
 	}
 
 	/**
@@ -228,7 +239,17 @@ final class Newspack_Popups {
 	 */
 	public static function enqueue_block_editor_assets() {
 		$screen = get_current_screen();
+
 		if ( self::NEWSPACK_PLUGINS_CPT !== $screen->post_type ) {
+			// Script for global settings.
+			\wp_enqueue_script(
+				'newspack-popups',
+				plugins_url( '../dist/documentSettings.js', __FILE__ ),
+				[],
+				filemtime( dirname( NEWSPACK_POPUPS_PLUGIN_FILE ) . '/dist/documentSettings.js' ),
+				true
+			);
+
 			return;
 		}
 

--- a/src/document-settings/index.js
+++ b/src/document-settings/index.js
@@ -4,24 +4,24 @@
 import { __ } from '@wordpress/i18n';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
-import { PluginPostStatusInfo } from '@wordpress/edit-post';
+import { PluginDocumentSettingPanel } from '@wordpress/edit-post';
 import { registerPlugin } from '@wordpress/plugins';
-import { FormToggle } from '@wordpress/components';
+import { ToggleControl } from '@wordpress/components';
 
-const PostStatusElement = ( { hasDisabledPopups, onChange } ) => {
-	return (
-		<PluginPostStatusInfo>
-			<label htmlFor="popups-disabled">{ __( 'Disable Popups', 'newspack-popups' ) }</label>
-			<FormToggle
-				checked={ hasDisabledPopups }
-				onChange={ () => onChange( ! hasDisabledPopups ) }
-				id="popups-disabled"
-			/>
-		</PluginPostStatusInfo>
-	);
-};
+const PopupsSettingsPanel = ( { hasDisabledPopups, onChange } ) => (
+	<PluginDocumentSettingPanel
+		name="newsletters-popups-settings-panel"
+		title={ __( 'Newspack Popups Settings', 'newspack-newsletters' ) }
+	>
+		<ToggleControl
+			checked={ hasDisabledPopups }
+			onChange={ () => onChange( ! hasDisabledPopups ) }
+			label={ __( 'Disable Popups on this post or page', 'newspack-popups' ) }
+		/>
+	</PluginDocumentSettingPanel>
+);
 
-const PostStatusElementWithSelect = compose( [
+const PopupsSettingsPanelWithSelect = compose( [
 	withSelect( select => {
 		const { getEditedPostAttribute } = select( 'core/editor' );
 		const meta = getEditedPostAttribute( 'meta' );
@@ -35,8 +35,9 @@ const PostStatusElementWithSelect = compose( [
 			},
 		};
 	} ),
-] )( PostStatusElement );
+] )( PopupsSettingsPanel );
 
 registerPlugin( 'newspack-popups-post-status-info', {
-	render: PostStatusElementWithSelect,
+	render: PopupsSettingsPanelWithSelect,
+	icon: false,
 } );

--- a/src/document-settings/index.js
+++ b/src/document-settings/index.js
@@ -1,0 +1,42 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { withSelect, withDispatch } from '@wordpress/data';
+import { compose } from '@wordpress/compose';
+import { PluginPostStatusInfo } from '@wordpress/edit-post';
+import { registerPlugin } from '@wordpress/plugins';
+import { FormToggle } from '@wordpress/components';
+
+const PostStatusElement = ( { hasDisabledPopups, onChange } ) => {
+	return (
+		<PluginPostStatusInfo>
+			<label htmlFor="popups-disabled">{ __( 'Disable Popups', 'newspack-popups' ) }</label>
+			<FormToggle
+				checked={ hasDisabledPopups }
+				onChange={ () => onChange( ! hasDisabledPopups ) }
+				id="popups-disabled"
+			/>
+		</PluginPostStatusInfo>
+	);
+};
+
+const PostStatusElementWithSelect = compose( [
+	withSelect( select => {
+		const { getEditedPostAttribute } = select( 'core/editor' );
+		const meta = getEditedPostAttribute( 'meta' );
+		return { hasDisabledPopups: meta.newspack_popups_has_disabled_popups };
+	} ),
+	withDispatch( dispatch => {
+		const { editPost } = dispatch( 'core/editor' );
+		return {
+			onChange: hasDisabledPopups => {
+				editPost( { meta: { newspack_popups_has_disabled_popups: hasDisabledPopups } } );
+			},
+		};
+	} ),
+] )( PostStatusElement );
+
+registerPlugin( 'newspack-popups-post-status-info', {
+	render: PostStatusElementWithSelect,
+} );

--- a/src/document-settings/index.js
+++ b/src/document-settings/index.js
@@ -11,12 +11,12 @@ import { ToggleControl } from '@wordpress/components';
 const PopupsSettingsPanel = ( { hasDisabledPopups, onChange } ) => (
 	<PluginDocumentSettingPanel
 		name="newsletters-popups-settings-panel"
-		title={ __( 'Newspack Popups Settings', 'newspack-newsletters' ) }
+		title={ __( 'Newspack Popups Settings', 'newspack-popups' ) }
 	>
 		<ToggleControl
 			checked={ hasDisabledPopups }
 			onChange={ () => onChange( ! hasDisabledPopups ) }
-			label={ __( 'Disable Popups on this post or page', 'newspack-popups' ) }
+			label={ __( 'Disable Pop-ups on this post or page', 'newspack-popups' ) }
 		/>
 	</PluginDocumentSettingPanel>
 );

--- a/src/document-settings/index.js
+++ b/src/document-settings/index.js
@@ -25,7 +25,7 @@ const PopupsSettingsPanelWithSelect = compose( [
 	withSelect( select => {
 		const { getEditedPostAttribute } = select( 'core/editor' );
 		const meta = getEditedPostAttribute( 'meta' );
-		return { hasDisabledPopups: meta.newspack_popups_has_disabled_popups };
+		return { hasDisabledPopups: meta && meta.newspack_popups_has_disabled_popups };
 	} ),
 	withDispatch( dispatch => {
 		const { editPost } = dispatch( 'core/editor' );

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,27 +6,23 @@
 /**
  * External dependencies
  */
-const fs = require( 'fs' );
 const getBaseWebpackConfig = require( '@automattic/calypso-build/webpack.config.js' );
 const path = require( 'path' );
-
-/**
- * Internal dependencies
- */
-// const { workerCount } = require( './webpack.common' ); // todo: shard...
 
 /**
  * Internal variables
  */
 const editor = path.join( __dirname, 'src', 'editor' );
 const view = path.join( __dirname, 'src', 'view' );
+const documentSettings = path.join( __dirname, 'src', 'document-settings' );
 
 const webpackConfig = getBaseWebpackConfig(
 	{ WP: true },
 	{
 		entry: {
-			editor: editor,
-			view: view,
+			editor,
+			view,
+			documentSettings,
 		},
 		'output-path': path.join( __dirname, 'dist' ),
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Instead of handling the form-with-post-on-AMP issue specifically, add option to disable popups for specific posts and pages.

### How to test the changes in this Pull Request:

1. Add a sitewide default popup
2. Visit a page or a post, observe popup displayed
3. Edit that page or post – check "Disable Popups" in Document panel i sidebar, save
2. Visit a page or a post, observe popup not show

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
