### PR TITLE
Prevent infinite loop with inline popups and paywalled content

### DIFF
--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -103,6 +103,12 @@ final class Newspack_Popups_Inserter {
 			return $content;
 		}
 
+		// Don't inject inline popups on paywalled posts.
+		// It doesn't make sense with a paywall message and also causes an infinite loop.
+		if ( function_exists( 'wc_memberships_is_post_content_restricted' ) && wc_memberships_is_post_content_restricted() ) {
+			return $content;
+		}
+
 		$popups = self::popups_for_post();
 
 		if ( empty( $popups ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR fixes an issue discovered when Asia Times was trying to set up a paywall. When a user gets the "content restricted" message, an infinite loop happens between the code that inserts popups into content and the code that blocks the content with a "Content restricted" message. This PR solves the issue by preventing popups in the content on posts that are restricted. It doesn't really make sense to inject a popup in that scenario anyways.

### How to test the changes in this Pull Request:

1. Set up WooCommerce, WooCommerce Subscriptions, WooCommerce Memberships. Restrict a category to only members.
2. Set up an inline popup.
3. In an incognito window, visit a restricted page. Observe fatal error:
<img width="350" alt="Screen Shot 2020-04-28 at 12 04 13 PM" src="https://user-images.githubusercontent.com/7317227/80527667-9560fa00-8949-11ea-8a76-01683fc476fb.png">
4. Apply patch. In an incognito window, visit a restricted page. Observe you get a "Restricted content" message:
<img width="1347" alt="Screen Shot 2020-04-28 at 12 03 53 PM" src="https://user-images.githubusercontent.com/7317227/80527679-9b56db00-8949-11ea-8313-64d4c97c215d.png">

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

cc @philipjohn just as a heads-up for what the issue ended up being.