### PR TITLE
refactor: rename pop-ups->campaigns

### DIFF
--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -47,7 +47,7 @@ final class Newspack_Popups_Model {
 		if ( ! $popup ) {
 			return new \WP_Error(
 				'newspack_popups_popup_doesnt_exist',
-				esc_html__( 'The Popup specified does not exist.', 'newspack-popups' ),
+				esc_html__( 'The Campaign specified does not exist.', 'newspack-popups' ),
 				[
 					'status' => 400,
 					'level'  => 'fatal',
@@ -59,7 +59,7 @@ final class Newspack_Popups_Model {
 		if ( 'inline' === $popup['options']['placement'] ) {
 			return new \WP_Error(
 				'newspack_popups_inline_sitewide',
-				esc_html__( 'An inline popup cannot be a sitewide default.', 'newspack-popups' ),
+				esc_html__( 'An inline Campaign cannot be a sitewide default.', 'newspack-popups' ),
 				[
 					'status' => 400,
 					'level'  => 'fatal',
@@ -79,7 +79,7 @@ final class Newspack_Popups_Model {
 		if ( ! $popup ) {
 			return new \WP_Error(
 				'newspack_popups_popup_doesnt_exist',
-				esc_html__( 'The Popup specified does not exist.', 'newspack-popups' ),
+				esc_html__( 'The Campaign specified does not exist.', 'newspack-popups' ),
 				[
 					'status' => 400,
 					'level'  => 'fatal',
@@ -102,7 +102,7 @@ final class Newspack_Popups_Model {
 		if ( ! $popup ) {
 			return new \WP_Error(
 				'newspack_popups_popup_doesnt_exist',
-				esc_html__( 'The Popup specified does not exist.', 'newspack-popups' ),
+				esc_html__( 'The Campaign specified does not exist.', 'newspack-popups' ),
 				[
 					'status' => 400,
 					'level'  => 'fatal',
@@ -129,7 +129,7 @@ final class Newspack_Popups_Model {
 		if ( ! $popup ) {
 			return new \WP_Error(
 				'newspack_popups_popup_doesnt_exist',
-				esc_html__( 'The Popup specified does not exist.', 'newspack-popups' ),
+				esc_html__( 'The Campaign specified does not exist.', 'newspack-popups' ),
 				[
 					'status' => 400,
 					'level'  => 'fatal',
@@ -167,7 +167,7 @@ final class Newspack_Popups_Model {
 				default:
 					return new \WP_Error(
 						'newspack_popups_invalid_option',
-						esc_html__( 'Invalid Pop-ups option.', 'newspack-popups' ),
+						esc_html__( 'Invalid Campaign option.', 'newspack-popups' ),
 						[
 							'status' => 400,
 							'level'  => 'fatal',

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -62,20 +62,20 @@ final class Newspack_Popups {
 	 */
 	public static function register_cpt() {
 		$labels = [
-			'name'               => _x( 'Pop-ups', 'post type general name', 'newspack-popups' ),
-			'singular_name'      => _x( 'Pop-up', 'post type singular name', 'newspack-popups' ),
-			'menu_name'          => _x( 'Pop-ups', 'admin menu', 'newspack-popups' ),
-			'name_admin_bar'     => _x( 'Pop-up', 'add new on admin bar', 'newspack-popups' ),
+			'name'               => _x( 'Campaigns', 'post type general name', 'newspack-popups' ),
+			'singular_name'      => _x( 'Campaign', 'post type singular name', 'newspack-popups' ),
+			'menu_name'          => _x( 'Campaigns', 'admin menu', 'newspack-popups' ),
+			'name_admin_bar'     => _x( 'Campaign', 'add new on admin bar', 'newspack-popups' ),
 			'add_new'            => _x( 'Add New', 'popup', 'newspack-popups' ),
-			'add_new_item'       => __( 'Add New Pop-up', 'newspack-popups' ),
-			'new_item'           => __( 'New Pop-up', 'newspack-popups' ),
-			'edit_item'          => __( 'Edit Pop-up', 'newspack-popups' ),
-			'view_item'          => __( 'View Pop-up', 'newspack-popups' ),
-			'all_items'          => __( 'All Pop-ups', 'newspack-popups' ),
-			'search_items'       => __( 'Search Pop-ups', 'newspack-popups' ),
-			'parent_item_colon'  => __( 'Parent Pop-ups:', 'newspack-popups' ),
-			'not_found'          => __( 'No pop-ups found.', 'newspack-popups' ),
-			'not_found_in_trash' => __( 'No pop-ups found in Trash.', 'newspack-popups' ),
+			'add_new_item'       => __( 'Add New Campaign', 'newspack-popups' ),
+			'new_item'           => __( 'New Campaign', 'newspack-popups' ),
+			'edit_item'          => __( 'Edit Campaign', 'newspack-popups' ),
+			'view_item'          => __( 'View Campaign', 'newspack-popups' ),
+			'all_items'          => __( 'All Campaigns', 'newspack-popups' ),
+			'search_items'       => __( 'Search Campaigns', 'newspack-popups' ),
+			'parent_item_colon'  => __( 'Parent Campaigns:', 'newspack-popups' ),
+			'not_found'          => __( 'No Campaigns found.', 'newspack-popups' ),
+			'not_found_in_trash' => __( 'No Campaigns found in Trash.', 'newspack-popups' ),
 		];
 
 		$cpt_args = [

--- a/newspack-popups.php
+++ b/newspack-popups.php
@@ -4,7 +4,7 @@
  * Plugin URI:      https://newspack.block
  * Description:     AMP-compatible overlay and inline Campaigns.
  * Author:          Automattic
- * Author URI:      https://newspack.block
+ * Author URI:      https://newspack.blog
  * Text Domain:     newspack-popups
  * Domain Path:     /languages
  * Version:         1.1.0

--- a/newspack-popups.php
+++ b/newspack-popups.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name:     Newspack Campaigns
- * Plugin URI:      https://newspack.block
+ * Plugin URI:      https://newspack.blog
  * Description:     AMP-compatible overlay and inline Campaigns.
  * Author:          Automattic
  * Author URI:      https://newspack.blog

--- a/newspack-popups.php
+++ b/newspack-popups.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * Plugin Name:     Newspack Popups
+ * Plugin Name:     Newspack Campaigns
  * Plugin URI:      https://newspack.block
- * Description:     AMP-compatible popup notifications.
+ * Description:     AMP-compatible overlay and inline Campaigns.
  * Author:          Automattic
  * Author URI:      https://newspack.block
  * Text Domain:     newspack-popups

--- a/src/document-settings/index.js
+++ b/src/document-settings/index.js
@@ -11,12 +11,12 @@ import { ToggleControl } from '@wordpress/components';
 const PopupsSettingsPanel = ( { hasDisabledPopups, onChange } ) => (
 	<PluginDocumentSettingPanel
 		name="newsletters-popups-settings-panel"
-		title={ __( 'Newspack Popups Settings', 'newspack-popups' ) }
+		title={ __( 'Newspack Campaigns Settings', 'newspack-popups' ) }
 	>
 		<ToggleControl
 			checked={ hasDisabledPopups }
 			onChange={ () => onChange( ! hasDisabledPopups ) }
-			label={ __( 'Disable Pop-ups on this post or page', 'newspack-popups' ) }
+			label={ __( 'Disable Campaigns on this post or page', 'newspack-popups' ) }
 		/>
 	</PluginDocumentSettingPanel>
 );

--- a/src/editor/index.js
+++ b/src/editor/index.js
@@ -117,7 +117,7 @@ class PopupSidebar extends Component {
 					<Fragment>
 						<RadioControl
 							label={ __( 'Trigger' ) }
-							help={ __( 'The event to trigger the popup' ) }
+							help={ __( 'The event to trigger the Campaign' ) }
 							selected={ trigger_type }
 							options={ [
 								{ label: __( 'Timer' ), value: 'time' },
@@ -160,14 +160,14 @@ class PopupSidebar extends Component {
 					onChange={ value => onMetaFieldChange( 'frequency', value ) }
 					options={ this.frequencyOptions( placement ) }
 					help={ __(
-						'In "Test Mode" logged-in admins will see the Pop-up every time, and non-admins will never see them.',
+						'In "Test Mode" logged-in admins will see the Campaign every time, and non-admins will never see them.',
 						'newspack-popups'
 					) }
 				/>
 				<TextControl
 					label={ __( 'UTM Suppression' ) }
 					help={ __(
-						'Users arriving at the site from URLs with this utm_source will never be shown the pop-up.'
+						'Users arriving at the site from URLs with this utm_source will never be shown the Campaign.'
 					) }
 					value={ utm_suppression }
 					onChange={ value => onMetaFieldChange( 'utm_suppression', value ) }
@@ -194,7 +194,7 @@ class PopupSidebar extends Component {
 					</Fragment>
 				) }
 				<ToggleControl
-					label={ __( 'Display Pop-up title', 'newspack-popups' ) }
+					label={ __( 'Display Campaign title', 'newspack-popups' ) }
 					checked={ display_title }
 					onChange={ value => onMetaFieldChange( 'display_title', value ) }
 				/>
@@ -223,7 +223,7 @@ const PopupSidebarWithData = compose( [
 ] )( PopupSidebar );
 
 const PluginDocumentSettingPanelDemo = () => (
-	<PluginDocumentSettingPanel name="popup-settings-panel" title={ __( ' Pop-up Settings' ) }>
+	<PluginDocumentSettingPanel name="popup-settings-panel" title={ __( 'Campaign Settings' ) }>
 		<PopupSidebarWithData />
 	</PluginDocumentSettingPanel>
 );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

We're renaming "Pop-ups" -> "Campaigns" (discussion in `pamTN9-15s-p2`). See complete testing instructions in https://github.com/Automattic/newspack-plugin/pull/522. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
