### PR TITLE
Dont load popups on products because of amp-form

### DIFF
--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -91,6 +91,18 @@ final class Newspack_Popups_Inserter {
 				return get_post_meta( get_the_ID(), 'newspack_popups_has_disabled_popups', true );
 			}
 		);
+
+		// Suppress popups on product pages.
+		// Until the popups non-AMP refactoring happens, they will break Add to Cart buttons.
+		add_filter(
+			'newspack_newsletters_assess_has_disabled_popups',
+			function( $disabled ) {
+				if ( function_exists( 'is_product' ) && is_product() ) {
+					return true;
+				}
+				return $disabled;
+			}
+		);
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR fixes an issue one of our publishers noticed. On product pages clicking the Add to Cart button doesn't do anything. This is because the amp-form script intercepts the button and prevents it submitting. Additionally, inline popups display in the product description.

### How to test the changes in this Pull Request:

1. Before applying this patch, create a Simple Product in WooCommerce, give it any price. Have an active Campaign.
2. In incognito mode, attempt to add the product to the cart. Observe a JS error is thrown in the console and there is also an inline popup in the content:
<img width="1545" alt="Screen Shot 2020-05-13 at 1 38 05 PM" src="https://user-images.githubusercontent.com/7317227/81863123-8bc9bb80-951f-11ea-9d27-bd0152884abd.png">

3. Apply this patch. Attempt to add the product to the cart. Observe it works. Observe no inline popup in the content.
<img width="794" alt="Screen Shot 2020-05-13 at 1 38 19 PM" src="https://user-images.githubusercontent.com/7317227/81863138-908e6f80-951f-11ea-93c9-b7433d89e4a2.png">

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
