### PR TITLE
Fix insertion of overlay scroll-triggered popups

### DIFF
--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -205,7 +205,9 @@ final class Newspack_Popups_Inserter {
 			$block_content = render_block( $block );
 			$pos          += strlen( $block_content );
 			if ( ! $is_inserted && $pos >= $precise_position ) {
-				$output     .= '<!-- wp:shortcode -->' . $popup_markup . '<!-- /wp:shortcode -->';
+				// Inline popups are placed as shortcodes, while overlay ones are raw markup.
+				$block_type  = $is_inline ? 'shortcode' : 'html';
+				$output     .= '<!-- wp:' . $block_type . ' -->' . $popup_markup . '<!-- /wp:' . $block_type . ' -->';
 				$is_inserted = true;
 			}
 			$output .= $block_content;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #124 .

### How to test the changes in this Pull Request:

1. On master, reproduce #124 
2. Add an inline popup, so we know that these are still working fine
2. Switch to this branch
3. Observe #124 is not reproducible anymore 
4. Observe that the inline popup works as expected

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
