### PR TITLE
fix: remove amp-form in non-amp requests

### DIFF
--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -168,6 +168,18 @@ final class Newspack_Popups_Inserter {
 	 * Enqueue the assets needed to display the popups.
 	 */
 	public static function enqueue_popup_assets() {
+		$is_amp = function_exists( 'is_amp_endpoint' ) && is_amp_endpoint();
+		if ( ! $is_amp ) {
+			wp_register_script(
+				'newspack-popups-view',
+				plugins_url( '../dist/view.js', __FILE__ ),
+				null,
+				filemtime( dirname( NEWSPACK_POPUPS_PLUGIN_FILE ) . '/dist/view.js' ),
+				true
+			);
+			wp_enqueue_script( 'newspack-popups-view' );
+		}
+
 		\wp_register_style(
 			'newspack-popups-view',
 			plugins_url( '../dist/view.css', __FILE__ ),
@@ -307,7 +319,7 @@ final class Newspack_Popups_Inserter {
 				true
 			);
 		}
-		$scripts = [ 'amp-access', 'amp-analytics', 'amp-animation', 'amp-form', 'amp-bind', 'amp-position-observer' ];
+		$scripts = [ 'amp-access', 'amp-analytics', 'amp-animation', 'amp-bind', 'amp-position-observer' ];
 		foreach ( $scripts as $script ) {
 			if ( ! wp_script_is( $script, 'registered' ) ) {
 				$path = "https://cdn.ampproject.org/v0/{$script}-latest.js";

--- a/package-lock.json
+++ b/package-lock.json
@@ -6390,11 +6390,26 @@
       }
     },
     "@wordpress/dom-ready": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-2.5.1.tgz",
-      "integrity": "sha512-HPEPWdShm/xJjQJVOOWpehvt4wtK0W5D/X0wpLfWAQjPOsTMTKnlRsRL3vTjIlgTrVZan1rv+3ZJv7AwH/1U5g==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-2.9.0.tgz",
+      "integrity": "sha512-2egz1f4LaLeeSPTsWUgvgerNUbV9A++x/YWBGiF8t/bC7KX1n4mqexQRihfuofvpBxlkalIJEXxka3pzrD1XHA==",
       "requires": {
-        "@babel/runtime": "^7.4.4"
+        "@babel/runtime": "^7.9.2"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.9.6",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.6.tgz",
+          "integrity": "sha512-64AF1xY3OAkFHqOb9s4jpgk1Mm5vDZ4L3acHvAml+53nO1XbXLuDodsVpO4OIUsmemlUHMxNdYMNJmsvOwLrvQ==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.5",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
+          "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
+        }
       }
     },
     "@wordpress/edit-post": {

--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
     "@wordpress/block-editor": "^3.7.5",
     "@wordpress/compose": "^3.11.0",
     "@wordpress/data": "^4.14.1",
+    "@wordpress/dom-ready": "^2.9.0",
     "@wordpress/element": "^2.11.0",
     "@wordpress/i18n": "^3.9.0",
     "newspack-components": "^1.0.5",

--- a/src/view/index.js
+++ b/src/view/index.js
@@ -10,11 +10,11 @@ import './style.scss';
 import './patterns.scss';
 
 const manageForms = container => {
-	const forms = Array.from( container.querySelectorAll( 'form.popup-action-form' ) );
+	const forms = [ ...container.querySelectorAll( 'form.popup-action-form' ) ];
 	forms.forEach( form => {
 		form.addEventListener( 'submit', event => {
 			const XHR = new XMLHttpRequest();
-			const inputs = Array.from( form.querySelectorAll( 'input' ) );
+			const inputs = [ ...form.querySelectorAll( 'input' ) ];
 			const pairs = inputs.map(
 				( { name, value } ) => encodeURIComponent( name ) + '=' + encodeURIComponent( value )
 			);
@@ -30,7 +30,7 @@ const manageForms = container => {
 
 if ( typeof window !== 'undefined' ) {
 	domReady( () => {
-		const campaignArray = Array.from( document.querySelectorAll( '.newspack-lightbox' ) );
+		const campaignArray = [ ...document.querySelectorAll( '.newspack-lightbox' ) ];
 		campaignArray.forEach( campaign => {
 			manageForms( campaign );
 		} );

--- a/src/view/index.js
+++ b/src/view/index.js
@@ -1,2 +1,38 @@
+/**
+ * WordPress dependencies
+ */
+import domReady from '@wordpress/dom-ready';
+
+/**
+ * Internal dependencies
+ */
 import './style.scss';
 import './patterns.scss';
+
+const manageForms = container => {
+	const forms = Array.from( container.querySelectorAll( 'form.popup-action-form' ) );
+	forms.forEach( form => {
+		form.addEventListener( 'submit', event => {
+			const XHR = new XMLHttpRequest();
+			const inputs = Array.from( form.querySelectorAll( 'input' ) );
+			const pairs = inputs.map(
+				( { name, value } ) => encodeURIComponent( name ) + '=' + encodeURIComponent( value )
+			);
+			const data = pairs.join( '&' ).replace( /%20/g, '+' );
+			const action = form.attributes[ 'action-xhr' ].value;
+			XHR.open( 'POST', action );
+			XHR.setRequestHeader( 'Content-Type', 'application/x-www-form-urlencoded' );
+			XHR.send( data );
+			event.preventDefault();
+		} );
+	} );
+};
+
+if ( typeof window !== 'undefined' ) {
+	domReady( () => {
+		const campaignArray = Array.from( document.querySelectorAll( '.newspack-lightbox' ) );
+		campaignArray.forEach( campaign => {
+			manageForms( campaign );
+		} );
+	} );
+}


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The plugin takes the unusual approach of using AMP libraries in non-AMP requests. This brings the benefits of a single implementation, but has led to a variety of problems mostly related to form handling. This PR begins the process of rewriting these pieces of functionality in vanilla Javascript. The plugin uses five AMP libraries: 'amp-access', 'amp-analytics', 'amp-animation', 'amp-form', 'amp-bind', and 'amp-position-observer'. This PR replaces `amp-form`.

### How to test the changes in this Pull Request:

1. Switch to AMP Transitional mode.
2. Create a few Campaigns.
3. Test in AMP and non-AMP pages, in a variety of browser. Verify the behavior is identical especially related to dismissal (clicking the overlay, clicking the close button, clicking "I'm not interested" link).
4. Test Campaigns that contain forms (Mailchimp, etc). Verify these work identically in AMP and non-AMP pages.
5. In non-AMP pages, verify `amp-form` is not being loaded.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
