### PR TITLE
Handle default colors in the editor

### DIFF
--- a/src/editor/index.js
+++ b/src/editor/index.js
@@ -174,14 +174,14 @@ class PopupSidebar extends Component {
 				/>
 				<ColorPaletteControl
 					value={ background_color }
-					onChange={ value => onMetaFieldChange( 'background_color', value ) }
+					onChange={ value => onMetaFieldChange( 'background_color', value || '#FFFFFF' ) }
 					label={ __( 'Background Color' ) }
 				/>
 				{ ! isInline && (
 					<Fragment>
 						<ColorPaletteControl
 							value={ overlay_color }
-							onChange={ value => onMetaFieldChange( 'overlay_color', value ) }
+							onChange={ value => onMetaFieldChange( 'overlay_color', value || '#000000' ) }
 							label={ __( 'Overlay Color' ) }
 						/>
 						<RangeControl


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #56.

### How to test the changes in this Pull Request:

1. On branch master, 
1. create or edit a campaign
2. Set background and overlay colors, save 
3. Unset colors 
3. Observe that the colors cannot be un-set
4. Switch to this branch, rebuild JS, do steps 2-4 again
4. Observe that the colors can now be unset. When unset, they are reverted to defaults – white for background color and black for overlay color

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
