### PR TITLE
fix: don't inject popups in content that isn't in main loop

### DIFF
--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -111,7 +111,7 @@ final class Newspack_Popups_Inserter {
 	 * @param string $content The content of the post.
 	 */
 	public static function insert_popups_in_content( $content = '' ) {
-		if ( is_admin() || ! is_singular() || self::assess_has_disabled_popups( $content ) ) {
+		if ( ! is_main_query() || ! in_the_loop() || is_admin() || ! is_singular() || self::assess_has_disabled_popups( $content ) ) {
 			return $content;
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

When Newspack Blocks Homepage Posts block has the excerpt option on, Campaign content will be injected into the excerpt. The resolution is to check if in the main loop before injecting campaigns. This alone isn't enough, though, because the loop used in Homepage Posts blocks is indistinguishable from the main loop. This is fixed in https://github.com/Automattic/newspack-blocks/pull/512, which saves the main loop into a temporary variable, then restores it after rendering the block content. 

Closes https://github.com/Automattic/newspack-popups/issues/134

### How to test the changes in this Pull Request:

1. Set Newspack Campaigns and Newspack Blocks on `master` branch.
2. Create a campaign with recognizable content, use Test Mode, Center. Publish the campaign and turn on Sitewide Default.
3. Create a Page, add Homepage Posts block, switch on Excerpt.
4. Publish and view the page. Observe that the content of the campaign is injected into post excerpts.
5. Switch Newspack Blocks to `try/stash-main-loop`, Newspack Campaigns to `try/dont-insert-unless-in-main-loop`.
6. Refresh the page. Observe the excerpt is displayed properly, and the Campaign is displayed as expected.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
