### PR TITLE
fix: related posts in campaigns

### DIFF
--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -309,16 +309,26 @@ final class Newspack_Popups_Model {
 	 */
 	protected static function create_popup_object( $campaign_post, $containing_post_id = null, $include_categories = false, $options = null ) {
 
-		// Set the post global to the containing post to enable dynamic blocks like Jetpack Related Posts to function properly.
+		// Query the containing post to enable dynamic blocks like Jetpack Related Posts to function properly.
 		if ( $containing_post_id ) {
-			global $post;
-			$post = get_post( $containing_post_id ); // phpcs:ignore
+			$containing_post = new WP_Query(
+				[
+					'p' => $containing_post_id,
+				]
+			);
+			if ( $containing_post->have_posts() ) {
+				$containing_post->the_post();
+			}
 		}
 		$blocks = parse_blocks( $campaign_post->post_content );
 		$body   = '';
 		foreach ( $blocks as $block ) {
 			$body .= render_block( $block );
 		}
+		if ( $containing_post_id ) {
+			wp_reset_postdata();
+		}
+
 		$id = $campaign_post->ID;
 
 		$post_options = isset( $options ) ? $options : [

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -229,6 +229,7 @@ final class Newspack_Popups_Model {
 	 * @return object Popup object.
 	 */
 	public static function retrieve_preview_popup( $post_id ) {
+		$containing_post_id = get_the_ID();
 		// Up-to-date post data is stored in an autosave.
 		$autosave    = wp_get_post_autosave( $post_id );
 		$post_object = $autosave ? $autosave : get_post( $post_id );
@@ -237,6 +238,7 @@ final class Newspack_Popups_Model {
 
 		return self::create_popup_object(
 			$post_object,
+			$containing_post_id,
 			false,
 			[
 				'background_color'        => filter_input( INPUT_GET, 'background_color', FILTER_SANITIZE_STRING ),
@@ -280,12 +282,14 @@ final class Newspack_Popups_Model {
 	 * @return array Popup objects array
 	 */
 	protected static function retrieve_popups_with_query( WP_Query $query, $include_categories = false ) {
-		$popups = [];
+		$containing_post_id = get_the_ID();
+		$popups             = [];
 		if ( $query->have_posts() ) {
 			while ( $query->have_posts() ) {
 				$query->the_post();
 				$popups[] = self::create_popup_object(
 					get_post( get_the_ID() ),
+					$containing_post_id,
 					$include_categories
 				);
 			}
@@ -297,21 +301,28 @@ final class Newspack_Popups_Model {
 	/**
 	 * Create the popup object.
 	 *
-	 * @param WP_Post $post The post object.
+	 * @param WP_Post $campaign_post The campaign post object.
+	 * @param integer $containing_post_id ID of the post that will contain the Campaign.
 	 * @param boolean $include_categories If true, returned objects will include assigned categories.
 	 * @param object  $options Popup options to use instead of the options retrieved from the post. Used for popup previews.
 	 * @return object Popup object
 	 */
-	protected static function create_popup_object( $post, $include_categories = false, $options = null ) {
-		$blocks = parse_blocks( $post->post_content );
+	protected static function create_popup_object( $campaign_post, $containing_post_id = null, $include_categories = false, $options = null ) {
+
+		// Set the post global to the containing post to enable dynamic blocks like Jetpack Related Posts to function properly.
+		if ( $containing_post_id ) {
+			global $post;
+			$post = get_post( $containing_post_id ); // phpcs:ignore
+		}
+		$blocks = parse_blocks( $campaign_post->post_content );
 		$body   = '';
 		foreach ( $blocks as $block ) {
 			$body .= render_block( $block );
 		}
-		$id = $post->ID;
+		$id = $campaign_post->ID;
 
 		$post_options = isset( $options ) ? $options : [
-			'background_color'        => get_post_meta( get_the_ID(), 'background_color', true ),
+			'background_color'        => get_post_meta( $id, 'background_color', true ),
 			'dismiss_text'            => get_post_meta( $id, 'dismiss_text', true ),
 			'display_title'           => get_post_meta( $id, 'display_title', true ),
 			'frequency'               => get_post_meta( $id, 'frequency', true ),
@@ -326,8 +337,8 @@ final class Newspack_Popups_Model {
 
 		$popup = [
 			'id'      => $id,
-			'status'  => $post->post_status,
-			'title'   => $post->post_title,
+			'status'  => $campaign_post->post_status,
+			'title'   => $campaign_post->post_title,
 			'body'    => $body,
 			'options' => wp_parse_args(
 				array_filter( $post_options ),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Jetpack Related Posts block fails in Campaigns because the Related Posts block seeks posts based on the ID of the Campaign, not the containing Post. This branch changes this by ~setting the containing Post as the global `post` object~ re-querying the containing post immediately before rendering the campaign.~ h/t @philipjohn for the approach.

Closes https://github.com/Automattic/newspack-popups/issues/143

### How to test the changes in this Pull Request:

1. Create an inline campaign. Add Jetpack Related Posts block. Give the campaign a title and click the toggle to display title so you'll be able to identify it even when empty.
2. On `master`, test the campaign in a post. It should render empty—a box with the title and nothing else.
3. Switch to this branch, and retest. Observe a normal Related Posts block with posts relevant to the containing page. 
4. Test a variety of other campaigns and verify they preview and render as expected.

### Screenshots

Before:
<img width="1602" alt="Screen Shot 2020-06-14 at 4 29 08 PM" src="https://user-images.githubusercontent.com/1477002/84603419-5edd3100-ae5c-11ea-857c-4e08b6c82378.png">

After:
<img width="1602" alt="Screen Shot 2020-06-14 at 4 30 03 PM" src="https://user-images.githubusercontent.com/1477002/84603421-64d31200-ae5c-11ea-9334-abcdf6af0240.png">

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
