### PR TITLE
fix: correct incorrect stacking of inline campaigns

### DIFF
--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -192,7 +192,17 @@ final class Newspack_Popups_Model {
 			'meta_value'  => 'inline',
 		];
 
-		return self::retrieve_popups_with_query( new WP_Query( $args ) );
+		$inline_popups = self::retrieve_popups_with_query( new WP_Query( $args ) );
+
+		// Sort inline campaigns to be in descending order of position in content.
+		usort(
+			$inline_popups,
+			function ( $popup1, $popup2 ) {
+				return $popup1['options']['trigger_scroll_progress'] > $popup2['options']['trigger_scroll_progress'] ? -1 : 1;
+			}
+		);
+
+		return $inline_popups;
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
