### PR TITLE
fix: insert all campaigns into content in one pass

### DIFF
--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -163,14 +163,54 @@ final class Newspack_Popups_Inserter {
 			$content = scaip_maybe_insert_shortcode( $content );
 		}
 
-		// Now insert the popups.
+		$total_length = strlen( $content );
+
+		// 1. Separate campaigns into inline and overlay.
+		$inline_popups  = [];
+		$overlay_popups = [];
 		foreach ( $popups as $popup ) {
-			$content = self::insert_popup( $content, $popup );
+			if ( 'inline' === $popup['options']['placement'] ) {
+				$percentage                = intval( $popup['options']['trigger_scroll_progress'] ) / 100;
+				$popup['precise_position'] = $total_length * $percentage;
+				$popup['is_inserted']      = false;
+				$inline_popups[]           = $popup;
+			} else {
+				$overlay_popups[] = $popup;
+			}
+		}
+
+		// 2. Iterate overall blocks and insert inline campaigns.
+		$pos    = 0;
+		$output = '';
+		foreach ( parse_blocks( $content ) as $block ) {
+			$block_content = render_block( $block );
+			$pos          += strlen( $block_content );
+			foreach ( $inline_popups as &$inline_popup ) {
+				if ( ! $inline_popup['is_inserted'] && $pos > $inline_popup['precise_position'] ) {
+					$output .= '<!-- wp:shortcode -->[newspack-popup id="' . $inline_popup['id'] . '"]<!-- /wp:shortcode -->';
+
+					$inline_popup['is_inserted'] = true;
+				}
+				$output .= $block_content;
+			}
+		}
+
+		// 3. Insert any remaining inline campaigns at the end.
+		foreach ( $inline_popups as $inline_popup ) {
+			if ( ! $inline_popup['is_inserted'] ) {
+				$output .= '<!-- wp:shortcode -->[newspack-popup id="' . $inline_popup['id'] . '"]<!-- /wp:shortcode -->';
+
+				$inline_popup['is_inserted'] = true;
+			}
+		}
+
+		// 4. Insert overlay campaigns at the top of content.
+		foreach ( $overlay_popups as $overlay_popup ) {
+			$output = $overlay_popup['markup'] . $output;
 		}
 
 		self::enqueue_popup_assets();
-
-		return $content;
+		return $output;
 	}
 
 	/**
@@ -216,44 +256,6 @@ final class Newspack_Popups_Inserter {
 		);
 		\wp_style_add_data( 'newspack-popups-view', 'rtl', 'replace' );
 		\wp_enqueue_style( 'newspack-popups-view' );
-	}
-
-	/**
-	 * Insert Popup markup into content.
-	 *
-	 * @param string $content The content of the post.
-	 * @param object $popup The popup object to insert.
-	 * @return string The content with popup markup inserted.
-	 */
-	public static function insert_popup( $content = '', $popup = [] ) {
-		$is_inline    = 'inline' === $popup['options']['placement'];
-		$popup_markup = $is_inline ? '[newspack-popup id="' . $popup['id'] . '"]' : $popup['markup'];
-
-		if ( ! $is_inline && 0 === $popup['options']['trigger_scroll_progress'] ) {
-			return $popup_markup . $content;
-		}
-
-		$percentage       = intval( $popup['options']['trigger_scroll_progress'] ) / 100;
-		$total_length     = strlen( $content );
-		$precise_position = $total_length * $percentage;
-
-		$blocks      = parse_blocks( $content );
-		$pos         = 0;
-		$output      = '';
-		$is_inserted = false;
-		foreach ( $blocks as $block ) {
-			$block_content = render_block( $block );
-			$pos          += strlen( $block_content );
-			if ( ! $is_inserted && $pos >= $precise_position ) {
-				// Inline popups are placed as shortcodes, while overlay ones are raw markup.
-				$block_type  = $is_inline ? 'shortcode' : 'html';
-				$output     .= '<!-- wp:' . $block_type . ' -->' . $popup_markup . '<!-- /wp:' . $block_type . ' -->';
-				$is_inserted = true;
-			}
-			$output .= $block_content;
-		}
-
-		return $output;
 	}
 
 	/**

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -206,7 +206,7 @@ final class Newspack_Popups_Inserter {
 
 		// 4. Insert overlay campaigns at the top of content.
 		foreach ( $overlay_popups as $overlay_popup ) {
-			$output = $overlay_popup['markup'] . $output;
+			$output = '<!-- wp:html -->' . $overlay_popup['markup'] . '<!-- /wp:html -->' . $output;
 		}
 
 		self::enqueue_popup_assets();

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -191,8 +191,8 @@ final class Newspack_Popups_Inserter {
 
 					$inline_popup['is_inserted'] = true;
 				}
-				$output .= $block_content;
 			}
+			$output .= $block_content;
 		}
 
 		// 3. Insert any remaining inline campaigns at the end.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR changes the approach to injecting campaigns into content, where all relevant campaigns are injected in a single pass through `parse_blocks`. This should resolve the issues where multiple inline campaigns are often positioned incorrectly.

Closes https://github.com/Automattic/newspack-popups/issues/142

### How to test the changes in this Pull Request:

1. Create 2 or more inline campaigns with different approximate position settings.
2. View a post, verify the campaign positions are roughly correct (the placements are approximations based on paragraph length so they will rarely be absolutely precise).
3. Experiment with different position settings, including swapping positions of two campaigns.
4. Add an Overlay campaign and make sure that performs correctly.
5. Verify the content of posts is correct and complete. Test with text and a variety of blocks.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
