### PR TITLE
fix: non-amp form handling for inline campaigns

### DIFF
--- a/src/view/index.js
+++ b/src/view/index.js
@@ -30,7 +30,10 @@ const manageForms = container => {
 
 if ( typeof window !== 'undefined' ) {
 	domReady( () => {
-		const campaignArray = [ ...document.querySelectorAll( '.newspack-lightbox' ) ];
+		const campaignArray = [
+			...document.querySelectorAll( '.newspack-lightbox' ),
+			...document.querySelectorAll( '.newspack-inline-popup' ),
+		];
 		campaignArray.forEach( campaign => {
 			manageForms( campaign );
 		} );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The non-AMP form handling introduced in https://github.com/Automattic/newspack-popups/pull/127 is not being applied properly to inline campaigns. As a result, the permanent dismissal buttons don't function properly.

Closes https://github.com/Automattic/newspack-popups/issues/153

### How to test the changes in this Pull Request:

1. Switch AMP plugin to Transitional.
2. Create an inline campaign set to display on Every Page.
3. On `master`, view a post as a non-AMP page. 
4. Click "I'm not interested."
5. Observe the campaign is not hidden, the page reloads, and the campaign is shown again.
6. Switch to this branch and repeat 3-5.
7. Observe the campaign is hidden, the page does not reload, and the campaign is not shown on any other pages.
8. Verify the same correct behavior in an AMP request.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
