### PR TITLE
Analytics: use newspack-plugin's filter where possible

### DIFF
--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -566,8 +566,9 @@ final class Newspack_Popups_Model {
 			return '';
 		}
 
+		$popup_id       = $popup['id'];
 		$event_category = 'Newspack Announcement';
-		$event_label    = 'Newspack Announcement: ' . $popup['title'] . ' (' . $popup['id'] . ')';
+		$event_label    = 'Newspack Announcement: ' . $popup['title'] . ' (' . $popup_id . ')';
 
 		$has_link                = preg_match( '/<a\s/', $popup['body'] ) !== 0;
 		$has_form                = preg_match( '/<form\s/', $popup['body'] ) !== 0;
@@ -576,7 +577,7 @@ final class Newspack_Popups_Model {
 
 		$analytics_events = [
 			[
-				'id'             => 'popupPageLoaded',
+				'id'             => 'popupPageLoaded-' . $popup_id,
 				'on'             => 'ini-load',
 				'element'        => '#' . esc_attr( $element_id ),
 				'event_name'     => esc_html__( 'Load', 'newspack-popups' ),
@@ -587,7 +588,7 @@ final class Newspack_Popups_Model {
 
 		if ( $has_link ) {
 			$analytics_events[] = [
-				'id'             => 'popupAnchorClicks',
+				'id'             => 'popupAnchorClicks-' . $popup_id,
 				'on'             => 'click',
 				'element'        => '#' . esc_attr( $element_id ) . ' a',
 				'amp_element'    => '#' . esc_attr( $element_id ) . ' a',
@@ -599,7 +600,7 @@ final class Newspack_Popups_Model {
 
 		if ( $has_form ) {
 			$analytics_events[] = [
-				'id'             => 'popupFormSubmitSuccess',
+				'id'             => 'popupFormSubmitSuccess-' . $popup_id,
 				'amp_on'         => 'amp-form-submit-success',
 				'on'             => 'submit',
 				'element'        => '#' . esc_attr( $element_id ) . ' form:not(.popup-action-form)',
@@ -610,7 +611,7 @@ final class Newspack_Popups_Model {
 		}
 		if ( $has_dismiss_form ) {
 			$analytics_events[] = [
-				'id'             => 'popupDismissed',
+				'id'             => 'popupDismissed-' . $popup_id,
 				'amp_on'         => 'amp-form-submit-success',
 				'on'             => 'submit',
 				'element'        => '#' . esc_attr( $element_id ) . ' form.popup-dismiss-form',
@@ -621,7 +622,7 @@ final class Newspack_Popups_Model {
 		}
 		if ( $has_not_interested_form ) {
 			$analytics_events[] = [
-				'id'             => 'popupNotInterested',
+				'id'             => 'popupNotInterested-' . $popup_id,
 				'amp_on'         => 'amp-form-submit-success',
 				'on'             => 'submit',
 				'element'        => '#' . esc_attr( $element_id ) . ' form.popup-not-interested-form',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Use newspack-plugin's `newspack_analytics_events` filter to report GA events for all events except [visibility](https://amp.dev/documentation/components/amp-analytics/#page-and-element-visibility-trigger). 

Closes #151 

### How to test the changes in this Pull Request:

1. Observe #151 not being reproducible
2. Observe analytics events reported as expected:
    1. Load event
    1. Seen event
    1. Link click
    1. Form submission
    1. Dismissal
    1. Permanent Dismissal

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
