### PR TITLE
feat: add class names for newsletter prompts, for analytics tracking

### DIFF
--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -629,13 +629,15 @@ final class Newspack_Popups_Model {
 	 */
 	public static function generate_inline_popup( $popup ) {
 		global $wp;
-		$element_id    = 'lightbox' . rand(); // phpcs:ignore WordPress.WP.AlternativeFunctions.rand_rand
-		$endpoint      = self::get_dismiss_endpoint();
-		$display_title = $popup['options']['display_title'];
-		$hidden_fields = self::get_hidden_fields( $popup );
-		$dismiss_text  = self::get_dismiss_text( $popup );
-		$classes       = [ 'newspack-inline-popup' ];
-		$classes[]     = ( ! empty( $popup['title'] ) && $display_title ) ? 'newspack-lightbox-has-title' : null;
+		$element_id           = 'lightbox' . rand(); // phpcs:ignore WordPress.WP.AlternativeFunctions.rand_rand
+		$endpoint             = self::get_dismiss_endpoint();
+		$display_title        = $popup['options']['display_title'];
+		$hidden_fields        = self::get_hidden_fields( $popup );
+		$dismiss_text         = self::get_dismiss_text( $popup );
+		$is_newsletter_prompt = false !== strpos( $popup['body'], 'wp-block-jetpack-mailchimp' ); // Is this a newsletter prompt? Add a class so we can target for analytics.
+		$classes              = array( 'newspack-inline-popup' );
+		$classes[]            = ( ! empty( $popup['title'] ) && $display_title ) ? 'newspack-lightbox-has-title' : null;
+		$classes[]            = $is_newsletter_prompt ? 'newspack-newsletter-prompt-inline' : null;
 		ob_start();
 		?>
 			<?php self::insert_event_tracking( $popup, $element_id ); ?>
@@ -670,15 +672,17 @@ final class Newspack_Popups_Model {
 	 * @return string The generated markup.
 	 */
 	public static function generate_popup( $popup ) {
-		$element_id      = 'lightbox' . rand(); // phpcs:ignore WordPress.WP.AlternativeFunctions.rand_rand
-		$endpoint        = self::get_dismiss_endpoint();
-		$dismiss_text    = self::get_dismiss_text( $popup );
-		$display_title   = $popup['options']['display_title'];
-		$overlay_opacity = absint( $popup['options']['overlay_opacity'] ) / 100;
-		$overlay_color   = $popup['options']['overlay_color'];
-		$hidden_fields   = self::get_hidden_fields( $popup );
-		$classes         = [ 'newspack-lightbox', 'newspack-lightbox-placement-' . $popup['options']['placement'] ];
-		$classes[]       = ( ! empty( $popup['title'] ) && $display_title ) ? 'newspack-lightbox-has-title' : null;
+		$element_id           = 'lightbox' . rand(); // phpcs:ignore WordPress.WP.AlternativeFunctions.rand_rand
+		$endpoint             = self::get_dismiss_endpoint();
+		$dismiss_text         = self::get_dismiss_text( $popup );
+		$display_title        = $popup['options']['display_title'];
+		$overlay_opacity      = absint( $popup['options']['overlay_opacity'] ) / 100;
+		$overlay_color        = $popup['options']['overlay_color'];
+		$hidden_fields        = self::get_hidden_fields( $popup );
+		$is_newsletter_prompt = false !== strpos( $popup['body'], 'wp-block-jetpack-mailchimp' ); // Is this a newsletter prompt? Add a class so we can target for analytics.
+		$classes              = array( 'newspack-lightbox', 'newspack-lightbox-placement-' . $popup['options']['placement'] );
+		$classes[]            = ( ! empty( $popup['title'] ) && $display_title ) ? 'newspack-lightbox-has-title' : null;
+		$classes[]            = $is_newsletter_prompt ? 'newspack-newsletter-prompt-overlay' : null;
 
 		ob_start();
 		?>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds a class name to `amp-lightbox` overlay and inline elements if the contents of the lightbox contains a Mailchimp newsletter prompt. This will allow us to target the AMP element for analytics. This relates to https://github.com/Automattic/newspack-plugin/pull/557.

If any additional newsletter services are implemented, they should be included in the check so the newsletter classes are added appropriately.

### How to test the changes in this Pull Request:

1. Create an overlay and inline campaign. In each campaign, add a Mailchimp newsletter form block.
2. On the front-end, inspect each campaign element. They should include the class names `newspack-newsletter-prompt-overlay` and `newspack-newsletter-prompt-inline`, respectively.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
