### PR TITLE
Try/add newsletter events with filter

### DIFF
--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -574,6 +574,8 @@ final class Newspack_Popups_Model {
 		$has_form                = preg_match( '/<form\s/', $popup['body'] ) !== 0;
 		$has_dismiss_form        = 'inline' !== $popup['options']['placement'];
 		$has_not_interested_form = self::get_dismiss_text( $popup );
+		$is_newsletter_prompt    = false !== strpos( $popup['body'], 'wp-block-jetpack-mailchimp' );
+		$is_inline               = self::is_inline( $popup );
 
 		$analytics_events = [
 			[
@@ -629,6 +631,28 @@ final class Newspack_Popups_Model {
 				'event_name'     => esc_html__( 'Permanent Dismissal', 'newspack-popups' ),
 				'event_label'    => esc_attr( $event_label ),
 				'event_category' => esc_attr( $event_category ),
+			];
+		}
+		if ( $is_newsletter_prompt ) {
+			$analytics_events[] = [ // phpcs:ignore Generic.Arrays.DisallowShortArraySyntax.Found
+				'id'             => 'newsletterImpression-' . $popup_id,
+				'on'             => 'visible',
+				'element'        => '#' . esc_attr( $element_id ),
+				'event_name'     => 'newsletter modal impression ' . esc_attr( $is_inline ? '2' : '1' ),
+				'event_label'    => esc_attr( get_the_title() ),
+				'event_category' => 'NTG newsletter',
+				'visibilitySpec' => [ // phpcs:ignore Generic.Arrays.DisallowShortArraySyntax.Found
+					'totalTimeMin' => 500,
+				],
+			];
+			$analytics_events[] = [ // phpcs:ignore Generic.Arrays.DisallowShortArraySyntax.Found
+				'id'             => 'newsletterSignup-' . $popup_id,
+				'amp_on'         => 'amp-form-submit-success',
+				'on'             => 'submit',
+				'element'        => '#' . esc_attr( $element_id ) . ' .wp-block-jetpack-mailchimp form',
+				'event_name'     => 'newsletter signup',
+				'event_label'    => 'success',
+				'event_category' => 'NTG newsletter',
 			];
 		}
 

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -634,18 +634,18 @@ final class Newspack_Popups_Model {
 			];
 		}
 		if ( $is_newsletter_prompt ) {
-			$analytics_events[] = [ // phpcs:ignore Generic.Arrays.DisallowShortArraySyntax.Found
+			$analytics_events[] = [
 				'id'             => 'newsletterImpression-' . $popup_id,
 				'on'             => 'visible',
 				'element'        => '#' . esc_attr( $element_id ),
 				'event_name'     => 'newsletter modal impression ' . esc_attr( $is_inline ? '2' : '1' ),
 				'event_label'    => esc_attr( get_the_title() ),
 				'event_category' => 'NTG newsletter',
-				'visibilitySpec' => [ // phpcs:ignore Generic.Arrays.DisallowShortArraySyntax.Found
+				'visibilitySpec' => [
 					'totalTimeMin' => 500,
 				],
 			];
-			$analytics_events[] = [ // phpcs:ignore Generic.Arrays.DisallowShortArraySyntax.Found
+			$analytics_events[] = [
 				'id'             => 'newsletterSignup-' . $popup_id,
 				'amp_on'         => 'amp-form-submit-success',
 				'on'             => 'submit',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This creates NTG newsletter events at the point the campaign popups and inline elements are injected into post content, rather than trying to handle analytics for campaigns in the core plugin. It relies on changes in https://github.com/Automattic/newspack-plugin/pull/557, so please don't merge until that PR is merged.

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

### How to test the changes in this Pull Request:

1. Check out https://github.com/Automattic/newspack-plugin/pull/557 in the newspack-plugin repo.
2. Create one or more inline and overlay campaigns which contain a Mailchimp signup block. All campaigns should be set to Active so they can be viewed as a non-logged-in user.
3. In a new Incognito window, view a page or post where the campaigns will appear.
4. Open the Network tab in dev tools. Filter by "ntg" to see only new requests containing "ntg".
5. Scroll down to the campaign (or wait until the overlay campaign appears). The event should fire only once and only when any part of the element first becomes visible within the viewport. Observe an NTG event request in the Network tab that looks something like this (important part is the `NTG%20newsletter&ea=newsletter%20modal%20impression%201` string), the last number of which indicates the type of prompt: 1 for overlay, 2 for inline, 3 for in-content): https://www.google-analytics.com/collect?v=1&_v=j83&aip=1&a=2091212415&t=event&_s=5&dl=http%3A%2F%2Fnewspack-dkoo.ngrok.io%2Fnon-consequat-commodo-eros-justo-vulputate-potenti%2F&ul=en-us&de=UTF-8&dt=Non%20consequat%20commodo%20eros%20justo%20vulputate%20potenti%20-%20Newspack&sd=30-bit&sr=1792x1120&vp=1303x1018&je=0&ec=NTG%20newsletter&ea=newsletter%20modal%20impression%201&el=Non%20consequat%20commodo%20eros%20justo%20vulputate%20potenti&_u=CCCACUABB~&jid=&gjid=&cid=305040532.1592848697&tid=UA-169138974-1&_gid=1339759271.1592848697&gtm=2ou6a0&z=2058936163
6. Enter an email address and submit the form. Observe an NTG event request in the Network tab that looks something like this (important part is the `NTG%20newsletter&ea=newsletter%20signup` string): https://www.google-analytics.com/r/collect?v=1&_v=j83&aip=1&a=2091212415&t=event&_s=6&dl=http%3A%2F%2Fnewspack-dkoo.ngrok.io%2Fnon-consequat-commodo-eros-justo-vulputate-potenti%2F&ul=en-us&de=UTF-8&dt=Non%20consequat%20commodo%20eros%20justo%20vulputate%20potenti%20-%20Newspack&sd=30-bit&sr=1792x1120&vp=1303x1018&je=0&ec=NTG%20newsletter&ea=newsletter%20signup&el=success&_u=CCCACUABB~&jid=1215251838&gjid=1120199689&cid=305040532.1592848697&tid=UA-169138974-1&_gid=1339759271.1592848697&_r=1&gtm=2ou6a0&z=1924980601
7. If you've connected your local Newspack environment to Site Kit and a Google Analytics account, after several hours you should see these events being reported in the analytics dashboard.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
