### PR TITLE
Fix ad insertion in overlay campaigns

### DIFF
--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -143,17 +143,7 @@ final class Newspack_Popups_Inserter {
 			return $content;
 		}
 
-		// First needs to check if there any inline popups, to handle SCAIP.
-		$has_an_inline_popup = count(
-			array_filter(
-				$popups,
-				function( $p ) {
-					return 'inline' === $p['options']['placement'];
-				}
-			)
-		);
-
-		if ( $has_an_inline_popup && function_exists( 'scaip_maybe_insert_shortcode' ) ) {
+		if ( function_exists( 'scaip_maybe_insert_shortcode' ) ) {
 			// Prevent default SCAIP insertion.
 			remove_filter( 'the_content', 'scaip_maybe_insert_shortcode', 10 );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Erroneusly there was an assumption that SCAIP ad insertion might create issues only with inline campaigns. This PR fixes this – now SCAIP will be prompted to insert its stuff before campaigns insertion, regardless of campaign type.

Closes #158.

### How to test the changes in this Pull Request:

1. Try to reproduce #158, observe it's not reproducible after changes from this branch are applied.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
