### PR TITLE
Refactor/hooks firing too often

### DIFF
--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -127,7 +127,38 @@ final class Newspack_Popups_Inserter {
 	 * @param string $content The content of the post.
 	 */
 	public static function insert_popups_in_content( $content = '' ) {
-		if ( is_admin() || ! is_singular() || self::assess_has_disabled_popups( $content ) ) {
+		// Not Frontend.
+		if ( is_admin() ) {
+			return $content;
+		}
+
+		// Content is empty.
+		if ( empty( trim( $content ) ) ) {
+			return $content;
+		}
+
+		// No campaign insertion in archive pages.
+		if ( ! is_singular() ) {
+			return $content;
+		}
+
+		// If not in the loop, ignore.
+		if ( ! in_the_loop() ) {
+			return $content;
+		}
+
+		// Ignore on front page.
+		if ( is_front_page() ) {
+			return $content;
+		}
+
+		// Campaigns disabled for this page.
+		if ( self::assess_has_disabled_popups() ) {
+			return $content;
+		}
+
+		// If the current post is a Campaign, ignore.
+		if ( Newspack_Popups::NEWSPACK_PLUGINS_CPT == get_post_type() ) {
 			return $content;
 		}
 

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -147,11 +147,6 @@ final class Newspack_Popups_Inserter {
 			return $content;
 		}
 
-		// Ignore on front page.
-		if ( is_front_page() ) {
-			return $content;
-		}
-
 		// Campaigns disabled for this page.
 		if ( self::assess_has_disabled_popups() ) {
 			return $content;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR cleans up a few aspects of the campaign insertion logic to avoid rendering campaign content more than once. In addition to performance benefits, multiple passes through the insertion logic can have other unexpected side effects. One of these concerns the Homepage Posts block, which excludes posts which have already been seen on the page. If this block is in a campaign it will not show the most recent posts since earlier render passes will have already taken a few posts off the table. 

### How to test the changes in this Pull Request:

As a refactor, this PR warrants a full round of functional testing:

1. Create five campaigns, all in test mode. Two inline campaigns at 30% and 70%. One Sitewide Default overlay. One overlay filtered to a category. One more overlay that isn't filtered to a category (this one should never be shown). I generally check the option to show the Campaign title, which makes testing a little easier. Publish them all.
2. View the homepage. Observe the Sitewide Default displays.
3. View a normal post (not in the filtered category). Observe the two inline campaigns and the Sitewide Default overlay. 
4. View a post that has the filtered category applied. Observe the two inline campaigns and the category overlay.
5. View the filtered category's archive page. Observe the category overlay. 
6. View any other archive page. Observe the Sitewide Default overlay.
7. Change Frequency to "Every page" for the inline campaigns and "Once a day" for the overlays.
8. Test all of the scenarios in an incognito browser. 
9. Verify the overlays are never shown more than once, and that dismissing the inline campaigns causes them to not show again.

Verify `insert_popups_in_content` is only being called once per page. This can be done by adding an `error_log()` statement [here](https://github.com/Automattic/newspack-popups/blob/7381e6b2442dea07b3e6bdcab3156fcaa6bd0428/includes/class-newspack-popups-inserter.php#L170) and watching the log. The same experiment on `master` should reveal multiple executions.

Also verify campaigns aren't rendered multiple times.

1. On `master`, add the Homepage Posts block to an inline Campaign. 
2. View a page with the campaign on it, observe you are not seeing the top posts.
3. Switch to this branch, observe you are seeing the top stories. Bonus: switch Newspack Blocks to https://github.com/Automattic/newspack-blocks/pull/539 (if it is still open) and observe Homepage Posts doesn't show the current page either. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
