### PR TITLE
fix: duplicate execution of the_content filter

### DIFF
--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -20,6 +20,14 @@ final class Newspack_Popups_Inserter {
 	protected static $popups = [];
 
 	/**
+	 * Whether we've already inserted campaigns into the content.
+	 * If we've already inserted campaigns into the content, don't try to do it again.
+	 *
+	 * @var boolean
+	 */
+	protected static $the_content_has_rendered = false;
+
+	/**
 	 * Retrieve the appropriate popups for the current post.
 	 *
 	 * @return array Popup objects.
@@ -127,6 +135,11 @@ final class Newspack_Popups_Inserter {
 	 * @param string $content The content of the post.
 	 */
 	public static function insert_popups_in_content( $content = '' ) {
+		// Avoid duplicate execution.
+		if ( true === self::$the_content_has_rendered ) {
+			return $content;
+		}
+
 		// Not Frontend.
 		if ( is_admin() ) {
 			return $content;
@@ -226,6 +239,7 @@ final class Newspack_Popups_Inserter {
 		}
 
 		self::enqueue_popup_assets();
+		self::$the_content_has_rendered = true;
 		return $output;
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This addresses behavior described in https://github.com/Automattic/newspack-plugin/pull/575#issuecomment-653256024.

High-level summary: when the Jetpack Related Posts module is enabled, and it displays at least one related post that lacks a featured image, it causes the `the_content` hook to fire multiple times. This results in the [`insert_popups_in_content`](https://github.com/Automattic/newspack-popups/pull/165/files#diff-9c9a6b7ce934e14992cebfb9a2b61470R137) callback to be run multiple times as well, which potentially results in AMP analytics event triggers to be outputted more than once per element. This in turn causes several JS errors for the duplicate event triggers and could potentially pose problems for AMP validation in the future.

This PR fixes this (and any other undiscovered conditions where `the_content` might fire multiple times) by only executing `insert_popups_in_content` the first time the `the_content` hook fires. Tested on several staging and live sites without issues.

### How to test the changes in this Pull Request:

1. Make sure to update the main Newspack plugin to the latest `master` (ensure that this commit is present: https://github.com/Automattic/newspack-plugin/commit/9017ddab56cc45e982283d2421c9287605bcff5d)
2. In **Jetpack Settings > Traffic**, enable Jetpack Related Posts and enable thumbnails if available (for convenience, this doesn't actually matter for reproducing the issue).
3. While on `master` of the popups plugin, view a post in AMP mode that will display at least one campaign containing the Mailchimp block. Doesn't matter if it's overlay or inline.
4. Confirm that there are related posts appearing at the bottom of the post content.
5. If all three related posts have featured images, edit one and remove the featured image, then save that post. If at least one related post already lacks a featured image, skip to the next step.
6. Refresh the post front-end. Observe in the JS console one or more `Element not found` AMP errors.
7. Check out this branch of the popups plugin. Hard-refresh the page and/or view in a new Incognito window to force campaigns to appear again.
8. Observe that the campaign behavior is unchanged, but that the JS errors no longer appear.
9. For good measure, insert a Mailchimp block into one of the campaigns and follow the [testing instructions](https://github.com/Automattic/newspack-plugin/pull/575#issue-442717333) for the new NTG newsletter analytics events to confirm that impression and signup events fire correctly.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
