### PR TITLE
Make popupVisible non-interactive event

### DIFF
--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -518,6 +518,9 @@ final class Newspack_Popups_Model {
 								"event_name": "<?php echo esc_html__( 'Seen', 'newspack-popups' ); ?>",
 								"event_label": "<?php echo esc_attr( $event_label ); ?>",
 								"event_category": "<?php echo esc_attr( $event_category ); ?>"
+							},
+							"extraUrlParams": {
+								"ni": 1
 							}
 						}
 					}

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -508,12 +508,13 @@ final class Newspack_Popups_Model {
 
 		$analytics_events = [
 			[
-				'id'             => 'popupPageLoaded-' . $popup_id,
-				'on'             => 'ini-load',
-				'element'        => '#' . esc_attr( $element_id ),
-				'event_name'     => esc_html__( 'Load', 'newspack-popups' ),
-				'event_label'    => esc_attr( $event_label ),
-				'event_category' => esc_attr( $event_category ),
+				'id'              => 'popupPageLoaded-' . $popup_id,
+				'on'              => 'ini-load',
+				'element'         => '#' . esc_attr( $element_id ),
+				'event_name'      => esc_html__( 'Load', 'newspack-popups' ),
+				'event_label'     => esc_attr( $event_label ),
+				'event_category'  => esc_attr( $event_category ),
+				'non_interaction' => true,
 			],
 			[
 				'id'              => 'popupSeen-' . $popup_id,

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -280,7 +280,7 @@ final class Newspack_Popups_Model {
 	 * @return array Popup objects array
 	 */
 	protected static function retrieve_popups_with_query( WP_Query $query, $include_categories = false ) {
-		$popups             = [];
+		$popups = [];
 		if ( $query->have_posts() ) {
 			while ( $query->have_posts() ) {
 				$query->the_post();
@@ -484,50 +484,6 @@ final class Newspack_Popups_Model {
 			</amp-analytics>
 		<?php endif; ?>
 		<?php
-
-		// GA events which are not supported by Newspack plugin filter.
-		if ( class_exists( '\Google\Site_Kit\Context', '\Google\Site_Kit\Modules\Analytics' ) ) {
-			$analytics           = new \Google\Site_Kit\Modules\Analytics( new \Google\Site_Kit\Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) );
-			$google_analytics_id = $analytics->get_settings()->get()['propertyID'];
-		} else {
-			return '';
-		}
-
-		$event_category = 'Newspack Announcement';
-		$event_label    = 'Newspack Announcement: ' . $popup['title'] . ' (' . $popup['id'] . ')';
-
-		?>
-		<amp-analytics type="gtag" data-credentials="include">
-			<script type="application/json">
-				{
-					"vars" : {
-						"gtag_id": "<?php echo esc_attr( $google_analytics_id ); ?>",
-						"config" : {
-							"<?php echo esc_attr( $google_analytics_id ); ?>": { "groups": "default", "send_page_view": false }
-						}
-					},
-					"triggers": {
-						"popupVisible": {
-							"on": "visible",
-							"request": "event",
-							"selector": "#<?php echo esc_attr( $element_id ); ?>",
-							"visibilitySpec": {
-								"totalTimeMin": "500"
-							},
-							"vars": {
-								"event_name": "<?php echo esc_html__( 'Seen', 'newspack-popups' ); ?>",
-								"event_label": "<?php echo esc_attr( $event_label ); ?>",
-								"event_category": "<?php echo esc_attr( $event_category ); ?>"
-							},
-							"extraUrlParams": {
-								"ni": 1
-							}
-						}
-					}
-				}
-			</script>
-		</amp-analytics>
-		<?php
 	}
 
 	/**
@@ -558,6 +514,18 @@ final class Newspack_Popups_Model {
 				'event_name'     => esc_html__( 'Load', 'newspack-popups' ),
 				'event_label'    => esc_attr( $event_label ),
 				'event_category' => esc_attr( $event_category ),
+			],
+			[
+				'id'              => 'popupSeen-' . $popup_id,
+				'on'              => 'visible',
+				'element'         => '#' . esc_attr( $element_id ),
+				'event_name'      => esc_html__( 'Seen', 'newspack-popups' ),
+				'event_label'     => esc_attr( $event_label ),
+				'event_category'  => esc_attr( $event_category ),
+				'non_interaction' => true,
+				'visibilitySpec'  => [
+					'totalTimeMin' => 500,
+				],
 			],
 		];
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR should fix an issue with artificially low bounce rates reported in Google Analytics. Since the popupVisible event wasn't marked as a non-interaction event, anyone that saw a campaign would be marked as a user that didn't bounce. 

### How to test the changes in this Pull Request:

I'm not sure how you'd really test this, since a local environment is going to have a weird bounce rate if you've hooked it up to GA, and bounce rate analytics aren't available in real-time AFAIK. I think we should find a willing participant and make the change on their site for a couple days to see how it affects things.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
