### PR TITLE
Fix settings styling

### DIFF
--- a/includes/class-newspack-popups-settings.php
+++ b/includes/class-newspack-popups-settings.php
@@ -76,6 +76,14 @@ class Newspack_Popups_Settings {
 			self::get_settings()
 		);
 		\wp_enqueue_script( 'newspack-popups-settings' );
+		\wp_register_style(
+			'newspack-popups-settings',
+			plugins_url( '../dist/settings.css', __FILE__ ),
+			null,
+			filemtime( dirname( NEWSPACK_POPUPS_PLUGIN_FILE ) . '/dist/settings.css' )
+		);
+		\wp_style_add_data( 'newspack-popups-settings', 'rtl', 'replace' );
+		\wp_enqueue_style( 'newspack-popups-settings' );
 	}
 }
 

--- a/src/settings/index.js
+++ b/src/settings/index.js
@@ -14,6 +14,11 @@ import apiFetch from '@wordpress/api-fetch';
 import { Card, Grid, FormattedHeader, CheckboxControl } from 'newspack-components';
 import HeaderIcon from '@material-ui/icons/Settings';
 
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
 const App = () => {
 	const [ inFlight, setInFlight ] = useState( false );
 	const [ settings, setSettings ] = useState( newspack_popups_settings );

--- a/src/settings/style.scss
+++ b/src/settings/style.scss
@@ -1,0 +1,3 @@
+.newspack-checkbox-control .components-checkbox-control__input::before {
+	content: none !important;
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Applies missing stylesheet to the settings view and fixes one styling issue.

### How to test the changes in this Pull Request:

1. On master, build the plugin files and visit the settings screen 
2. Observe that there is no Newspack-brand-related styling applied and there is no `settings.css` file loaded
3. Observe that there's a checkmark render on top of the checkbox (when checked)
4. Switch to this branch and rebuild
4. Observe both issues resolved

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
