### PR TITLE
Add option to suppress all newsletter campaigns if one was dismissed

### DIFF
--- a/includes/class-newspack-popups-api.php
+++ b/includes/class-newspack-popups-api.php
@@ -12,8 +12,7 @@ defined( 'ABSPATH' ) || exit;
  */
 final class Newspack_Popups_API {
 
-	const NEWSPACK_POPUPS_VIEW_LIMIT                                   = 1;
-	const NEWSPACK_POPUPS_NEWSLETTER_POPUPS_SUPPRESSION_TRANSIENT_NAME = '_newspack_newsletter_popups_suppression';
+	const NEWSPACK_POPUPS_VIEW_LIMIT = 1;
 
 	/**
 	 * Constructor.
@@ -210,7 +209,7 @@ final class Newspack_Popups_API {
 			$response['displayPopup'] = true;
 		};
 
-		$is_suppressing_newsletter_popups = get_transient( self::NEWSPACK_POPUPS_NEWSLETTER_POPUPS_SUPPRESSION_TRANSIENT_NAME, true );
+		$is_suppressing_newsletter_popups = get_transient( $this->get_newsletter_campaigns_suppression_transient_name( $request ), true );
 		$is_newsletter_popup              = \Newspack_Popups_Model::has_newsletter_prompt( $popup );
 		$settings                         = \Newspack_Popups_Settings::get_settings();
 		if ( $settings['suppress_all_newsletter_campaigns_if_one_dismissed'] && $is_suppressing_newsletter_popups && $is_newsletter_popup ) {
@@ -248,7 +247,7 @@ final class Newspack_Popups_API {
 					$popup               = \Newspack_Popups_Model::retrieve_popup_by_id( $popup_id );
 					$is_newsletter_popup = \Newspack_Popups_Model::has_newsletter_prompt( $popup );
 					if ( $is_newsletter_popup ) {
-						set_transient( self::NEWSPACK_POPUPS_NEWSLETTER_POPUPS_SUPPRESSION_TRANSIENT_NAME, true );
+						set_transient( $this->get_newsletter_campaigns_suppression_transient_name( $request ), true );
 					}
 				}
 
@@ -302,6 +301,23 @@ final class Newspack_Popups_API {
 		}
 		if ( $reader_id && $url && $popup_id ) {
 			return $reader_id . '-' . $popup_id . '-popup';
+		}
+		return false;
+	}
+
+	/**
+	 * Get transient name for newsletter campaigns suppression feature.
+	 *
+	 * @param WP_REST_Request $request amp-access request.
+	 * @return string Transient id.
+	 */
+	public function get_newsletter_campaigns_suppression_transient_name( $request ) {
+		$reader_id = isset( $request['rid'] ) ? esc_attr( $request['rid'] ) : false;
+		if ( ! $reader_id ) {
+			$reader_id = $this->get_reader_id();
+		}
+		if ( $reader_id ) {
+			return $reader_id . '-newsletter-campaign-suppression';
 		}
 		return false;
 	}

--- a/includes/class-newspack-popups-settings.php
+++ b/includes/class-newspack-popups-settings.php
@@ -50,6 +50,7 @@ class Newspack_Popups_Settings {
 	public static function get_settings() {
 		return [
 			'suppress_newsletter_campaigns' => get_option( 'suppress_newsletter_campaigns', true ),
+			'suppress_all_newsletter_campaigns_if_one_dismissed' => get_option( 'suppress_all_newsletter_campaigns_if_one_dismissed', true ),
 		];
 	}
 

--- a/src/settings/index.js
+++ b/src/settings/index.js
@@ -38,7 +38,7 @@ const App = () => {
 			<Card>
 				<CheckboxControl
 					label={ __(
-						'Supress Newsletter campaigns if visitor is coming from email.',
+						'Suppress Newsletter campaigns if visitor is coming from email.',
 						'newspack-popups'
 					) }
 					disabled={ inFlight }
@@ -47,7 +47,7 @@ const App = () => {
 				/>
 				<CheckboxControl
 					label={ __(
-						'Supress all Newsletter campaigns if at least once Newsletter campaign was permanently dismissed.',
+						'Suppress all Newsletter campaigns if at least once Newsletter campaign was permanently dismissed.',
 						'newspack-popups'
 					) }
 					disabled={ inFlight }

--- a/src/settings/index.js
+++ b/src/settings/index.js
@@ -45,6 +45,15 @@ const App = () => {
 					checked={ settings.suppress_newsletter_campaigns === '1' }
 					onChange={ handleSettingChange( 'suppress_newsletter_campaigns' ) }
 				/>
+				<CheckboxControl
+					label={ __(
+						'Supress all Newsletter campaigns if at least once Newsletter campaign was permanently dismissed.',
+						'newspack-popups'
+					) }
+					disabled={ inFlight }
+					checked={ settings.suppress_all_newsletter_campaigns_if_one_dismissed === '1' }
+					onChange={ handleSettingChange( 'suppress_all_newsletter_campaigns_if_one_dismissed' ) }
+				/>
 			</Card>
 		</Grid>
 	);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Add a setting (on by default) to suppress all Newsletter Campaigns if one of them was dismissed permanently.

### How to test the changes in this Pull Request:

1. Create three campaigns – two with newsletter forms (Jetpack Mailchimp form), one without. Set all to "Every page" frequency.
2. Visit the site, observe all three are shown.
3. Dismiss permanently ("Not interested" button at the bottom) one of the newsletter campaigns
3. Reload the page – observe that both newsletter campaigns are not visible, and only the non-newsletter one renders
4. Visit Campaigns settings, uncheck the "Supress all Newsletter campaigns if at least once Newsletter campaign was permanently dismissed." option
4. Revisit the site – observe that only the dismissed campaign is not displayed.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
