### PR TITLE
Fix: UTM params suppression conflict

### DIFF
--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -127,15 +127,6 @@ final class Newspack_Popups_Inserter {
 				add_filter( 'the_content', [ $this, 'insert_popups_in_content' ], 1 );
 			}
 		);
-
-		// Tell WP to take utm_medium param into account when we ask get_query_var.
-		add_filter(
-			'query_vars',
-			function ( $vars ) {
-				$vars[] .= 'utm_medium';
-				return $vars;
-			}
-		);
 	}
 
 	/**
@@ -454,29 +445,7 @@ final class Newspack_Popups_Inserter {
 	}
 
 	/**
-	 * If:
-	 * - the visitor is coming from email (utm_medium param),
-	 * - the suppress_newsletter_campaigns setting is on,
-	 * - the pop-up has a newsletter form,
-	 * then it should not be displayed.
-	 *
-	 * @param object $popup The popup to assess.
-	 * @return bool Should popup be shown.
-	 */
-	public static function assess_newsletter_campaign_suppression( $popup ) {
-		$settings = \Newspack_Popups_Settings::get_settings();
-		if (
-			'email' === get_query_var( 'utm_medium' ) &&
-			$settings['suppress_newsletter_campaigns'] &&
-			\Newspack_Popups_Model::has_newsletter_prompt( $popup )
-		) {
-			return false;
-		}
-		return true;
-	}
-
-	/**
-	 * Should Popup be displayed, based on universal conditions.
+	 * Should Popup be rendered, based on universal conditions.
 	 *
 	 * @param object $popup The popup to assess.
 	 * @return bool Should popup be shown.
@@ -488,8 +457,7 @@ final class Newspack_Popups_Inserter {
 		}
 		return self::assess_is_post( $popup ) &&
 			self::assess_test_mode( $popup ) &&
-			self::assess_categories_filter( $popup ) &&
-			self::assess_newsletter_campaign_suppression( $popup );
+			self::assess_categories_filter( $popup );
 	}
 }
 $newspack_popups_inserter = new Newspack_Popups_Inserter();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes issues cased by #173.

### How to test the changes in this Pull Request:

1. Create inline, every page campaigns: two with newsltter signup forms (A, B) and one without (C)  
2. Add "UTM Suppression" to campaign A of value `My Newsletter`
3. Visit an article to verify all campaigns are shown
4. Visit that article with `utm_source=My%20Newsletter` parameter in URL
4. Observe that only B and C campaigns are visible
4. Navigate to another article (so that there's no `utm_source` parameter in the URL)
4. Observe that only B and C campaigns are visible
4. Visit that article with `utm_medium=email` parameter in URL
4. Observe that only C campaign is visible
4. Navigate to another article (so that there's no `utm_medium` parameter in the URL)
4. Observe that only C campaign is visible

A tip: if your local instance is as slow as mine, you'll get amp-access timeout errors. Instead of visually checking for campaigns visibility, you can take a peek a devtools network tab and the response from `wp-json/newspack-popups/v1/reader` endpoint – `displayPopup` is the boolean responsible for visiblity.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
