### PR TITLE
fix: a typo in one of the campaign settings options

### DIFF
--- a/src/settings/index.js
+++ b/src/settings/index.js
@@ -52,7 +52,7 @@ const App = () => {
 				/>
 				<CheckboxControl
 					label={ __(
-						'Suppress all Newsletter campaigns if at least once Newsletter campaign was permanently dismissed.',
+						'Suppress all Newsletter campaigns if at least one Newsletter campaign was permanently dismissed.',
 						'newspack-popups'
 					) }
 					disabled={ inFlight }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a typo in one of the option labels. From:

```
Suppress all Newsletter campaigns if at least once Newsletter campaign was permanently dismissed.
```
to:
```
Suppress all Newsletter campaigns if at least one Newsletter campaign was permanently dismissed.
```

### How to test the changes in this Pull Request:

1. Visit **Campaigns > Settings** and review the second option.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
