### PR TITLE
Add all campaigns view (Campaigns wizard from Newspack Plugin)

### DIFF
--- a/includes/analytics/class-analytics-utils.php
+++ b/includes/analytics/class-analytics-utils.php
@@ -1,0 +1,300 @@
+<?php
+/**
+ * Popups Analytics utils.
+ *
+ * @package Newspack
+ */
+
+use Google\Site_Kit\Modules\Analytics;
+use Google\Site_Kit\Context;
+use Google\Site_Kit_Dependencies\Google_Service_AnalyticsReporting_DateRange;
+use Google\Site_Kit_Dependencies\Google_Service_AnalyticsReporting_Metric;
+use Google\Site_Kit_Dependencies\Google_Service_AnalyticsReporting_ReportRequest;
+use Google\Site_Kit_Dependencies\Google_Service_AnalyticsReporting_Dimension;
+use Google\Site_Kit_Dependencies\Google_Service_AnalyticsReporting_GetReportsRequest;
+use Google\Site_Kit_Dependencies\Google_Service_AnalyticsReporting;
+use Google\Site_Kit_Dependencies\Google_Service_AnalyticsReporting_SegmentDimensionFilter;
+use Google\Site_Kit_Dependencies\Google_Service_AnalyticsReporting_DimensionFilterClause;
+use Google\Site_Kit\Core\Storage\Options;
+use Google\Site_Kit\Core\Storage\User_Options;
+use Google\Site_Kit\Core\Authentication\Authentication;
+
+/**
+ * Popup Analytics Utilities.
+ */
+class Analytics_Utils {
+	// Category is fixed, it identifies the GA custom event.
+	const EVENT_CATEGORY = 'Newspack Announcement';
+
+	/**
+	 * Get dates in range.
+	 *
+	 * @param Date   $start start date.
+	 * @param Date   $end end date.
+	 * @param string $format date format.
+	 * @return array array of dates in the given range.
+	 */
+	private static function get_dates_in_range( $start, $end, $format = 'Y-m-d' ) {
+		return array_map(
+			function( $timestamp ) use ( $format ) {
+				return gmdate( $format, $timestamp );
+			},
+			range( strtotime( $start ) + ( $start < $end ? 4000 : 8000 ), strtotime( $end ) + ( $start < $end ? 8000 : 4000 ), 86400 )
+		);
+	}
+
+	/**
+	 * Date before.
+	 *
+	 * @param string $offset date offset in days.
+	 * @return string formatted date.
+	 */
+	private static function date_before( $offset ) {
+		$today = new \DateTime();
+		$today = $today->modify( '-' . $offset . ' days' );
+		return $today->format( 'Y-m-d' );
+	}
+
+	/**
+	 * Fill in dates.
+	 *
+	 * @param array  $input array of days.
+	 * @param string $offset date offset in days.
+	 * @return array array of dates.
+	 */
+	private static function fill_in_dates( $input, $offset ) {
+		$all_days = self::get_dates_in_range(
+			self::date_before( $offset ),
+			self::date_before( '1' )
+		);
+
+		$days_filled = array_map(
+			function ( $day ) use ( $input ) {
+				return array(
+					'date'  => $day,
+					'value' => isset( $input[ $day ] ) ? intval( $input[ $day ] ) : 0,
+				);
+			},
+			$all_days
+		);
+
+		return $days_filled;
+	}
+
+	/**
+	 * Get GA report.
+	 *
+	 * @param Object $options options.
+	 * @return array array of rows with GA report data.
+	 */
+	public static function get_ga_report( $options ) {
+		$offset = $options['offset'];
+
+		// Load and query analytics.
+		if ( defined( 'GOOGLESITEKIT_PLUGIN_MAIN_FILE' ) ) {
+			$context   = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
+			$analytics = new Analytics( $context );
+
+			if ( $analytics->is_connected() ) {
+				// Create the DateRange object.
+				$date_range = new Google_Service_AnalyticsReporting_DateRange();
+				$start_date = gmdate( 'Y-m-d', strtotime( $offset . ' days ago' ) );
+				$end_date   = gmdate( 'Y-m-d', strtotime( '1 days ago' ) );
+				$date_range->setStartDate( $start_date );
+				$date_range->setEndDate( $end_date );
+
+				// Create the Metrics object.
+				$metrics = new Google_Service_AnalyticsReporting_Metric();
+				$metrics->setExpression( 'ga:totalEvents' );
+				$metrics->setAlias( 'events' );
+
+				// Filter just the popups custom event category.
+				$dimension_category_filter = new Google_Service_AnalyticsReporting_SegmentDimensionFilter();
+				$dimension_category_filter->setDimensionName( 'ga:eventCategory' );
+				$dimension_category_filter->setOperator( 'EXACT' );
+				$dimension_category_filter->setExpressions( array( self::EVENT_CATEGORY ) );
+
+				// Create the DimensionFilterClauses.
+				$dimension_filter_clause = new Google_Service_AnalyticsReporting_DimensionFilterClause();
+				$dimension_filter_clause->setFilters( array( $dimension_category_filter ) );
+
+				// Create the Dimension objects.
+				$date_dimension = new Google_Service_AnalyticsReporting_Dimension();
+				$date_dimension->setName( 'ga:date' );
+				$action_dimension = new Google_Service_AnalyticsReporting_Dimension();
+				$action_dimension->setName( 'ga:eventAction' );
+				$label_dimension = new Google_Service_AnalyticsReporting_Dimension();
+				$label_dimension->setName( 'ga:eventLabel' );
+
+				// Create the ReportRequest object.
+				$profile_id = $analytics->get_data( 'profile-id' );
+				$request    = new Google_Service_AnalyticsReporting_ReportRequest();
+				$request->setViewId( $profile_id );
+				$request->setDateRanges( $date_range );
+				$request->setDimensions(
+					array(
+						$date_dimension,
+						$action_dimension,
+						$label_dimension,
+					)
+				);
+				$request->setMetrics( array( $metrics ) );
+				$request->setDimensionFilterClauses( array( $dimension_filter_clause ) );
+
+				$body = new Google_Service_AnalyticsReporting_GetReportsRequest();
+				$body->setReportRequests( array( $request ) );
+				$ga_options     = new Options( $context );
+				$user_options   = new User_Options( $context );
+				$authentication = new Authentication( $context, $ga_options, $user_options );
+				$client         = $authentication->get_oauth_client()->get_client();
+
+				try {
+					$analyticsreporting = new Google_Service_AnalyticsReporting( $client );
+					$report_results     = $analyticsreporting->reports->batchGet( $body );
+					if ( isset( $report_results->reports[0] ) ) {
+						return $report_results->reports[0]->data->rows;
+					}
+				} catch ( \Exception $error ) {
+					$error_data = json_decode( $error->getMessage() );
+					if ( isset( $error_data ) && 'UNAUTHENTICATED' === $error_data->error->status ) {
+						return new WP_Error( 'newspack_campaign_analytics_sitekit_auth', __( 'Please authenticate with Google Analytics to view Campaign analytics.', 'newspack' ) );
+					}
+					return new WP_Error( 'newspack_campaign_analytics', __( 'Google Analytics data fetching error.', 'newspack' ), $error_data );
+				}
+			} else {
+				return new WP_Error( 'newspack_campaign_analytics_sitekit_disconnected', __( 'Connect Site Kit plugin to view Campaign Analytics.', 'newspack' ) );
+			}
+		}
+	}
+
+	/**
+	 * Get report.
+	 *
+	 * @param Object $options options.
+	 * @return Object report data.
+	 */
+	public static function get_report( $options ) {
+		$offset         = $options['offset'];
+		$event_label_id = $options['event_label_id'];
+		$event_action   = $options['event_action'];
+
+		$ga_data_rows = self::get_ga_report( $options );
+		if ( is_wp_error( $ga_data_rows ) ) {
+			return $ga_data_rows;
+		}
+
+		$all_actions = [];
+		$all_labels  = [];
+
+		// Key metrics.
+		$aggregate_seen_events            = 0;
+		$aggregate_form_submission_events = -1;
+		$aggregate_link_click_events      = -1;
+
+		$post_edit_link = null;
+
+		$ga_data_days = array_reduce(
+			$ga_data_rows,
+			function ( $days, $row ) use ( $event_label_id, $event_action, &$all_actions, &$all_labels, &$aggregate_seen_events, &$aggregate_form_submission_events, &$aggregate_link_click_events, &$post_edit_link ) {
+				$action = array(
+					'label' => $row['dimensions'][1],
+					'value' => $row['dimensions'][1],
+				);
+
+				$label_name = str_replace( self::EVENT_CATEGORY . ': ', '', $row['dimensions'][2] );
+				preg_match(
+					'/\(([0-9]*)\)$/',
+					$label_name,
+					$id_matches
+				);
+
+				$post_id = isset( $id_matches[1] ) ? $id_matches[1] : '';
+				$label   = array(
+					// Remove post id in parens.
+					'label' => str_replace( " ($post_id)", '', $label_name ),
+					'value' => $post_id,
+				);
+
+				$matches_label  = '' == $event_label_id || $post_id == $event_label_id;
+				$matches_action = '' == $event_action || $action['value'] == $event_action;
+
+				if ( $matches_label && $post_id ) {
+					$value = $row['metrics'][0]['values'][0];
+
+					$post = get_post( $post_id, ARRAY_A );
+					if ( isset( $post['post_content'] ) ) {
+						$post_content = $post['post_content'];
+						if (
+							-1 === $aggregate_link_click_events &&
+							strpos( $post_content, '<a ' ) !== false
+						) {
+							$aggregate_link_click_events = 0;
+						}
+						if (
+							-1 === $aggregate_form_submission_events &&
+							strpos( $post_content, '<!-- wp:jetpack/mailchimp' ) !== false ||
+							strpos( $post_content, '<!-- wp:mailchimp-for-wp/form' ) !== false ||
+							strpos( $post_content, '<form' ) !== false
+						) {
+							$aggregate_form_submission_events = 0;
+						}
+
+						if ( '' != $event_label_id && get_post_status( $post['ID'] ) == 'publish' ) {
+							$post_edit_link = get_edit_post_link( $post['ID'] );
+						}
+					}
+
+					// Key metrics.
+					if ( 'Seen' == $action['value'] ) {
+						$aggregate_seen_events = $aggregate_seen_events + $value;
+					}
+					if ( 'Form Submission' == $action['value'] ) {
+						$aggregate_form_submission_events = $aggregate_form_submission_events + $value;
+					}
+					if ( 'Link Click' == $action['value'] ) {
+						$aggregate_link_click_events = $aggregate_link_click_events + $value;
+					}
+
+					if ( $matches_action ) {
+						if ( ! in_array( $action, $all_actions ) ) {
+							$all_actions[] = $action;
+						}
+
+						if ( $post_id ) {
+							// Last event with this label will be the final one.
+							// If a popup was renamed, the last title will end up as the label.
+							$all_labels[ $post_id ] = $label;
+						}
+
+						$parsed_date = date_create( $row['dimensions'][0] );
+						$date        = date_format( $parsed_date, 'Y-m-d' );
+						if ( isset( $days[ $date ] ) ) {
+							$value = $days[ $date ] + $value;
+						}
+						$days[ $date ] = $value;
+					}
+				}
+
+
+				return $days;
+
+			},
+			array()
+		);
+
+		// Key metrics.
+		$key_metrics = array(
+			'seen'             => $aggregate_seen_events,
+			'form_submissions' => $aggregate_form_submission_events,
+			'link_clicks'      => $aggregate_link_click_events,
+		);
+
+		return array(
+			'report'         => self::fill_in_dates( $ga_data_days, $offset ),
+			'actions'        => $all_actions,
+			'labels'         => array_values( $all_labels ),
+			'key_metrics'    => $key_metrics,
+			'post_edit_link' => isset( $post_edit_link ) ? $post_edit_link : false,
+		);
+	}
+}

--- a/includes/class-newspack-popups-api.php
+++ b/includes/class-newspack-popups-api.php
@@ -7,6 +7,8 @@
 
 defined( 'ABSPATH' ) || exit;
 
+require_once dirname( NEWSPACK_POPUPS_PLUGIN_FILE ) . '/includes/analytics/class-analytics-utils.php';
+
 /**
  * API endpoints
  */
@@ -83,6 +85,28 @@ final class Newspack_Popups_API {
 					],
 					'option_value' => [
 						'sanitize_callback' => 'esc_attr',
+					],
+				],
+			]
+		);
+		register_rest_route(
+			'newspack-popups/v1',
+			'analytics/report',
+			[
+				[
+					'methods'             => \WP_REST_Server::READABLE,
+					'callback'            => [ $this, 'get_analytics_report' ],
+					'permission_callback' => [ $this, 'permission_callback' ],
+					'args'                => [
+						'offset'         => [
+							'sanitize_callback' => 'sanitize_text_field',
+						],
+						'event_label_id' => [
+							'sanitize_callback' => 'sanitize_text_field',
+						],
+						'event_action'   => [
+							'sanitize_callback' => 'sanitize_text_field',
+						],
 					],
 				],
 			]
@@ -432,6 +456,21 @@ final class Newspack_Popups_API {
 	public function get_reader_id() {
 		// TODO: Is retrieving the amp-access cookie the best way to get READER_ID outside the context of amp-access?
 		return isset( $_COOKIE['amp-access'] ) ? esc_attr( $_COOKIE['amp-access'] ) : false; // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+	}
+
+	/**
+	 * Get Campaigns Analytics report.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+	 */
+	public function get_analytics_report( $request ) {
+		$options = array(
+			'offset'         => $request['offset'],
+			'event_label_id' => $request['event_label_id'],
+			'event_action'   => $request['event_action'],
+		);
+		return rest_ensure_response( \Analytics_Utils::get_report( $options ) );
 	}
 }
 $newspack_popups_api = new Newspack_Popups_API();

--- a/includes/class-newspack-popups-api.php
+++ b/includes/class-newspack-popups-api.php
@@ -107,7 +107,7 @@ final class Newspack_Popups_API {
 		if ( ! current_user_can( 'manage_options' ) ) {
 			return new \WP_Error(
 				'newspack_rest_forbidden',
-				esc_html__( 'You cannot use this resource.', 'newspack' ),
+				esc_html__( 'You cannot use this resource.', 'newspack-popups' ),
 				[
 					'status' => 403,
 				]
@@ -127,7 +127,7 @@ final class Newspack_Popups_API {
 		} else {
 			return new \WP_Error(
 				'newspack_popups_settings_error',
-				esc_html__( 'Error updating the settings.', 'newspack' )
+				esc_html__( 'Error updating the settings.', 'newspack-popups' )
 			);
 		}
 	}

--- a/includes/class-newspack-popups-api.php
+++ b/includes/class-newspack-popups-api.php
@@ -76,7 +76,7 @@ final class Newspack_Popups_API {
 		);
 		\register_rest_route(
 			'newspack-popups/v1',
-			'sitewide_default/(?P<id>\d+)',
+			'sitewide-default/(?P<id>\d+)',
 			[
 				'methods'             => \WP_REST_Server::EDITABLE,
 				'callback'            => [ $this, 'set_sitewide_default_endpoint' ],
@@ -90,7 +90,7 @@ final class Newspack_Popups_API {
 		);
 		\register_rest_route(
 			'newspack-popups/v1',
-			'sitewide_default/(?P<id>\d+)',
+			'sitewide-default/(?P<id>\d+)',
 			[
 				'methods'             => \WP_REST_Server::DELETABLE,
 				'callback'            => [ $this, 'unset_sitewide_default_endpoint' ],
@@ -346,7 +346,7 @@ final class Newspack_Popups_API {
 	 */
 	public function set_sitewide_default_endpoint( $request ) {
 		$response = Newspack_Popups_Model::set_sitewide_popup( $request['id'] );
-		return is_wp_error( $response ) ? $response : [ 'success' => true ];
+		return is_wp_error( $response ) ? $response : $this->api_get_settings();
 	}
 
 	/**
@@ -356,7 +356,7 @@ final class Newspack_Popups_API {
 	 */
 	public function unset_sitewide_default_endpoint( $request ) {
 		$response = Newspack_Popups_Model::unset_sitewide_popup( $request['id'] );
-		return is_wp_error( $response ) ? $response : [ 'success' => true ];
+		return is_wp_error( $response ) ? $response : $this->api_get_settings();
 	}
 
 	/**

--- a/includes/class-newspack-popups-api.php
+++ b/includes/class-newspack-popups-api.php
@@ -119,6 +119,23 @@ final class Newspack_Popups_API {
 				],
 			]
 		);
+		register_rest_route(
+			'newspack-popups/v1',
+			'/(?P<id>\d+)/publish',
+			[
+				'methods'             => \WP_REST_Server::EDITABLE,
+				'callback'            => [ $this, 'api_publish_popup' ],
+				'permission_callback' => [ $this, 'permission_callback' ],
+				'args'                => [
+					'id'      => [
+						'sanitize_callback' => 'absint',
+					],
+					'options' => [
+						'validate_callback' => [ $this, 'api_validate_options' ],
+					],
+				],
+			]
+		);
 		\register_rest_route(
 			'newspack-popups/v1',
 			'settings',
@@ -569,6 +586,21 @@ final class Newspack_Popups_API {
 			return $response;
 		}
 
+		return $this->api_get_settings();
+	}
+
+	/**
+	 * Publish a Pop-up.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response
+	 */
+	public function api_publish_popup( $request ) {
+		$id    = $request['id'];
+		$popup = get_post( $id );
+		if ( is_a( $popup, 'WP_Post' ) && Newspack_Popups::NEWSPACK_PLUGINS_CPT === $popup->post_type ) {
+			wp_publish_post( $id );
+		}
 		return $this->api_get_settings();
 	}
 

--- a/includes/class-newspack-popups-api.php
+++ b/includes/class-newspack-popups-api.php
@@ -60,6 +60,20 @@ final class Newspack_Popups_API {
 				],
 			]
 		);
+		register_rest_route(
+			'newspack-popups/v1',
+			'/(?P<id>\d+)',
+			[
+				'methods'             => \WP_REST_Server::DELETABLE,
+				'callback'            => [ $this, 'api_delete_popup' ],
+				'permission_callback' => [ $this, 'permission_callback' ],
+				'args'                => [
+					'id' => [
+						'sanitize_callback' => 'absint',
+					],
+				],
+			]
+		);
 		\register_rest_route(
 			'newspack-popups/v1',
 			'sitewide_default/(?P<id>\d+)',
@@ -502,6 +516,23 @@ final class Newspack_Popups_API {
 		$response = Newspack_Popups_Model::set_popup_options( $id, $options );
 		if ( is_wp_error( $response ) ) {
 			return $response;
+		}
+
+		return $this->api_get_settings();
+	}
+
+	/**
+	 * Delete a Pop-up.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response
+	 */
+	public function api_delete_popup( $request ) {
+		$id = $request['id'];
+
+		$popup = get_post( $id );
+		if ( is_a( $popup, 'WP_Post' ) && Newspack_Popups::NEWSPACK_PLUGINS_CPT === $popup->post_type ) {
+			wp_delete_post( $id );
 		}
 
 		return $this->api_get_settings();

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -869,4 +869,19 @@ final class Newspack_Popups_Model {
 		<?php
 		return ob_get_clean();
 	}
+
+	/**
+	 * Get popups list with edit links.
+	 *
+	 * @return Array
+	 */
+	public static function get_popups_list() {
+		return array_map(
+			function( $popup ) {
+				$popup['edit_link'] = get_edit_post_link( $popup['id'] );
+				return $popup;
+			},
+			self::retrieve_popups( true )
+		);
+	}
 }

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -122,12 +122,18 @@ final class Newspack_Popups {
 
 		$preview_post = count( $recent_posts ) > 0 ? get_the_permalink( $recent_posts[0] ) : '';
 
+		$newspack_dashboard_url = null;
+		if ( defined( 'NEWSPACK_PLUGIN_FILE' ) ) {
+			$newspack_dashboard_url = \Newspack\Wizards::get_url( 'dashboard' );
+		}
+
 		\wp_localize_script(
 			self::NEWSPACK_PLUGINS_CPT,
 			'newspack_popups_frontend_data',
 			[
-				'preview_post' => $preview_post,
-				'all_popups'   => Newspack_Popups_Model::get_popups_list(),
+				'preview_post'           => $preview_post,
+				'all_popups'             => Newspack_Popups_Model::get_popups_list(),
+				'newspack_dashboard_url' => $newspack_dashboard_url,
 			]
 		);
 

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -323,7 +323,7 @@ final class Newspack_Popups {
 	}
 
 	/**
-	 * Load up common JS/CSS for wizards.
+	 * Load up common JS/CSS.
 	 */
 	public static function enqueue_block_editor_assets() {
 		$screen = get_current_screen();

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -124,9 +124,16 @@ final class Newspack_Popups {
 
 		\wp_localize_script(
 			self::NEWSPACK_PLUGINS_CPT,
-			'newspack_popups_wizard_data',
+			'newspack_popups_frontend_data',
 			[
 				'preview_post' => $preview_post,
+				'all_popups'   => array_map(
+					function( $popup ) {
+						$popup['edit_link'] = get_edit_post_link( $popup['id'] );
+						return $popup;
+					},
+					\Newspack_Popups_Model::retrieve_popups( true )
+				),
 			]
 		);
 

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -127,13 +127,7 @@ final class Newspack_Popups {
 			'newspack_popups_frontend_data',
 			[
 				'preview_post' => $preview_post,
-				'all_popups'   => array_map(
-					function( $popup ) {
-						$popup['edit_link'] = get_edit_post_link( $popup['id'] );
-						return $popup;
-					},
-					\Newspack_Popups_Model::retrieve_popups( true )
-				),
+				'all_popups'   => Newspack_Popups_Model::get_popups_list(),
 			]
 		);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -555,31 +555,220 @@
       }
     },
     "@babel/core": {
-      "version": "7.6.4",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.6.4.tgz",
-      "integrity": "sha512-Rm0HGw101GY8FTzpWSyRbki/jzq+/PkNQJ+nSulrdY6gFGOsNseCqD6KHRYe2E+EdzuBdr2pxCp6s4Uk6eJ+XQ==",
+      "version": "7.10.5",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.10.5.tgz",
+      "integrity": "sha512-O34LQooYVDXPl7QWCdW9p4NR+QlzOr7xShPPJz8GsuCU3/8ua/wqTr7gmnxXv+WBESiGU/G5s16i6tUvHkNb+w==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.5.5",
-        "@babel/generator": "^7.6.4",
-        "@babel/helpers": "^7.6.2",
-        "@babel/parser": "^7.6.4",
-        "@babel/template": "^7.6.0",
-        "@babel/traverse": "^7.6.3",
-        "@babel/types": "^7.6.3",
-        "convert-source-map": "^1.1.0",
+        "@babel/code-frame": "^7.10.4",
+        "@babel/generator": "^7.10.5",
+        "@babel/helper-module-transforms": "^7.10.5",
+        "@babel/helpers": "^7.10.4",
+        "@babel/parser": "^7.10.5",
+        "@babel/template": "^7.10.4",
+        "@babel/traverse": "^7.10.5",
+        "@babel/types": "^7.10.5",
+        "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
-        "json5": "^2.1.0",
-        "lodash": "^4.17.13",
+        "gensync": "^1.0.0-beta.1",
+        "json5": "^2.1.2",
+        "lodash": "^4.17.19",
         "resolve": "^1.3.2",
         "semver": "^5.4.1",
         "source-map": "^0.5.0"
       },
       "dependencies": {
-        "lodash": {
-          "version": "4.17.15",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+        "@babel/code-frame": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+          "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "^7.10.4"
+          }
+        },
+        "@babel/generator": {
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.10.5.tgz",
+          "integrity": "sha512-3vXxr3FEW7E7lJZiWQ3bM4+v/Vyr9C+hpolQ8BGFr9Y8Ri2tFLWTixmwKBafDujO1WVah4fhZBeU1bieKdghig==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.10.5",
+            "jsesc": "^2.5.1",
+            "source-map": "^0.5.0"
+          }
+        },
+        "@babel/helper-function-name": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
+          "integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-get-function-arity": "^7.10.4",
+            "@babel/template": "^7.10.4",
+            "@babel/types": "^7.10.4"
+          }
+        },
+        "@babel/helper-get-function-arity": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz",
+          "integrity": "sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.10.4"
+          }
+        },
+        "@babel/helper-member-expression-to-functions": {
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.10.5.tgz",
+          "integrity": "sha512-HiqJpYD5+WopCXIAbQDG0zye5XYVvcO9w/DHp5GsaGkRUaamLj2bEtu6i8rnGGprAhHM3qidCMgp71HF4endhA==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.10.5"
+          }
+        },
+        "@babel/helper-module-imports": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.10.4.tgz",
+          "integrity": "sha512-nEQJHqYavI217oD9+s5MUBzk6x1IlvoS9WTPfgG43CbMEeStE0v+r+TucWdx8KFGowPGvyOkDT9+7DHedIDnVw==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.10.4"
+          }
+        },
+        "@babel/helper-module-transforms": {
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.10.5.tgz",
+          "integrity": "sha512-4P+CWMJ6/j1W915ITJaUkadLObmCRRSC234uctJfn/vHrsLNxsR8dwlcXv9ZhJWzl77awf+mWXSZEKt5t0OnlA==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-module-imports": "^7.10.4",
+            "@babel/helper-replace-supers": "^7.10.4",
+            "@babel/helper-simple-access": "^7.10.4",
+            "@babel/helper-split-export-declaration": "^7.10.4",
+            "@babel/template": "^7.10.4",
+            "@babel/types": "^7.10.5",
+            "lodash": "^4.17.19"
+          }
+        },
+        "@babel/helper-optimise-call-expression": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.4.tgz",
+          "integrity": "sha512-n3UGKY4VXwXThEiKrgRAoVPBMqeoPgHVqiHZOanAJCG9nQUL2pLRQirUzl0ioKclHGpGqRgIOkgcIJaIWLpygg==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.10.4"
+          }
+        },
+        "@babel/helper-replace-supers": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.10.4.tgz",
+          "integrity": "sha512-sPxZfFXocEymYTdVK1UNmFPBN+Hv5mJkLPsYWwGBxZAxaWfFu+xqp7b6qWD0yjNuNL2VKc6L5M18tOXUP7NU0A==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-member-expression-to-functions": "^7.10.4",
+            "@babel/helper-optimise-call-expression": "^7.10.4",
+            "@babel/traverse": "^7.10.4",
+            "@babel/types": "^7.10.4"
+          }
+        },
+        "@babel/helper-simple-access": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.10.4.tgz",
+          "integrity": "sha512-0fMy72ej/VEvF8ULmX6yb5MtHG4uH4Dbd6I/aHDb/JVg0bbivwt9Wg+h3uMvX+QSFtwr5MeItvazbrc4jtRAXw==",
+          "dev": true,
+          "requires": {
+            "@babel/template": "^7.10.4",
+            "@babel/types": "^7.10.4"
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.10.4.tgz",
+          "integrity": "sha512-pySBTeoUff56fL5CBU2hWm9TesA4r/rOkI9DyJLvvgz09MB9YtfIYe3iBriVaYNaPe+Alua0vBIOVOLs2buWhg==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.10.4"
+          }
+        },
+        "@babel/highlight": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+          "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.10.4",
+            "chalk": "^2.0.0",
+            "js-tokens": "^4.0.0"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.5.tgz",
+          "integrity": "sha512-wfryxy4bE1UivvQKSQDU4/X6dr+i8bctjUjj8Zyt3DQy7NtPizJXT8M52nqpNKL+nq2PW8lxk4ZqLj0fD4B4hQ==",
+          "dev": true
+        },
+        "@babel/template": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.4.tgz",
+          "integrity": "sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.10.4",
+            "@babel/parser": "^7.10.4",
+            "@babel/types": "^7.10.4"
+          }
+        },
+        "@babel/traverse": {
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.10.5.tgz",
+          "integrity": "sha512-yc/fyv2gUjPqzTz0WHeRJH2pv7jA9kA7mBX2tXl/x5iOE81uaVPuGPtaYk7wmkx4b67mQ7NqI8rmT2pF47KYKQ==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.10.4",
+            "@babel/generator": "^7.10.5",
+            "@babel/helper-function-name": "^7.10.4",
+            "@babel/helper-split-export-declaration": "^7.10.4",
+            "@babel/parser": "^7.10.5",
+            "@babel/types": "^7.10.5",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0",
+            "lodash": "^4.17.19"
+          }
+        },
+        "@babel/types": {
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.5.tgz",
+          "integrity": "sha512-ixV66KWfCI6GKoA/2H9v6bQdbfXEwwpOdQ8cRvb4F+eyvhlaHxWFMQB4+3d9QFJXZsiiiqVrewNV0DFEQpyT4Q==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.10.4",
+            "lodash": "^4.17.19",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "convert-source-map": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
+          "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.1"
+          }
+        },
+        "json5": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
+          "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.5"
+          }
+        },
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
           "dev": true
         }
       }
@@ -1694,6 +1883,12 @@
         "@babel/types": "^7.4.4"
       }
     },
+    "@babel/helper-validator-identifier": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+      "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
+      "dev": true
+    },
     "@babel/helper-wrap-function": {
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.8.3.tgz",
@@ -1821,14 +2016,121 @@
       }
     },
     "@babel/helpers": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.6.2.tgz",
-      "integrity": "sha512-3/bAUL8zZxYs1cdX2ilEE0WobqbCmKWr/889lf2SS0PpDcpEIY8pb1CCyz0pEcX3pEb+MCbks1jIokz2xLtGTA==",
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.10.4.tgz",
+      "integrity": "sha512-L2gX/XeUONeEbI78dXSrJzGdz4GQ+ZTA/aazfUsFaWjSe95kiCuOZ5HsXvkiw3iwF+mFHSRUfJU8t6YavocdXA==",
       "dev": true,
       "requires": {
-        "@babel/template": "^7.6.0",
-        "@babel/traverse": "^7.6.2",
-        "@babel/types": "^7.6.0"
+        "@babel/template": "^7.10.4",
+        "@babel/traverse": "^7.10.4",
+        "@babel/types": "^7.10.4"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+          "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "^7.10.4"
+          }
+        },
+        "@babel/generator": {
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.10.5.tgz",
+          "integrity": "sha512-3vXxr3FEW7E7lJZiWQ3bM4+v/Vyr9C+hpolQ8BGFr9Y8Ri2tFLWTixmwKBafDujO1WVah4fhZBeU1bieKdghig==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.10.5",
+            "jsesc": "^2.5.1",
+            "source-map": "^0.5.0"
+          }
+        },
+        "@babel/helper-function-name": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
+          "integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-get-function-arity": "^7.10.4",
+            "@babel/template": "^7.10.4",
+            "@babel/types": "^7.10.4"
+          }
+        },
+        "@babel/helper-get-function-arity": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz",
+          "integrity": "sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.10.4"
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.10.4.tgz",
+          "integrity": "sha512-pySBTeoUff56fL5CBU2hWm9TesA4r/rOkI9DyJLvvgz09MB9YtfIYe3iBriVaYNaPe+Alua0vBIOVOLs2buWhg==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.10.4"
+          }
+        },
+        "@babel/highlight": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+          "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.10.4",
+            "chalk": "^2.0.0",
+            "js-tokens": "^4.0.0"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.5.tgz",
+          "integrity": "sha512-wfryxy4bE1UivvQKSQDU4/X6dr+i8bctjUjj8Zyt3DQy7NtPizJXT8M52nqpNKL+nq2PW8lxk4ZqLj0fD4B4hQ==",
+          "dev": true
+        },
+        "@babel/template": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.4.tgz",
+          "integrity": "sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.10.4",
+            "@babel/parser": "^7.10.4",
+            "@babel/types": "^7.10.4"
+          }
+        },
+        "@babel/traverse": {
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.10.5.tgz",
+          "integrity": "sha512-yc/fyv2gUjPqzTz0WHeRJH2pv7jA9kA7mBX2tXl/x5iOE81uaVPuGPtaYk7wmkx4b67mQ7NqI8rmT2pF47KYKQ==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.10.4",
+            "@babel/generator": "^7.10.5",
+            "@babel/helper-function-name": "^7.10.4",
+            "@babel/helper-split-export-declaration": "^7.10.4",
+            "@babel/parser": "^7.10.5",
+            "@babel/types": "^7.10.5",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0",
+            "lodash": "^4.17.19"
+          }
+        },
+        "@babel/types": {
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.5.tgz",
+          "integrity": "sha512-ixV66KWfCI6GKoA/2H9v6bQdbfXEwwpOdQ8cRvb4F+eyvhlaHxWFMQB4+3d9QFJXZsiiiqVrewNV0DFEQpyT4Q==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.10.4",
+            "lodash": "^4.17.19",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
       }
     },
     "@babel/highlight": {
@@ -2708,11 +3010,18 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.3.tgz",
-      "integrity": "sha512-kq6anf9JGjW8Nt5rYfEuGRaEAaH1mkv3Bbu6rYvLOpPh/RusSJXuKPEAoZ7L7gybZkchE8+NV5g9vKF4AGAtsA==",
+      "version": "7.10.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.5.tgz",
+      "integrity": "sha512-otddXKhdNn7d0ptoFRHtMLa8LqDxLYwTjB4nYgM1yy5N6gU/MUf8zqyyLltCH3yAVitBzmwK4us+DD0l/MauAg==",
       "requires": {
-        "regenerator-runtime": "^0.13.2"
+        "regenerator-runtime": "^0.13.4"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.13.5",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
+          "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
+        }
       }
     },
     "@babel/runtime-corejs3": {
@@ -4734,9 +5043,9 @@
       "dev": true
     },
     "@types/react": {
-      "version": "16.9.41",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.41.tgz",
-      "integrity": "sha512-6cFei7F7L4wwuM+IND/Q2cV1koQUvJ8iSV+Gwn0c3kvABZ691g7sp3hfEQHOUBJtccl1gPi+EyNjMIl9nGA0ug==",
+      "version": "16.9.43",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.43.tgz",
+      "integrity": "sha512-PxshAFcnJqIWYpJbLPriClH53Z2WlJcVZE+NP2etUtWQs2s7yIMj3/LDKZT/5CHJ/F62iyjVCDu2H3jHEXIxSg==",
       "requires": {
         "@types/prop-types": "*",
         "csstype": "^2.2.0"
@@ -5073,9 +5382,9 @@
       "dev": true
     },
     "@wordpress/base-styles": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-1.2.0.tgz",
-      "integrity": "sha512-jiU7naQ5ARrPhnCOvSXHudDX2zFTW4XfqmqKqnMzZC4A4fjywwfC00P98bcKXvSEhev5IH8BSxS+UxNzbUpPxQ=="
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-1.6.0.tgz",
+      "integrity": "sha512-eM9nPwiU/CriySco3Is62Aj6keoYr1bzxTOyVZWHdPRUTcsAUc0TrfwColv4J2vbr941jc24vQ5JvYhEReGlfg=="
     },
     "@wordpress/blob": {
       "version": "2.5.1",
@@ -7164,12 +7473,11 @@
       }
     },
     "@wordpress/html-entities": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-2.5.0.tgz",
-      "integrity": "sha512-7TKaJKkOX2Tas0OyXNPz1kA2my1Z804weBf2RsPLiNXm593JDsf6Em8z1TA4mXtn7FO2ZAKTj/3yRemKK4PhnA==",
-      "dev": true,
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-2.8.0.tgz",
+      "integrity": "sha512-LD1yHgw0JxqMEFFwHpj9MXDBHT7b9PPFJ6xIwBdT6FxQBNhjAzA155UA5/NHIboFZ5DSQOKX6cgYCsk8+lnSIg==",
       "requires": {
-        "@babel/runtime": "^7.4.4"
+        "@babel/runtime": "^7.9.2"
       }
     },
     "@wordpress/i18n": {
@@ -7391,19 +7699,81 @@
       }
     },
     "@wordpress/keycodes": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-2.6.2.tgz",
-      "integrity": "sha512-xWwyTYdyesZFc6V3RDn2Gjkx5bfa5fGDGrX0WcxT+vA2oEMFqLA2JzUqEzylR7aX3uFfsdDEp0GbPl8ipcLChw==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-2.14.0.tgz",
+      "integrity": "sha512-R/0orMutajuQ1d1kFFIvksXKR5C5TtszEkbnxSfdNlKaOW7p9Srv8+8m2QqM+AKNvEGMaq6cn7BfDtTbZ33Dbw==",
       "requires": {
-        "@babel/runtime": "^7.4.4",
-        "@wordpress/i18n": "^3.6.1",
+        "@babel/runtime": "^7.9.2",
+        "@wordpress/i18n": "^3.14.0",
         "lodash": "^4.17.15"
       },
       "dependencies": {
-        "lodash": {
-          "version": "4.17.15",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+        "@tannin/compile": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@tannin/compile/-/compile-1.1.0.tgz",
+          "integrity": "sha512-n8m9eNDfoNZoxdvWiTfW/hSPhehzLJ3zW7f8E7oT6mCROoMNWCB4TYtv041+2FMAxweiE0j7i1jubQU4MEC/Gg==",
+          "requires": {
+            "@tannin/evaluate": "^1.2.0",
+            "@tannin/postfix": "^1.1.0"
+          }
+        },
+        "@tannin/evaluate": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/@tannin/evaluate/-/evaluate-1.2.0.tgz",
+          "integrity": "sha512-3ioXvNowbO/wSrxsDG5DKIMxC81P0QrQTYai8zFNY+umuoHWRPbQ/TuuDEOju9E+jQDXmj6yI5GyejNuh8I+eg=="
+        },
+        "@tannin/plural-forms": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@tannin/plural-forms/-/plural-forms-1.1.0.tgz",
+          "integrity": "sha512-xl9R2mDZO/qiHam1AgMnAES6IKIg7OBhcXqy6eDsRCdXuxAFPcjrej9HMjyCLE0DJ/8cHf0i5OQTstuBRhpbHw==",
+          "requires": {
+            "@tannin/compile": "^1.1.0"
+          }
+        },
+        "@tannin/postfix": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@tannin/postfix/-/postfix-1.1.0.tgz",
+          "integrity": "sha512-oocsqY7g0cR+Gur5jRQLSrX2OtpMLMse1I10JQBm8CdGMrDkh1Mg2gjsiquMHRtBs4Qwu5wgEp5GgIYHk4SNPw=="
+        },
+        "@wordpress/i18n": {
+          "version": "3.14.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.14.0.tgz",
+          "integrity": "sha512-FQbSggdvkdS+IWMNhTl3n1nThqfzAPxORvoFpjDma7DOwuRKOA8iPyomwacfeG/krAeaurj1DIDzDvZh9Ex79w==",
+          "requires": {
+            "@babel/runtime": "^7.9.2",
+            "gettext-parser": "^1.3.1",
+            "lodash": "^4.17.15",
+            "memize": "^1.1.0",
+            "sprintf-js": "^1.1.1",
+            "tannin": "^1.2.0"
+          }
+        },
+        "gettext-parser": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-1.4.0.tgz",
+          "integrity": "sha512-sedZYLHlHeBop/gZ1jdg59hlUEcpcZJofLq2JFwJT1zTqAU3l2wFv6IsuwFHGqbiT9DWzMUW4/em2+hspnmMMA==",
+          "requires": {
+            "encoding": "^0.1.12",
+            "safe-buffer": "^5.1.1"
+          }
+        },
+        "memize": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/memize/-/memize-1.1.0.tgz",
+          "integrity": "sha512-K4FcPETOMTwe7KL2LK0orMhpOmWD2wRGwWWpbZy0fyArwsyIKR8YJVz8+efBAh3BO4zPqlSICu4vsLTRRqtFAg=="
+        },
+        "sprintf-js": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+          "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
+        },
+        "tannin": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/tannin/-/tannin-1.2.0.tgz",
+          "integrity": "sha512-U7GgX/RcSeUETbV7gYgoz8PD7Ni4y95pgIP/Z6ayI3CfhSujwKEBlGFTCRN+Aqnuyf4AN2yHL+L8x+TCGjb9uA==",
+          "requires": {
+            "@tannin/plural-forms": "^1.1.0"
+          }
         }
       }
     },
@@ -9092,8 +9462,7 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "base": {
       "version": "0.11.2",
@@ -10928,9 +11297,9 @@
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.4.tgz",
-          "integrity": "sha512-UpTN5yUJr9b4EX2CnGNWIvER7Ab83ibv0pcvvHc4UOdrBI5jb8bj+32cCwPX6xu0mt2daFNjYhoi+X7beH0RSw==",
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.5.tgz",
+          "integrity": "sha512-otddXKhdNn7d0ptoFRHtMLa8LqDxLYwTjB4nYgM1yy5N6gU/MUf8zqyyLltCH3yAVitBzmwK4us+DD0l/MauAg==",
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
@@ -11091,6 +11460,73 @@
         "word-wrap": "^1.0.3"
       }
     },
+    "d3-array": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
+      "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw=="
+    },
+    "d3-collection": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/d3-collection/-/d3-collection-1.0.7.tgz",
+      "integrity": "sha512-ii0/r5f4sjKNTfh84Di+DpztYwqKhEyUlKoPrzUFfeSkWxjW49xU2QzO9qrPrNkpdI0XJkfzvmTu8V2Zylln6A=="
+    },
+    "d3-color": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.4.1.tgz",
+      "integrity": "sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q=="
+    },
+    "d3-format": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.4.4.tgz",
+      "integrity": "sha512-TWks25e7t8/cqctxCmxpUuzZN11QxIA7YrMbram94zMQ0PXjE4LVIMe/f6a4+xxL8HQ3OsAFULOINQi1pE62Aw=="
+    },
+    "d3-interpolate": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.4.0.tgz",
+      "integrity": "sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==",
+      "requires": {
+        "d3-color": "1"
+      }
+    },
+    "d3-path": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="
+    },
+    "d3-scale": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-2.2.2.tgz",
+      "integrity": "sha512-LbeEvGgIb8UMcAa0EATLNX0lelKWGYDQiPdHj+gLblGVhGLyNbaCn3EvrJf0A3Y/uOOU5aD6MTh5ZFCdEwGiCw==",
+      "requires": {
+        "d3-array": "^1.2.0",
+        "d3-collection": "1",
+        "d3-format": "1",
+        "d3-interpolate": "1",
+        "d3-time": "1",
+        "d3-time-format": "2"
+      }
+    },
+    "d3-shape": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+      "requires": {
+        "d3-path": "1"
+      }
+    },
+    "d3-time": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-1.1.0.tgz",
+      "integrity": "sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA=="
+    },
+    "d3-time-format": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.2.3.tgz",
+      "integrity": "sha512-RAHNnD8+XvC4Zc4d2A56Uw0yJoM7bsvOlJR33bclxq399Rak/b9bhvu/InjxdWhPtkgU53JJcleJTGkNRnN6IA==",
+      "requires": {
+        "d3-time": "1"
+      }
+    },
     "damerau-levenshtein": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.6.tgz",
@@ -11140,10 +11576,9 @@
       }
     },
     "date-fns": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
-      "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==",
-      "dev": true
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.14.0.tgz",
+      "integrity": "sha512-1zD+68jhFgDIM0rF05rcwYO8cExdNqxjq4xP1QKM60Q45mnO6zaMWB4tOzrIr4M4GSLntsKeE4c9Bdl2jhL/yw=="
     },
     "date-now": {
       "version": "0.1.4",
@@ -11180,6 +11615,11 @@
         "decamelize": "^1.1.0",
         "map-obj": "^1.0.0"
       }
+    },
+    "decimal.js-light": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.0.tgz",
+      "integrity": "sha512-b3VJCbd2hwUpeRGG3Toob+CRo8W22xplipNhP3tN7TSVB/cyMX71P1vM2Xjc9H74uV6dS2hDDmo/rHq8L87Upg=="
     },
     "decode-uri-component": {
       "version": "0.2.0",
@@ -11431,9 +11871,9 @@
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.4.tgz",
-          "integrity": "sha512-UpTN5yUJr9b4EX2CnGNWIvER7Ab83ibv0pcvvHc4UOdrBI5jb8bj+32cCwPX6xu0mt2daFNjYhoi+X7beH0RSw==",
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.5.tgz",
+          "integrity": "sha512-otddXKhdNn7d0ptoFRHtMLa8LqDxLYwTjB4nYgM1yy5N6gU/MUf8zqyyLltCH3yAVitBzmwK4us+DD0l/MauAg==",
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
@@ -14377,6 +14817,12 @@
         "globule": "^1.0.0"
       }
     },
+    "gensync": {
+      "version": "1.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.1.tgz",
+      "integrity": "sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg==",
+      "dev": true
+    },
     "get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -14887,6 +15333,14 @@
         "rimraf": "~2.2.8",
         "underscore.string": "~2.2.1",
         "which": "~1.0.5"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "0.9.2",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz",
+          "integrity": "sha1-jzSZxSRdNG1oLlsNO0B2fgnxqSw=",
+          "dev": true
+        }
       }
     },
     "grunt-legacy-log": {
@@ -14954,6 +15408,14 @@
         "lodash": "~0.9.2",
         "underscore.string": "~2.2.1",
         "which": "~1.0.5"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "0.9.2",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz",
+          "integrity": "sha1-jzSZxSRdNG1oLlsNO0B2fgnxqSw=",
+          "dev": true
+        }
       }
     },
     "grunt-wp-i18n": {
@@ -14994,11 +15456,6 @@
       "resolved": "https://registry.npmjs.org/grunt-wp-readme-to-markdown/-/grunt-wp-readme-to-markdown-1.0.0.tgz",
       "integrity": "sha1-dJ/9gDtYTVC9ZOc6ehqRhz6djPs=",
       "dev": true
-    },
-    "gud": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/gud/-/gud-1.0.0.tgz",
-      "integrity": "sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw=="
     },
     "handlebars": {
       "version": "4.7.3",
@@ -15312,6 +15769,14 @@
         "debug": "4"
       }
     },
+    "human-number": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/human-number/-/human-number-1.0.5.tgz",
+      "integrity": "sha512-U0vVDQuPGvvHKWAhI89rmiGChRTGCWRQ86J//zQDtlhyFFgKmJ7ehmAiUOXQBKUHGO7XZ3Z1bbhKE8zTuh5iVw==",
+      "requires": {
+        "round-to": "~4.1.0"
+      }
+    },
     "human-signals": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
@@ -15319,9 +15784,9 @@
       "dev": true
     },
     "hyphenate-style-name": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.3.tgz",
-      "integrity": "sha512-EcuixamT82oplpoJ2XU4pDtKGWQ7b00CD9f1ug9IaQ3p1bkHMiKCZ9ut9QDI6qsa6cpUuB+A/I+zLtdNK4n2DQ=="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz",
+      "integrity": "sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ=="
     },
     "iconv-lite": {
       "version": "0.2.11",
@@ -17298,6 +17763,14 @@
         "cli-cursor": "^2.1.0",
         "date-fns": "^1.27.2",
         "figures": "^2.0.0"
+      },
+      "dependencies": {
+        "date-fns": {
+          "version": "1.30.1",
+          "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
+          "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==",
+          "dev": true
+        }
       }
     },
     "load-json-file": {
@@ -17365,10 +17838,9 @@
       }
     },
     "lodash": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz",
-      "integrity": "sha1-jzSZxSRdNG1oLlsNO0B2fgnxqSw=",
-      "dev": true
+      "version": "4.17.19",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
     },
     "lodash._baseisequal": {
       "version": "3.0.7",
@@ -17404,6 +17876,11 @@
       "resolved": "https://registry.npmjs.org/lodash.capitalize/-/lodash.capitalize-4.2.1.tgz",
       "integrity": "sha1-+CbJtOKoUR2E46yinbBeGk87cqk=",
       "dev": true
+    },
+    "lodash.debounce": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
     },
     "lodash.escape": {
       "version": "4.0.1",
@@ -17518,6 +17995,11 @@
       "requires": {
         "lodash._reinterpolate": "^3.0.0"
       }
+    },
+    "lodash.throttle": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
+      "integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ="
     },
     "lodash.toarray": {
       "version": "4.4.0",
@@ -17795,6 +18277,11 @@
           "dev": true
         }
       }
+    },
+    "math-expression-evaluator": {
+      "version": "1.2.22",
+      "resolved": "https://registry.npmjs.org/math-expression-evaluator/-/math-expression-evaluator-1.2.22.tgz",
+      "integrity": "sha512-L0j0tFVZBQQLeEjmWOvDLoRciIY8gQGWahvkztXUal8jH8R5Rlqo9GCvgqvXcy9LQhEWdQCVvzqAbxgYNt4blQ=="
     },
     "mathml-tag-names": {
       "version": "2.1.3",
@@ -18080,13 +18567,12 @@
       "dev": true
     },
     "mini-create-react-context": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/mini-create-react-context/-/mini-create-react-context-0.3.2.tgz",
-      "integrity": "sha512-2v+OeetEyliMt5VHMXsBhABoJ0/M4RCe7fatd/fBy6SMiKazUSEt3gxxypfnk2SHMkdBYvorHRoQxuGoiwbzAw==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/mini-create-react-context/-/mini-create-react-context-0.4.0.tgz",
+      "integrity": "sha512-b0TytUgFSbgFJGzJqXPKCFCBWigAjpjo+Fl7Vf7ZbKRDptszpppKxXH6DRXEABZ/gcEQczeb0iZ7JvL8e8jjCA==",
       "requires": {
-        "@babel/runtime": "^7.4.0",
-        "gud": "^1.0.0",
-        "tiny-warning": "^1.0.2"
+        "@babel/runtime": "^7.5.5",
+        "tiny-warning": "^1.0.3"
       }
     },
     "mini-css-extract-plugin-with-rtl": {
@@ -18386,18 +18872,47 @@
       "dev": true
     },
     "newspack-components": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/newspack-components/-/newspack-components-1.0.5.tgz",
-      "integrity": "sha512-40n2u3nwIof/vsBpwyyMUDBUC9Drz+pGbWVm8ICBL9I/USAxGgjuE8OGdP7w0TiKGltZKBFo+LDjGvIZM9t9Kg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/newspack-components/-/newspack-components-1.3.0.tgz",
+      "integrity": "sha512-ZEeBUEOYqcHktOa2kc3X4Dh+VwPgGMLka4gBhrFXej/kjY97ee/pmRTZlMb1qrb5qaUI4oaTupE5700frEsLPw==",
       "requires": {
         "@material-ui/core": "^4.8.2",
         "@material-ui/icons": "^4.5.1",
         "@wordpress/base-styles": "^1.0.0",
         "@wordpress/components": "^7.3.1",
         "@wordpress/element": "^2.3.0",
+        "@wordpress/i18n": "^3.11.0",
+        "classnames": "^2.2.6",
         "react-router-dom": "^5.0.1"
       },
       "dependencies": {
+        "@tannin/compile": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@tannin/compile/-/compile-1.1.0.tgz",
+          "integrity": "sha512-n8m9eNDfoNZoxdvWiTfW/hSPhehzLJ3zW7f8E7oT6mCROoMNWCB4TYtv041+2FMAxweiE0j7i1jubQU4MEC/Gg==",
+          "requires": {
+            "@tannin/evaluate": "^1.2.0",
+            "@tannin/postfix": "^1.1.0"
+          }
+        },
+        "@tannin/evaluate": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/@tannin/evaluate/-/evaluate-1.2.0.tgz",
+          "integrity": "sha512-3ioXvNowbO/wSrxsDG5DKIMxC81P0QrQTYai8zFNY+umuoHWRPbQ/TuuDEOju9E+jQDXmj6yI5GyejNuh8I+eg=="
+        },
+        "@tannin/plural-forms": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@tannin/plural-forms/-/plural-forms-1.1.0.tgz",
+          "integrity": "sha512-xl9R2mDZO/qiHam1AgMnAES6IKIg7OBhcXqy6eDsRCdXuxAFPcjrej9HMjyCLE0DJ/8cHf0i5OQTstuBRhpbHw==",
+          "requires": {
+            "@tannin/compile": "^1.1.0"
+          }
+        },
+        "@tannin/postfix": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@tannin/postfix/-/postfix-1.1.0.tgz",
+          "integrity": "sha512-oocsqY7g0cR+Gur5jRQLSrX2OtpMLMse1I10JQBm8CdGMrDkh1Mg2gjsiquMHRtBs4Qwu5wgEp5GgIYHk4SNPw=="
+        },
         "@wordpress/components": {
           "version": "7.4.0",
           "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-7.4.0.tgz",
@@ -18431,15 +18946,52 @@
             "uuid": "^3.3.2"
           }
         },
-        "lodash": {
-          "version": "4.17.15",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+        "@wordpress/i18n": {
+          "version": "3.14.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.14.0.tgz",
+          "integrity": "sha512-FQbSggdvkdS+IWMNhTl3n1nThqfzAPxORvoFpjDma7DOwuRKOA8iPyomwacfeG/krAeaurj1DIDzDvZh9Ex79w==",
+          "requires": {
+            "@babel/runtime": "^7.9.2",
+            "gettext-parser": "^1.3.1",
+            "lodash": "^4.17.15",
+            "memize": "^1.1.0",
+            "sprintf-js": "^1.1.1",
+            "tannin": "^1.2.0"
+          },
+          "dependencies": {
+            "memize": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/memize/-/memize-1.1.0.tgz",
+              "integrity": "sha512-K4FcPETOMTwe7KL2LK0orMhpOmWD2wRGwWWpbZy0fyArwsyIKR8YJVz8+efBAh3BO4zPqlSICu4vsLTRRqtFAg=="
+            }
+          }
+        },
+        "gettext-parser": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-1.4.0.tgz",
+          "integrity": "sha512-sedZYLHlHeBop/gZ1jdg59hlUEcpcZJofLq2JFwJT1zTqAU3l2wFv6IsuwFHGqbiT9DWzMUW4/em2+hspnmMMA==",
+          "requires": {
+            "encoding": "^0.1.12",
+            "safe-buffer": "^5.1.1"
+          }
         },
         "re-resizable": {
           "version": "4.11.0",
           "resolved": "https://registry.npmjs.org/re-resizable/-/re-resizable-4.11.0.tgz",
           "integrity": "sha512-dye+7rERqNf/6mDT1iwps+4Gf42420xuZgygF33uX178DxffqcyeuHbBuJ382FIcB5iP6mMZOhfW7kI0uXwb/Q=="
+        },
+        "sprintf-js": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+          "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
+        },
+        "tannin": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/tannin/-/tannin-1.2.0.tgz",
+          "integrity": "sha512-U7GgX/RcSeUETbV7gYgoz8PD7Ni4y95pgIP/Z6ayI3CfhSujwKEBlGFTCRN+Aqnuyf4AN2yHL+L8x+TCGjb9uA==",
+          "requires": {
+            "@tannin/plural-forms": "^1.1.0"
+          }
         }
       }
     },
@@ -23061,8 +23613,7 @@
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
-      "dev": true
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "picomatch": {
       "version": "2.2.1",
@@ -24148,7 +24699,6 @@
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
       "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
-      "dev": true,
       "requires": {
         "performance-now": "^2.1.0"
       }
@@ -24295,6 +24845,11 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.11.0.tgz",
       "integrity": "sha512-gbBVYR2p8mnriqAwWx9LbuUrShnAuSCNnuPGyc7GJrMVQtPDAh8iLpv7FRuMPFb56KkaVZIYSz1PrjI9q0QPCw=="
     },
+    "react-lifecycles-compat": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
+      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+    },
     "react-moment-proptypes": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/react-moment-proptypes/-/react-moment-proptypes-1.7.0.tgz",
@@ -24328,16 +24883,27 @@
       "resolved": "https://registry.npmjs.org/react-resize-aware/-/react-resize-aware-3.0.0.tgz",
       "integrity": "sha512-UyLk1KNbFHDye9AFLyr7HBGmzkRDGz2mYp6LDS+LCxM6DXGpviwS5Q4JRzXWdw0tk+n46UE/Kotku/cb8HCh0Q=="
     },
+    "react-resize-detector": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/react-resize-detector/-/react-resize-detector-2.3.0.tgz",
+      "integrity": "sha512-oCAddEWWeFWYH5FAcHdBYcZjAw9fMzRUK9sWSx6WvSSOPVRxcHd5zTIGy/mOus+AhN/u6T4TMiWxvq79PywnJQ==",
+      "requires": {
+        "lodash.debounce": "^4.0.8",
+        "lodash.throttle": "^4.1.1",
+        "prop-types": "^15.6.0",
+        "resize-observer-polyfill": "^1.5.0"
+      }
+    },
     "react-router": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.1.2.tgz",
-      "integrity": "sha512-yjEuMFy1ONK246B+rsa0cUam5OeAQ8pyclRDgpxuSCrAlJ1qN9uZ5IgyKC7gQg0w8OM50NXHEegPh/ks9YuR2A==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.2.0.tgz",
+      "integrity": "sha512-smz1DUuFHRKdcJC0jobGo8cVbhO3x50tCL4icacOlcwDOEQPq4TMqwx3sY1TP+DvtTgz4nm3thuo7A+BK2U0Dw==",
       "requires": {
         "@babel/runtime": "^7.1.2",
         "history": "^4.9.0",
         "hoist-non-react-statics": "^3.1.0",
         "loose-envify": "^1.3.1",
-        "mini-create-react-context": "^0.3.0",
+        "mini-create-react-context": "^0.4.0",
         "path-to-regexp": "^1.7.0",
         "prop-types": "^15.6.2",
         "react-is": "^16.6.0",
@@ -24346,17 +24912,54 @@
       }
     },
     "react-router-dom": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.1.2.tgz",
-      "integrity": "sha512-7BPHAaIwWpZS074UKaw1FjVdZBSVWEk8IuDXdB+OkLb8vd/WRQIpA4ag9WQk61aEfQs47wHyjWUoUGGZxpQXew==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.2.0.tgz",
+      "integrity": "sha512-gxAmfylo2QUjcwxI63RhQ5G85Qqt4voZpUXSEqCwykV0baaOTQDR1f0PmY8AELqIyVc0NEZUj0Gov5lNGcXgsA==",
       "requires": {
         "@babel/runtime": "^7.1.2",
         "history": "^4.9.0",
         "loose-envify": "^1.3.1",
         "prop-types": "^15.6.2",
-        "react-router": "5.1.2",
+        "react-router": "5.2.0",
         "tiny-invariant": "^1.0.2",
         "tiny-warning": "^1.0.0"
+      }
+    },
+    "react-smooth": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-1.0.5.tgz",
+      "integrity": "sha512-eW057HT0lFgCKh8ilr0y2JaH2YbNcuEdFpxyg7Gf/qDKk9hqGMyXryZJ8iMGJEuKH0+wxS0ccSsBBB3W8yCn8w==",
+      "requires": {
+        "lodash": "~4.17.4",
+        "prop-types": "^15.6.0",
+        "raf": "^3.4.0",
+        "react-transition-group": "^2.5.0"
+      },
+      "dependencies": {
+        "dom-helpers": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.4.0.tgz",
+          "integrity": "sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==",
+          "requires": {
+            "@babel/runtime": "^7.1.2"
+          }
+        },
+        "lodash": {
+          "version": "4.17.19",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+          "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
+        },
+        "react-transition-group": {
+          "version": "2.9.0",
+          "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.9.0.tgz",
+          "integrity": "sha512-+HzNTCHpeQyl4MJ/bdE0u6XRMe9+XG/+aL4mCxVN4DnPBQ0/5bfHWPDuOZUzYdMj94daZaZdCCc1Dzt9R/xSSg==",
+          "requires": {
+            "dom-helpers": "^3.4.0",
+            "loose-envify": "^1.4.0",
+            "prop-types": "^15.6.2",
+            "react-lifecycles-compat": "^3.0.4"
+          }
+        }
       }
     },
     "react-spring": {
@@ -24523,6 +25126,44 @@
         "util.promisify": "^1.0.0"
       }
     },
+    "recharts": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-1.8.5.tgz",
+      "integrity": "sha512-tM9mprJbXVEBxjM7zHsIy6Cc41oO/pVYqyAsOHLxlJrbNBuLs0PHB3iys2M+RqCF0//k8nJtZF6X6swSkWY3tg==",
+      "requires": {
+        "classnames": "^2.2.5",
+        "core-js": "^2.6.10",
+        "d3-interpolate": "^1.3.0",
+        "d3-scale": "^2.1.0",
+        "d3-shape": "^1.2.0",
+        "lodash": "^4.17.5",
+        "prop-types": "^15.6.0",
+        "react-resize-detector": "^2.3.0",
+        "react-smooth": "^1.0.5",
+        "recharts-scale": "^0.4.2",
+        "reduce-css-calc": "^1.3.0"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.6.11",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+          "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
+        },
+        "lodash": {
+          "version": "4.17.19",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+          "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
+        }
+      }
+    },
+    "recharts-scale": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/recharts-scale/-/recharts-scale-0.4.3.tgz",
+      "integrity": "sha512-t8p5sccG9Blm7c1JQK/ak9O8o95WGhNXD7TXg/BW5bYbVlr6eCeRBNpgyigD4p6pSSMehC5nSvBUPj6F68rbFA==",
+      "requires": {
+        "decimal.js-light": "^2.4.1"
+      }
+    },
     "rechoir": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
@@ -24595,6 +25236,31 @@
           "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
           "dev": true
         }
+      }
+    },
+    "reduce-css-calc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.3.0.tgz",
+      "integrity": "sha1-dHyRTgSWFKTJz7umKYca0dKSdxY=",
+      "requires": {
+        "balanced-match": "^0.4.2",
+        "math-expression-evaluator": "^1.2.14",
+        "reduce-function-call": "^1.0.1"
+      },
+      "dependencies": {
+        "balanced-match": {
+          "version": "0.4.2",
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+          "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
+        }
+      }
+    },
+    "reduce-function-call": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.3.tgz",
+      "integrity": "sha512-Hl/tuV2VDgWgCSEeWMLwxLZqX7OK59eU1guxXsRKTAyeYimivsKdtcV4fu3r710tpG5GmDKDhQ0HSZLExnNmyQ==",
+      "requires": {
+        "balanced-match": "^1.0.0"
       }
     },
     "redux": {
@@ -25004,6 +25670,11 @@
       "integrity": "sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==",
       "dev": true
     },
+    "resize-observer-polyfill": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
+    },
     "resolve": {
       "version": "1.12.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
@@ -25131,6 +25802,11 @@
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1"
       }
+    },
+    "round-to": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/round-to/-/round-to-4.1.0.tgz",
+      "integrity": "sha512-H/4z+4QdWS82iMZ23+5St302Mv2jJws0hUvEogrD6gC8NN6Z5TalDtbg51owCrVy4V/4c8ePvwVLNtlhEfPo5g=="
     },
     "rst-selector-parser": {
       "version": "2.2.3",
@@ -28336,9 +29012,9 @@
       "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q=="
     },
     "tiny-invariant": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.0.6.tgz",
-      "integrity": "sha512-FOyLWWVjG+aC0UqG76V53yAWdXfH8bO6FNmyZOuUrzDzK8DI3/JRY25UD7+g49JWM1LXwymsKERB+DzI0dTEQA=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.1.0.tgz",
+      "integrity": "sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw=="
     },
     "tiny-warning": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "author": "YOUR NAME HERE",
   "devDependencies": {
     "@automattic/calypso-build": "^5.1.0",
-    "@babel/core": "^7.6.4",
+    "@babel/core": "^7.10.5",
+    "@babel/runtime": "^7.10.5",
     "@commitlint/cli": "^8.3.5",
     "@commitlint/config-conventional": "^8.3.4",
     "@semantic-release/changelog": "^5.0.0",
@@ -113,13 +114,21 @@
     "@material-ui/core": "^4.11.0",
     "@material-ui/icons": "^4.9.1",
     "@wordpress/api-fetch": "^3.11.0",
+    "@wordpress/base-styles": "^1.6.0",
     "@wordpress/block-editor": "^3.7.5",
     "@wordpress/compose": "^3.11.0",
     "@wordpress/data": "^4.14.1",
     "@wordpress/dom-ready": "^2.9.0",
     "@wordpress/element": "^2.11.0",
+    "@wordpress/html-entities": "^2.8.0",
     "@wordpress/i18n": "^3.9.0",
-    "newspack-components": "^1.0.5",
-    "qs": "^6.9.1"
+    "@wordpress/keycodes": "^2.14.0",
+    "classnames": "^2.2.6",
+    "date-fns": "^2.14.0",
+    "human-number": "^1.0.5",
+    "lodash": "^4.17.19",
+    "newspack-components": "^1.3.0",
+    "qs": "^6.9.1",
+    "recharts": "^1.8.5"
   }
 }

--- a/src/all/PopupsManager/components/popup-action-card/index.js
+++ b/src/all/PopupsManager/components/popup-action-card/index.js
@@ -1,0 +1,112 @@
+/**
+ * Popup Action Card
+ */
+
+/**
+ * WordPress dependencies.
+ */
+import { __ } from '@wordpress/i18n';
+import { Component, Fragment } from '@wordpress/element';
+import { decodeEntities } from '@wordpress/html-entities';
+import { Tooltip } from '@wordpress/components';
+
+/**
+ * External dependencies.
+ */
+import FilterListIcon from '@material-ui/icons/FilterList';
+import MoreVertIcon from '@material-ui/icons/MoreVert';
+import { ActionCard, Button, CategoryAutocomplete } from 'newspack-components';
+
+/**
+ * Internal dependencies.
+ */
+import PopupPopover from '../popup-popover';
+import './style.scss';
+
+class PopupActionCard extends Component {
+	state = {
+		categoriesVisibility: false,
+		popoverVisibility: false,
+	};
+
+	/**
+	 * Render.
+	 */
+	render = () => {
+		const { categoriesVisibility, popoverVisibility } = this.state;
+		const {
+			className,
+			description,
+			deletePopup,
+			popup,
+			previewPopup,
+			setCategoriesForPopup,
+			setSitewideDefaultPopup,
+			publishPopup,
+			updatePopup,
+		} = this.props;
+		const { id, categories, title, sitewide_default: sitewideDefault, status } = popup;
+		return (
+			<ActionCard
+				isSmall
+				className={ className }
+				title={ title.length ? decodeEntities( title ) : __( '(no title)', 'newspack-popups' ) }
+				key={ id }
+				description={ description }
+				actionText={
+					<Fragment>
+						{ ! sitewideDefault && (
+							<Tooltip text={ __( 'Category filtering', 'newspack-popups' ) }>
+								<Button
+									className="icon-only"
+									onClick={ () =>
+										this.setState( { categoriesVisibility: ! categoriesVisibility } )
+									}
+								>
+									<FilterListIcon />
+								</Button>
+							</Tooltip>
+						) }
+						<Tooltip text={ __( 'More options', 'newspack-popups' ) }>
+							<Button
+								className="icon-only"
+								onClick={ () => this.setState( { popoverVisibility: ! popoverVisibility } ) }
+							>
+								<MoreVertIcon />
+							</Button>
+						</Tooltip>
+						{ popoverVisibility && (
+							<PopupPopover
+								deletePopup={ deletePopup }
+								onFocusOutside={ () => this.setState( { popoverVisibility: false } ) }
+								popup={ popup }
+								setSitewideDefaultPopup={ setSitewideDefaultPopup }
+								updatePopup={ updatePopup }
+								previewPopup={ previewPopup }
+								publishPopup={ 'publish' !== status ? publishPopup : null }
+							/>
+						) }
+					</Fragment>
+				}
+			>
+				{ categoriesVisibility && (
+					<CategoryAutocomplete
+						value={ categories || [] }
+						onChange={ tokens => setCategoriesForPopup( id, tokens ) }
+						label={ __( 'Category filtering', 'newspack ' ) }
+						disabled={ sitewideDefault }
+					/>
+				) }
+			</ActionCard>
+		);
+	};
+}
+
+PopupActionCard.defaultProps = {
+	popup: {},
+	deletePopup: () => null,
+	setCategoriesForPopup: () => null,
+	setSitewideDefaultPopup: () => null,
+};
+
+export default PopupActionCard;

--- a/src/all/PopupsManager/components/popup-action-card/style.scss
+++ b/src/all/PopupsManager/components/popup-action-card/style.scss
@@ -1,0 +1,24 @@
+/**
+ * Popup Action Card styles
+ */
+
+@import '~@wordpress/base-styles/colors';
+
+.newspack-menu-group__sitewide {
+	> div {
+		padding-left: 15px;
+		padding-right: 15px;
+	}
+}
+
+.newspack-action-card {
+	.newspack-popover {
+		.components-menu-group + .components-menu-group {
+			border-top: 1px solid $light-gray-500;
+		}
+	}
+
+	&:not( .newspack-card__is-primary ) .newspack-popover {
+		margin-left: 18px;
+	}
+}

--- a/src/all/PopupsManager/components/popup-popover/index.js
+++ b/src/all/PopupsManager/components/popup-popover/index.js
@@ -1,0 +1,150 @@
+/**
+ * Popup Action Card
+ */
+
+/**
+ * WordPress dependencies.
+ */
+import { __ } from '@wordpress/i18n';
+import { Component } from '@wordpress/element';
+import { decodeEntities } from '@wordpress/html-entities';
+import { MenuItem } from '@wordpress/components';
+import { ESCAPE } from '@wordpress/keycodes';
+
+/**
+ * External dependencies.
+ */
+import EditIcon from '@material-ui/icons/Edit';
+import DeleteIcon from '@material-ui/icons/Delete';
+import PreviewIcon from '@material-ui/icons/Visibility';
+import FrequencyIcon from '@material-ui/icons/Today';
+import PublishIcon from '@material-ui/icons/Publish';
+import TestIcon from '@material-ui/icons/BugReport';
+import SitewideDefaultIcon from '@material-ui/icons/Public';
+import { Popover, SelectControl, ToggleControl } from 'newspack-components';
+
+/**
+ * Internal dependencies.
+ */
+import './style.scss';
+
+const frequencyMap = {
+	never: __( 'Never', 'newspack-popups' ),
+	once: __( 'Once', 'newspack-popups' ),
+	daily: __( 'Once a day', 'newspack-popups' ),
+	always: __( 'Every page', 'newspack-popups' ),
+};
+
+const frequenciesForPopup = ( { options } ) => {
+	const { placement } = options;
+	return Object.keys( frequencyMap )
+		.filter( key => ! ( 'always' === key && 'inline' !== placement ) )
+		.map( key => ( { label: frequencyMap[ key ], value: key } ) );
+};
+
+class PopupPopover extends Component {
+	/**
+	 * Render.
+	 */
+	render = () => {
+		const {
+			deletePopup,
+			popup,
+			previewPopup,
+			setSitewideDefaultPopup,
+			onFocusOutside,
+			publishPopup,
+			updatePopup,
+		} = this.props;
+		const { id, sitewide_default: sitewideDefault, edit_link: editLink, options } = popup;
+		const { frequency, placement } = options;
+		return (
+			<Popover
+				position="bottom left"
+				onFocusOutside={ onFocusOutside }
+				onKeyDown={ event => ESCAPE === event.keyCode && onFocusOutside() }
+			>
+				{ 'inline' !== placement && (
+					<MenuItem
+						onClick={ () => {
+							setSitewideDefaultPopup( id, ! sitewideDefault );
+							onFocusOutside();
+						} }
+						icon={ <SitewideDefaultIcon /> }
+						className="newspack-button"
+					>
+						{ __( 'Sitewide default', 'newspack-popups' ) }
+						<ToggleControl
+							className="newspack-popup-action-card-popover-control"
+							checked={ sitewideDefault }
+							onChange={ () => null }
+						/>
+					</MenuItem>
+				) }
+				<MenuItem
+					onClick={ () => {
+						updatePopup( id, { frequency: 'test' === frequency ? 'daily' : 'test' } );
+						onFocusOutside();
+					} }
+					icon={ <TestIcon /> }
+					className="newspack-button"
+				>
+					{ __( 'Test mode', 'newspack-popups' ) }
+					<ToggleControl
+						className="newspack-popup-action-card-popover-control"
+						checked={ 'test' === frequency }
+						onChange={ () => null }
+					/>
+				</MenuItem>
+				{ 'test' !== frequency && (
+					<MenuItem icon={ <FrequencyIcon /> } className="newspack-button">
+						<SelectControl
+							onChange={ value => {
+								updatePopup( id, { frequency: value } );
+								onFocusOutside();
+							} }
+							options={ frequenciesForPopup( popup ) }
+							value={ frequency }
+						/>
+					</MenuItem>
+				) }
+				<MenuItem
+					onClick={ () => {
+						onFocusOutside();
+						previewPopup( popup );
+					} }
+					icon={ <PreviewIcon /> }
+					className="newspack-button"
+				>
+					{ __( 'Preview', 'newspack-popups' ) }
+				</MenuItem>
+				<MenuItem
+					href={ decodeEntities( editLink ) }
+					icon={ <EditIcon /> }
+					className="newspack-button"
+					isLink
+				>
+					{ __( 'Edit', 'newspack-popups' ) }
+				</MenuItem>
+				{ publishPopup && (
+					<MenuItem
+						onClick={ () => publishPopup( id ) }
+						icon={ <PublishIcon /> }
+						className="newspack-button"
+					>
+						{ __( 'Publish', 'newspack-popups' ) }
+					</MenuItem>
+				) }
+				<MenuItem
+					onClick={ () => deletePopup( id ) }
+					icon={ <DeleteIcon /> }
+					className="newspack-button"
+				>
+					{ __( 'Delete', 'newspack-popups' ) }
+				</MenuItem>
+			</Popover>
+		);
+	};
+}
+
+export default PopupPopover;

--- a/src/all/PopupsManager/components/popup-popover/style.scss
+++ b/src/all/PopupsManager/components/popup-popover/style.scss
@@ -1,0 +1,4 @@
+.newspack-popup-action-card-popover-control {
+	position: absolute;
+	right: 0;
+}

--- a/src/all/PopupsManager/index.js
+++ b/src/all/PopupsManager/index.js
@@ -75,7 +75,7 @@ class PopupsManager extends Component {
 	setCategoriesForPopup = ( popupId, categories ) => {
 		const { setError, wizardApiFetch } = this.props;
 		return wizardApiFetch( {
-			path: `/newspack/v1/wizard/newspack-popups-wizard/popup-categories/${ popupId }`,
+			path: `/newspack-popups/v1/categories/${ popupId }`,
 			method: 'POST',
 			data: {
 				categories,

--- a/src/all/PopupsManager/index.js
+++ b/src/all/PopupsManager/index.js
@@ -119,7 +119,7 @@ class PopupsManager extends Component {
 	publishPopup = popupId => {
 		const { setError, wizardApiFetch } = this.props;
 		return wizardApiFetch( {
-			path: `/newspack/v1/wizard/newspack-popups-wizard/${ popupId }/publish`,
+			path: `/newspack-popups/v1/${ popupId }/publish`,
 			method: 'POST',
 		} )
 			.then( ( { popups } ) => this.setState( { popups: this.sortPopups( popups ) } ) )

--- a/src/all/PopupsManager/index.js
+++ b/src/all/PopupsManager/index.js
@@ -88,7 +88,7 @@ class PopupsManager extends Component {
 	updatePopup = ( popupId, options ) => {
 		const { setError, wizardApiFetch } = this.props;
 		return wizardApiFetch( {
-			path: `/newspack/v1/wizard/newspack-popups-wizard/${ popupId }`,
+			path: `/newspack-popups/v1/${ popupId }`,
 			method: 'POST',
 			data: { options },
 		} )

--- a/src/all/PopupsManager/index.js
+++ b/src/all/PopupsManager/index.js
@@ -262,4 +262,6 @@ class PopupsManager extends Component {
 
 const PopupsManagerWizard = withWizard( PopupsManager );
 
-export default () => <PopupsManagerWizard />;
+export default () => (
+	<PopupsManagerWizard logoLink={ newspack_popups_frontend_data.newspack_dashboard_url } />
+);

--- a/src/all/PopupsManager/index.js
+++ b/src/all/PopupsManager/index.js
@@ -1,3 +1,5 @@
+/* global newspack_popups_frontend_data */
+
 /**
  * WordPress dependencies.
  */
@@ -43,28 +45,10 @@ class PopupsManager extends Component {
 	constructor( props ) {
 		super( props );
 		this.state = {
-			popups: {
-				inline: [],
-				overlay: [],
-			},
+			popups: this.sortPopups( newspack_popups_frontend_data.all_popups ),
 			previewUrl: null,
 		};
 	}
-	onWizardReady = () => {
-		this.getPopups();
-	};
-
-	/**
-	 * Get Pop-ups for the current wizard.
-	 */
-	getPopups = () => {
-		const { setError, wizardApiFetch } = this.props;
-		return wizardApiFetch( {
-			path: '/newspack/v1/wizard/newspack-popups-wizard/',
-		} )
-			.then( ( { popups } ) => this.setState( { popups: this.sortPopups( popups ) } ) )
-			.catch( error => setError( error ) );
-	};
 
 	/**
 	 * Designate which popup should be the sitewide default.
@@ -194,9 +178,7 @@ class PopupsManager extends Component {
 		const { placement, trigger_type: triggerType } = options;
 		const previewURL =
 			'inline' === placement || 'scroll' === triggerType
-				? window &&
-				  window.newspack_popups_wizard_data &&
-				  window.newspack_popups_wizard_data.preview_post
+				? newspack_popups_frontend_data.preview_post
 				: '/';
 		return `${ previewURL }?${ stringify( { ...options, newspack_popups_preview_id: id } ) }`;
 	};

--- a/src/all/PopupsManager/index.js
+++ b/src/all/PopupsManager/index.js
@@ -104,7 +104,7 @@ class PopupsManager extends Component {
 	deletePopup = popupId => {
 		const { setError, wizardApiFetch } = this.props;
 		return wizardApiFetch( {
-			path: `/newspack/v1/wizard/newspack-popups-wizard/${ popupId }`,
+			path: `/newspack-popups/v1/${ popupId }`,
 			method: 'DELETE',
 		} )
 			.then( ( { popups } ) => this.setState( { popups: this.sortPopups( popups ) } ) )

--- a/src/all/PopupsManager/index.js
+++ b/src/all/PopupsManager/index.js
@@ -1,0 +1,283 @@
+/**
+ * WordPress dependencies.
+ */
+import { Component } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * External dependencies.
+ */
+import HeaderIcon from '@material-ui/icons/NewReleases';
+import { stringify } from 'qs';
+import { withWizard, WebPreview, Router } from 'newspack-components';
+
+/**
+ * Internal dependencies.
+ */
+import { PopupGroup, Analytics } from './views';
+
+const { HashRouter, Redirect, Route, Switch } = Router;
+
+const headerText = __( 'Campaigns', 'newspack-popups' );
+const subHeaderText = __( 'Reach your readers with configurable campaigns.', 'newspack-popups' );
+
+const tabbedNavigation = [
+	{
+		label: __( 'Overlay', 'newpack' ),
+		path: '/overlay',
+		exact: true,
+	},
+	{
+		label: __( 'Inline', 'newpack' ),
+		path: '/inline',
+		exact: true,
+	},
+	{
+		label: __( 'Analytics', 'newpack' ),
+		path: '/analytics',
+		exact: true,
+	},
+];
+
+class PopupsManager extends Component {
+	constructor( props ) {
+		super( props );
+		this.state = {
+			popups: {
+				inline: [],
+				overlay: [],
+			},
+			previewUrl: null,
+		};
+	}
+	onWizardReady = () => {
+		this.getPopups();
+	};
+
+	/**
+	 * Get Pop-ups for the current wizard.
+	 */
+	getPopups = () => {
+		const { setError, wizardApiFetch } = this.props;
+		return wizardApiFetch( {
+			path: '/newspack/v1/wizard/newspack-popups-wizard/',
+		} )
+			.then( ( { popups } ) => this.setState( { popups: this.sortPopups( popups ) } ) )
+			.catch( error => setError( error ) );
+	};
+
+	/**
+	 * Designate which popup should be the sitewide default.
+	 *
+	 * @param {number} popupId ID of the Popup to become sitewide default.
+	 * @param {boolean} isSitewideDefault is sitewide default
+	 */
+	setSitewideDefaultPopup = ( popupId, isSitewideDefault ) => {
+		const { setError, wizardApiFetch } = this.props;
+		return wizardApiFetch( {
+			path: `/newspack/v1/wizard/newspack-popups-wizard/sitewide-popup/${ popupId }`,
+			method: isSitewideDefault ? 'POST' : 'DELETE',
+		} )
+			.then( ( { popups } ) => this.setState( { popups: this.sortPopups( popups ) } ) )
+			.catch( error => setError( error ) );
+	};
+
+	/**
+	 * Set categories for a Popup.
+	 *
+	 * @param {number} popupId ID of the Popup to alter.
+	 * @param {Array} categories Array of categories to assign to the Popup.
+	 */
+	setCategoriesForPopup = ( popupId, categories ) => {
+		const { setError, wizardApiFetch } = this.props;
+		return wizardApiFetch( {
+			path: `/newspack/v1/wizard/newspack-popups-wizard/popup-categories/${ popupId }`,
+			method: 'POST',
+			data: {
+				categories,
+			},
+		} )
+			.then( ( { popups } ) => this.setState( { popups: this.sortPopups( popups ) } ) )
+			.catch( error => setError( error ) );
+	};
+
+	updatePopup = ( popupId, options ) => {
+		const { setError, wizardApiFetch } = this.props;
+		return wizardApiFetch( {
+			path: `/newspack/v1/wizard/newspack-popups-wizard/${ popupId }`,
+			method: 'POST',
+			data: { options },
+		} )
+			.then( ( { popups } ) => this.setState( { popups: this.sortPopups( popups ) } ) )
+			.catch( error => setError( error ) );
+	};
+
+	/**
+	 * Delete a popup.
+	 *
+	 * @param {number} popupId ID of the Popup to alter.
+	 */
+	deletePopup = popupId => {
+		const { setError, wizardApiFetch } = this.props;
+		return wizardApiFetch( {
+			path: `/newspack/v1/wizard/newspack-popups-wizard/${ popupId }`,
+			method: 'DELETE',
+		} )
+			.then( ( { popups } ) => this.setState( { popups: this.sortPopups( popups ) } ) )
+			.catch( error => setError( error ) );
+	};
+
+	/**
+	 * Publish a popup.
+	 *
+	 * @param {number} popupId ID of the Popup to alter.
+	 */
+	publishPopup = popupId => {
+		const { setError, wizardApiFetch } = this.props;
+		return wizardApiFetch( {
+			path: `/newspack/v1/wizard/newspack-popups-wizard/${ popupId }/publish`,
+			method: 'POST',
+		} )
+			.then( ( { popups } ) => this.setState( { popups: this.sortPopups( popups ) } ) )
+			.catch( error => setError( error ) );
+	};
+
+	/**
+	 * Sort Pop-ups into categories.
+	 *
+	 * @param {[Object]} popups array of popup objects
+	 */
+	sortPopups = popups => {
+		const overlay = this.sortPopupGroup(
+			popups.filter( ( { options } ) => 'inline' !== options.placement )
+		);
+		const inline = this.sortPopupGroup(
+			popups.filter( ( { options } ) => 'inline' === options.placement )
+		);
+		return { overlay, inline };
+	};
+
+	/**
+	 * Sort Pop-up groups into categories.
+	 *
+	 * @param {[Object]} popups array of popup objects
+	 */
+	sortPopupGroup = popups => {
+		const test = popups.filter(
+			( { options, status } ) => 'publish' === status && 'test' === options.frequency
+		);
+		const draft = popups.filter( ( { status } ) => 'draft' === status );
+		const active = popups.filter(
+			( { categories, options, sitewide_default: sitewideDefault, status } ) =>
+				'inline' === options.placement
+					? 'test' !== options.frequency && 'never' !== options.frequency && 'publish' === status
+					: 'test' !== options.frequency &&
+					  ( sitewideDefault || categories.length ) &&
+					  'publish' === status
+		);
+		const activeWithSitewideDefaultFirst = [
+			...active.filter( ( { sitewide_default: sitewideDefault } ) => sitewideDefault ),
+			...active.filter( ( { sitewide_default: sitewideDefault } ) => ! sitewideDefault ),
+		];
+		const inactive = popups.filter(
+			( { categories, options, sitewide_default: sitewideDefault, status } ) =>
+				'inline' === options.placement
+					? 'never' === options.frequency && 'publish' === status
+					: 'test' !== options.frequency &&
+					  ( ! sitewideDefault && ! categories.length ) &&
+					  'publish' === status
+		);
+		return { draft, test, active: activeWithSitewideDefaultFirst, inactive };
+	};
+
+	previewUrlForPopup = ( { options, id } ) => {
+		const { placement, trigger_type: triggerType } = options;
+		const previewURL =
+			'inline' === placement || 'scroll' === triggerType
+				? window &&
+				  window.newspack_popups_wizard_data &&
+				  window.newspack_popups_wizard_data.preview_post
+				: '/';
+		return `${ previewURL }?${ stringify( { ...options, newspack_popups_preview_id: id } ) }`;
+	};
+
+	render() {
+		const { setError, isLoading, startLoading, doneLoading, errorData } = this.props;
+		const { popups, previewUrl } = this.state;
+		const { inline, overlay } = popups;
+		return (
+			<WebPreview
+				url={ previewUrl }
+				renderButton={ ( { showPreview } ) => {
+					const sharedProps = {
+						headerIcon: <HeaderIcon />,
+						headerText,
+						subHeaderText,
+						tabbedNavigation,
+						setError,
+						isLoading,
+						startLoading,
+						doneLoading,
+						errorData,
+					};
+					const popupManagementSharedProps = {
+						...sharedProps,
+						setSitewideDefaultPopup: this.setSitewideDefaultPopup,
+						setCategoriesForPopup: this.setCategoriesForPopup,
+						updatePopup: this.updatePopup,
+						deletePopup: this.deletePopup,
+						previewPopup: popup =>
+							this.setState( { previewUrl: this.previewUrlForPopup( popup ) }, () =>
+								showPreview()
+							),
+						publishPopup: this.publishPopup,
+					};
+					return (
+						<HashRouter hashType="slash">
+							<Switch>
+								<Route
+									path="/overlay"
+									render={ () => (
+										<PopupGroup
+											{ ...popupManagementSharedProps }
+											items={ overlay }
+											buttonText={ __( 'Add new Overlay Campaign', 'newspack-popups' ) }
+											buttonAction="/wp-admin/post-new.php?post_type=newspack_popups_cpt"
+											emptyMessage={
+												isLoading
+													? ''
+													: __( 'No Overlay Campaigns have been created yet.', 'newspack-popups' )
+											}
+										/>
+									) }
+								/>
+								<Route
+									path="/inline"
+									render={ () => (
+										<PopupGroup
+											{ ...popupManagementSharedProps }
+											items={ inline }
+											buttonText={ __( 'Add new Inline Campaign', 'newspack-popups' ) }
+											buttonAction="/wp-admin/post-new.php?post_type=newspack_popups_cpt&placement=inline"
+											emptyMessage={
+												isLoading
+													? ''
+													: __( 'No Inline Campaigns have been created yet.', 'newspack-popups' )
+											}
+										/>
+									) }
+								/>
+								<Route path="/analytics" render={ () => <Analytics { ...sharedProps } isWide /> } />
+								<Redirect to="/overlay" />
+							</Switch>
+						</HashRouter>
+					);
+				} }
+			/>
+		);
+	}
+}
+
+const PopupsManagerWizard = withWizard( PopupsManager );
+
+export default () => <PopupsManagerWizard />;

--- a/src/all/PopupsManager/index.js
+++ b/src/all/PopupsManager/index.js
@@ -59,7 +59,7 @@ class PopupsManager extends Component {
 	setSitewideDefaultPopup = ( popupId, isSitewideDefault ) => {
 		const { setError, wizardApiFetch } = this.props;
 		return wizardApiFetch( {
-			path: `/newspack/v1/wizard/newspack-popups-wizard/sitewide-popup/${ popupId }`,
+			path: `/newspack-popups/v1/sitewide-default/${ popupId }`,
 			method: isSitewideDefault ? 'POST' : 'DELETE',
 		} )
 			.then( ( { popups } ) => this.setState( { popups: this.sortPopups( popups ) } ) )

--- a/src/all/PopupsManager/views/analytics/Chart.js
+++ b/src/all/PopupsManager/views/analytics/Chart.js
@@ -1,0 +1,34 @@
+/**
+ * External dependencies.
+ */
+import { format } from 'date-fns';
+import humanNumber from 'human-number';
+import {
+	ResponsiveContainer,
+	AreaChart,
+	Area,
+	CartesianGrid,
+	XAxis,
+	YAxis,
+	Tooltip,
+} from 'recharts';
+
+const Chart = ( { data } ) => (
+	<div className="newspack-campaigns-wizard-analytics__chart">
+		<ResponsiveContainer width={ '100%' } height={ 300 }>
+			<AreaChart data={ data } margin={ { top: 5, right: 20, bottom: 5, left: -15 } }>
+				<Area type="monotoneX" dataKey="value" stroke="#36f" fill="#3366ff1c" />
+				<CartesianGrid stroke="#ccc" strokeDasharray="5 5" />
+				<XAxis
+					dataKey="date"
+					tickFormatter={ date => format( new Date( date ), 'MMM d' ) }
+					tickMargin={ 10 }
+				/>
+				<YAxis allowDecimals={ false } tickFormatter={ humanNumber } />
+				<Tooltip formatter={ value => humanNumber( value ) } />
+			</AreaChart>
+		</ResponsiveContainer>
+	</div>
+);
+
+export default Chart;

--- a/src/all/PopupsManager/views/analytics/Chart.js
+++ b/src/all/PopupsManager/views/analytics/Chart.js
@@ -14,7 +14,7 @@ import {
 } from 'recharts';
 
 const Chart = ( { data } ) => (
-	<div className="newspack-campaigns-wizard-analytics__chart">
+	<div className="newspack-popups-manager-analytics__chart">
 		<ResponsiveContainer width={ '100%' } height={ 300 }>
 			<AreaChart data={ data } margin={ { top: 5, right: 20, bottom: 5, left: -15 } }>
 				<Area type="monotoneX" dataKey="value" stroke="#36f" fill="#3366ff1c" />

--- a/src/all/PopupsManager/views/analytics/Filters.js
+++ b/src/all/PopupsManager/views/analytics/Filters.js
@@ -8,8 +8,8 @@ import { OFFSETS } from './consts';
 
 const Info = ( { filtersState, labelFilters, eventActionFilters, onChange, disabled } ) => {
 	return (
-		<div className="newspack-campaigns-wizard-analytics__filters">
-			<div className="newspack-campaigns-wizard-analytics__filters__group">
+		<div className="newspack-popups-manager-analytics__filters">
+			<div className="newspack-popups-manager-analytics__filters__group">
 				<SelectControl
 					options={ [
 						{ label: __( 'All Campaigns', 'newspack-popups' ), value: '' },

--- a/src/all/PopupsManager/views/analytics/Filters.js
+++ b/src/all/PopupsManager/views/analytics/Filters.js
@@ -1,0 +1,42 @@
+/**
+ * WordPress dependencies.
+ */
+import { __ } from '@wordpress/i18n';
+import { SelectControl } from '@wordpress/components';
+
+import { OFFSETS } from './consts';
+
+const Info = ( { filtersState, labelFilters, eventActionFilters, onChange, disabled } ) => {
+	return (
+		<div className="newspack-campaigns-wizard-analytics__filters">
+			<div className="newspack-campaigns-wizard-analytics__filters__group">
+				<SelectControl
+					options={ [
+						{ label: __( 'All Campaigns', 'newspack-popups' ), value: '' },
+						...labelFilters,
+					] }
+					onChange={ onChange( 'SET_EVENT_LABEL_FILTER' ) }
+					value={ filtersState.event_label_id }
+					disabled={ disabled }
+				/>
+				<SelectControl
+					options={ [
+						{ label: __( 'All Events', 'newspack-popups' ), value: '' },
+						...eventActionFilters,
+					] }
+					onChange={ onChange( 'SET_EVENT_ACTION_FILTER' ) }
+					value={ filtersState.event_action }
+					disabled={ disabled }
+				/>
+			</div>
+			<SelectControl
+				options={ OFFSETS }
+				onChange={ onChange( 'SET_OFFSET_FILTER' ) }
+				value={ filtersState.offset }
+				disabled={ disabled }
+			/>
+		</div>
+	);
+};
+
+export default Info;

--- a/src/all/PopupsManager/views/analytics/Info.js
+++ b/src/all/PopupsManager/views/analytics/Info.js
@@ -26,7 +26,7 @@ const Info = ( { keyMetrics, filtersState, labelFilters, isLoading, postEditLink
 	const notApplicable = __( 'n/a', 'newspack-popups' );
 
 	return (
-		<div className="newspack-campaigns-wizard-analytics__info">
+		<div className="newspack-popups-manager-analytics__info">
 			<h2>
 				{ nameFilter ? `${ nameFilter.label }:` : __( 'All:', 'newspack-popups' ) }
 				{ postEditLink && (
@@ -36,7 +36,7 @@ const Info = ( { keyMetrics, filtersState, labelFilters, isLoading, postEditLink
 					</Fragment>
 				) }
 			</h2>
-			<div className="newspack-campaigns-wizard-analytics__info__sections">
+			<div className="newspack-popups-manager-analytics__info__sections">
 				{ [
 					{
 						label: __( 'Seen', 'newspack-popups' ),
@@ -62,15 +62,12 @@ const Info = ( { keyMetrics, filtersState, labelFilters, isLoading, postEditLink
 					},
 				].map( ( section, i ) => (
 					<div
-						className={ classnames(
-							'newspack-campaigns-wizard-analytics__info__sections__section',
-							{
-								'newspack-campaigns-wizard-analytics__info__sections__section--with-separator':
-									section.withSeparator,
-								'newspack-campaigns-wizard-analytics__info__sections__section--dimmed':
-									! isLoading && section.value === notApplicable,
-							}
-						) }
+						className={ classnames( 'newspack-popups-manager-analytics__info__sections__section', {
+							'newspack-popups-manager-analytics__info__sections__section--with-separator':
+								section.withSeparator,
+							'newspack-popups-manager-analytics__info__sections__section--dimmed':
+								! isLoading && section.value === notApplicable,
+						} ) }
 						key={ i }
 					>
 						<h2>{ isLoading ? '-' : section.value }</h2>

--- a/src/all/PopupsManager/views/analytics/Info.js
+++ b/src/all/PopupsManager/views/analytics/Info.js
@@ -1,0 +1,94 @@
+/**
+ * External dependencies.
+ */
+import classnames from 'classnames';
+import { unescape } from 'lodash';
+import humanNumber from 'human-number';
+import { Notice } from 'newspack-components';
+
+/**
+ * WordPress dependencies.
+ */
+import { Fragment } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+const formatPercentage = num => `${ String( ( num * 100 ).toFixed( 2 ) ).replace( /\.00$/, '' ) }%`;
+
+const Info = ( { keyMetrics, filtersState, labelFilters, isLoading, postEditLink } ) => {
+	const nameFilter =
+		filtersState.event_label_id !== '' &&
+		labelFilters.find( ( { value } ) => value === filtersState.event_label_id );
+
+	const { seen, form_submissions, link_clicks } = keyMetrics;
+
+	const hasConversionRate = form_submissions >= 0 && seen > 0;
+	const hasClickThroughRate = link_clicks >= 0 && seen > 0;
+	const notApplicable = __( 'n/a', 'newspack-popups' );
+
+	return (
+		<div className="newspack-campaigns-wizard-analytics__info">
+			<h2>
+				{ nameFilter ? `${ nameFilter.label }:` : __( 'All:', 'newspack-popups' ) }
+				{ postEditLink && (
+					<Fragment>
+						{' '}
+						(<a href={ unescape( postEditLink ) }>edit</a>)
+					</Fragment>
+				) }
+			</h2>
+			<div className="newspack-campaigns-wizard-analytics__info__sections">
+				{ [
+					{
+						label: __( 'Seen', 'newspack-popups' ),
+						value: humanNumber( seen ),
+						withSeparator: true,
+					},
+					{
+						label: __( 'Conversion Rate', 'newspack-popups' ),
+						value: hasConversionRate ? formatPercentage( form_submissions / seen ) : notApplicable,
+					},
+					{
+						label: __( 'Form Submissions', 'newspack-popups' ),
+						value: hasConversionRate ? form_submissions : notApplicable,
+						withSeparator: true,
+					},
+					{
+						label: __( 'Click-through Rate', 'newspack-popups' ),
+						value: hasClickThroughRate ? formatPercentage( link_clicks / seen ) : notApplicable,
+					},
+					{
+						label: __( 'Link Clicks', 'newspack-popups' ),
+						value: hasClickThroughRate ? link_clicks : notApplicable,
+					},
+				].map( ( section, i ) => (
+					<div
+						className={ classnames(
+							'newspack-campaigns-wizard-analytics__info__sections__section',
+							{
+								'newspack-campaigns-wizard-analytics__info__sections__section--with-separator':
+									section.withSeparator,
+								'newspack-campaigns-wizard-analytics__info__sections__section--dimmed':
+									! isLoading && section.value === notApplicable,
+							}
+						) }
+						key={ i }
+					>
+						<h2>{ isLoading ? '-' : section.value }</h2>
+						<span>{ section.label }</span>
+					</div>
+				) ) }
+			</div>
+			{ ! nameFilter && labelFilters.length !== 1 && (
+				<Notice
+					noticeText={ __(
+						'These are aggregated metrics for multiple campaigns. Some of them might not have links or forms, which can skew the displayed rates.',
+						'newspack-popups'
+					) }
+					isWarning
+				/>
+			) }
+		</div>
+	);
+};
+
+export default Info;

--- a/src/all/PopupsManager/views/analytics/consts.js
+++ b/src/all/PopupsManager/views/analytics/consts.js
@@ -1,0 +1,12 @@
+/**
+ * WordPress dependencies.
+ */
+import { __ } from '@wordpress/i18n';
+
+export const OFFSETS = [
+	{ label: __( 'Last 7 days', 'newspack-popups' ), value: '7' },
+	{ label: __( 'Last 14 days', 'newspack-popups' ), value: '14' },
+	{ label: __( 'Last 28 days', 'newspack-popups' ), value: '28' },
+	{ label: __( 'Last 90 days', 'newspack-popups' ), value: '90' },
+];
+export const DEFAULT_OFFSET = OFFSETS[ 0 ];

--- a/src/all/PopupsManager/views/analytics/index.js
+++ b/src/all/PopupsManager/views/analytics/index.js
@@ -31,7 +31,7 @@ const PopupAnalytics = ( { setError, errorData, isLoading, startLoading, doneLoa
 
 	useEffect(() => {
 		startLoading();
-		apiFetch( { path: `/newspack/v1/popups-analytics/report/?${ stringify( filtersState ) }` } )
+		apiFetch( { path: `/newspack-popups/v1/analytics/report/?${ stringify( filtersState ) }` } )
 			.then( response => {
 				updateState( { type: 'UPDATE_ALL', payload: response } );
 				doneLoading();

--- a/src/all/PopupsManager/views/analytics/index.js
+++ b/src/all/PopupsManager/views/analytics/index.js
@@ -1,0 +1,99 @@
+/**
+ * External dependencies.
+ */
+import { stringify } from 'qs';
+import classnames from 'classnames';
+import { withWizardScreen, Notice } from 'newspack-components';
+
+/**
+ * WordPress dependencies.
+ */
+import { useEffect, useState } from '@wordpress/element';
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * Internal dependencies.
+ */
+import Filters from './Filters';
+import Chart from './Chart';
+import Info from './Info';
+import './style.scss';
+import { useFiltersState, useAnalyticsState } from './utils';
+
+/**
+ * Popups Analytics screen.
+ */
+const PopupAnalytics = ( { setError, errorData, isLoading, startLoading, doneLoading } ) => {
+	const [ filtersState, dispatchFilter ] = useFiltersState();
+	const [ siteKitWarningText, setSiteKitWarningText ] = useState();
+	const [ state, updateState ] = useAnalyticsState();
+	const { report, labels, actions, key_metrics, post_edit_link, hasFetchedOnce } = state;
+
+	useEffect(() => {
+		startLoading();
+		apiFetch( { path: `/newspack/v1/popups-analytics/report/?${ stringify( filtersState ) }` } )
+			.then( response => {
+				updateState( { type: 'UPDATE_ALL', payload: response } );
+				doneLoading();
+			} )
+			.catch( error => {
+				if (
+					error.code === 'newspack_campaign_analytics_sitekit_disconnected' ||
+					error.code === 'newspack_campaign_analytics_sitekit_auth'
+				) {
+					setSiteKitWarningText( error.message );
+				} else {
+					setError( error );
+				}
+				doneLoading();
+			} );
+	}, [ filtersState ]);
+
+	if ( ! hasFetchedOnce && isLoading ) {
+		return null;
+	}
+
+	const handleFilterChange = type => payload => dispatchFilter( { type, payload } );
+
+	if ( siteKitWarningText ) {
+		return (
+			<Notice
+				rawHTML
+				isWarning
+				noticeText={ `<a href="/wp-admin/admin.php?page=googlesitekit-splash">${ siteKitWarningText }</a>` }
+			/>
+		);
+	}
+
+	if ( errorData ) {
+		return <Notice isError noticeText={ errorData.message } />;
+	}
+
+	return (
+		<div
+			className={ classnames( 'newspack-campaigns-wizard-analytics__wrapper', {
+				'newspack-campaigns-wizard-analytics__wrapper--loading': isLoading,
+			} ) }
+		>
+			<Filters
+				disabled={ isLoading }
+				labelFilters={ labels }
+				eventActionFilters={ actions }
+				filtersState={ filtersState }
+				onChange={ handleFilterChange }
+			/>
+			{ report && <Chart data={ report } isLoading={ isLoading } /> }
+			{ key_metrics && (
+				<Info
+					keyMetrics={ key_metrics }
+					filtersState={ filtersState }
+					labelFilters={ labels }
+					isLoading={ isLoading }
+					postEditLink={ post_edit_link }
+				/>
+			) }
+		</div>
+	);
+};
+
+export default withWizardScreen( PopupAnalytics );

--- a/src/all/PopupsManager/views/analytics/index.js
+++ b/src/all/PopupsManager/views/analytics/index.js
@@ -71,8 +71,8 @@ const PopupAnalytics = ( { setError, errorData, isLoading, startLoading, doneLoa
 
 	return (
 		<div
-			className={ classnames( 'newspack-campaigns-wizard-analytics__wrapper', {
-				'newspack-campaigns-wizard-analytics__wrapper--loading': isLoading,
+			className={ classnames( 'newspack-popups-manager-analytics__wrapper', {
+				'newspack-popups-manager-analytics__wrapper--loading': isLoading,
 			} ) }
 		>
 			<Filters

--- a/src/all/PopupsManager/views/analytics/style.scss
+++ b/src/all/PopupsManager/views/analytics/style.scss
@@ -1,0 +1,63 @@
+/**
+ * Popups Analytics
+ */
+
+.newspack-campaigns-wizard-analytics {
+	&__wrapper {
+		transition: opacity 200ms;
+		&--loading {
+			opacity: 0.5;
+		}
+	}
+	&__filters {
+		margin: 20px 0;
+		&,
+		&__group {
+			display: flex;
+			justify-content: space-between;
+		}
+	}
+	&__filters__group {
+		> div {
+			margin-left: 10px;
+		}
+	}
+
+	&__info {
+		&__sections {
+			display: flex;
+			margin: 40px 0;
+			&__section {
+				display: flex;
+				flex: 1;
+				justify-content: center;
+				align-items: center;
+				flex-direction: column;
+				transition: opacity 200ms;
+				h2 {
+					margin: 0;
+					padding-bottom: 20px;
+					font-size: 40px;
+				}
+				&--with-separator {
+					position: relative;
+					&::after {
+						content: '';
+						position: absolute;
+						height: 80%;
+						width: 1px;
+						background-color: #cecece;
+						right: 0;
+						top: 10%;
+					}
+				}
+				&--dimmed {
+					opacity: 0.3;
+					h2 {
+						font-weight: normal;
+					}
+				}
+			}
+		}
+	}
+}

--- a/src/all/PopupsManager/views/analytics/style.scss
+++ b/src/all/PopupsManager/views/analytics/style.scss
@@ -2,7 +2,7 @@
  * Popups Analytics
  */
 
-.newspack-campaigns-wizard-analytics {
+.newspack-popups-manager-analytics {
 	&__wrapper {
 		transition: opacity 200ms;
 		&--loading {

--- a/src/all/PopupsManager/views/analytics/utils.js
+++ b/src/all/PopupsManager/views/analytics/utils.js
@@ -1,0 +1,63 @@
+/**
+ * External dependencies.
+ */
+import { uniqBy } from 'lodash';
+
+/**
+ * WordPress dependencies.
+ */
+import { useReducer } from '@wordpress/element';
+
+/**
+ * Internal dependencies.
+ */
+import { DEFAULT_OFFSET } from './consts';
+
+const filtersInitialState = {
+	event_label_id: '',
+	event_action: '',
+	offset: DEFAULT_OFFSET.value,
+};
+
+const filtersReducer = ( state, action ) => {
+	switch ( action.type ) {
+		case 'SET_OFFSET_FILTER':
+			return { ...state, offset: action.payload };
+		case 'SET_EVENT_LABEL_FILTER':
+			return { ...state, event_label_id: action.payload };
+		case 'SET_EVENT_ACTION_FILTER':
+			return { ...state, event_action: action.payload };
+		default:
+			return state;
+	}
+};
+
+export const useFiltersState = () => useReducer( filtersReducer, filtersInitialState );
+
+const analyticsInitialState = {
+	labels: [],
+	actions: [],
+	hasFetchedOnce: false,
+};
+
+const analyticsReducer = ( state, action ) => {
+	switch ( action.type ) {
+		case 'UPDATE_ALL':
+			const { labels, actions, ...rest } = action.payload;
+			const newState = {
+				...state,
+				...rest,
+				// Persist all fetched labels and actions, so the select options do not disappear
+				labels: uniqBy( [ ...state.labels, ...labels ], 'value' ),
+				actions: uniqBy( [ ...state.actions, ...actions ], 'value' ),
+			};
+			if ( ! state.hasFetchedOnce ) {
+				newState.hasFetchedOnce = true;
+			}
+			return newState;
+		default:
+			return state;
+	}
+};
+
+export const useAnalyticsState = () => useReducer( analyticsReducer, analyticsInitialState );

--- a/src/all/PopupsManager/views/index.js
+++ b/src/all/PopupsManager/views/index.js
@@ -1,0 +1,2 @@
+export { default as PopupGroup } from './popup-group';
+export { default as Analytics } from './analytics';

--- a/src/all/PopupsManager/views/popup-group/index.js
+++ b/src/all/PopupsManager/views/popup-group/index.js
@@ -1,0 +1,100 @@
+/**
+ * WordPress dependencies.
+ */
+import { Component } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * External dependencies
+ */
+import { withWizardScreen, ActionCardSections, Notice } from 'newspack-components';
+
+/**
+ * Internal dependencies
+ */
+import PopupActionCard from '../../components/popup-action-card';
+
+/**
+ * Popup group screen
+ */
+
+class PopupGroup extends Component {
+	/**
+	 * Construct the appropriate description for a single Pop-up based on categories and sitewide default status.
+	 *
+	 * @param {Object} popup object.
+	 */
+	descriptionForPopup = ( { categories, sitewide_default: sitewideDefault } ) => {
+		if ( sitewideDefault ) {
+			return __( 'Sitewide default', 'newspack-popups' );
+		}
+		if ( categories.length > 0 ) {
+			return (
+				__( 'Categories: ', 'newspack-popups' ) +
+				categories.map( category => category.name ).join( ', ' )
+			);
+		}
+		return null;
+	};
+
+	/**
+	 * Render.
+	 */
+	render() {
+		const {
+			deletePopup,
+			emptyMessage,
+			items: { active = [], draft = [], test = [], inactive = [] },
+			previewPopup,
+			setCategoriesForPopup,
+			setSitewideDefaultPopup,
+			publishPopup,
+			updatePopup,
+			errorData,
+		} = this.props;
+
+		if ( errorData ) {
+			return <Notice isError noticeText={ errorData.message } />;
+		}
+
+		const getCardClassName = ( { key }, { sitewide_default } ) =>
+			( {
+				active: sitewide_default ? 'newspack-card__is-primary' : 'newspack-card__is-supported',
+				test: 'newspack-card__is-secondary',
+				inactive: 'newspack-card__is-disabled',
+				draft: 'newspack-card__is-disabled',
+			}[ key ] );
+
+		return (
+			<ActionCardSections
+				sections={ [
+					{ key: 'active', label: __( 'Active', 'newspack-popups' ), items: active },
+					{ key: 'draft', label: __( 'Draft', 'newspack-popups' ), items: draft },
+					{ key: 'test', label: __( 'Test', 'newspack-popups' ), items: test },
+					{ key: 'inactive', label: __( 'Inactive', 'newspack-popups' ), items: inactive },
+				] }
+				renderCard={ ( popup, section ) => (
+					<PopupActionCard
+						className={ getCardClassName( section, popup ) }
+						deletePopup={ deletePopup }
+						description={ this.descriptionForPopup( popup ) }
+						key={ popup.id }
+						popup={ popup }
+						previewPopup={ previewPopup }
+						setCategoriesForPopup={
+							section.key === 'active' || section.key === 'test'
+								? setCategoriesForPopup
+								: () => null
+						}
+						setSitewideDefaultPopup={ setSitewideDefaultPopup }
+						updatePopup={ updatePopup }
+						publishPopup={ section.key === 'draft' ? publishPopup : undefined }
+					/>
+				) }
+				emptyMessage={ emptyMessage }
+			/>
+		);
+	}
+}
+
+export default withWizardScreen( PopupGroup );

--- a/src/all/index.js
+++ b/src/all/index.js
@@ -1,0 +1,16 @@
+/**
+ * WordPress dependencies.
+ */
+import domReady from '@wordpress/dom-ready';
+import { render } from '@wordpress/element';
+
+/**
+ * Internal dependencies.
+ */
+import PopupsManager from './PopupsManager';
+import './style.scss';
+
+domReady( () => {
+	const element = document.getElementById( 'newspack-popups-all-popups-admin' );
+	render( <PopupsManager />, element );
+} );

--- a/src/all/style.scss
+++ b/src/all/style.scss
@@ -1,0 +1,3 @@
+.newspack_popups_cpt_page_newspack_popups_cpt #wpcontent {
+	padding-left: 0;
+}

--- a/src/editor/index.js
+++ b/src/editor/index.js
@@ -41,7 +41,7 @@ class PopupSidebar extends Component {
 		const { isSiteWideDefault } = this.state;
 		if ( ! prevProps.isSavingPost && isSavingPost ) {
 			const params = {
-				path: '/newspack-popups/v1/sitewide_default/' + id,
+				path: `/newspack-popups/v1/sitewide-default/${ id }`,
 				method: isSiteWideDefault ? 'POST' : 'DELETE',
 			};
 			apiFetch( params );

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,6 +16,7 @@ const editor = path.join( __dirname, 'src', 'editor' );
 const view = path.join( __dirname, 'src', 'view' );
 const documentSettings = path.join( __dirname, 'src', 'document-settings' );
 const settings = path.join( __dirname, 'src', 'settings' );
+const all = path.join( __dirname, 'src', 'all' );
 
 const webpackConfig = getBaseWebpackConfig(
 	{ WP: true },
@@ -25,6 +26,7 @@ const webpackConfig = getBaseWebpackConfig(
 			view,
 			documentSettings,
 			settings,
+			all,
 		},
 		'output-path': path.join( __dirname, 'dist' ),
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Include the enhanced campaigns UI (Campaigns wizard from Newspack Plugin) in this plugin.
The Campaigns wizard is removed from Newspack plugin in https://github.com/Automattic/newspack-plugin/pull/594

### How to test the changes in this Pull Request:

1. In WP Admin, click "All Campaigns", observe the UI from Newspack plugin instead of native WP posts list UI rendered
2. Test out the whole functionality offered by this view, it should work in the same way as in the Newspack Plugin
3. Observe that the logo in the top part of the view links to:
    - Newspack plugin dashboard, if the Newspack plugin is active
    - newspack.pub if the Newspack plugin is not active

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
