### PR TITLE
Build: change release zip structure 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,4 +55,6 @@ workflows:
             - build
           filters:
             branches:
-              only: release
+              only:
+                - release
+                - alpha

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,6 +36,9 @@ jobs:
     steps:
       - checkout_code
       - run:
+          name: Install rsync
+          command: sudo apt install rsync
+      - run:
           name: Release new version
           command: npm run release
 

--- a/.distignore
+++ b/.distignore
@@ -35,19 +35,15 @@ PULL_REQUEST_TEMPLATE.md
 webpack.config.js
 wp-cli.local.yml
 yarn.lock
-tests
-vendor
-node_modules
 *.sql
 *.tar.gz
 *.zip
 
-node_modules/*
-.git/*
-vendor/*
-src/*
-.github/*
-.circleci/*
-tests/*
-bin/*
-release/*
+node_modules
+.git
+.github
+.circleci
+/src
+/tests
+/bin
+/release

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "lint:scss:staged": "stylelint --syntax scss",
     "build": "calypso-build --config='./webpack.config.js'",
     "clean": "rm -rf dist/",
-    "release:archive": "mkdir -p release && zip -r release/newspack-popups.zip . -x@.distignore",
+    "release:archive": "rm -rf release && mkdir -p release && rsync -r . ./release/newspack-popups --exclude-from='./.distignore' && cd release && zip -r newspack-popups.zip newspack-popups",
     "release": "npm run build && npm run semantic-release"
   },
   "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,11 @@
   },
   "release": {
     "branches": [
-      "release"
+      "release",
+      {
+        "name": "alpha",
+        "prerelease": "alpha"
+      }
     ],
     "prepare": [
       "@semantic-release/changelog",


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

1. Change release ZIP file structure, so that it matches the structure used by WPORG plugins
1. `semantic-release` config update which will enable [prereleases](https://semantic-release.gitbook.io/semantic-release/usage/workflow-configuration#pre-release-branches). 

### How to test the changes in this Pull Request:

1. Run `npm run release:archive`
2. Install the plugin on a fresh site, confirm that it works as before

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
