### PR TITLE
Add permission callbacks (required in WP 5.5.)

### DIFF
--- a/includes/class-newspack-popups-api.php
+++ b/includes/class-newspack-popups-api.php
@@ -29,16 +29,18 @@ final class Newspack_Popups_API {
 			'newspack-popups/v1',
 			'reader',
 			[
-				'methods'  => \WP_REST_Server::READABLE,
-				'callback' => [ $this, 'reader_get_endpoint' ],
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => [ $this, 'reader_get_endpoint' ],
+				'permission_callback' => '__return_true',
 			]
 		);
 		\register_rest_route(
 			'newspack-popups/v1',
 			'reader',
 			[
-				'methods'  => \WP_REST_Server::CREATABLE,
-				'callback' => [ $this, 'reader_post_endpoint' ],
+				'methods'             => \WP_REST_Server::CREATABLE,
+				'callback'            => [ $this, 'reader_post_endpoint' ],
+				'permission_callback' => '__return_true',
 			]
 		);
 		\register_rest_route(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds `permission_callback` to `register_rest_route` calls, as it's a required argument in WP 5.5

### How to test the changes in this Pull Request:

1. On a page with popups, verify that calls to `/reader` endpoint are working as before – by dismissing a popup permanently and then checking that it's not displayed any more

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
