### PR TITLE
Fix bounce rates: dismissals as non-interaction

### DIFF
--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -565,24 +565,26 @@ final class Newspack_Popups_Model {
 		}
 		if ( $has_dismiss_form ) {
 			$analytics_events[] = [
-				'id'             => 'popupDismissed-' . $popup_id,
-				'amp_on'         => 'amp-form-submit-success',
-				'on'             => 'submit',
-				'element'        => '#' . esc_attr( $element_id ) . ' form.popup-dismiss-form',
-				'event_name'     => esc_html__( 'Dismissal', 'newspack-popups' ),
-				'event_label'    => esc_attr( $event_label ),
-				'event_category' => esc_attr( $event_category ),
+				'id'              => 'popupDismissed-' . $popup_id,
+				'amp_on'          => 'amp-form-submit-success',
+				'on'              => 'submit',
+				'element'         => '#' . esc_attr( $element_id ) . ' form.popup-dismiss-form',
+				'event_name'      => esc_html__( 'Dismissal', 'newspack-popups' ),
+				'event_label'     => esc_attr( $event_label ),
+				'event_category'  => esc_attr( $event_category ),
+				'non_interaction' => true,
 			];
 		}
 		if ( $has_not_interested_form ) {
 			$analytics_events[] = [
-				'id'             => 'popupNotInterested-' . $popup_id,
-				'amp_on'         => 'amp-form-submit-success',
-				'on'             => 'submit',
-				'element'        => '#' . esc_attr( $element_id ) . ' form.popup-not-interested-form',
-				'event_name'     => esc_html__( 'Permanent Dismissal', 'newspack-popups' ),
-				'event_label'    => esc_attr( $event_label ),
-				'event_category' => esc_attr( $event_category ),
+				'id'              => 'popupNotInterested-' . $popup_id,
+				'amp_on'          => 'amp-form-submit-success',
+				'on'              => 'submit',
+				'element'         => '#' . esc_attr( $element_id ) . ' form.popup-not-interested-form',
+				'event_name'      => esc_html__( 'Permanent Dismissal', 'newspack-popups' ),
+				'event_label'     => esc_attr( $event_label ),
+				'event_category'  => esc_attr( $event_category ),
+				'non_interaction' => true,
 			];
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Because of hos events are set up, a user dismissing a campaign and leaving the site would now count as a bounce. This PR fixes that. 

### How to test the changes in this Pull Request:

1. Create a campaign
2. Visit page, dismiss the campaign
3. Observe the event is sent as non-interaction to GA (`ni` parameter of value `1` in the request)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
