### PR TITLE
Add interoperation features

### DIFF
--- a/includes/class-newspack-popups-api.php
+++ b/includes/class-newspack-popups-api.php
@@ -281,6 +281,15 @@ final class Newspack_Popups_API {
 			if ( $this->get_mailing_list_status( $request ) ) {
 				$data['mailing_list_status'] = true;
 			}
+			$email_address = $this->get_email_address( $request );
+			if ( $email_address ) {
+				do_action(
+					'newspack_popups_mailing_list_subscription',
+					[
+						'email' => $email_address,
+					]
+				);
+			}
 			set_transient( $transient_name, $data, 0 );
 		}
 		return $this->reader_get_endpoint( $request );
@@ -360,6 +369,21 @@ final class Newspack_Popups_API {
 			$mailing_list_status = isset( $body['mailing_list_status'] ) ? $body['mailing_list_status'] : false;
 		}
 		return 'subscribed' === $mailing_list_status;
+	}
+
+	/**
+	 * Get email address.
+	 *
+	 * @param WP_REST_Request $request amp-access request.
+	 * @return string Email address.
+	 */
+	public function get_email_address( $request ) {
+		$email_address = isset( $request['email'] ) ? esc_attr( $request['email'] ) : false;
+		if ( ! $email_address ) {
+			$body          = json_decode( $request->get_body(), true );
+			$email_address = isset( $body['email'] ) ? $body['email'] : false;
+		}
+		return $email_address;
 	}
 
 	/**

--- a/includes/class-newspack-popups-api.php
+++ b/includes/class-newspack-popups-api.php
@@ -381,7 +381,7 @@ final class Newspack_Popups_API {
 		$email_address = isset( $request['email'] ) ? esc_attr( $request['email'] ) : false;
 		if ( ! $email_address ) {
 			$body          = json_decode( $request->get_body(), true );
-			$email_address = isset( $body['email'] ) ? $body['email'] : false;
+			$email_address = isset( $body['email'] ) ? esc_attr( $body['email'] ) : false;
 		}
 		return $email_address;
 	}

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -595,6 +595,7 @@ final class Newspack_Popups_Model {
 	/**
 	 * Add "newspack-popups-content-block" class name to a block.
 	 * This way a block rendered inside of a popup can be easily told apart.
+	 * This will not work which have HTML content assigned in the editor (most basic blocks)
 	 *
 	 * @param object $block A block.
 	 * @return object Block with className appended.

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -593,6 +593,20 @@ final class Newspack_Popups_Model {
 	}
 
 	/**
+	 * Add "newspack-popups-content-block" class name to a block.
+	 * This way a block rendered inside of a popup can be easily told apart.
+	 *
+	 * @param object $block A block.
+	 * @return object Block with className appended.
+	 */
+	public static function append_class_to_block( $block ) {
+		if ( isset( $block['attrs']['className'] ) ) {
+			$block['attrs']['className'] = $block['attrs']['className'] . ' newspack-popups-content-block';
+		}
+		return $block;
+	}
+
+	/**
 	 * Generate markup inline popup.
 	 *
 	 * @param string $popup The popup object.
@@ -605,7 +619,7 @@ final class Newspack_Popups_Model {
 		$blocks = parse_blocks( $popup['content'] );
 		$body   = '';
 		foreach ( $blocks as $block ) {
-			$body .= render_block( $block );
+			$body .= render_block( self::append_class_to_block( $block ) );
 		}
 		do_action( 'newspack_campaigns_after_campaign_render', $popup );
 
@@ -669,7 +683,7 @@ final class Newspack_Popups_Model {
 		$blocks = parse_blocks( $popup['content'] );
 		$body   = '';
 		foreach ( $blocks as $block ) {
-			$body .= render_block( $block );
+			$body .= render_block( self::append_class_to_block( $block ) );
 		}
 		do_action( 'newspack_campaigns_after_campaign_render', $popup );
 

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -600,8 +600,11 @@ final class Newspack_Popups_Model {
 	 * @return object Block with className appended.
 	 */
 	public static function append_class_to_block( $block ) {
+		$class_name = 'newspack-popups-content-block';
 		if ( isset( $block['attrs']['className'] ) ) {
-			$block['attrs']['className'] = $block['attrs']['className'] . ' newspack-popups-content-block';
+			$block['attrs']['className'] = $block['attrs']['className'] . ' ' . $class_name;
+		} else {
+			$block['attrs']['className'] = $class_name;
 		}
 		return $block;
 	}

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -595,7 +595,7 @@ final class Newspack_Popups_Model {
 	/**
 	 * Add "newspack-popups-content-block" class name to a block.
 	 * This way a block rendered inside of a popup can be easily told apart.
-	 * This will not work which have HTML content assigned in the editor (most basic blocks)
+	 * This will only work in dynamic blocks. 
 	 *
 	 * @param object $block A block.
 	 * @return object Block with className appended.

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -595,7 +595,7 @@ final class Newspack_Popups_Model {
 	/**
 	 * Add "newspack-popups-content-block" class name to a block.
 	 * This way a block rendered inside of a popup can be easily told apart.
-	 * This will only work in dynamic blocks. 
+	 * This will only work in dynamic blocks.
 	 *
 	 * @param object $block A block.
 	 * @return object Block with className appended.
@@ -607,6 +607,9 @@ final class Newspack_Popups_Model {
 		} else {
 			$block['attrs']['className'] = $class_name;
 		}
+
+		$block['innerBlocks'] = array_map( [ __CLASS__, 'append_class_to_block' ], $block['innerBlocks'] );
+
 		return $block;
 	}
 

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -445,7 +445,8 @@ final class Newspack_Popups_Model {
 								"extraUrlParams": {
 									"popup_id": "<?php echo ( esc_attr( $popup['id'] ) ); ?>",
 									"url": "<?php echo esc_url( home_url( $wp->request ) ); ?>",
-									"mailing_list_status": "subscribed"
+									"mailing_list_status": "subscribed",
+									"email": "${formFields[email]}"
 								}
 							}
 						},


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

For a better interop with other plugins, two features are introduced here:

1. A hook which allows other plugins to receive the submitted email if a newsletter signup form in a Campaign was submitted
3. Blocks rendered within a Campaign are furnished with a `newspack-popups-content-block` class, for better event handling

### How to test the changes in this Pull Request:

1. Create a Campaign with a Newsletter signup block (Jetpack Mailchimp block)
2. In a different plugin, subscribe to `newspack_popups_mailing_list_subscription` hook
3. Visit an AMP page ([won't work with non-AMP](https://github.com/Automattic/newspack-popups/issues/200))
4. Subscribe to the newsletter 
5. Observe the hook receives a payload object with an `email` key, the value of which is the submitted email
6. Observe the blocks rendered within the Campaign have the `newspack-popups-content-block` class

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
