### PR TITLE
Handle false get_transient return value

### DIFF
--- a/includes/class-newspack-popups-api.php
+++ b/includes/class-newspack-popups-api.php
@@ -159,6 +159,11 @@ final class Newspack_Popups_API {
 			return rest_ensure_response( $response );
 		}
 		$data = get_transient( $transient_name );
+		if ( false === $data ) {
+			$data = [
+				'count' => 0,
+			];
+		}
 
 		$response['currentViews'] = (int) $data['count'];
 

--- a/includes/class-newspack-popups-api.php
+++ b/includes/class-newspack-popups-api.php
@@ -263,7 +263,12 @@ final class Newspack_Popups_API {
 	public function reader_post_endpoint( $request ) {
 		$transient_name = $this->get_popup_data_transient_name( $request );
 		if ( $transient_name && ! $this->is_preview_request( $request ) ) {
-			$data          = get_transient( $transient_name );
+			$data = get_transient( $transient_name );
+			if ( false === $data ) {
+				$data = [
+					'count' => 0,
+				];
+			}
 			$data['count'] = (int) $data['count'] + 1;
 			$data['time']  = time();
 			if ( $request['suppress_forever'] ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

It appears that something about get_transient has changed when PHP 7.4 is running.

Closes #179 

### How to test the changes in this Pull Request:

1. Switch to PHP 7.4
2. On `master`, observe a notice logged when Campaigns POST endpoint is hit
3. Switch to this branch, observe no notice logged

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
