### PR TITLE
Single GET per page; lightweight POST endpoint

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -1,0 +1,23 @@
+# Lightweight API
+
+The lightweight API is a stripped-down alternative to the WordPress REST API. Campaigns will often be present on every page of a site, which can lead to performance issues as a result of a large number of uncacheable API requests.
+
+The feature requires a custom config file named `newspack-popups-config.php` at the root of the site, with the following constants:
+
+```
+define( 'DB_NAME', 'dbname' );
+define( 'DB_USER', 'dbuser' );
+define( 'DB_PASSWORD', 'dbpass' );
+define( 'DB_HOST', 'localhost' );
+define( 'DB_CHARSET', 'utf8' );
+define( 'DB_PREFIX', 'wp_' );
+```
+
+Copy the WP_CACHE_KEY_SALT define from `wp-content.php`.
+
+To include information about database, cache and time in the response, add this constant:
+
+```
+define( 'NEWSPACK_POPUPS_DEBUG', true );
+```
+

--- a/api/classes/class-lightweight-api.php
+++ b/api/classes/class-lightweight-api.php
@@ -1,0 +1,272 @@
+<?php
+/**
+ * Newspack Campaigns lightweight API
+ *
+ * @package Newspack
+ * @phpcs:disable WordPress.DB.RestrictedClasses.mysql__PDO
+ */
+
+/**
+ * API endpoints
+ */
+class Lightweight_API {
+
+	/**
+	 * Database object.
+	 *
+	 * @var db
+	 */
+	public $db;
+
+	/**
+	 * Unique client ID.
+	 *
+	 * @var client_id
+	 */
+	public $client_id;
+
+	/**
+	 * Campaign ID.
+	 *
+	 * @var popup_id
+	 */
+	public $popup_id;
+
+	/**
+	 * Campaign frequency.
+	 *
+	 * @var frequency
+	 */
+	public $frequency;
+
+	/**
+	 * Campaign placement.
+	 *
+	 * @var placement
+	 */
+	public $placement;
+
+	/**
+	 * Campaign UTM Suppression.
+	 *
+	 * @var utm_suppression
+	 */
+	public $utm_suppression;
+
+	/**
+	 * Suppress Newsletter Campaigns setting.
+	 *
+	 * @var suppress_newsletter_campaigns
+	 */
+	public $suppress_newsletter_campaigns;
+
+	/**
+	 * Suppress all newsletter campaigns if one dismissed setting.
+	 *
+	 * @var suppress_all_newsletter_campaigns_if_one_dismissed
+	 */
+	public $suppress_all_newsletter_campaigns_if_one_dismissed;
+
+	/**
+	 * Campaign has Newsletter prompt.
+	 *
+	 * @var has_newsletter_prompt
+	 */
+	public $has_newsletter_prompt;
+
+	/**
+	 * Response object.
+	 *
+	 * @var response
+	 */
+	public $response = [];
+
+	/**
+	 * The referer URL.
+	 *
+	 * @var referer_url
+	 */
+	public $referer_url;
+
+	/**
+	 * Database credentials.
+	 *
+	 * @var credentials
+	 */
+	public $credentials;
+
+	/**
+	 * Debugging info.
+	 *
+	 * @var debug
+	 */
+	public $debug;
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		if ( ! $this->verify_referer() ) {
+			$this->error( 'invalid_referer' );
+		}
+		$this->debug = [
+			'read_query_count'       => 0,
+			'write_query_count'      => 0,
+			'cache_count'            => 0,
+			'read_empty_transients'  => 0,
+			'write_empty_transients' => 0,
+			'start_time'             => microtime( true ),
+			'end_time'               => null,
+			'duration'               => null,
+		];
+
+		$this->client_id       = ! empty( $_REQUEST['rid'] ) ? // phpcs:ignore
+			filter_input( INPUT_POST | INPUT_GET, 'rid', FILTER_SANITIZE_SPECIAL_CHARS ) :
+			null; // phpcs:ignore
+		$this->popup_id        = ! empty( $_REQUEST['popup_id'] ) ? // phpcs:ignore
+			filter_input( INPUT_POST | INPUT_GET, 'popup_id', FILTER_SANITIZE_SPECIAL_CHARS ) :
+			null; // phpcs:ignore
+		$this->frequency       = ! empty( $_REQUEST['frequency'] ) ? // phpcs:ignore
+			filter_input( INPUT_POST | INPUT_GET, 'frequency', FILTER_SANITIZE_SPECIAL_CHARS ) :
+			null; // phpcs:ignore
+		$this->placement       = ! empty( $_REQUEST['placement'] ) ? // phpcs:ignore
+			filter_input( INPUT_POST | INPUT_GET, 'placement', FILTER_SANITIZE_SPECIAL_CHARS ) :
+			null; // phpcs:ignore
+		$this->utm_suppression = ! empty( $_REQUEST['utm_suppression'] ) ? // phpcs:ignore
+			filter_input( INPUT_POST | INPUT_GET, 'utm_suppression', FILTER_SANITIZE_SPECIAL_CHARS ) :
+			null; // phpcs:ignore
+
+		$this->suppress_newsletter_campaigns                      = ! empty( $_REQUEST['suppress_newsletter_campaigns'] ) ? // phpcs:ignore
+			filter_input( INPUT_POST | INPUT_GET, 'suppress_newsletter_campaigns', FILTER_SANITIZE_SPECIAL_CHARS ) :
+			null; // phpcs:ignore
+		$this->suppress_all_newsletter_campaigns_if_one_dismissed = ! empty( $_REQUEST['suppress_all_newsletter_campaigns_if_one_dismissed'] ) ? // phpcs:ignore
+			filter_input( INPUT_POST | INPUT_GET, 'suppress_all_newsletter_campaigns_if_one_dismissed', FILTER_SANITIZE_SPECIAL_CHARS ) :
+			null; // phpcs:ignore
+		$this->has_newsletter_prompt = ! empty( $_REQUEST['has_newsletter_prompt'] ) ? // phpcs:ignore
+			filter_input( INPUT_POST | INPUT_GET, 'has_newsletter_prompt', FILTER_SANITIZE_SPECIAL_CHARS ) :
+			null; // phpcs:ignore
+
+		$this->referer_url = filter_input( INPUT_SERVER, 'HTTP_REFERER', FILTER_SANITIZE_STRING );
+
+		if ( 'inline' !== $this->placement && 'always' === $this->frequency ) {
+			$this->frequency = 'once';
+		}
+	}
+
+	/**
+	 * Verify referer is valid.
+	 */
+	public function verify_referer() {
+		$http_referer = ! empty( $_SERVER['HTTP_REFERER'] ) ? parse_url( $_SERVER['HTTP_REFERER'] , PHP_URL_HOST ) : null; // phpcs:ignore
+		$valid_referers = [
+			$http_referer,
+			// TODO: Add AMP Cache.
+		];
+		$http_host = ! empty( $_SERVER['HTTP_HOST'] ) ? $_SERVER['HTTP_HOST'] : null; // phpcs:ignore
+		return ! empty( $http_referer ) && ! empty( $http_host ) && in_array( strtolower( $http_host ), $valid_referers, true );
+	}
+
+	/**
+	 * Get transient name.
+	 */
+	public function get_transient_name() {
+		return sprintf( '%s-%s-popup', $this->client_id, $this->popup_id );
+	}
+
+	/**
+	 * Get suppression-related transient value
+	 *
+	 * @param string $prefix transient prefix.
+	 */
+	public function get_suppression_data_transient_name( $prefix ) {
+		return sprintf(
+			'%s-%s',
+			$prefix,
+			$this->client_id
+		);
+	}
+
+	/**
+	 * Get suppression-related transient value for newsletter-campaign-suppression, which has the order of client_id and key reversed from the others.
+	 *
+	 * @param string $prefix transient prefix.
+	 */
+	public function legacy_get_suppression_data_transient_name_reversed( $prefix ) {
+		return sprintf(
+			'%s-%s',
+			$this->client_id,
+			$prefix
+		);
+	}
+
+	/**
+	 * Complete the API and print response.
+	 */
+	public function respond() {
+		$this->debug['end_time'] = microtime( true );
+		$this->debug['duration'] = $this->debug['end_time'] - $this->debug['start_time'];
+		if ( defined( 'NEWSPACK_POPUPS_DEBUG' ) && NEWSPACK_POPUPS_DEBUG ) {
+			$this->response['debug'] = $this->debug;
+		}
+		http_response_code( 200 );
+		print json_encode( $this->response ); // phpcs:ignore
+		exit;
+	}
+
+	/**
+	 * Return a 400 code error.
+	 *
+	 * @param string $code The error code.
+	 */
+	public function error( $code ) {
+		http_response_code( 400 );
+		print json_encode( [ 'error' => $code ] ); // phpcs:ignore
+		exit;
+	}
+
+	/**
+	 * Get data from transient.
+	 *
+	 * @param string $name The transient's name.
+	 */
+	public function get_transient( $name ) {
+		global $wpdb;
+		$name = '_transient_' . $name;
+
+		$value = wp_cache_get( $name, 'newspack-popups' );
+		if ( -1 === $value ) {
+			$this->debug['read_empty_transients'] += 1;
+			$this->debug['cache_count'] += 1;
+			return null;
+		} elseif ( false === $value ) {
+			$this->debug['read_query_count'] += 1;
+			$value = $wpdb->get_var( $wpdb->prepare( "SELECT option_value FROM $wpdb->options WHERE option_name = %s LIMIT 1", $name ) ); // phpcs:ignore
+			if ( $value ) {
+				wp_cache_set( $name, $value, 'newspack-popups' );
+			} else {
+				$this->debug['write_empty_transients'] += 1;
+				wp_cache_set( $name, -1, 'newspack-popups' );
+			}
+		} else {
+			$this->debug['cache_count'] += 1;
+		}
+		return maybe_unserialize( $value );
+	}
+
+	/**
+	 * Upsert transient.
+	 *
+	 * @param string $name THe transient's name.
+	 * @param string $value THe transient's value.
+	 */
+	public function set_transient( $name, $value ) {
+		global $wpdb;
+		$name             = '_transient_' . $name;
+		$serialized_value = maybe_serialize( $value );
+		$autoload         = 'no';
+		wp_cache_set( $name, $serialized_value, 'newspack-popups' );
+		$result           = $wpdb->query( $wpdb->prepare( "INSERT INTO `$wpdb->options` (`option_name`, `option_value`, `autoload`) VALUES (%s, %s, %s) ON DUPLICATE KEY UPDATE `option_name` = VALUES(`option_name`), `option_value` = VALUES(`option_value`), `autoload` = VALUES(`autoload`)", $name, $serialized_value, $autoload ) ); // phpcs:ignore
+
+		$this->debug['write_query_count'] += 1;
+	}
+}

--- a/api/classes/class-lightweight-api.php
+++ b/api/classes/class-lightweight-api.php
@@ -19,74 +19,11 @@ class Lightweight_API {
 	public $db;
 
 	/**
-	 * Unique client ID.
-	 *
-	 * @var client_id
-	 */
-	public $client_id;
-
-	/**
-	 * Campaign ID.
-	 *
-	 * @var popup_id
-	 */
-	public $popup_id;
-
-	/**
-	 * Campaign frequency.
-	 *
-	 * @var frequency
-	 */
-	public $frequency;
-
-	/**
-	 * Campaign placement.
-	 *
-	 * @var placement
-	 */
-	public $placement;
-
-	/**
-	 * Campaign UTM Suppression.
-	 *
-	 * @var utm_suppression
-	 */
-	public $utm_suppression;
-
-	/**
-	 * Suppress Newsletter Campaigns setting.
-	 *
-	 * @var suppress_newsletter_campaigns
-	 */
-	public $suppress_newsletter_campaigns;
-
-	/**
-	 * Suppress all newsletter campaigns if one dismissed setting.
-	 *
-	 * @var suppress_all_newsletter_campaigns_if_one_dismissed
-	 */
-	public $suppress_all_newsletter_campaigns_if_one_dismissed;
-
-	/**
-	 * Campaign has Newsletter prompt.
-	 *
-	 * @var has_newsletter_prompt
-	 */
-	public $has_newsletter_prompt;
-
-	/**
 	 * Response object.
 	 *
 	 * @var response
 	 */
 	public $response = [];
-
-	/**
-	 * The referer URL.
-	 *
-	 * @var referer_url
-	 */
-	public $referer_url;
 
 	/**
 	 * Database credentials.
@@ -115,42 +52,11 @@ class Lightweight_API {
 			'cache_count'            => 0,
 			'read_empty_transients'  => 0,
 			'write_empty_transients' => 0,
+			'write_read_query_count' => 0,
 			'start_time'             => microtime( true ),
 			'end_time'               => null,
 			'duration'               => null,
 		];
-
-		$this->client_id       = ! empty( $_REQUEST['rid'] ) ? // phpcs:ignore
-			filter_input( INPUT_POST | INPUT_GET, 'rid', FILTER_SANITIZE_SPECIAL_CHARS ) :
-			null; // phpcs:ignore
-		$this->popup_id        = ! empty( $_REQUEST['popup_id'] ) ? // phpcs:ignore
-			filter_input( INPUT_POST | INPUT_GET, 'popup_id', FILTER_SANITIZE_SPECIAL_CHARS ) :
-			null; // phpcs:ignore
-		$this->frequency       = ! empty( $_REQUEST['frequency'] ) ? // phpcs:ignore
-			filter_input( INPUT_POST | INPUT_GET, 'frequency', FILTER_SANITIZE_SPECIAL_CHARS ) :
-			null; // phpcs:ignore
-		$this->placement       = ! empty( $_REQUEST['placement'] ) ? // phpcs:ignore
-			filter_input( INPUT_POST | INPUT_GET, 'placement', FILTER_SANITIZE_SPECIAL_CHARS ) :
-			null; // phpcs:ignore
-		$this->utm_suppression = ! empty( $_REQUEST['utm_suppression'] ) ? // phpcs:ignore
-			filter_input( INPUT_POST | INPUT_GET, 'utm_suppression', FILTER_SANITIZE_SPECIAL_CHARS ) :
-			null; // phpcs:ignore
-
-		$this->suppress_newsletter_campaigns                      = ! empty( $_REQUEST['suppress_newsletter_campaigns'] ) ? // phpcs:ignore
-			filter_input( INPUT_POST | INPUT_GET, 'suppress_newsletter_campaigns', FILTER_SANITIZE_SPECIAL_CHARS ) :
-			null; // phpcs:ignore
-		$this->suppress_all_newsletter_campaigns_if_one_dismissed = ! empty( $_REQUEST['suppress_all_newsletter_campaigns_if_one_dismissed'] ) ? // phpcs:ignore
-			filter_input( INPUT_POST | INPUT_GET, 'suppress_all_newsletter_campaigns_if_one_dismissed', FILTER_SANITIZE_SPECIAL_CHARS ) :
-			null; // phpcs:ignore
-		$this->has_newsletter_prompt = ! empty( $_REQUEST['has_newsletter_prompt'] ) ? // phpcs:ignore
-			filter_input( INPUT_POST | INPUT_GET, 'has_newsletter_prompt', FILTER_SANITIZE_SPECIAL_CHARS ) :
-			null; // phpcs:ignore
-
-		$this->referer_url = filter_input( INPUT_SERVER, 'HTTP_REFERER', FILTER_SANITIZE_STRING );
-
-		if ( 'inline' !== $this->placement && 'always' === $this->frequency ) {
-			$this->frequency = 'once';
-		}
 	}
 
 	/**
@@ -169,34 +75,12 @@ class Lightweight_API {
 	/**
 	 * Get transient name.
 	 */
-	public function get_transient_name() {
-		return sprintf( '%s-%s-popup', $this->client_id, $this->popup_id );
-	}
-
-	/**
-	 * Get suppression-related transient value
-	 *
-	 * @param string $prefix transient prefix.
-	 */
-	public function get_suppression_data_transient_name( $prefix ) {
-		return sprintf(
-			'%s-%s',
-			$prefix,
-			$this->client_id
-		);
-	}
-
-	/**
-	 * Get suppression-related transient value for newsletter-campaign-suppression, which has the order of client_id and key reversed from the others.
-	 *
-	 * @param string $prefix transient prefix.
-	 */
-	public function legacy_get_suppression_data_transient_name_reversed( $prefix ) {
-		return sprintf(
-			'%s-%s',
-			$this->client_id,
-			$prefix
-		);
+	public function get_transient_name( $client_id, $popup_id = null ) {
+		if ( null === $popup_id ) {
+			// For data about popups in general.
+			return sprintf( '%s-popups', $client_id );
+		}
+		return sprintf( '%s-%s-popup', $client_id, $popup_id );
 	}
 
 	/**
@@ -236,7 +120,7 @@ class Lightweight_API {
 		$value = wp_cache_get( $name, 'newspack-popups' );
 		if ( -1 === $value ) {
 			$this->debug['read_empty_transients'] += 1;
-			$this->debug['cache_count'] += 1;
+			$this->debug['cache_count']           += 1;
 			return null;
 		} elseif ( false === $value ) {
 			$this->debug['read_query_count'] += 1;
@@ -268,5 +152,49 @@ class Lightweight_API {
 		$result           = $wpdb->query( $wpdb->prepare( "INSERT INTO `$wpdb->options` (`option_name`, `option_value`, `autoload`) VALUES (%s, %s, %s) ON DUPLICATE KEY UPDATE `option_name` = VALUES(`option_name`), `option_value` = VALUES(`option_value`), `autoload` = VALUES(`autoload`)", $name, $serialized_value, $autoload ) ); // phpcs:ignore
 
 		$this->debug['write_query_count'] += 1;
+	}
+
+	/**
+	 * Retrieve campaign data.
+	 *
+	 * @param string $client_id Client ID.
+	 * @param string $campaign_id Campaign ID.
+	 * @return object Campaign data.
+	 */
+	public function get_campaign_data( $client_id, $campaign_id ) {
+		$data = $this->get_transient( $this->get_transient_name( $client_id, $campaign_id ) );
+		return [
+			'count'            => ! empty( $data['count'] ) ? (int) $data['count'] : 0,
+			'last_viewed'      => ! empty( $data['last_viewed'] ) ? (int) $data['last_viewed'] : 0,
+			// Primarily caused by permanent dismissal, but also by email signup
+			// (on a newsletter campaign) or a UTM param suppression.
+			'suppress_forever' => ! empty( $data['suppress_forever'] ) ? (int) $data['suppress_forever'] : false,
+		];
+	}
+
+	/**
+	 * Save campaign data.
+	 *
+	 * @param string $client_id Client ID.
+	 * @param string $campaign_id Campaign ID.
+	 * @param string $campaign_data Campaign data.
+	 */
+	public function save_campaign_data( $client_id, $campaign_id, $campaign_data ) {
+		return $this->set_transient( $this->get_transient_name( $client_id, $campaign_id ), $campaign_data );
+	}
+
+	/**
+	 * Retrieve client data.
+	 *
+	 * @param string $client_id Client ID.
+	 */
+	public function get_client_data( $client_id ) {
+		$data = $this->get_transient( $this->get_transient_name( $client_id ) );
+		if ( ! $data ) {
+			return [
+				'suppressed_newsletter_campaign' => false,
+			];
+		}
+		return $data;
 	}
 }

--- a/api/classes/class-lightweight-api.php
+++ b/api/classes/class-lightweight-api.php
@@ -197,4 +197,14 @@ class Lightweight_API {
 		}
 		return $data;
 	}
+
+	/**
+	 * Save client data.
+	 *
+	 * @param string $client_id Client ID.
+	 * @param string $client_data Client data.
+	 */
+	public function save_client_data( $client_id, $client_data ) {
+		return $this->set_transient( $this->get_transient_name( $client_id ), $client_data );
+	}
 }

--- a/api/classes/class-lightweight-api.php
+++ b/api/classes/class-lightweight-api.php
@@ -74,6 +74,9 @@ class Lightweight_API {
 
 	/**
 	 * Get transient name.
+	 *
+	 * @param string $client_id Client ID.
+	 * @param string $popup_id Popup ID.
 	 */
 	public function get_transient_name( $client_id, $popup_id = null ) {
 		if ( null === $popup_id ) {

--- a/api/classes/class-maybe-show-campaign.php
+++ b/api/classes/class-maybe-show-campaign.php
@@ -1,0 +1,167 @@
+<?php
+/**
+ * Newspack Campaigns maybe display campaign.
+ *
+ * @package Newspack
+ */
+
+/**
+ * Extend the base Lightweight_API class.
+ */
+require_once 'class-lightweight-api.php';
+
+/**
+ * GET endpoint to determine if campaign is shown or not.
+ */
+class Maybe_Show_Campaign extends Lightweight_API {
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		parent::__construct();
+		$should_show = $this->should_campaign_be_shown();
+		if ( ( $should_show || $this->should_perform_utm_logic() ) && 'test' !== $this->frequency ) {
+			if ( $this->should_suppress_because_utm_suppression() ) {
+				$should_show = false;
+			}
+			if ( $this->should_suppress_because_utm_medium() ) {
+				$should_show = false;
+			}
+			if ( $should_show && $this->should_suppress_because_newsletter_campaign_dismissed() ) {
+				$should_show = false;
+			}
+		}
+
+		$this->response['displayPopup'] = $should_show;
+		$this->respond();
+	}
+
+	/**
+	 * Primary campaign visibility logic.
+	 *
+	 * @return bool Whether campaign should be shown.
+	 */
+	public function should_campaign_be_shown() {
+		$data                = $this->get_transient( $this->get_transient_name() );
+		$current_views       = ! empty( $data['count'] ) ? (int) $data['count'] : 0;
+		$suppress_forever    = ! empty( $data['suppress_forever'] ) ? (int) $data['suppress_forever'] : false;
+		$mailing_list_status = ! empty( $data['mailing_list_status'] ) ? (int) $data['mailing_list_status'] : false;
+		$last_view           = ! empty( $data['time'] ) ? (int) $data['time'] : 0;
+
+		if ( $suppress_forever ) {
+			return false;
+		}
+		if ( $mailing_list_status ) {
+			return false;
+		}
+		if ( 'always' === $this->frequency || 'test' === $this->frequency ) {
+			return true;
+		}
+		if ( 'daily' === $this->frequency ) {
+			return $last_view < strtotime( '-1 day' );
+		}
+		if ( 'once' === $this->frequency ) {
+			return $current_views < 1;
+		}
+		return false;
+	}
+
+	/**
+	 * Assess whether the UTM logic is necessary.
+	 *
+	 * @return bool Whether UTM logic should be performed.
+	 */
+	public function should_perform_utm_logic() {
+		if ( $this->utm_suppression && stripos( urldecode( $this->referer_url ), 'utm_source=' . $this->utm_suppression ) ) {
+			return true;
+		}
+		if ( stripos( $this->referer_url, 'utm_medium=email' ) ) {
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Handle utm_source query param, update transients if needed.
+	 *
+	 * @return bool Should campaign be shown.
+	 */
+	public function should_suppress_because_utm_suppression() {
+		if ( ! $this->utm_suppression ) {
+			return false;
+		}
+		// Suppressing based on UTM Source parameter in the URL.
+		// If the visitor came from a campaign with suppressed utm_source, then it should not be displayed.
+		$utm_source_transient_name = $this->get_suppression_data_transient_name( 'utm_source' );
+		$utm_source_transient      = $this->get_transient( $utm_source_transient_name );
+		if ( ! $utm_source_transient || ! is_array( $utm_source_transient ) ) {
+			$utm_source_transient = [];
+		}
+		if ( $this->referer_url && stripos( urldecode( $this->referer_url ), 'utm_source=' . $this->utm_suppression ) ) {
+			$utm_source_transient[ $this->utm_suppression ] = true;
+			$this->set_transient( $utm_source_transient_name, $utm_source_transient );
+			return true;
+		}
+
+		if ( ! empty( $utm_source_transient[ $this->utm_suppression ] ) ) {
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Handle utm_medium query param, update transients if needed.
+	 *
+	 * @return bool Should campaign be shown.
+	 */
+	public function should_suppress_because_utm_medium() {
+		// Suppressing based on UTM Medium parameter in the URL. If:
+		// - the visitor came from email,
+		// - the suppress_newsletter_campaigns setting is on,
+		// - the pop-up has a newsletter form,
+		// then it should not be displayed.
+		$has_utm_medium_in_url     = stripos( $this->referer_url, 'utm_medium=email' );
+		$utm_medium_transient_name = $this->get_suppression_data_transient_name( 'utm_medium' );
+
+		if (
+			$this->suppress_newsletter_campaigns &&
+			$this->has_newsletter_prompt &&
+			( $has_utm_medium_in_url || $this->get_transient( $utm_medium_transient_name ) )
+		) {
+			$this->set_transient( $utm_medium_transient_name, true );
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Should campaign be suppressed because it is a Newsletter campaign and a Newsletter campaign was previously dismissed.
+	 *
+	 * @return bool Should campaign be shown.
+	 */
+	public function should_suppress_because_newsletter_campaign_dismissed() {
+		// Suppressing a newsletter campaign if any newsletter campaign was dismissed.
+		$name = $this->legacy_get_suppression_data_transient_name_reversed( 'newsletter-campaign-suppression' );
+
+		if ( $this->suppress_all_newsletter_campaigns_if_one_dismissed && $this->has_newsletter_prompt && $this->get_transient( $name ) ) {
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Set the utm_source suppression-related transient.
+	 *
+	 * @param string $utm_source utm_source param.
+	 */
+	public function set_utm_source_transient( $utm_source ) {
+		if ( ! empty( $utm_source ) ) {
+			$transient_name           = $this->get_suppression_data_transient_name( 'utm_source' );
+			$transient                = $this->get_transient( $transient_name );
+			$transient[ $utm_source ] = true;
+			$this->set_transient( $transient_name, true );
+		}
+	}
+}
+new Maybe_Show_Campaign();

--- a/api/classes/class-maybe-show-campaign.php
+++ b/api/classes/class-maybe-show-campaign.php
@@ -20,148 +20,91 @@ class Maybe_Show_Campaign extends Lightweight_API {
 	 */
 	public function __construct() {
 		parent::__construct();
-		$should_show = $this->should_campaign_be_shown();
-		if ( ( $should_show || $this->should_perform_utm_logic() ) && 'test' !== $this->frequency ) {
-			if ( $this->should_suppress_because_utm_suppression() ) {
-				$should_show = false;
-			}
-			if ( $this->should_suppress_because_utm_medium() ) {
-				$should_show = false;
-			}
-			if ( $should_show && $this->should_suppress_because_newsletter_campaign_dismissed() ) {
-				$should_show = false;
-			}
+		$campaigns = json_decode( $_REQUEST['popups'] );
+		$settings  = json_decode( $_REQUEST['settings'] );
+		$response  = [];
+		foreach ( $campaigns as $campaign ) {
+			$response[ $campaign->id ] = $this->should_campaign_be_shown( $_REQUEST['cid'], $campaign, $settings );
 		}
-
-		$this->response['displayPopup'] = $should_show;
+		$this->response = $response;
 		$this->respond();
 	}
 
 	/**
 	 * Primary campaign visibility logic.
 	 *
+	 * @param string $client_id Client ID.
+	 * @param string $campaign_id Campaign ID.
+	 * @param object $settings Settings.
 	 * @return bool Whether campaign should be shown.
 	 */
-	public function should_campaign_be_shown() {
-		$data                = $this->get_transient( $this->get_transient_name() );
-		$current_views       = ! empty( $data['count'] ) ? (int) $data['count'] : 0;
-		$suppress_forever    = ! empty( $data['suppress_forever'] ) ? (int) $data['suppress_forever'] : false;
-		$mailing_list_status = ! empty( $data['mailing_list_status'] ) ? (int) $data['mailing_list_status'] : false;
-		$last_view           = ! empty( $data['time'] ) ? (int) $data['time'] : 0;
+	public function should_campaign_be_shown( $client_id, $campaign, $settings ) {
+		$campaign_data = $this->get_campaign_data( $client_id, $campaign->id );
 
-		if ( $suppress_forever ) {
+		if ( $campaign_data['suppress_forever'] ) {
 			return false;
 		}
-		if ( $mailing_list_status ) {
-			return false;
-		}
-		if ( 'always' === $this->frequency || 'test' === $this->frequency ) {
-			return true;
-		}
-		if ( 'daily' === $this->frequency ) {
-			return $last_view < strtotime( '-1 day' );
-		}
-		if ( 'once' === $this->frequency ) {
-			return $current_views < 1;
-		}
-		return false;
-	}
 
-	/**
-	 * Assess whether the UTM logic is necessary.
-	 *
-	 * @return bool Whether UTM logic should be performed.
-	 */
-	public function should_perform_utm_logic() {
-		if ( $this->utm_suppression && stripos( urldecode( $this->referer_url ), 'utm_source=' . $this->utm_suppression ) ) {
-			return true;
-		}
-		if ( stripos( $this->referer_url, 'utm_medium=email' ) ) {
-			return true;
-		}
-		return false;
-	}
+		$should_display = true;
 
-	/**
-	 * Handle utm_source query param, update transients if needed.
-	 *
-	 * @return bool Should campaign be shown.
-	 */
-	public function should_suppress_because_utm_suppression() {
-		if ( ! $this->utm_suppression ) {
-			return false;
-		}
-		// Suppressing based on UTM Source parameter in the URL.
-		// If the visitor came from a campaign with suppressed utm_source, then it should not be displayed.
-		$utm_source_transient_name = $this->get_suppression_data_transient_name( 'utm_source' );
-		$utm_source_transient      = $this->get_transient( $utm_source_transient_name );
-		if ( ! $utm_source_transient || ! is_array( $utm_source_transient ) ) {
-			$utm_source_transient = [];
-		}
-		if ( $this->referer_url && stripos( urldecode( $this->referer_url ), 'utm_source=' . $this->utm_suppression ) ) {
-			$utm_source_transient[ $this->utm_suppression ] = true;
-			$this->set_transient( $utm_source_transient_name, $utm_source_transient );
-			return true;
+		// Handle frequency.
+		$frequency = $campaign->f;
+		switch ( $frequency ) {
+			case 'daily':
+				$should_display = $campaign_data['last_viewed'] < strtotime( '-1 day' );
+				break;
+			case 'once':
+				$should_display = $campaign_data['count'] < 1;
+				break;
+			case 'always':
+				$should_display = true;
+				break;
+			case 'never':
+			default:
+				$should_display = false;
+				break;
 		}
 
-		if ( ! empty( $utm_source_transient[ $this->utm_suppression ] ) ) {
-			return true;
+		$has_newsletter_prompt = $campaign->n;
+
+		// Handle referer-based conditions.
+		$referer_url = filter_input( INPUT_SERVER, 'HTTP_REFERER', FILTER_SANITIZE_STRING );
+		if ( ! empty( $referer_url ) ) {
+			// Suppressing based on UTM Source parameter in the URL.
+			$utm_suppression = ! empty( $campaign->utm ) ? urldecode( $campaign->utm ) : null;
+			if ( $utm_suppression && stripos( urldecode( $referer_url ), 'utm_source=' . $utm_suppression ) ) {
+				$should_display                    = false;
+				$campaign_data['suppress_forever'] = true;
+			}
+
+			// Suppressing based on UTM Medium parameter in the URL.
+			$has_utm_medium_in_url = stripos( $referer_url, 'utm_medium=email' );
+			if (
+				$has_utm_medium_in_url &&
+				$settings->suppress_newsletter_campaigns &&
+				$has_newsletter_prompt
+			) {
+				$should_display                    = false;
+				$campaign_data['suppress_forever'] = true;
+			}
 		}
-		return false;
-	}
 
-	/**
-	 * Handle utm_medium query param, update transients if needed.
-	 *
-	 * @return bool Should campaign be shown.
-	 */
-	public function should_suppress_because_utm_medium() {
-		// Suppressing based on UTM Medium parameter in the URL. If:
-		// - the visitor came from email,
-		// - the suppress_newsletter_campaigns setting is on,
-		// - the pop-up has a newsletter form,
-		// then it should not be displayed.
-		$has_utm_medium_in_url     = stripos( $this->referer_url, 'utm_medium=email' );
-		$utm_medium_transient_name = $this->get_suppression_data_transient_name( 'utm_medium' );
+		$client_data                        = $this->get_client_data( $client_id );
+		$has_suppressed_newsletter_campaign = $client_data['suppressed_newsletter_campaign'];
 
+		// Handle suppressing a newsletter campaign if any newsletter campaign was dismissed.
 		if (
-			$this->suppress_newsletter_campaigns &&
-			$this->has_newsletter_prompt &&
-			( $has_utm_medium_in_url || $this->get_transient( $utm_medium_transient_name ) )
+		   $has_newsletter_prompt &&
+		   $settings->suppress_all_newsletter_campaigns_if_one_dismissed &&
+		   $has_suppressed_newsletter_campaign
 		) {
-			$this->set_transient( $utm_medium_transient_name, true );
-			return true;
+			$should_display                    = false;
+			$campaign_data['suppress_forever'] = true;
 		}
-		return false;
-	}
 
-	/**
-	 * Should campaign be suppressed because it is a Newsletter campaign and a Newsletter campaign was previously dismissed.
-	 *
-	 * @return bool Should campaign be shown.
-	 */
-	public function should_suppress_because_newsletter_campaign_dismissed() {
-		// Suppressing a newsletter campaign if any newsletter campaign was dismissed.
-		$name = $this->legacy_get_suppression_data_transient_name_reversed( 'newsletter-campaign-suppression' );
+		$this->save_campaign_data( $client_id, $campaign->id, $campaign_data );
 
-		if ( $this->suppress_all_newsletter_campaigns_if_one_dismissed && $this->has_newsletter_prompt && $this->get_transient( $name ) ) {
-			return true;
-		}
-		return false;
-	}
-
-	/**
-	 * Set the utm_source suppression-related transient.
-	 *
-	 * @param string $utm_source utm_source param.
-	 */
-	public function set_utm_source_transient( $utm_source ) {
-		if ( ! empty( $utm_source ) ) {
-			$transient_name           = $this->get_suppression_data_transient_name( 'utm_source' );
-			$transient                = $this->get_transient( $transient_name );
-			$transient[ $utm_source ] = true;
-			$this->set_transient( $transient_name, true );
-		}
+		return $should_display;
 	}
 }
 new Maybe_Show_Campaign();

--- a/api/classes/class-maybe-show-campaign.php
+++ b/api/classes/class-maybe-show-campaign.php
@@ -20,11 +20,14 @@ class Maybe_Show_Campaign extends Lightweight_API {
 	 */
 	public function __construct() {
 		parent::__construct();
-		$campaigns = json_decode( $_REQUEST['popups'] );
-		$settings  = json_decode( $_REQUEST['settings'] );
+		if ( ! isset( $_REQUEST['popups'], $_REQUEST['settings'], $_REQUEST['cid'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			return;
+		}
+		$campaigns = json_decode( $_REQUEST['popups'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		$settings  = json_decode( $_REQUEST['settings'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		$response  = [];
 		foreach ( $campaigns as $campaign ) {
-			$response[ $campaign->id ] = $this->should_campaign_be_shown( $_REQUEST['cid'], $campaign, $settings );
+			$response[ $campaign->id ] = $this->should_campaign_be_shown( $_REQUEST['cid'], $campaign, $settings ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		}
 		$this->response = $response;
 		$this->respond();
@@ -34,7 +37,7 @@ class Maybe_Show_Campaign extends Lightweight_API {
 	 * Primary campaign visibility logic.
 	 *
 	 * @param string $client_id Client ID.
-	 * @param string $campaign_id Campaign ID.
+	 * @param object $campaign Campaign.
 	 * @param object $settings Settings.
 	 * @return bool Whether campaign should be shown.
 	 */
@@ -94,9 +97,9 @@ class Maybe_Show_Campaign extends Lightweight_API {
 
 		// Handle suppressing a newsletter campaign if any newsletter campaign was dismissed.
 		if (
-		   $has_newsletter_prompt &&
-		   $settings->suppress_all_newsletter_campaigns_if_one_dismissed &&
-		   $has_suppressed_newsletter_campaign
+			$has_newsletter_prompt &&
+			$settings->suppress_all_newsletter_campaigns_if_one_dismissed &&
+			$has_suppressed_newsletter_campaign
 		) {
 			$should_display                    = false;
 			$campaign_data['suppress_forever'] = true;

--- a/api/classes/class-maybe-show-campaign.php
+++ b/api/classes/class-maybe-show-campaign.php
@@ -42,7 +42,8 @@ class Maybe_Show_Campaign extends Lightweight_API {
 	 * @return bool Whether campaign should be shown.
 	 */
 	public function should_campaign_be_shown( $client_id, $campaign, $settings ) {
-		$campaign_data = $this->get_campaign_data( $client_id, $campaign->id );
+		$campaign_data      = $this->get_campaign_data( $client_id, $campaign->id );
+		$init_campaign_data = $campaign_data;
 
 		if ( $campaign_data['suppress_forever'] ) {
 			return false;
@@ -105,7 +106,9 @@ class Maybe_Show_Campaign extends Lightweight_API {
 			$campaign_data['suppress_forever'] = true;
 		}
 
-		$this->save_campaign_data( $client_id, $campaign->id, $campaign_data );
+		if ( ! empty( array_diff( $init_campaign_data, $campaign_data ) ) ) {
+			$this->save_campaign_data( $client_id, $campaign->id, $campaign_data );
+		}
 
 		return $should_display;
 	}

--- a/api/classes/class-report-campaign-data.php
+++ b/api/classes/class-report-campaign-data.php
@@ -20,11 +20,11 @@ class Report_Campaign_Data extends Lightweight_API {
 	 */
 	public function __construct() {
 		parent::__construct();
-		$payload = $_POST;
+		$payload = $_POST; // phpcs:ignore WordPress.Security.NonceVerification.Missing
 		if ( null == $payload ) {
 			// A POST request made by amp-analytics has to be parsed in this way.
 			// $_POST contains the payload if the request has FormData.
-			$payload = file_get_contents( 'php://input' );
+			$payload = wpcom_vip_file_get_contents( 'php://input' );
 			if ( ! empty( $payload ) ) {
 				$payload = (array) json_decode( $payload );
 			}
@@ -36,8 +36,7 @@ class Report_Campaign_Data extends Lightweight_API {
 	/**
 	 * Handle reporting campaign data – e.g. views, dismissals.
 	 *
-	 * @param string $client_id Client ID.
-	 * @param string $campaign_id Campaign ID.
+	 * @param object $request A request.
 	 */
 	public function report_campaign( $request ) {
 		$client_id     = $this->get_request_param( 'cid', $request );
@@ -78,6 +77,7 @@ class Report_Campaign_Data extends Lightweight_API {
 	/**
 	 * Get request param.
 	 *
+	 * @param string $param Param name.
 	 * @param object $request A POST request.
 	 */
 	public function get_request_param( $param, $request ) {

--- a/api/classes/class-report-campaign-data.php
+++ b/api/classes/class-report-campaign-data.php
@@ -24,7 +24,7 @@ class Report_Campaign_Data extends Lightweight_API {
 		if ( null == $payload ) {
 			// A POST request made by amp-analytics has to be parsed in this way.
 			// $_POST contains the payload if the request has FormData.
-			$payload = wpcom_vip_file_get_contents( 'php://input' );
+			$payload = file_get_contents( 'php://input' ); // phpcs:ignore WordPressVIPMinimum.Performance.FetchingRemoteData.FileGetContentsRemoteFile
 			if ( ! empty( $payload ) ) {
 				$payload = (array) json_decode( $payload );
 			}

--- a/api/classes/class-report-campaign-data.php
+++ b/api/classes/class-report-campaign-data.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * Newspack Campaigns report campaign data.
+ *
+ * @package Newspack
+ */
+
+/**
+ * Extend the base Lightweight_API class.
+ */
+require_once 'class-lightweight-api.php';
+
+/**
+ * POST endpoint to report campaign data.
+ */
+class Report_Campaign_Data extends Lightweight_API {
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		parent::__construct();
+		$payload = $_POST;
+		if ( null == $payload ) {
+			// A POST request made by amp-analytics has to be parsed in this way.
+			// $_POST contains the payload if the request has FormData.
+			$payload = file_get_contents( 'php://input' );
+			if ( ! empty( $payload ) ) {
+				$payload = (array) json_decode( $payload );
+			}
+		}
+		$this->report_campaign( $payload );
+		$this->respond();
+	}
+
+	/**
+	 * Handle reporting campaign data – e.g. views, dismissals.
+	 *
+	 * @param string $client_id Client ID.
+	 * @param string $campaign_id Campaign ID.
+	 */
+	public function report_campaign( $request ) {
+		$client_id     = $this->get_request_param( 'cid', $request );
+		$campaign_id   = $this->get_request_param( 'popup_id', $request );
+		$campaign_data = $this->get_campaign_data( $client_id, $campaign_id );
+		$client_data   = $this->get_client_data( $client_id );
+
+		$campaign_data['count']       = (int) $campaign_data['count'] + 1;
+		$campaign_data['last_viewed'] = time();
+
+		// Handle permanent suppression.
+		if ( $this->get_request_param( 'suppress_forever', $request ) ) {
+			$campaign_data['suppress_forever'] = true;
+
+			// Suppressed a newsletter campaign.
+			if ( $this->get_request_param( 'is_newsletter_popup', $request ) ) {
+				$client_data['suppressed_newsletter_campaign'] = true;
+			}
+		}
+
+		// Subscribed to a newsletter.
+		if ( 'subscribed' === $this->get_request_param( 'mailing_list_status', $request ) ) {
+			$campaign_data['suppress_forever'] = true;
+		}
+
+		// Add an email subscription to client.
+		$email_address = $this->get_request_param( 'email', $request );
+		if ( $email_address ) {
+			$client_data['email_subscriptions'] = [
+				'email' => $email_address,
+			];
+		}
+
+		$this->save_client_data( $client_id, $client_data );
+		$this->save_campaign_data( $client_id, $campaign_id, $campaign_data );
+	}
+
+	/**
+	 * Get request param.
+	 *
+	 * @param object $request A POST request.
+	 */
+	public function get_request_param( $param, $request ) {
+		$value = isset( $request[ $param ] ) ? $request[ $param ] : false;
+		return $value;
+	}
+}
+new Report_Campaign_Data();

--- a/api/index.php
+++ b/api/index.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Route Newspack Campaigns API requests based on method.
+ *
+ * @package Newspack
+ */
+
+$plugin_path = str_replace( 'wp-content/plugins/newspack-popups/api/index.php', '', $_SERVER['SCRIPT_FILENAME'] ); // phpcs:ignore
+
+if ( file_exists( $plugin_path . '__wp__' ) ) {
+	define( 'ABSPATH', $plugin_path . '__wp__/' );
+} else {
+	define( 'ABSPATH', $plugin_path );
+}
+
+define( 'WPINC', 'wp-includes/' );
+if ( ! defined( 'WP_CONTENT_DIR' ) ) {
+	define( 'WP_CONTENT_DIR', ABSPATH . 'wp-content/' );
+}
+if ( ! defined( 'WP_DEBUG' ) ) {
+	define( 'WP_DEBUG', false );
+}
+
+require_once $plugin_path . 'newspack-popups-config.php';
+
+// phpcs:disable
+
+function __( $in ) { return $in; }
+function wp_load_translations_early() {return null;}
+function add_filter() {}
+function do_action() {}
+function has_filter() { return false;}
+function apply_filters( $f, $in ) { return $in; }
+function is_multisite() { return false;}
+
+if ( file_exists( ABSPATH . WPINC . '/wp-db.php' ) ) {
+	require_once ABSPATH . WPINC . '/wp-db.php';
+	require_once ABSPATH . WPINC . '/functions.php';
+} else {
+	die( "{ error: 'no_wordpress' }" );
+}
+
+if ( file_exists( WP_CONTENT_DIR . '/object-cache.php' ) ) {
+	require WP_CONTENT_DIR . '/object-cache.php';
+} else {
+	require_once ABSPATH . WPINC . '/cache.php';
+}
+
+$wpdb = new wpdb( DB_USER, DB_PASSWORD, DB_NAME, DB_HOST );
+$wpdb->set_prefix( DB_PREFIX );
+
+global $table_prefix;
+$table_prefix = DB_PREFIX;
+
+wp_cache_init();
+
+// phpcs:enable
+
+switch ( $_SERVER['REQUEST_METHOD'] ) { //phpcs:ignore
+	case 'GET':
+		include 'classes/class-maybe-show-campaign.php';
+		break;
+	default:
+		die( "{ error: 'unsupported_method' }" );
+}

--- a/api/index.php
+++ b/api/index.php
@@ -60,6 +60,9 @@ switch ( $_SERVER['REQUEST_METHOD'] ) { //phpcs:ignore
 	case 'GET':
 		include 'classes/class-maybe-show-campaign.php';
 		break;
+	case 'POST':
+		include 'classes/class-report-campaign-data.php';
+		break;
 	default:
 		die( "{ error: 'unsupported_method' }" );
 }

--- a/includes/class-newspack-popups-api.php
+++ b/includes/class-newspack-popups-api.php
@@ -12,8 +12,6 @@ defined( 'ABSPATH' ) || exit;
  */
 final class Newspack_Popups_API {
 
-	const NEWSPACK_POPUPS_VIEW_LIMIT = 1;
-
 	/**
 	 * Constructor.
 	 */

--- a/includes/class-newspack-popups-api.php
+++ b/includes/class-newspack-popups-api.php
@@ -27,15 +27,6 @@ final class Newspack_Popups_API {
 	public function register_api_endpoints() {
 		\register_rest_route(
 			'newspack-popups/v1',
-			'reader',
-			[
-				'methods'             => \WP_REST_Server::CREATABLE,
-				'callback'            => [ $this, 'reader_post_endpoint' ],
-				'permission_callback' => '__return_true',
-			]
-		);
-		\register_rest_route(
-			'newspack-popups/v1',
 			'sitewide_default/(?P<id>\d+)',
 			[
 				'methods'             => \WP_REST_Server::EDITABLE,
@@ -126,61 +117,6 @@ final class Newspack_Popups_API {
 	}
 
 	/**
-	 * Handle POST requests to the reader endpoint.
-	 *
-	 * @param WP_REST_Request $request amp-access request.
-	 * @return WP_REST_Response with updated info about reader.
-	 */
-	public function reader_post_endpoint( $request ) {
-		$transient_name = $this->get_popup_data_transient_name( $request );
-		if ( $transient_name ) {
-			$data                = get_transient( $transient_name );
-			$data['count']       = (int) $data['count'] + 1;
-			$data['last_viewed'] = time();
-			if ( $request['suppress_forever'] ) {
-				$popup_id = self::get_request_param( 'popup_id', $request );
-				if ( $popup_id && self::get_request_param( 'is_newsletter_popup', $request ) ) {
-					$client_data_transient_name = $this->get_client_data_transient_name( $request );
-					$client_data                = get_transient( $client_data_transient_name );
-					if ( ! $client_data ) {
-						$client_data = [];
-					}
-					$client_data['suppressed_newsletter_campaign'] = true;
-					$this->update_cache( $client_data_transient_name, $client_data );
-					set_transient( $client_data_transient_name, $client_data );
-				}
-
-				$data['suppress_forever'] = true;
-			}
-			if ( 'subscribed' === $this->get_request_param( 'mailing_list_status', $request ) ) {
-				$data['suppress_forever'] = true;
-			}
-			$email_address = $this->get_request_param( 'email', $request );
-			if ( $email_address ) {
-				do_action(
-					'newspack_popups_mailing_list_subscription',
-					[
-						'email' => $email_address,
-					]
-				);
-			}
-			$this->update_cache( $transient_name, $data );
-		}
-	}
-
-	/**
-	 * Update the cache after setting a transient.
-	 *
-	 * @param string $transient_name The transient name.
-	 * @param mixed  $data The transient data.
-	 */
-	public function update_cache( $transient_name, $data ) {
-		$full_name = '_transient_' . $transient_name;
-		wp_cache_set( $full_name, maybe_serialize( $data ), 'newspack-popups' );
-		set_transient( $transient_name, $data, 0 );
-	}
-
-	/**
 	 * Set sitewide default Popup
 	 *
 	 * @param WP_REST_Request $request Request object.
@@ -198,49 +134,6 @@ final class Newspack_Popups_API {
 	public function unset_sitewide_default_endpoint( $request ) {
 		$response = Newspack_Popups_Model::unset_sitewide_popup( $request['id'] );
 		return is_wp_error( $response ) ? $response : [ 'success' => true ];
-	}
-
-	/**
-	 * Get transient name.
-	 *
-	 * @param WP_REST_Request $request amp-access request.
-	 * @return string Transient id.
-	 */
-	public function get_popup_data_transient_name( $request ) {
-		$client_id = $this->get_request_param( 'cid', $request );
-		$popup_id  = $this->get_request_param( 'popup_id', $request );
-		if ( $client_id && $popup_id ) {
-			return $client_id . '-' . $popup_id . '-popup';
-		}
-		return false;
-	}
-
-	/**
-	 * Get transient name for client data, not related to a specifi campaign.
-	 *
-	 * @param WP_REST_Request $request A request.
-	 * @return string Transient id.
-	 */
-	public function get_client_data_transient_name( $request ) {
-		$client_id = $this->get_request_param( 'cid', $request );
-		if ( $client_id ) {
-			return $client_id . '-popups';
-		}
-		return false;
-	}
-
-	/**
-	 * Get request param.
-	 *
-	 * @param WP_REST_Request $request A request.
-	 */
-	public function get_request_param( $param, $request ) {
-		$value = isset( $request[ $param ] ) ? esc_attr( $request[ $param ] ) : false;
-		if ( ! $value ) {
-			$body  = json_decode( $request->get_body(), true );
-			$value = isset( $body[ $param ] ) ? $body[ $param ] : false;
-		}
-		return $value;
 	}
 }
 $newspack_popups_api = new Newspack_Popups_API();

--- a/includes/class-newspack-popups-api.php
+++ b/includes/class-newspack-popups-api.php
@@ -29,15 +29,6 @@ final class Newspack_Popups_API {
 			'newspack-popups/v1',
 			'reader',
 			[
-				'methods'             => \WP_REST_Server::READABLE,
-				'callback'            => [ $this, 'reader_get_endpoint' ],
-				'permission_callback' => '__return_true',
-			]
-		);
-		\register_rest_route(
-			'newspack-popups/v1',
-			'reader',
-			[
 				'methods'             => \WP_REST_Server::CREATABLE,
 				'callback'            => [ $this, 'reader_post_endpoint' ],
 				'permission_callback' => '__return_true',
@@ -135,125 +126,6 @@ final class Newspack_Popups_API {
 	}
 
 	/**
-	 * Handle GET requests to the reader endpoint.
-	 *
-	 * @param WP_REST_Request $request amp-access request.
-	 * @return WP_REST_Response with info about reader.
-	 */
-	public function reader_get_endpoint( $request ) {
-		$popup_id = isset( $request['popup_id'] ) ? $request['popup_id'] : false;
-
-		if ( $this->is_preview_request( $request ) ) {
-			$popup = Newspack_Popups_Model::retrieve_preview_popup( $popup_id );
-		} else {
-			$popup = Newspack_Popups_Model::retrieve_popup_by_id( $popup_id );
-		}
-
-		$response = [
-			'currentViews' => 0,
-			'displayPopup' => false,
-		];
-
-		$transient_name = $this->get_popup_data_transient_name( $request );
-		if ( ! $transient_name ) {
-			return rest_ensure_response( $response );
-		}
-		$data = get_transient( $transient_name );
-
-		$response['currentViews'] = (int) $data['count'];
-
-		$frequency = $popup['options']['frequency'];
-		$placement = $popup['options']['placement'];
-		if ( 'inline' !== $placement && 'always' === $frequency ) {
-			$frequency = 'once';
-		}
-
-		$utm_suppression       = ! empty( $popup['options']['utm_suppression'] ) ? urldecode( $popup['options']['utm_suppression'] ) : null;
-		$current_views         = ! empty( $response['currentViews'] ) ? (int) $response['currentViews'] : 0;
-		$suppress_forever      = ! empty( $data['suppress_forever'] ) ? (int) $data['suppress_forever'] : false;
-		$mailing_list_status   = ! empty( $data['mailing_list_status'] ) ? (int) $data['mailing_list_status'] : false;
-		$last_view             = ! empty( $data['time'] ) ? (int) $data['time'] : 0;
-		$response['frequency'] = $frequency;
-		switch ( $frequency ) {
-			case 'daily':
-				$response['displayPopup'] = $last_view < strtotime( '-1 day' );
-				break;
-			case 'once':
-				$response['displayPopup'] = $current_views < 1;
-				break;
-			case 'test':
-			case 'always':
-				$response['displayPopup'] = true;
-				break;
-			case 'never':
-			default:
-				$response['displayPopup'] = false;
-				break;
-		}
-		$referer_url = filter_input( INPUT_SERVER, 'HTTP_REFERER', FILTER_SANITIZE_STRING );
-
-		// Suppressing based on UTM Source parameter in the URL.
-		// If the visitor came from a campaign with suppressed utm_source, then it should not be displayed.
-		if ( $utm_suppression ) {
-			if ( ! empty( $referer_url ) && stripos( urldecode( $referer_url ), 'utm_source=' . $utm_suppression ) ) {
-				$response['displayPopup'] = false;
-				$this->set_utm_source_transient( $utm_suppression );
-			}
-
-			$utm_source_transient = $this->get_utm_source_transient();
-			if ( ! empty( $utm_source_transient[ $utm_suppression ] ) ) {
-				$response['displayPopup'] = false;
-			}
-		}
-
-		// Suppressing based on UTM Medium parameter in the URL. If:
-		// - the visitor came from email,
-		// - the suppress_newsletter_campaigns setting is on,
-		// - the pop-up has a newsletter form,
-		// then it should not be displayed.
-		$settings              = \Newspack_Popups_Settings::get_settings();
-		$has_utm_medium_in_url = ! empty( $referer_url ) && stripos( $referer_url, 'utm_medium=email' );
-		if (
-			( $has_utm_medium_in_url || $this->get_utm_medium_transient() ) &&
-			$settings['suppress_newsletter_campaigns'] &&
-			\Newspack_Popups_Model::has_newsletter_prompt( $popup )
-		) {
-			$response['displayPopup'] = false;
-			$this->set_utm_medium_transient();
-		}
-
-		// Suppressing because user has dismissed the popup permanently, or signed up to the newsletter.
-		if ( $suppress_forever || $mailing_list_status ) {
-			$response['displayPopup'] = false;
-		}
-
-		// Suppressing a newsletter campaign if any newsletter campaign was dismissed.
-		$is_suppressing_newsletter_popups = get_transient( $this->get_newsletter_campaigns_suppression_transient_name( $request ), true );
-		$is_newsletter_popup              = \Newspack_Popups_Model::has_newsletter_prompt( $popup );
-		$settings                         = \Newspack_Popups_Settings::get_settings();
-		if ( $settings['suppress_all_newsletter_campaigns_if_one_dismissed'] && $is_suppressing_newsletter_popups && $is_newsletter_popup ) {
-			$response['displayPopup'] = false;
-		}
-
-		// Unsuppressing for previews and test popups.
-		if ( $this->is_preview_request( $request ) || 'test' === $frequency ) {
-			$response['displayPopup'] = true;
-		};
-
-		return rest_ensure_response( $response );
-	}
-
-	/**
-	 * Detect a popup preview request.
-	 *
-	 * @param  WP_REST_Request $request a request.
-	 * @return Boolean
-	 */
-	public function is_preview_request( $request ) {
-		return Newspack_Popups::previewed_popup_id( $request->get_header( 'referer' ) );
-	}
-
-	/**
 	 * Handle POST requests to the reader endpoint.
 	 *
 	 * @param WP_REST_Request $request amp-access request.
@@ -261,27 +133,29 @@ final class Newspack_Popups_API {
 	 */
 	public function reader_post_endpoint( $request ) {
 		$transient_name = $this->get_popup_data_transient_name( $request );
-		if ( $transient_name && ! $this->is_preview_request( $request ) ) {
-			$data          = get_transient( $transient_name );
-			$data['count'] = (int) $data['count'] + 1;
-			$data['time']  = time();
+		if ( $transient_name ) {
+			$data                = get_transient( $transient_name );
+			$data['count']       = (int) $data['count'] + 1;
+			$data['last_viewed'] = time();
 			if ( $request['suppress_forever'] ) {
-				$popup_id = isset( $request['popup_id'] ) ? $request['popup_id'] : false;
-				if ( $popup_id ) {
-					$popup               = \Newspack_Popups_Model::retrieve_popup_by_id( $popup_id );
-					$is_newsletter_popup = \Newspack_Popups_Model::has_newsletter_prompt( $popup );
-					if ( $is_newsletter_popup ) {
-						$suppression_transient_name = $this->get_newsletter_campaigns_suppression_transient_name( $request );
-						$this->update_cache( $suppression_transient_name, true );
+				$popup_id = self::get_request_param( 'popup_id', $request );
+				if ( $popup_id && self::get_request_param( 'is_newsletter_popup', $request ) ) {
+					$client_data_transient_name = $this->get_client_data_transient_name( $request );
+					$client_data                = get_transient( $client_data_transient_name );
+					if ( ! $client_data ) {
+						$client_data = [];
 					}
+					$client_data['suppressed_newsletter_campaign'] = true;
+					$this->update_cache( $client_data_transient_name, $client_data );
+					set_transient( $client_data_transient_name, $client_data );
 				}
 
 				$data['suppress_forever'] = true;
 			}
-			if ( $this->get_mailing_list_status( $request ) ) {
-				$data['mailing_list_status'] = true;
+			if ( 'subscribed' === $this->get_request_param( 'mailing_list_status', $request ) ) {
+				$data['suppress_forever'] = true;
 			}
-			$email_address = $this->get_email_address( $request );
+			$email_address = $this->get_request_param( 'email', $request );
 			if ( $email_address ) {
 				do_action(
 					'newspack_popups_mailing_list_subscription',
@@ -292,7 +166,6 @@ final class Newspack_Popups_API {
 			}
 			$this->update_cache( $transient_name, $data );
 		}
-		return $this->reader_get_endpoint( $request );
 	}
 
 	/**
@@ -334,142 +207,40 @@ final class Newspack_Popups_API {
 	 * @return string Transient id.
 	 */
 	public function get_popup_data_transient_name( $request ) {
-		$reader_id = isset( $request['rid'] ) ? esc_attr( $request['rid'] ) : false;
-		if ( ! $reader_id ) {
-			$reader_id = $this->get_reader_id();
-		}
-		$popup_id = isset( $request['popup_id'] ) ? $request['popup_id'] : false;
-		$url      = isset( $request['url'] ) ? esc_url_raw( urldecode( $request['url'] ) ) : false;
-		if ( ! $popup_id && ! $url ) {
-			$body     = json_decode( $request->get_body(), true );
-			$popup_id = isset( $body['popup_id'] ) ? $body['popup_id'] : false;
-			$url      = isset( $body['url'] ) ? esc_url_raw( urldecode( $body['url'] ) ) : false;
-		}
-		if ( $reader_id && $url && $popup_id ) {
-			return $reader_id . '-' . $popup_id . '-popup';
+		$client_id = $this->get_request_param( 'cid', $request );
+		$popup_id  = $this->get_request_param( 'popup_id', $request );
+		if ( $client_id && $popup_id ) {
+			return $client_id . '-' . $popup_id . '-popup';
 		}
 		return false;
 	}
 
 	/**
-	 * Get transient name for newsletter campaigns suppression feature.
+	 * Get transient name for client data, not related to a specifi campaign.
 	 *
-	 * @param WP_REST_Request $request amp-access request.
+	 * @param WP_REST_Request $request A request.
 	 * @return string Transient id.
 	 */
-	public function get_newsletter_campaigns_suppression_transient_name( $request ) {
-		$reader_id = isset( $request['rid'] ) ? esc_attr( $request['rid'] ) : false;
-		if ( ! $reader_id ) {
-			$reader_id = $this->get_reader_id();
-		}
-		if ( $reader_id ) {
-			return $reader_id . '-newsletter-campaign-suppression';
+	public function get_client_data_transient_name( $request ) {
+		$client_id = $this->get_request_param( 'cid', $request );
+		if ( $client_id ) {
+			return $client_id . '-popups';
 		}
 		return false;
 	}
 
 	/**
-	 * Get mailing list status.
+	 * Get request param.
 	 *
-	 * @param WP_REST_Request $request amp-access request.
-	 * @return string Mailing list status.
+	 * @param WP_REST_Request $request A request.
 	 */
-	public function get_mailing_list_status( $request ) {
-		$mailing_list_status = isset( $request['mailing_list_status'] ) ? esc_attr( $request['mailing_list_status'] ) : false;
-		if ( ! $mailing_list_status ) {
-			$body                = json_decode( $request->get_body(), true );
-			$mailing_list_status = isset( $body['mailing_list_status'] ) ? $body['mailing_list_status'] : false;
+	public function get_request_param( $param, $request ) {
+		$value = isset( $request[ $param ] ) ? esc_attr( $request[ $param ] ) : false;
+		if ( ! $value ) {
+			$body  = json_decode( $request->get_body(), true );
+			$value = isset( $body[ $param ] ) ? $body[ $param ] : false;
 		}
-		return 'subscribed' === $mailing_list_status;
-	}
-
-	/**
-	 * Get email address.
-	 *
-	 * @param WP_REST_Request $request amp-access request.
-	 * @return string Email address.
-	 */
-	public function get_email_address( $request ) {
-		$email_address = isset( $request['email'] ) ? esc_attr( $request['email'] ) : false;
-		if ( ! $email_address ) {
-			$body          = json_decode( $request->get_body(), true );
-			$email_address = isset( $body['email'] ) ? esc_attr( $body['email'] ) : false;
-		}
-		return $email_address;
-	}
-
-	/**
-	 * Set the utm_source suppression-related transient.
-	 *
-	 * @param string $utm_source utm_source param.
-	 */
-	public function set_utm_source_transient( $utm_source ) {
-		if ( ! empty( $utm_source ) ) {
-			$transient_name = self::get_suppression_data_transient_name( 'utm_source' );
-			if ( $transient_name ) {
-				$transient                = self::get_utm_source_transient();
-				$transient[ $utm_source ] = true;
-				$this->update_cache( $transient_name, $transient );
-			}
-		}
-	}
-
-
-	/**
-	 * Set the utm_medium suppression-related transient.
-	 */
-	public function set_utm_medium_transient() {
-		$transient_name = self::get_suppression_data_transient_name( 'utm_medium' );
-		if ( $transient_name ) {
-			$this->update_cache( $transient_name, true );
-		}
-	}
-
-	/**
-	 * Assess utm_source transient name
-	 *
-	 * @return array UTM Source Transient.
-	 */
-	public function get_utm_source_transient() {
-		$transient_name = self::get_suppression_data_transient_name( 'utm_source' );
-		if ( $transient_name ) {
-			$transient = get_transient( $transient_name );
-		}
-		return $transient ? $transient : [];
-	}
-
-	/**
-	 * Assess utm_medium transient name
-	 *
-	 * @return boolean UTM Medium Transient.
-	 */
-	public function get_utm_medium_transient() {
-		$transient_name = self::get_suppression_data_transient_name( 'utm_medium' );
-		if ( $transient_name ) {
-			$transient = get_transient( $transient_name );
-		}
-		return $transient ? $transient : false;
-	}
-
-	/**
-	 * Get suppression-related transient value
-	 *
-	 * @param string $prefix transient prefix.
-	 */
-	public function get_suppression_data_transient_name( $prefix ) {
-		$reader_id = $this->get_reader_id();
-		if ( $reader_id ) {
-			return $prefix . '-' . $reader_id;
-		}
-		return null;
-	}
-
-	/**
-	 * Get AMP-Access cookie
-	 */
-	public function get_reader_id() {
-		// TODO: Is retrieving the amp-access cookie the best way to get READER_ID outside the context of amp-access?
-		return isset( $_COOKIE['amp-access'] ) ? esc_attr( $_COOKIE['amp-access'] ) : false; // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		return $value;
 	}
 }
 $newspack_popups_api = new Newspack_Popups_API();

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -324,16 +324,9 @@ final class Newspack_Popups_Inserter {
 			return;
 		}
 
-		$endpoint               = str_replace(
-			'http://',
-			'//',
-			! Newspack_Popups::previewed_popup_id() && self::should_use_lightweight_api() ?
-				plugins_url( '../api/', __FILE__ ) :
-				get_rest_url( null, 'newspack-popups/v1/reader' )
-		);
 		$popups_access_provider = [
 			'namespace'     => 'popups',
-			'authorization' => esc_url( $endpoint ) . '?cid=CLIENT_ID(newspack-cid)',
+			'authorization' => esc_url( Newspack_Popups_Model::get_reader_endpoint() ) . '?cid=CLIENT_ID(newspack-cid)',
 			'noPingback'    => true,
 		];
 
@@ -468,15 +461,6 @@ final class Newspack_Popups_Inserter {
 		return self::assess_is_post( $popup ) &&
 			self::assess_test_mode( $popup ) &&
 			self::assess_categories_filter( $popup );
-	}
-
-	/**
-	 * Should the lightweight API be used.
-	 *
-	 * @return bool Should lightweight API be used.
-	 */
-	public static function should_use_lightweight_api() {
-		return file_exists( WP_CONTENT_DIR . '/../newspack-popups-config.php' );
 	}
 }
 $newspack_popups_inserter = new Newspack_Popups_Inserter();

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -306,69 +306,60 @@ final class Newspack_Popups_Inserter {
 
 	/**
 	 * Add amp-access header code.
-	 *
-	 * @param object $popups The popup objects to handle.
 	 */
-	public static function insert_popups_amp_access( $popups ) {
+	public static function insert_popups_amp_access() {
 		if ( is_admin() || self::assess_has_disabled_popups() ) {
 			return;
 		}
 
-		$popups                  = self::popups_for_post();
-		$endpoint                = str_replace(
+		$popups = self::popups_for_post();
+
+		if (
+			empty( $popups ) ||
+			(
+				// A preview (or a single test popup) – no need to hit the API.
+				1 === count( $popups ) && '' === Newspack_Popups_Model::get_access_attrs( reset( $popups ) )
+			)
+		) {
+			return;
+		}
+
+		$endpoint               = str_replace(
 			'http://',
 			'//',
 			! Newspack_Popups::previewed_popup_id() && self::should_use_lightweight_api() ?
 				plugins_url( '../api/', __FILE__ ) :
 				get_rest_url( null, 'newspack-popups/v1/reader' )
 		);
-		$popups_access_providers = [];
+		$popups_access_provider = [
+			'namespace'     => 'popups',
+			'authorization' => esc_url( $endpoint ) . '?cid=CLIENT_ID(newspack-cid)',
+			'noPingback'    => true,
+		];
 
-		$settings = \Newspack_Popups_Settings::get_settings();
-
+		$popups_configs = [];
 		foreach ( $popups as $popup ) {
-			// In test frequency cases (logged in site editor) and when previewing,
-			// fallback to authorization of true to avoid possible amp-access timeouts.
-			$authorization_fallback_response = (
-				( 'test' === $popup['options']['frequency'] || Newspack_Popups::previewed_popup_id() ) &&
-				is_user_logged_in() &&
-				current_user_can( 'edit_others_pages' )
-			);
-
-			$authorization =
-				esc_url( $endpoint ) .
-				'?popup_id=' . esc_attr( $popup['id'] ) .
-				'&rid=READER_ID&url=CANONICAL_URL&RANDOM&' .
-				'frequency=' . esc_attr( $popup['options']['frequency'] ) .
-				'&placement=' . esc_attr( $popup['options']['placement'] ) .
-				'&utm_suppression=' . esc_attr( $popup['options']['utm_suppression'] ) .
-				'&suppress_newsletter_campaigns=' . esc_attr( $settings['suppress_newsletter_campaigns'] ) .
-				'&suppress_all_newsletter_campaigns_if_one_dismissed=' . esc_attr( $settings['suppress_all_newsletter_campaigns_if_one_dismissed'] ) .
-				'&has_newsletter_prompt=' . esc_attr( \Newspack_Popups_Model::has_newsletter_prompt( $popup ) );
-
-			$amp_access_provider = array(
-				'namespace'                     => 'popup_' . $popup['id'],
-				'authorization'                 => $authorization,
-				'noPingback'                    => true,
-				'authorizationTimeout'          => 10000, // For development purposes. If #development=1 is appended to URL the maximum timeout for amp-access is raised to 10s.
-				'authorizationFallbackResponse' => array(
-					'displayPopup' => $authorization_fallback_response,
-				),
-			);
-
-			array_push(
-				$popups_access_providers,
-				$amp_access_provider
-			);
+			$popup_id_string = Newspack_Popups_Model::canonize_popup_id( esc_attr( $popup['id'] ) );
+			$frequency       = $popup['options']['frequency'];
+			if ( 'inline' !== $popup['options']['placement'] && 'always' === $frequency ) {
+				$frequency = 'once';
+			}
+			$popups_configs[] = [
+				'id'  => $popup_id_string,
+				'f'   => $frequency,
+				'utm' => $popup['options']['utm_suppression'],
+				'n'   => \Newspack_Popups_Model::has_newsletter_prompt( $popup ),
+			];
 		}
 
-		if ( ! empty( $popups_access_providers ) ) {
-			?>
-			<script id="amp-access" type="application/json">
-				<?php echo wp_json_encode( $popups_access_providers ); ?>
-			</script>
-			<?php
-		}
+		$popups_access_provider['authorization'] .= '&popups=' . wp_json_encode( $popups_configs );
+		$popups_access_provider['authorization'] .= '&settings=' . wp_json_encode( \Newspack_Popups_Settings::get_settings() );
+
+		?>
+		<script id="amp-access" type="application/json">
+			<?php echo wp_json_encode( $popups_access_provider ); ?>
+		</script>
+		<?php
 	}
 
 	/**

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -885,16 +885,20 @@ final class Newspack_Popups_Model {
 	}
 
 	/**
-	 * Endpoint to dismiss Pop-up.
+	 * Endpoint to report Pop-up data.
 	 *
 	 * @return string Endpoint URL.
 	 */
 	public static function get_reader_endpoint() {
-		return str_replace( 'http://', '//', get_rest_url( null, 'newspack-popups/v1/reader' ) );
+		return str_replace(
+			'http://',
+			'//',
+			plugins_url( '../api/', __FILE__ )
+		);
 	}
 
 	/**
-	 * Generate hidden fields to be used in all dismiss FORMs.
+	 * Generate hidden fields to be used in all forms.
 	 *
 	 * @param  object $popup A Pop-up object.
 	 * @return string Hidden fields markup.

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -258,6 +258,7 @@ final class Newspack_Popups_Model {
 	 * Retrieve popup CPT post by ID.
 	 *
 	 * @param string $post_id Post id.
+	 * @param bool   $include_drafts Include drafts.
 	 * @return object Popup object.
 	 */
 	public static function retrieve_popup_by_id( $post_id, $include_drafts = false ) {
@@ -410,6 +411,7 @@ final class Newspack_Popups_Model {
 	 * Insert amp-analytics tracking code.
 	 *
 	 * @param object $popup The popup object.
+	 * @param string $body Post body.
 	 * @param string $element_id The id of the popup element.
 	 * @return string Prints the generated amp-analytics element.
 	 */
@@ -445,7 +447,7 @@ final class Newspack_Popups_Model {
 								"request": "event",
 								"selector": "#<?php echo esc_attr( $element_id ); ?> <?php echo esc_attr( $mailchimp_form_selector ); ?>",
 								"extraUrlParams": {
-									"popup_id": "<?php echo self::canonize_popup_id( esc_attr( $popup['id'] ) ); ?>",
+									"popup_id": "<?php echo esc_attr( self::canonize_popup_id( $popup['id'] ) ); ?>",
 									"cid": "CLIENT_ID(newspack-cid)",
 									"mailing_list_status": "subscribed",
 									"email": "${formFields[email]}"
@@ -481,7 +483,7 @@ final class Newspack_Popups_Model {
 									"continuousTimeMin": 200
 								},
 								"extraUrlParams": {
-									"popup_id": "<?php echo self::canonize_popup_id( esc_attr( $popup['id'] ) ); ?>",
+									"popup_id": "<?php echo esc_attr( self::canonize_popup_id( $popup['id'] ) ); ?>",
 									"cid": "CLIENT_ID(newspack-cid)"
 								}
 							}
@@ -503,6 +505,7 @@ final class Newspack_Popups_Model {
 	 * Add tracked analytics events to use in Newspack Plugin's newspack_analytics_events filter.
 	 *
 	 * @param object $popup The popup object.
+	 * @param string $body Post body.
 	 * @param string $element_id The id of the popup element.
 	 */
 	protected static function get_analytics_events( $popup, $body, $element_id ) {
@@ -680,7 +683,7 @@ final class Newspack_Popups_Model {
 		ob_start();
 		?>
 			<?php self::insert_event_tracking( $popup, $body, $element_id ); ?>
-			<amp-layout <?php echo self::get_access_attrs( $popup ); ?> class="<?php echo esc_attr( implode( ' ', $classes ) ); ?>" role="button" tabindex="0" style="<?php echo esc_attr( self::container_style( $popup ) ); ?>" id="<?php echo esc_attr( $element_id ); ?>">
+			<amp-layout <?php echo self::get_access_attrs( $popup ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?> class="<?php echo esc_attr( implode( ' ', $classes ) ); ?>" role="button" tabindex="0" style="<?php echo esc_attr( self::container_style( $popup ) ); ?>" id="<?php echo esc_attr( $element_id ); ?>">
 						<?php if ( ! empty( $popup['title'] ) && $display_title ) : ?>
 					<h1 class="newspack-popup-title"><?php echo esc_html( $popup['title'] ); ?></h1>
 				<?php endif; ?>
@@ -745,7 +748,7 @@ final class Newspack_Popups_Model {
 
 		ob_start();
 		?>
-		<amp-layout <?php echo self::get_access_attrs( $popup ); ?> class="<?php echo esc_attr( implode( ' ', $classes ) ); ?>" role="button" tabindex="0" id="<?php echo esc_attr( $element_id ); ?>">
+		<amp-layout <?php echo self::get_access_attrs( $popup ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?> class="<?php echo esc_attr( implode( ' ', $classes ) ); ?>" role="button" tabindex="0" id="<?php echo esc_attr( $element_id ); ?>">
 			<div class="newspack-popup-wrapper" style="<?php echo esc_attr( self::container_style( $popup ) ); ?>">
 				<div class="newspack-popup">
 					<?php if ( ! empty( $popup['title'] ) && $display_title ) : ?>
@@ -911,14 +914,14 @@ final class Newspack_Popups_Model {
 		<input
 			name="popup_id"
 			type="hidden"
-			value="<?php echo self::canonize_popup_id( esc_attr( $popup['id'] ) ); ?>"
+			value="<?php echo esc_attr( self::canonize_popup_id( $popup['id'] ) ); ?>"
 		/>
 		<input
-		 name="cid"
-		 type="hidden"
-		 value="CLIENT_ID(newspack-cid)"
-		 data-amp-replace="CLIENT_ID"
-	   />
+			name="cid"
+			type="hidden"
+			value="CLIENT_ID(newspack-cid)"
+			data-amp-replace="CLIENT_ID"
+		/>
 		<input
 			name="mailing_list_status"
 			type="hidden"
@@ -927,7 +930,7 @@ final class Newspack_Popups_Model {
 		<input
 			name="is_newsletter_popup"
 			type="hidden"
-			value="<?php echo self::has_newsletter_prompt( $popup ); ?>"
+			value="<?php echo esc_attr( self::has_newsletter_prompt( $popup ) ); ?>"
 		/>
 		<?php
 		return ob_get_clean();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Switches the plugin to use lightweight API, adds POST requests handling; changes how `amp-access` is used – to make just one GET request per page.

### How to test the changes in this Pull Request:

1. Create multiple campaigns
2. On a page where they all appear, observe that one GET request is made to get campaigns visibility
3. Dismiss a campaign – observe the POST request is made to the lighweight API endpoint
4. Observe all campaign functionality related to display conditions is working as before

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
