### PR TITLE
Fix: enable drafts handling for setting options and categories

### DIFF
--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -99,7 +99,7 @@ final class Newspack_Popups_Model {
 	 * @param array   $categories Array of categories to be set.
 	 */
 	public static function set_popup_categories( $id, $categories ) {
-		$popup = self::retrieve_popup_by_id( $id );
+		$popup = self::retrieve_popup_by_id( $id, true );
 		if ( ! $popup ) {
 			return new \WP_Error(
 				'newspack_popups_popup_doesnt_exist',
@@ -126,7 +126,7 @@ final class Newspack_Popups_Model {
 	 * @param array   $options Array of options to update.
 	 */
 	public static function set_popup_options( $id, $options ) {
-		$popup = self::retrieve_popup_by_id( $id );
+		$popup = self::retrieve_popup_by_id( $id, true );
 		if ( ! $popup ) {
 			return new \WP_Error(
 				'newspack_popups_popup_doesnt_exist',
@@ -260,13 +260,15 @@ final class Newspack_Popups_Model {
 	 * @param string $post_id Post id.
 	 * @return object Popup object.
 	 */
-	public static function retrieve_popup_by_id( $post_id ) {
+	public static function retrieve_popup_by_id( $post_id, $include_drafts = false ) {
 		$args = [
 			'post_type'      => Newspack_Popups::NEWSPACK_PLUGINS_CPT,
-			'post_status'    => 'publish',
 			'posts_per_page' => 1,
 			'p'              => $post_id,
 		];
+		if ( false === $include_drafts ) {
+			$args['post_status'] = 'publish';
+		}
 
 		$popups = self::retrieve_popups_with_query( new WP_Query( $args ) );
 		return count( $popups ) > 0 ? $popups[0] : null;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #185 

### How to test the changes in this Pull Request:

1. Create a draft campaign, then in the Newspack plugin's Campaigns wizard set it to test mode
2. Observe that this action does not trigger an error and set the draft campaign to test mode (and back)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
