### PR TITLE
API: allow requests from AMP Cache

### DIFF
--- a/api/classes/class-lightweight-api.php
+++ b/api/classes/class-lightweight-api.php
@@ -66,9 +66,12 @@ class Lightweight_API {
 		$http_referer = ! empty( $_SERVER['HTTP_REFERER'] ) ? parse_url( $_SERVER['HTTP_REFERER'] , PHP_URL_HOST ) : null; // phpcs:ignore
 		$valid_referers = [
 			$http_referer,
-			// TODO: Add AMP Cache.
 		];
 		$http_host = ! empty( $_SERVER['HTTP_HOST'] ) ? $_SERVER['HTTP_HOST'] : null; // phpcs:ignore
+		// Enable requests from AMP Cache.
+		if ( preg_match( '/\.cdn\.ampproject\.org/', $http_host ) ) {
+			return true;
+		}
 		return ! empty( $http_referer ) && ! empty( $http_host ) && in_array( strtolower( $http_host ), $valid_referers, true );
 	}
 

--- a/api/classes/class-lightweight-api.php
+++ b/api/classes/class-lightweight-api.php
@@ -69,7 +69,7 @@ class Lightweight_API {
 		];
 		$http_host = ! empty( $_SERVER['HTTP_HOST'] ) ? $_SERVER['HTTP_HOST'] : null; // phpcs:ignore
 		// Enable requests from AMP Cache.
-		if ( preg_match( '/\.cdn\.ampproject\.org/', $http_host ) ) {
+		if ( preg_match( '/\.cdn\.ampproject\.org/', $http_referer ) ) {
 			return true;
 		}
 		return ! empty( $http_referer ) && ! empty( $http_host ) && in_array( strtolower( $http_host ), $valid_referers, true );
@@ -98,6 +98,8 @@ class Lightweight_API {
 		if ( defined( 'NEWSPACK_POPUPS_DEBUG' ) && NEWSPACK_POPUPS_DEBUG ) {
 			$this->response['debug'] = $this->debug;
 		}
+		header( 'Access-Control-Allow-Origin: https://' . parse_url( $_SERVER['HTTP_REFERER'] )['host'], false ); // phpcs:ignore
+		header( 'Access-Control-Allow-Credentials: true', false );
 		http_response_code( 200 );
 		print json_encode( $this->response ); // phpcs:ignore
 		exit;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Enables requests from AMP Cache. 

### How to test the changes in this Pull Request:

For a real test this code would have to be put on a site served by Google's AMP Cache – if you can't do that, just replace with value of `$http_host` with `site-url.cdn.ampproject.org` and observe the API requests completing (not returning 4XXs). Otherwise:

1. Visit site via AMP Cache
3. Observe API requests coming through

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
