### PR TITLE
API: config creation fix

### DIFF
--- a/api/index.php
+++ b/api/index.php
@@ -5,7 +5,7 @@
  * @package Newspack
  */
 
-$plugin_path = str_replace( 'wp-content/plugins/newspack-popups/api/index.php', '', $_SERVER['SCRIPT_FILENAME'] ); // phpcs:ignore
+$plugin_path = substr($_SERVER['SCRIPT_FILENAME'], 0, strrpos($_SERVER['SCRIPT_FILENAME'], 'wp-content/plugins/')); // phpcs:ignore
 
 if ( file_exists( $plugin_path . '__wp__' ) ) {
 	define( 'ABSPATH', $plugin_path . '__wp__/' );

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -403,10 +403,9 @@ final class Newspack_Popups {
 	 * Create the config file for the API, unless it exists.
 	 */
 	public static function create_lightweight_api_config() {
-		if ( get_option( 'newspack_has_tried_to_create_lightweight_api_config' ) ) {
+		if ( ! ( defined( 'ATOMIC_SITE_ID' ) && ATOMIC_SITE_ID ) ) {
 			return;
-		};
-		add_option( 'newspack_has_tried_to_create_lightweight_api_config', true );
+		}
 		if ( file_exists( self::LIGHTWEIGHT_API_CONFIG_FILE_PATH ) ) {
 			return;
 		}

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -403,10 +403,7 @@ final class Newspack_Popups {
 	 * Create the config file for the API, unless it exists.
 	 */
 	public static function create_lightweight_api_config() {
-		if ( ! ( defined( 'ATOMIC_SITE_ID' ) && ATOMIC_SITE_ID ) ) {
-			return;
-		}
-		if ( file_exists( self::LIGHTWEIGHT_API_CONFIG_FILE_PATH ) ) {
+		if ( ! ( defined( 'ATOMIC_SITE_ID' ) && ATOMIC_SITE_ID ) || file_exists( self::LIGHTWEIGHT_API_CONFIG_FILE_PATH ) ) {
 			return;
 		}
 		global $wpdb;

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -407,8 +407,7 @@ final class Newspack_Popups {
 			return;
 		};
 		add_option( 'newspack_has_tried_to_create_lightweight_api_config', true );
-		$has_db_config_in_env = getenv( 'DB_USER' ) && getenv( 'DB_PASSWORD' ) && getenv( 'DB_NAME' ) && getenv( 'DB_HOST' );
-		if ( ! $has_db_config_in_env || file_exists( self::LIGHTWEIGHT_API_CONFIG_FILE_PATH ) ) {
+		if ( file_exists( self::LIGHTWEIGHT_API_CONFIG_FILE_PATH ) ) {
 			return;
 		}
 		global $wpdb;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes two issues related to config:

1. The path to the config assumed the plugin folder is named `newspack-popups` – it can be named differently, e.g. when it's an alpha build it will have the version appended after plugin name
2. On certain environments for some reason PHP does not have access to the environment, so here the `DB_USER` etc. checks are removed

### How to test the changes in this Pull Request:

1. Remove the config file of present
2. Verify that the config file is created (you might need to remove the `newspack_has_tried_to_create_lightweight_api_config` option)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
