### PR TITLE
Fix scroll-triggered campaigns

### DIFF
--- a/src/view/style.scss
+++ b/src/view/style.scss
@@ -157,6 +157,7 @@ $color__secondary-variation: darken( $color__secondary, 10% );
 
 // Alignment
 .entry-content {
+	/* stylelint-disable-next-line no-duplicate-selectors */
 	.newspack-lightbox {
 		.newspack-popup {
 			.alignfull,
@@ -237,6 +238,7 @@ $color__secondary-variation: darken( $color__secondary, 10% );
 
 // This is needed for the scroll-triggered popups to function properly.
 // (#page-position-marker element is an absolutely-placed child of .entry-content)
+/* stylelint-disable-next-line no-duplicate-selectors */
 .entry-content {
 	position: relative !important;
 }

--- a/src/view/style.scss
+++ b/src/view/style.scss
@@ -234,3 +234,9 @@ $color__secondary-variation: darken( $color__secondary, 10% );
 		}
 	}
 }
+
+// This is needed for the scroll-triggered popups to function properly.
+// (#page-position-marker element is an absolutely-placed child of .entry-content)
+.entry-content {
+	position: relative !important;
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

In some situations the .entry-content might not be of position relative.
(#page-position-marker element is an absolutely-placed child of .entry-content)

### How to test the changes in this Pull Request:

1. Create a scroll-triggered campaign
2. Verify it displays correctly on a homepage

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
