### PR TITLE
Segmentation: use cacheing for client data

### DIFF
--- a/api/campaigns/class-maybe-show-campaign.php
+++ b/api/campaigns/class-maybe-show-campaign.php
@@ -19,8 +19,6 @@ class Maybe_Show_Campaign extends Lightweight_API {
 
 	/**
 	 * Constructor.
-	 *
-	 * @codeCoverageIgnore
 	 */
 	public function __construct() {
 		parent::__construct();
@@ -29,17 +27,41 @@ class Maybe_Show_Campaign extends Lightweight_API {
 		}
 		$campaigns = json_decode( $_REQUEST['popups'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		$settings  = json_decode( $_REQUEST['settings'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-		$visit     = json_decode( $_REQUEST['visit'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.InputNotValidated
+		$visit     = (array) json_decode( $_REQUEST['visit'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.InputNotValidated
 		$response  = [];
 		$client_id = $_REQUEST['cid']; // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 
 		if ( defined( 'ENABLE_CAMPAIGN_EVENT_LOGGING' ) && ENABLE_CAMPAIGN_EVENT_LOGGING ) {
-			Segmentation_Report::api_handle_post_read(
+			// Update the cache.
+			$posts_read        = $this->get_client_data( $client_id )['posts_read'];
+			$already_read_post = count(
+				array_filter(
+					$posts_read,
+					function ( $post_data ) use ( $visit ) {
+						return $post_data['post_id'] == $visit['post_id'];
+					}
+				)
+			) > 0;
+
+			if ( false === $already_read_post ) {
+				$posts_read[] = [
+					'post_id'      => $visit['post_id'],
+					'category_ids' => $visit['categories'],
+				];
+				$this->save_client_data(
+					$client_id,
+					[
+						'posts_read' => $posts_read,
+					]
+				);
+			}
+
+			Segmentation_Report::log_single_visit(
 				array_merge(
 					[
 						'clientId' => $client_id,
 					],
-					(array) $visit
+					$visit
 				)
 			);
 		}

--- a/api/campaigns/index.php
+++ b/api/campaigns/index.php
@@ -5,6 +5,7 @@
  * @package Newspack
  */
 
+// @codeCoverageIgnoreStart
 require_once '../setup.php';
 
 switch ( $_SERVER['REQUEST_METHOD'] ) { //phpcs:ignore
@@ -17,3 +18,4 @@ switch ( $_SERVER['REQUEST_METHOD'] ) { //phpcs:ignore
 	default:
 		die( "{ error: 'unsupported_method' }" );
 }
+// @codeCoverageIgnoreEnd

--- a/api/classes/class-lightweight-api.php
+++ b/api/classes/class-lightweight-api.php
@@ -26,6 +26,16 @@ class Lightweight_API {
 	public $debug;
 
 	/**
+	 * Default client data.
+	 *
+	 * @var client_data_blueprint
+	 */
+	private $client_data_blueprint = [
+		'suppressed_newsletter_campaign' => false,
+		'posts_read'                     => [],
+	];
+
+	/**
 	 * Constructor.
 	 *
 	 * @codeCoverageIgnore
@@ -49,8 +59,6 @@ class Lightweight_API {
 
 	/**
 	 * Verify referer is valid.
-	 *
-	 * @codeCoverageIgnore
 	 */
 	public function verify_referer() {
 		$http_referer = ! empty( $_SERVER['HTTP_REFERER'] ) ? parse_url( $_SERVER['HTTP_REFERER'] , PHP_URL_HOST ) : null; // phpcs:ignore
@@ -85,6 +93,9 @@ class Lightweight_API {
 	 * @codeCoverageIgnore
 	 */
 	public function respond() {
+		if ( defined( 'IS_TEST_ENV' ) && IS_TEST_ENV ) {
+			return;
+		}
 		$this->debug['end_time'] = microtime( true );
 		$this->debug['duration'] = $this->debug['end_time'] - $this->debug['start_time'];
 		if ( defined( 'NEWSPACK_POPUPS_DEBUG' ) && NEWSPACK_POPUPS_DEBUG ) {
@@ -191,9 +202,30 @@ class Lightweight_API {
 	public function get_client_data( $client_id ) {
 		$data = $this->get_transient( $this->get_transient_name( $client_id ) );
 		if ( ! $data ) {
-			return [
-				'suppressed_newsletter_campaign' => false,
-			];
+			// Rebuild cache, it might've been purged.
+
+			global $wpdb;
+			$events_table_name       = Segmentation::get_events_table_name();
+			$client_post_read_events = $wpdb->get_results( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+				$wpdb->prepare( "SELECT * FROM $events_table_name WHERE client_id = %s AND type = 'post_read'", $client_id ) // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			);
+
+			$this->save_client_data(
+				$client_id,
+				[
+					'posts_read' => array_map(
+						function ( $item ) {
+							return [
+								'post_id'      => $item->post_id,
+								'category_ids' => $item->category_ids,
+							];
+						},
+						$client_post_read_events
+					),
+				]
+			);
+
+			return $this->client_data_blueprint;
 		}
 		return $data;
 	}
@@ -205,7 +237,13 @@ class Lightweight_API {
 	 * @param string $client_data Client data.
 	 */
 	public function save_client_data( $client_id, $client_data ) {
-		return $this->set_transient( $this->get_transient_name( $client_id ), $client_data );
+		return $this->set_transient(
+			$this->get_transient_name( $client_id ),
+			array_merge(
+				$this->client_data_blueprint,
+				$client_data
+			)
+		);
 	}
 
 	/**

--- a/api/segmentation/class-segmentation-report.php
+++ b/api/segmentation/class-segmentation-report.php
@@ -14,7 +14,7 @@ class Segmentation_Report {
 	 *
 	 * @param object $payload a payload.
 	 */
-	public static function api_handle_post_read( $payload ) {
+	public static function log_single_visit( $payload ) {
 		if ( $payload['is_post'] ) {
 			// Add line to log file.
 			$line = implode(

--- a/api/setup.php
+++ b/api/setup.php
@@ -5,6 +5,7 @@
  * @package Newspack
  */
 
+// @codeCoverageIgnoreStart
 $wp_root_path = substr( $_SERVER['SCRIPT_FILENAME'], 0, strrpos( $_SERVER['SCRIPT_FILENAME'], 'wp-content/plugins/' ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.InputNotValidated
 
 if ( file_exists( $wp_root_path . '__wp__' ) ) {
@@ -62,3 +63,5 @@ wp_cache_init();
 // phpcs:enable
 
 require_once 'segmentation/class-segmentation.php';
+
+// @codeCoverageIgnoreEnd

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,7 +10,7 @@
 	<filter>
 		<whitelist addUncoveredFilesFromWhitelist="true">
 			<directory>./includes</directory>
-			<directory>./api/classes</directory>
+			<directory>./api</directory>
 		</whitelist>
 	</filter>
 	<testsuites>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -32,6 +32,7 @@ function _manually_load_plugin() {
 tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
 
 define( 'IS_TEST_ENV', 1 );
+define( 'ENABLE_CAMPAIGN_EVENT_LOGGING', 1 );
 
 // Start up the WP testing environment.
 require $_tests_dir . '/includes/bootstrap.php';

--- a/tests/test-segmentation.php
+++ b/tests/test-segmentation.php
@@ -10,11 +10,13 @@
  */
 class SegmentationTest extends WP_UnitTestCase {
 	private static $post_read_payload = [ // phpcs:ignore Squiz.Commenting.VariableComment.Missing
-		'is_post'    => '1',
+		'is_post'    => true,
 		'clientId'   => 'test-1',
 		'post_id'    => '42',
 		'categories' => '5,6',
 	];
+
+	private static $request = []; // phpcs:ignore Squiz.Commenting.VariableComment.Missing
 
 	public function setUp() { // phpcs:ignore Squiz.Commenting.FunctionComment.Missing
 		global $wpdb;
@@ -23,13 +25,33 @@ class SegmentationTest extends WP_UnitTestCase {
 		if ( file_exists( Segmentation::get_log_file_path() ) ) {
 			unlink( Segmentation::get_log_file_path() ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_unlink
 		}
+		// Reset client id.
+		self::$post_read_payload = array_merge(
+			self::$post_read_payload,
+			[
+				'clientId' => 'test-' . uniqid(),
+			]
+		);
+		self::$request           = [
+			'cid'      => self::$post_read_payload['clientId'],
+			'popups'   => wp_json_encode( [] ),
+			'settings' => wp_json_encode( [] ),
+			'visit'    => wp_json_encode(
+				[
+					'post_id'    => self::$post_read_payload['post_id'],
+					'categories' => self::$post_read_payload['categories'],
+					'is_post'    => true,
+					'date'       => gmdate( 'Y-m-d', time() ),
+				]
+			),
+		];
 	}
 
 	/**
 	 * Log file updating with a post_read event.
 	 */
-	public function test_log_post_read() {
-		Segmentation_Report::api_handle_post_read( self::$post_read_payload );
+	public function test_log_visit() {
+		Segmentation_Report::log_single_visit( self::$post_read_payload );
 
 		$expected_log_line = implode(
 			';',
@@ -48,11 +70,11 @@ class SegmentationTest extends WP_UnitTestCase {
 			'Log file contains the expected line.'
 		);
 
-		Segmentation_Report::api_handle_post_read(
+		Segmentation_Report::log_single_visit(
 			array_merge(
 				self::$post_read_payload,
 				[
-					'is_post' => '0',
+					'is_post' => false,
 				]
 			)
 		);
@@ -62,33 +84,47 @@ class SegmentationTest extends WP_UnitTestCase {
 			file_get_contents( Segmentation::get_log_file_path() ),
 			'Log file is not updated after a non-post visit is reported.'
 		);
-	}
-
-	/**
-	 * Log file parsing.
-	 */
-	public function test_log_parsing() {
-		// Duplicate article read, but on a different date.
-		Segmentation_Report::api_handle_post_read(
-			array_merge(
-				self::$post_read_payload,
-				[
-					'date' => gmdate( 'Y-m-d', strtotime( '-1 week' ) ),
-				]
-			)
-		);
-		Segmentation_Report::api_handle_post_read( self::$post_read_payload );
-		// Duplicate log entry – to ensure that unique lines are processed.
-		Segmentation_Report::api_handle_post_read( self::$post_read_payload );
 
 		Newspack_Popups_Parse_Logs::parse_events_logs();
 
-		$read_posts = Segmentation::get_client_read_posts( self::$post_read_payload['clientId'] );
+		self::assertEquals(
+			'',
+			file_get_contents( Segmentation::get_log_file_path() ),
+			'Log file is emptied after parsing logs.'
+		);
+	}
+
+	/**
+	 * Reporting visits while checking popups visibility.
+	 */
+	public function test_visit_reporting() {
+		$_REQUEST = self::$request;
+
+		// Log an article read event.
+		// Checking campaign visibility will log a visit, this way there are less API requests.
+		$maybe_show_campaign = new Maybe_Show_Campaign();
+
+		// And a duplicate.
+		$maybe_show_campaign = new Maybe_Show_Campaign();
+
+		// Duplicate article read, but on a different date.
+		$_REQUEST            = self::$request;
+		$_REQUEST['visit']   = wp_json_encode(
+			array_merge(
+				(array) json_decode( self::$request['visit'] ),
+				[
+					'date' => gmdate( 'Y-m-d', strtotime( '+1 week' ) ),
+				]
+			)
+		);
+		$maybe_show_campaign = new Maybe_Show_Campaign();
+
+		$read_posts = $maybe_show_campaign->get_client_data( self::$post_read_payload['clientId'] )['posts_read'];
 
 		self::assertEquals(
 			1,
 			count( $read_posts ),
-			'The read posts array is of expected length.'
+			'The read posts array is of expected length – the duplicates were not inserted.'
 		);
 
 		self::assertEquals(
@@ -97,13 +133,28 @@ class SegmentationTest extends WP_UnitTestCase {
 				'category_ids' => self::$post_read_payload['categories'],
 			],
 			$read_posts[0],
-			'The read posts array contains the reported post after logs parsing.'
+			'The read posts array contains the reported post.'
 		);
 
+		// Now a visit with a different post id.
+		$_REQUEST            = self::$request;
+		$_REQUEST['visit']   = wp_json_encode(
+			array_merge(
+				(array) json_decode( self::$request['visit'] ),
+				[
+					'post_id' => '23',
+					'date'    => gmdate( 'Y-m-d', strtotime( '+1 week' ) ),
+				]
+			)
+		);
+		$maybe_show_campaign = new Maybe_Show_Campaign();
+
+		$read_posts = $maybe_show_campaign->get_client_data( self::$post_read_payload['clientId'] )['posts_read'];
+
 		self::assertEquals(
-			'',
-			file_get_contents( Segmentation::get_log_file_path() ),
-			'Log file is emptied after parsing logs.'
+			2,
+			count( $read_posts ),
+			'The read posts array is of expected length after reading another post.'
 		);
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds cacheing, so the segmentation data is available before the logs are parsed.

Without cacheing, the to-be-implemented segmentation features (e.g. show a campaign after 3 posts are read) would work after a lag, since the events log is parsed in a cron job. 

### How to test the changes in this Pull Request:

Since there are no user-facing features here, testing can be done by inspecting the results of `Maybe_Show_Campaign::get_client_data` method in `Maybe_Show_Campaign`'s constructor, and following the tests to see how it's supposed to work.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
