### PR TITLE
Fix: scroll-triggered popups on non-AMP pages

### DIFF
--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -789,7 +789,7 @@ final class Newspack_Popups_Model {
 			</form>
 		</amp-layout>
 		<div id="page-position-marker" style="position: absolute; top: <?php echo esc_attr( $popup['options']['trigger_scroll_progress'] ); ?>%"></div>
-		<amp-position-observer target="page-position-marker" on="enter:showAnim.start;" once layout="nodisplay" />
+		<amp-position-observer target="page-position-marker" on="enter:showAnim.start;" once layout="nodisplay"></amp-position-observer>
 		<amp-animation id="showAnim" layout="nodisplay">
 			<script type="application/json">
 				{


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

AMP Components can be self-closing, but if page is served as non-AMP, in some cases this may not be handled. 
In the case of this bug, the `amp-position-observer` component can be treated as not-closed, resulting in the page content being inserted as children of it. 

### How to test the changes in this Pull Request:

1. On `master`, create an overlay, scroll-triggered campaign, set to sitewide default 
2. Set your site to AMP transitional mode
3. Visit the (non-AMP) homepage, observe only the header and footer are displayed
3. Visit a (non-AMP) post, observe only the header and footer are displayed
4. Switch to this branch, reload site
5. Observe the homepage and post are rendered as expected, with the campaign triggered by scroll as expected
6. Also check the AMP version

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
