### PR TITLE
Fix time-triggered popups edge case

### DIFF
--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -398,9 +398,6 @@ final class Newspack_Popups_Inserter {
 	 * Register and enqueue all required AMP scripts, if needed.
 	 */
 	public static function register_amp_scripts() {
-		if ( ! Newspack_Popups_Segmentation::is_tracking() ) {
-			return;
-		}
 		if ( ! is_admin() && ! wp_script_is( 'amp-runtime', 'registered' ) ) {
 		// phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion
 			wp_register_script(

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -738,6 +738,7 @@ final class Newspack_Popups_Model {
 		$classes              = array( 'newspack-lightbox', 'newspack-lightbox-placement-' . $popup['options']['placement'] );
 		$classes[]            = ( ! empty( $popup['title'] ) && $display_title ) ? 'newspack-lightbox-has-title' : null;
 		$classes[]            = $is_newsletter_prompt ? 'newspack-newsletter-prompt-overlay' : null;
+		$is_scroll_triggered  = 'scroll' === $popup['options']['trigger_type'];
 
 		add_filter(
 			'newspack_analytics_events',
@@ -788,9 +789,11 @@ final class Newspack_Popups_Model {
 				<button style="opacity: <?php echo floatval( $overlay_opacity ); ?>;background-color:<?php echo esc_attr( $overlay_color ); ?>;" class="newspack-lightbox-shim" on="tap:<?php echo esc_attr( $element_id ); ?>.hide"></button>
 			</form>
 		</amp-layout>
-		<div id="page-position-marker" style="position: absolute; top: <?php echo esc_attr( $popup['options']['trigger_scroll_progress'] ); ?>%"></div>
-		<amp-position-observer target="page-position-marker" on="enter:showAnim.start;" once layout="nodisplay" />
-		<amp-animation id="showAnim" layout="nodisplay">
+		<?php if ( $is_scroll_triggered ) : ?>
+			<div id="page-position-marker" style="position: absolute; top: <?php echo esc_attr( $popup['options']['trigger_scroll_progress'] ); ?>%"></div>
+			<amp-position-observer target="page-position-marker" on="enter:showAnim.start;" once layout="nodisplay"/>
+		<?php endif; ?>
+		<amp-animation id="showAnim" layout="nodisplay" <?php echo $is_scroll_triggered ? '' : 'trigger="visibility"'; ?>>
 			<script type="application/json">
 				{
 					"duration": "125ms",

--- a/includes/class-newspack-popups-segmentation.php
+++ b/includes/class-newspack-popups-segmentation.php
@@ -73,10 +73,6 @@ final class Newspack_Popups_Segmentation {
 	 * Insert amp-analytics scripts.
 	 */
 	public static function wp_enqueue_scripts() {
-		if ( ! self::is_tracking() ) {
-			return;
-		}
-
 		// Register AMP scripts explicitly for non-AMP pages.
 		if ( ! wp_script_is( 'amp-runtime', 'registered' ) ) {
 			// phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion

--- a/tests/test-model.php
+++ b/tests/test-model.php
@@ -69,13 +69,37 @@ class ModelTest extends WP_UnitTestCase {
 		@$dom->loadHTML( Newspack_Popups_Model::generate_popup( $popup_object_default ) ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
 		$xpath = new DOMXpath( $dom );
 
+		self::assertEquals(
+			0,
+			$xpath->query( '//*[@id="page-position-marker"]' )->length,
+			'The page position marker is not output for a default (time-triggered) popup.'
+		);
+
+		self::assertEquals(
+			'visibility',
+			$xpath->query( '//amp-animation' )->item( 0 )->getAttribute( 'trigger' ),
+			'The amp-animation trigger is set to "visibility" for default (time-triggered) popup.'
+		);
+
+		$popup_object_with_just_scroll = Newspack_Popups_Model::create_popup_object(
+			get_post( self::$popup_id ),
+			false,
+			[
+				'trigger_type' => 'scroll',
+			]
+		);
+
+		$dom = new DomDocument();
+		@$dom->loadHTML( Newspack_Popups_Model::generate_popup( $popup_object_with_just_scroll ) ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+		$xpath = new DOMXpath( $dom );
+
 		self::assertContains(
 			'top: 0%',
 			$xpath->query( '//*[@id="page-position-marker"]' )->item( 0 )->getAttribute( 'style' ),
 			'The position marker is set at 0% by default.'
 		);
 
-		$popup_object = Newspack_Popups_Model::create_popup_object(
+		$popup_object_with_set_scroll_progress = Newspack_Popups_Model::create_popup_object(
 			get_post( self::$popup_id ),
 			false,
 			[
@@ -85,7 +109,7 @@ class ModelTest extends WP_UnitTestCase {
 		);
 
 		$dom = new DomDocument();
-		@$dom->loadHTML( Newspack_Popups_Model::generate_popup( $popup_object ) ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+		@$dom->loadHTML( Newspack_Popups_Model::generate_popup( $popup_object_with_set_scroll_progress ) ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
 		$xpath = new DOMXpath( $dom );
 
 		self::assertContains(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

In some cases, time-triggered popups will not show until scrolling.

Closes #241 
Closes #247

### How to test the changes in this Pull Request:

1. Create a time-triggered popup, set to test mode
1. On `master`, visit the site, scroll to the bottom, and reload
2. Observe the popup is not shown until site is scrolled to top
3. Switch to this branch
4. Observe the popup is displayed when loading the page with scroll offset

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
