### PR TITLE
Non-interactive (aka high traffic) mode

### DIFF
--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -25,7 +25,7 @@ final class Newspack_Popups_Inserter {
 	 *
 	 * @var boolean
 	 */
-	protected static $the_content_has_rendered = false;
+	public static $the_content_has_rendered = false;
 
 	/**
 	 * Retrieve the appropriate popups for the current post.
@@ -269,6 +269,9 @@ final class Newspack_Popups_Inserter {
 	 * Enqueue the assets needed to display the popups.
 	 */
 	public static function enqueue_popup_assets() {
+		if ( defined( 'IS_TEST_ENV' ) && IS_TEST_ENV ) {
+			return;
+		}
 		$is_amp = function_exists( 'is_amp_endpoint' ) && is_amp_endpoint();
 		if ( ! $is_amp ) {
 			wp_register_script(
@@ -484,6 +487,10 @@ final class Newspack_Popups_Inserter {
 	public static function should_display( $popup ) {
 		// Hide non-test mode campaigns for logged-in users.
 		if ( is_user_logged_in() && 'test' !== $popup['options']['frequency'] ) {
+			return false;
+		}
+		// Hide overlay campaigns in non-interactive mode, for non-logged-in users.
+		if ( ! is_user_logged_in() && Newspack_Popups_Settings::is_non_interactive() && ! Newspack_Popups_Model::is_inline( $popup ) ) {
 			return false;
 		}
 		return self::assess_is_post( $popup ) &&

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -637,11 +637,13 @@ final class Newspack_Popups_Model {
 	 * @param object $popup Popup.
 	 */
 	public static function get_access_attrs( $popup ) {
+		if ( Newspack_Popups_Settings::is_non_interactive() ) {
+			return '';
+		}
 		if (
 			( 'test' === $popup['options']['frequency'] || Newspack_Popups::previewed_popup_id() ) &&
 			is_user_logged_in() &&
-			current_user_can( 'edit_others_pages' ) ||
-			Newspack_Popups_Settings::is_non_interactive()
+			current_user_can( 'edit_others_pages' )
 		) {
 			return '';
 		}

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -396,7 +396,7 @@ final class Newspack_Popups_Model {
 	 * @param object $popup The popup object.
 	 * @return boolean True if it is an inline popup.
 	 */
-	protected static function is_inline( $popup ) {
+	public static function is_inline( $popup ) {
 		return 'inline' === $popup['options']['placement'];
 	}
 
@@ -419,7 +419,11 @@ final class Newspack_Popups_Model {
 	 * @return string Prints the generated amp-analytics element.
 	 */
 	protected static function insert_event_tracking( $popup, $body, $element_id ) {
-		if ( Newspack_Popups::previewed_popup_id() || 'test' === $popup['options']['frequency'] ) {
+		if (
+			Newspack_Popups::previewed_popup_id() ||
+			'test' === $popup['options']['frequency'] ||
+			Newspack_Popups_Settings::is_non_interactive()
+		) {
 			return '';
 		}
 		global $wp;
@@ -636,7 +640,8 @@ final class Newspack_Popups_Model {
 		if (
 			( 'test' === $popup['options']['frequency'] || Newspack_Popups::previewed_popup_id() ) &&
 			is_user_logged_in() &&
-			current_user_can( 'edit_others_pages' )
+			current_user_can( 'edit_others_pages' ) ||
+			Newspack_Popups_Settings::is_non_interactive()
 		) {
 			return '';
 		}
@@ -688,7 +693,7 @@ final class Newspack_Popups_Model {
 					<h1 class="newspack-popup-title"><?php echo esc_html( $popup['title'] ); ?></h1>
 				<?php endif; ?>
 						<?php echo ( $body ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
-						<?php if ( $dismiss_text ) : ?>
+						<?php if ( $dismiss_text && ! Newspack_Popups_Settings::is_non_interactive() ) : ?>
 					<form class="popup-not-interested-form popup-action-form"
 						method="POST"
 						action-xhr="<?php echo esc_url( $endpoint ); ?>"

--- a/includes/class-newspack-popups-segmentation.php
+++ b/includes/class-newspack-popups-segmentation.php
@@ -63,7 +63,7 @@ final class Newspack_Popups_Segmentation {
 	 * Should tracking code be inserted?
 	 */
 	public static function is_tracking() {
-		if ( is_admin() || self::is_admin_user() ) {
+		if ( is_admin() || self::is_admin_user() || Newspack_Popups_Settings::is_non_interactive() ) {
 			return false;
 		}
 		return true;

--- a/includes/class-newspack-popups-settings.php
+++ b/includes/class-newspack-popups-settings.php
@@ -49,9 +49,17 @@ class Newspack_Popups_Settings {
 	 */
 	public static function get_settings() {
 		return [
-			'suppress_newsletter_campaigns' => get_option( 'suppress_newsletter_campaigns', true ),
+			'suppress_newsletter_campaigns'            => get_option( 'suppress_newsletter_campaigns', true ),
 			'suppress_all_newsletter_campaigns_if_one_dismissed' => get_option( 'suppress_all_newsletter_campaigns_if_one_dismissed', true ),
+			'newspack_newsletters_non_interative_mode' => self::is_non_interactive(),
 		];
+	}
+
+	/**
+	 * Is the non-interactive setting on?
+	 */
+	public static function is_non_interactive() {
+		return get_option( 'newspack_newsletters_non_interative_mode', false );
 	}
 
 	/**

--- a/src/settings/index.js
+++ b/src/settings/index.js
@@ -60,8 +60,9 @@ const App = () => {
 					onChange={ handleSettingChange( 'suppress_all_newsletter_campaigns_if_one_dismissed' ) }
 				/>
 				<CheckboxControl
-					label={ __(
-						'Non-interactive mode. When enabled, campaigns will not be dismissible and overlay campaigns will not be displayed. This will lessen the load on the server.',
+					label={ __( 'Enable non-interactive mode.', 'newspack-popups' ) }
+					help={ __(
+						'Use this setting in high traffic scenarios. No API requests will be made, reducing server load. Inline campaigns will be shown to all users without dismissal buttons, and overlay campaigns will be suppressed.',
 						'newspack-popups'
 					) }
 					disabled={ inFlight }

--- a/src/settings/index.js
+++ b/src/settings/index.js
@@ -59,6 +59,15 @@ const App = () => {
 					checked={ settings.suppress_all_newsletter_campaigns_if_one_dismissed === '1' }
 					onChange={ handleSettingChange( 'suppress_all_newsletter_campaigns_if_one_dismissed' ) }
 				/>
+				<CheckboxControl
+					label={ __(
+						'Non-interactive mode. When enabled, campaigns will not be dismissible and overlay campaigns will not be displayed. This will lessen the load on the server.',
+						'newspack-popups'
+					) }
+					disabled={ inFlight }
+					checked={ settings.newspack_newsletters_non_interative_mode === '1' }
+					onChange={ handleSettingChange( 'newspack_newsletters_non_interative_mode' ) }
+				/>
 			</Card>
 		</Grid>
 	);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -31,5 +31,7 @@ function _manually_load_plugin() {
 }
 tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
 
+define( 'IS_TEST_ENV', 1 );
+
 // Start up the WP testing environment.
 require $_tests_dir . '/includes/bootstrap.php';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

In some situations the user might wish to lessen the load on the server by disabling the API calls. 
In non-interactive mode the overlay campaigns will not be displayed, and inline campaigns will not be dismissible. All inline campaigns will be displayed, since the suppression logic will not be called.

Closes #248.

### How to test the changes in this Pull Request:

1. Create some inline and overlay (non-test-mode) campaigns. 
2. Observe they are displayed as expected. Dismiss the inline campaigns permanently.
3. Observe no campaigns are displayed.
4. Visit plugin settings, turn on the "non-interactive mode" setting.
5. Observe the overlay campaigns are still not displayed, but inline ones are.
6. In a new session, observe the above again. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
