### PR TITLE
Handle MC4WP; store email subscriptions as an array

### DIFF
--- a/api/campaigns/class-report-campaign-data.php
+++ b/api/campaigns/class-report-campaign-data.php
@@ -54,15 +54,16 @@ class Report_Campaign_Data extends Lightweight_API {
 			}
 		}
 
-		// Subscribed to a newsletter.
+		// Subscribed to a newsletter – suppress this campaign.
 		if ( 'subscribed' === $this->get_request_param( 'mailing_list_status', $request ) ) {
 			$campaign_data['suppress_forever'] = true;
 		}
 
-		// Add an email subscription to client.
+		// Add an email subscription to client data.
 		$email_address = $this->get_request_param( 'email', $request );
 		if ( $email_address ) {
-			$client_data['email_subscriptions'] = [
+			// This is an array, so it's possible to collect data for separate lists in the future.
+			$client_data['email_subscriptions'][] = [
 				'email' => $email_address,
 			];
 		}

--- a/api/classes/class-lightweight-api.php
+++ b/api/classes/class-lightweight-api.php
@@ -33,6 +33,7 @@ class Lightweight_API {
 	private $client_data_blueprint = [
 		'suppressed_newsletter_campaign' => false,
 		'posts_read'                     => [],
+		'email_subscriptions'            => [],
 	];
 
 	/**

--- a/api/classes/class-lightweight-api.php
+++ b/api/classes/class-lightweight-api.php
@@ -193,6 +193,7 @@ class Lightweight_API {
 		if ( ! $data ) {
 			return [
 				'suppressed_newsletter_campaign' => false,
+				'email_subscriptions'            => [],
 			];
 		}
 		return $data;

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -432,11 +432,13 @@ final class Newspack_Popups_Model {
 
 		// Mailchimp.
 		$mailchimp_form_selector = '';
+		$email_form_field_name   = 'email';
 		if ( preg_match( '/wp-block-jetpack-mailchimp/', $body ) !== 0 ) {
 			$mailchimp_form_selector = '.wp-block-jetpack-mailchimp form';
 		}
 		if ( preg_match( '/mc4wp-form/', $body ) !== 0 ) {
 			$mailchimp_form_selector = '.mc4wp-form';
+			$email_form_field_name   = 'EMAIL';
 		}
 
 		?>
@@ -456,7 +458,7 @@ final class Newspack_Popups_Model {
 									"popup_id": "<?php echo esc_attr( self::canonize_popup_id( $popup['id'] ) ); ?>",
 									"cid": "CLIENT_ID( <?php echo esc_attr( Newspack_Popups_Segmentation::NEWSPACK_SEGMENTATION_CID_NAME ); ?> )",
 									"mailing_list_status": "subscribed",
-									"email": "${formFields[email]}"
+									"email": "${formFields[<?php echo esc_attr( $email_form_field_name ); ?>]}"
 								}
 							}
 						},

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,7 +10,7 @@
 	<filter>
 		<whitelist addUncoveredFilesFromWhitelist="true">
 			<directory>./includes</directory>
-			<directory>./api/classes</directory>
+			<directory>./api</directory>
 		</whitelist>
 	</filter>
 	<testsuites>

--- a/tests/test-api.php
+++ b/tests/test-api.php
@@ -408,6 +408,7 @@ class APITest extends WP_UnitTestCase {
 			self::$report_campaign_data->get_client_data( $client_id ),
 			[
 				'suppressed_newsletter_campaign' => false,
+				'posts_read'                     => [],
 				'email_subscriptions'            => [],
 			],
 			'The initial client data has expected shape.'
@@ -428,6 +429,7 @@ class APITest extends WP_UnitTestCase {
 			self::$report_campaign_data->get_client_data( $client_id ),
 			[
 				'suppressed_newsletter_campaign' => false,
+				'posts_read'                     => [],
 				'email_subscriptions'            => [
 					[
 						'email' => $email_address,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds handling of an MC4WP plugin form subscription event. 

Related: #250

### How to test the changes in this Pull Request:

1. Create two campaigns, one with a Jetpack Mailchimp form, one with MC4WP form
2. Submit both 
3. Inspect the value of client data (`self::get_client_data( $client_id )`, e.g. in `Maybe_Show_Campaign`'s constructor)
4. Observe the email addresses were saved in client data

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
