### PR TITLE
Testing overlay campaigns

### DIFF
--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -42,10 +42,18 @@ final class Newspack_Popups_Inserter {
 			return [ Newspack_Popups_Model::retrieve_preview_popup( Newspack_Popups::previewed_popup_id() ) ];
 		}
 
-		// 1. Get all inline popups in there first.
+		// 1. Get all inline popups.
 		$popups_to_maybe_display = Newspack_Popups_Model::retrieve_inline_popups();
 
-		// 2. Get the overlay popup.
+		// 2. Get the overlay popup/s. There can be only one displayed, unless in test mode.
+
+		// Any overlay test popups, if the user is logged in.
+		if ( is_user_logged_in() ) {
+			$popups_to_maybe_display = array_merge(
+				$popups_to_maybe_display,
+				Newspack_Popups_Model::retrieve_overlay_test_popups()
+			);
+		}
 
 		// Check if there's an overlay popup with matching category.
 		$category_overlay_popup = Newspack_Popups_Model::retrieve_category_overlay_popup();

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -199,6 +199,31 @@ final class Newspack_Popups_Model {
 	}
 
 	/**
+	 * Get overlay test popups.
+	 *
+	 * @return array Overlay test popup objects.
+	 */
+	public static function retrieve_overlay_test_popups() {
+		$args = [
+			'post_type'   => Newspack_Popups::NEWSPACK_PLUGINS_CPT,
+			'post_status' => 'publish',
+			'meta_query'  => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+				[
+					'key'     => 'placement',
+					'value'   => 'inline',
+					'compare' => '!=',
+				],
+				[
+					'key'   => 'frequency',
+					'value' => 'test',
+				],
+			],
+		];
+
+		return self::retrieve_popups_with_query( new WP_Query( $args ) );
+	}
+
+	/**
 	 * Retrieve first overlay popup matching post categries.
 	 *
 	 * @return object|null Popup object.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Allows for testing of overlay campaigns.

Closes #62.

### How to test the changes in this Pull Request:
 
1. On `master`, create an overlay campaign in test mode
2. Observe that it will not be visible unless it's set to sitewide default. This will un-set the campaign which was the sitewide default up until now. Not cool.
3. Switch to this branch, observe that a test overlay campaign will be available for testing without the need to unset the sitewide default
4. Observe that you can make a mess by creating multiple overlay test campaigns

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
