### PR TITLE
Allow inline campaigns to appear before first block

### DIFF
--- a/src/editor/index.js
+++ b/src/editor/index.js
@@ -150,7 +150,7 @@ class PopupSidebar extends Component {
 						label={ __( 'Approximate position (in percent)' ) }
 						value={ trigger_scroll_progress }
 						onChange={ value => onMetaFieldChange( 'trigger_scroll_progress', value ) }
-						min={ 1 }
+						min={ 0 }
 						max={ 100 }
 					/>
 				) }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #209.

### How to test the changes in this Pull Request:

1. Create a campaign, placement inline at 0%
2. Create a post with a one-word first paragraph
3. Observe the inline campaign is inserted before the first paragraph

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
