### PR TITLE
Disable native preview button

### DIFF
--- a/src/editor/index.js
+++ b/src/editor/index.js
@@ -27,6 +27,7 @@ import { ColorPaletteControl } from '@wordpress/block-editor';
  */
 import { optionsFieldsSelector, updateEditorColors } from './utils';
 import PopupPreview from './PopupPreview';
+import './style.scss';
 
 class PopupSidebar extends Component {
 	state = {

--- a/src/editor/style.scss
+++ b/src/editor/style.scss
@@ -1,0 +1,3 @@
+.block-editor-post-preview__button-toggle {
+	display: none;
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #130.

### How to test the changes in this Pull Request:

1. Create or edit a campaign
2. Observe there is no native preview button (the one next to Publish/Update)
3. There's only one preview button, for the modal preview

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
