### PR TITLE
Fix previews if latest post has campaigns disabled

### DIFF
--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -272,20 +272,34 @@ final class Newspack_Popups {
 			filemtime( dirname( NEWSPACK_POPUPS_PLUGIN_FILE ) . '/dist/editor.js' ),
 			true
 		);
-		$recent_posts = wp_get_recent_posts(
+
+		$query                  = new WP_Query(
 			[
-				'numberposts' => 1,
-				'post_status' => 'publish',
-			],
-			OBJECT
+				'posts_per_page' => 1,
+				'post_status'    => 'publish',
+				'orderby'        => 'post_date',
+				'order'          => 'DESC',
+				'meta_query'     => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+					'relation' => 'OR',
+					[
+						'key'     => 'newspack_popups_has_disabled_popups',
+						'compare' => 'NOT EXISTS',
+					],
+					[
+						'key'   => 'newspack_popups_has_disabled_popups',
+						'value' => '',
+					],
+				],
+			]
 		);
-		$preview_post = count( $recent_posts ) > 0 ? get_the_permalink( $recent_posts[0] ) : '';
+		$recent_posts           = $query->get_posts();
+		$preview_post_permalink = $recent_posts && count( $recent_posts ) > 0 ? get_the_permalink( $recent_posts[0] ) : '';
 
 		\wp_localize_script(
 			'newspack-popups',
 			'newspack_popups_data',
 			[
-				'preview_post' => $preview_post,
+				'preview_post' => $preview_post_permalink,
 			]
 		);
 		\wp_enqueue_style(

--- a/src/editor/PopupPreview.js
+++ b/src/editor/PopupPreview.js
@@ -19,12 +19,8 @@ const PopupPreviewSetting = ( { autosavePost, isSavingPost, postId, metaFields }
 		...metaFields,
 	} );
 
-	// For inline and scroll-triggered popups, use most recent post to preview. For anything else, use the home.
-	const shouldDisplayOnPost =
-		'inline' === metaFields.placement || 'scroll' === metaFields.trigger_type;
-	const previewURL = shouldDisplayOnPost
-		? window && window.newspack_popups_data && window.newspack_popups_data.preview_post
-		: '/';
+	const previewURL =
+		( window && window.newspack_popups_data && window.newspack_popups_data.preview_post ) || '/';
 
 	return (
 		<WebPreview


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #110.

### How to test the changes in this Pull Request:

1. Disable campaigns on the latest post
2. Create or edit an inline campaign, observe that preview uses the lastest post which does not have disabled campaigns

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
