### PR TITLE
Disable "Every page" frequency for overlay campaigns

### DIFF
--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -53,7 +53,7 @@ final class Newspack_Popups {
 		add_action( 'save_post_' . self::NEWSPACK_PLUGINS_CPT, [ __CLASS__, 'popup_default_fields' ], 10, 3 );
 
 		if ( filter_input( INPUT_GET, 'newspack_popups_preview_id', FILTER_SANITIZE_STRING ) ) {
-			add_filter( 'show_admin_bar', [ __CLASS__, 'hide_admin_bar_for_preview' ], 10, 2 );
+			add_filter( 'show_admin_bar', [ __CLASS__, 'hide_admin_bar_for_preview' ], 10, 2 ); // phpcs:ignore WordPressVIPMinimum.UserExperience.AdminBarRemoval.RemovalDetected
 		}
 
 		include_once dirname( __FILE__ ) . '/class-newspack-popups-model.php';

--- a/src/editor/index.js
+++ b/src/editor/index.js
@@ -50,18 +50,6 @@ class PopupSidebar extends Component {
 			updateEditorColors( background_color );
 		}
 	}
-	frequencyOptions = placement => {
-		const options = [
-			{ value: 'test', label: __( 'Test mode', 'newspack-popups' ) },
-			{ value: 'never', label: __( 'Never', 'newspack-popups' ) },
-			{ value: 'once', label: __( 'Once', 'newspack-popups' ) },
-			{ value: 'daily', label: __( 'Once a day', 'newspack-popups' ) },
-		];
-		if ( 'inline' === placement ) {
-			options.push( { value: 'always', label: __( 'Every page', 'newspack-popups' ) } );
-		}
-		return options;
-	};
 	/**
 	 * Render
 	 */
@@ -88,6 +76,13 @@ class PopupSidebar extends Component {
 		// The sitewide default option is for overlay popups only.
 		const canBeSiteWideDefault = ! isInline && isCurrentPostPublished;
 
+		const updatePlacement = value => {
+			onMetaFieldChange( 'placement', value );
+			if ( value !== 'inline' && frequency === 'always' ) {
+				onMetaFieldChange( 'frequency', 'once' );
+			}
+		};
+
 		return (
 			<Fragment>
 				{ canBeSiteWideDefault && (
@@ -105,7 +100,7 @@ class PopupSidebar extends Component {
 				<SelectControl
 					label={ __( 'Placement' ) }
 					value={ placement }
-					onChange={ value => onMetaFieldChange( 'placement', value ) }
+					onChange={ updatePlacement }
 					options={ [
 						{ value: 'center', label: __( 'Center' ) },
 						{ value: 'top', label: __( 'Top' ) },
@@ -158,7 +153,17 @@ class PopupSidebar extends Component {
 					label={ __( 'Frequency' ) }
 					value={ frequency }
 					onChange={ value => onMetaFieldChange( 'frequency', value ) }
-					options={ this.frequencyOptions( placement ) }
+					options={ [
+						{ value: 'test', label: __( 'Test mode', 'newspack-popups' ) },
+						{ value: 'never', label: __( 'Never', 'newspack-popups' ) },
+						{ value: 'once', label: __( 'Once', 'newspack-popups' ) },
+						{ value: 'daily', label: __( 'Once a day', 'newspack-popups' ) },
+						{
+							value: 'always',
+							label: __( 'Every page', 'newspack-popups' ),
+							disabled: 'inline' !== placement,
+						},
+					] }
 					help={ __(
 						'In "Test Mode" logged-in admins will see the Campaign every time, and non-admins will never see them.',
 						'newspack-popups'


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #105.

### How to test the changes in this Pull Request:

1. Create a new campaign
2. Observe that in the "Frequency" setting, "Every page" option is disabled if it's an overlay campaign, and enabled when it's an inline campaign
3. Set it to "Every page", then change placement to non-inline – observe the frequency value is updated to "Once"

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
