### PR TITLE
Segmentation: save WC donation data

### DIFF
--- a/api/classes/class-lightweight-api.php
+++ b/api/classes/class-lightweight-api.php
@@ -193,6 +193,7 @@ class Lightweight_API {
 		if ( ! $data ) {
 			return [
 				'suppressed_newsletter_campaign' => false,
+				'donations'                      => [],
 			];
 		}
 		return $data;

--- a/api/segmentation/class-segmentation-client-data.php
+++ b/api/segmentation/class-segmentation-client-data.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Newspack Campaigns report client data.
+ *
+ * @package Newspack
+ */
+
+/**
+ * Extend the base Lightweight_API class.
+ */
+require_once dirname( __FILE__ ) . '/../classes/class-lightweight-api.php';
+
+/**
+ * POST endpoint to report client data.
+ */
+class Segmentation_Client_Data extends Lightweight_API {
+	/**
+	 * Constructor.
+	 *
+	 * @codeCoverageIgnore
+	 */
+	public function __construct() {
+		parent::__construct();
+		$payload = $this->get_post_payload();
+		if ( empty( $payload ) ) {
+			return;
+		}
+		$this->report_client_data( $payload );
+		$this->respond();
+	}
+
+	/**
+	 * Handle reporting client data – e.g. views, dismissals.
+	 *
+	 * @param object $request A request.
+	 */
+	public function report_client_data( $request ) {
+		$client_id   = $this->get_request_param( 'client_id', $request );
+		$client_data = $this->get_client_data( $client_id );
+
+		// Add a donation to client.
+		$donation = $this->get_request_param( 'donation', $request );
+		if ( $donation ) {
+			$client_data['donations'][] = $donation;
+		}
+
+		$this->save_client_data( $client_id, $client_data );
+	}
+}
+new Segmentation_Client_Data();

--- a/api/segmentation/class-segmentation-client-data.php
+++ b/api/segmentation/class-segmentation-client-data.php
@@ -35,16 +35,16 @@ class Segmentation_Client_Data extends Lightweight_API {
 	 * @param object $request A request.
 	 */
 	public function report_client_data( $request ) {
-		$client_id   = $this->get_request_param( 'client_id', $request );
-		$client_data = $this->get_client_data( $client_id );
+		$client_id          = $this->get_request_param( 'client_id', $request );
+		$client_data_update = [];
 
 		// Add a donation to client.
 		$donation = $this->get_request_param( 'donation', $request );
 		if ( $donation ) {
-			$client_data['donations'][] = $donation;
+			$client_data_update['donations'][] = $donation;
 		}
 
-		$this->save_client_data( $client_id, $client_data );
+		$this->save_client_data( $client_id, $client_data_update );
 	}
 }
 new Segmentation_Client_Data();

--- a/api/segmentation/index.php
+++ b/api/segmentation/index.php
@@ -1,0 +1,16 @@
+<?php // phpcs:ignore Squiz.Commenting.FileComment.Missing
+/**
+ * Route Newspack Campaigns API requests based on method.
+ *
+ * @package Newspack
+ */
+
+require_once '../setup.php';
+
+switch ( $_SERVER['REQUEST_METHOD'] ) { //phpcs:ignore
+	case 'POST':
+		include './class-segmentation-client-data.php';
+		break;
+	default:
+		die( "{ error: 'unsupported_method' }" );
+}

--- a/includes/class-newspack-popups-donations.php
+++ b/includes/class-newspack-popups-donations.php
@@ -1,0 +1,147 @@
+<?php
+/**
+ * Newspack Popups Donations
+ *
+ * @package Newspack
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+require_once dirname( __FILE__ ) . '/../api/segmentation/class-segmentation.php';
+
+/**
+ * Main Newspack Popups Donations Class.
+ */
+final class Newspack_Popups_Donations {
+	/**
+	 * The single instance of the class.
+	 *
+	 * @var Newspack_Popups_Donations
+	 */
+	protected static $instance = null;
+
+	/**
+	 * WC-related variables.
+	 */
+	const WC_WEBHOOK_ID = 'newspack_popups_wc_webhook_id';
+
+	/**
+	 * Main Newspack Popups Donations Instance.
+	 * Ensures only one instance of Newspack Popups Donations Instance is loaded or can be loaded.
+	 *
+	 * @return Newspack Popups Donations Instance - Main instance.
+	 */
+	public static function instance() {
+		if ( is_null( self::$instance ) ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		add_action( 'rest_api_init', [ __CLASS__, 'rest_api_init' ] );
+		add_action( 'admin_init', [ __CLASS__, 'create_wc_webhook' ] );
+		add_action( 'woocommerce_checkout_update_order_meta', [ __CLASS__, 'woocommerce_checkout_update_order_meta' ] );
+		add_filter( 'woocommerce_billing_fields', [ __CLASS__, 'woocommerce_billing_fields' ] );
+	}
+
+	/**
+	 * Initialise REST API endpoints.
+	 */
+	public static function rest_api_init() {
+		\register_rest_route(
+			'newspack-popups/v1',
+			'woocommerce-sync',
+			[
+				'methods'             => \WP_REST_Server::EDITABLE,
+				'callback'            => [ __CLASS__, 'api_woocommerce_sync' ],
+				'permission_callback' => '__return_true',
+			]
+		);
+	}
+
+	/**
+	 * Create a WooCommerce webhook.
+	 */
+	public static function create_wc_webhook() {
+		$webhook_id = get_option( self::WC_WEBHOOK_ID, 0 );
+		if ( empty( $webhook_id ) ) {
+			$webhook = new \WC_Webhook();
+			$webhook->set_name( 'Sync to Newspack Popups on order checkout' );
+			$webhook->set_topic( 'order.created' ); // Trigger on checkout.
+			$webhook->set_delivery_url( get_rest_url( null, 'newspack-popups/v1/woocommerce-sync' ) );
+			$webhook->set_status( 'active' );
+			$webhook->set_user_id( get_current_user_id() );
+			$webhook->save();
+			$webhook_id = $webhook->get_id();
+
+			update_option( self::WC_WEBHOOK_ID, $webhook_id );
+		}
+	}
+
+	/**
+	 * Webhook callback handler for syncing WooCommerce data.
+	 *
+	 * @param WP_REST_Request $request Request containing webhook.
+	 */
+	public static function api_woocommerce_sync( $request ) {
+		$wc_order_data = $request->get_params();
+		if ( ! isset( $wc_order_data['id'] ) ) {
+			return;
+		}
+
+		$client_id = get_post_meta( $wc_order_data['id'], Newspack_Popups_Segmentation::NEWSPACK_SEGMENTATION_CID_NAME, true );
+
+		// If there was a donation, update the client data.
+		if ( isset( $client_id ) ) {
+			$client_data_report_endpoint = plugins_url( '../api/segmentation/index.php', __FILE__ );
+			wp_safe_remote_post(
+				$client_data_report_endpoint,
+				[
+					'body' => [
+						'client_id' => $client_id,
+						'donation'  => [
+							'order_id' => $wc_order_data['id'],
+							'date'     => date_format( date_create( $wc_order_data['date_created'] ), 'Y-m-d' ),
+							'amount'   => $wc_order_data['total'],
+						],
+					],
+				]
+			);
+		}
+	}
+
+	/**
+	 * Update WC order with the client id from hidden form field.
+	 *
+	 * @param String $order_id WC order id.
+	 */
+	public static function woocommerce_checkout_update_order_meta( $order_id ) {
+		if ( ! empty( $_POST[ Newspack_Popups_Segmentation::NEWSPACK_SEGMENTATION_CID_NAME ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
+			update_post_meta( $order_id, Newspack_Popups_Segmentation::NEWSPACK_SEGMENTATION_CID_NAME, sanitize_text_field( $_POST[ Newspack_Popups_Segmentation::NEWSPACK_SEGMENTATION_CID_NAME ] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
+		}
+	}
+
+	/**
+	 * Add a hidden billing field with client id.
+	 *
+	 * @param Array $form_fields WC form fields.
+	 */
+	public static function woocommerce_billing_fields( $form_fields ) {
+		$client_id = isset( $_COOKIE[ Newspack_Popups_Segmentation::NEWSPACK_SEGMENTATION_CID_NAME ] ) ? esc_attr( $_COOKIE[ Newspack_Popups_Segmentation::NEWSPACK_SEGMENTATION_CID_NAME ] ) : false; // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+
+		if ( $client_id ) {
+			$form_fields[ Newspack_Popups_Segmentation::NEWSPACK_SEGMENTATION_CID_NAME ] = [
+				'type'    => 'text',
+				'default' => $client_id,
+				'class'   => [ 'hide' ],
+			];
+		}
+
+		return $form_fields;
+	}
+}
+Newspack_Popups_Donations::instance();

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -62,6 +62,7 @@ final class Newspack_Popups {
 		include_once dirname( __FILE__ ) . '/class-newspack-popups-settings.php';
 		include_once dirname( __FILE__ ) . '/class-newspack-popups-segmentation.php';
 		include_once dirname( __FILE__ ) . '/class-newspack-popups-parse-logs.php';
+		include_once dirname( __FILE__ ) . '/class-newspack-popups-donations.php';
 	}
 
 	/**

--- a/tests/test-api.php
+++ b/tests/test-api.php
@@ -404,6 +404,7 @@ class APITest extends WP_UnitTestCase {
 				'suppressed_newsletter_campaign' => false,
 				'posts_read'                     => [],
 				'email_subscriptions'            => [],
+				'donations'                      => [],
 			],
 			'Returns expected data blueprint in absence of saved data.'
 		);
@@ -428,6 +429,7 @@ class APITest extends WP_UnitTestCase {
 				'suppressed_newsletter_campaign' => false,
 				'posts_read'                     => $posts_read,
 				'email_subscriptions'            => [],
+				'donations'                      => [],
 			],
 			'Returns data with saved post after an article reading was reported.'
 		);
@@ -446,6 +448,7 @@ class APITest extends WP_UnitTestCase {
 				'posts_read'                     => $posts_read,
 				'email_subscriptions'            => [],
 				'some_other_data'                => 42,
+				'donations'                      => [],
 			],
 			'Returns data without overwriting the existing data.'
 		);
@@ -470,6 +473,7 @@ class APITest extends WP_UnitTestCase {
 				'suppressed_newsletter_campaign' => false,
 				'posts_read'                     => [],
 				'email_subscriptions'            => [],
+				'donations'                      => [],
 			],
 			'The initial client data has expected shape.'
 		);
@@ -490,6 +494,7 @@ class APITest extends WP_UnitTestCase {
 			[
 				'suppressed_newsletter_campaign' => false,
 				'posts_read'                     => [],
+				'donations'                      => [],
 				'email_subscriptions'            => [
 					[
 						'email' => $email_address,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Save WC order data as donation.

Related: #249

### How to test the changes in this Pull Request:

1. Make a donation on site
2. Check the options table for client data (use the `newspack-cid` cookie value)
3. Observe the donation data was saved

_Note: you might need to bypass HTTPS check on a local instance, to make WC webhook succeed:_

```
add_filter(
	'http_request_args',
	function ( $r ) {
		$r['sslverify'] = false;
		return $r;
	}
);
```

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
