### PR TITLE
Report reader frequency as custom dimension to GA

### DIFF
--- a/api/campaigns/class-maybe-show-campaign.php
+++ b/api/campaigns/class-maybe-show-campaign.php
@@ -47,6 +47,7 @@ class Maybe_Show_Campaign extends Lightweight_API {
 				$posts_read[] = [
 					'post_id'      => $visit['post_id'],
 					'category_ids' => $visit['categories'],
+					'date'         => gmdate( 'Y-m-d' ),
 				];
 				$this->save_client_data(
 					$client_id,

--- a/api/segmentation/class-report-client-data.php
+++ b/api/segmentation/class-report-client-data.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Newspack Campaigns report campaign data.
+ *
+ * @package Newspack
+ */
+
+/**
+ * Extend the base Lightweight_API class.
+ */
+require_once dirname( __FILE__ ) . '/../classes/class-lightweight-api.php';
+
+/**
+ * POST endpoint to report campaign data.
+ */
+class Report_Client_Data extends Lightweight_API {
+
+	/**
+	 * Constructor.
+	 *
+	 * @codeCoverageIgnore
+	 */
+	public function __construct() {
+		parent::__construct();
+		if ( isset( $_REQUEST['cid'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+			$response = [
+				'f' => self::get_client_reading_frequency( $_REQUEST['cid'] ), // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+			];
+		}
+		$this->response = $response;
+		$this->respond();
+	}
+
+	/**
+	 * Handle reporting campaign data – e.g. views, dismissals.
+	 *
+	 * @param object $client_id Client ID.
+	 */
+	public function get_client_reading_frequency( $client_id ) {
+		$period_ago_date      = date( 'Y-m-d', strtotime( '-1 months' ) ); // phpcs:ignore WordPress.DateTime.RestrictedFunctions.date_date
+		$posts_read           = self::get_client_data( $client_id )['posts_read'];
+		$posts_in_last_period = array_filter(
+			$posts_read,
+			function ( $item ) use ( $period_ago_date ) {
+				return $item['date'] >= $period_ago_date;
+			}
+		);
+		$read_count           = count( $posts_in_last_period );
+
+		// NCI-inspired tiers, but we may opt for more fine-grained Memberkit-inspired tiers.
+		if ( $read_count > 1 && $read_count <= 14 ) {
+			return 'loyal';
+		} elseif ( $read_count > 14 ) {
+			return 'brand_lover';
+		}
+		return 'casual';
+	}
+}
+new Report_Client_Data();

--- a/api/segmentation/class-segmentation-report.php
+++ b/api/segmentation/class-segmentation-report.php
@@ -22,7 +22,7 @@ class Segmentation_Report {
 				[
 					'post_read',
 					$payload['clientId'],
-					isset( $payload['date'] ) ? $payload['date'] : gmdate( 'Y-m-d', time() ),
+					isset( $payload['date'] ) ? $payload['date'] : gmdate( 'Y-m-d' ),
 					$payload['post_id'],
 					$payload['categories'],
 				]

--- a/api/segmentation/class-segmentation.php
+++ b/api/segmentation/class-segmentation.php
@@ -12,28 +12,6 @@ defined( 'ABSPATH' ) || exit;
  */
 class Segmentation {
 	/**
-	 * Get client's read posts.
-	 *
-	 * @param string $client_id Client ID.
-	 */
-	public static function get_client_read_posts( $client_id ) {
-		global $wpdb;
-		$events_table_name = self::get_events_table_name();
-		$clients_events    = $wpdb->get_results( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-			$wpdb->prepare( "SELECT * FROM $events_table_name WHERE client_id = %s AND type = 'post_read'", $client_id ) // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-		);
-		return array_map(
-			function ( $item ) {
-				return [
-					'post_id'      => $item->post_id,
-					'category_ids' => $item->category_ids,
-				];
-			},
-			$clients_events
-		);
-	}
-
-	/**
 	 * Get log file path.
 	 */
 	public static function get_log_file_path() {

--- a/api/segmentation/index.php
+++ b/api/segmentation/index.php
@@ -1,0 +1,16 @@
+<?php // phpcs:ignore Squiz.Commenting.FileComment.Missing
+/**
+ * Route Newspack Campaigns API requests based on method.
+ *
+ * @package Newspack
+ */
+
+require_once '../setup.php';
+
+switch ( $_SERVER['REQUEST_METHOD'] ) { //phpcs:ignore
+	case 'GET':
+		include './class-report-client-data.php';
+		break;
+	default:
+		die( "{ error: 'unsupported_method' }" );
+}

--- a/tests/test-segmentation.php
+++ b/tests/test-segmentation.php
@@ -131,6 +131,7 @@ class SegmentationTest extends WP_UnitTestCase {
 			[
 				'post_id'      => self::$post_read_payload['post_id'],
 				'category_ids' => self::$post_read_payload['categories'],
+				'date'         => gmdate( 'Y-m-d' ),
 			],
 			$read_posts[0],
 			'The read posts array contains the reported post.'


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #259

### How to test the changes in this Pull Request:

1. In `newspack-plugin` repo, use branch of PR https://github.com/Automattic/newspack-plugin/pull/685
1. In Newspack plugin's Analytics Wizard, create a new custom dimension and set its role to "Reader frequency"
2. Visit an article as a non-logged-in user, observe that a custom dimension is being sent* to GA with the value `casual`
3. Visit another article, observe the dimension's value is `loyal`
4. Visit at least 12 other articles, observe the dimension's value is now `brand_lover` 

/* In network tab of devtools, filter for `collect` request and look at the params

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
