### PR TITLE
Fix: check of WC-related class exists

### DIFF
--- a/includes/class-newspack-popups-donations.php
+++ b/includes/class-newspack-popups-donations.php
@@ -67,6 +67,9 @@ final class Newspack_Popups_Donations {
 	 * Create a WooCommerce webhook.
 	 */
 	public static function create_wc_webhook() {
+		if ( ! class_exists( 'WC_Webhook' ) ) {
+			return;
+		}
 		$webhook_id = get_option( self::WC_WEBHOOK_ID, 0 );
 		if ( empty( $webhook_id ) ) {
 			$webhook = new \WC_Webhook();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

On a site with no WooCommerce plugin, this plugin breaks. This fixes it.

### How to test the changes in this Pull Request:

1. Install the plugin from branch `master` on a site with no WooCommerce plugin installed
2. Observe the admin panel does not load
3. Install the plugin from this branch
4. Observe the admin panel works as expected

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
