### PR TITLE
fix: add posts_read array to legacy client data

### DIFF
--- a/api/classes/class-lightweight-api.php
+++ b/api/classes/class-lightweight-api.php
@@ -205,6 +205,10 @@ class Lightweight_API {
 	public function get_client_data( $client_id, $do_not_rebuild = false ) {
 		$data = $this->get_transient( $this->get_transient_name( $client_id ) );
 		if ( $data ) {
+			// Handle legacy data without the posts_read array.
+			if ( ! isset( $data['posts_read'] ) ) {
+				$data['posts_read'] = [];
+			}
 			return $data;
 		}
 		if ( $do_not_rebuild ) {

--- a/api/classes/class-lightweight-api.php
+++ b/api/classes/class-lightweight-api.php
@@ -205,11 +205,11 @@ class Lightweight_API {
 	public function get_client_data( $client_id, $do_not_rebuild = false ) {
 		$data = $this->get_transient( $this->get_transient_name( $client_id ) );
 		if ( $data ) {
-			// Handle legacy data without the posts_read array.
-			if ( ! isset( $data['posts_read'] ) ) {
-				$data['posts_read'] = [];
-			}
-			return $data;
+			// Handle legacy data which might not have some default keys.
+			return array_merge(
+				$this->client_data_blueprint,
+				$data
+			);
 		}
 		if ( $do_not_rebuild ) {
 			return $this->client_data_blueprint;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fixes issue that causes the following warnings to be logged:

```
[27-Oct-2020 19:23:08 UTC] PHP Warning:  array_filter() expects parameter 1 to be array, null given in /wordpress/plugins/newspack-popups/1.15.0/api/campaigns/class-maybe-show-campaign.php on line 42
[27-Oct-2020 19:23:08 UTC] PHP Warning:  count(): Parameter must be an array or an object that implements Countable in /wordpress/plugins/newspack-popups/1.15.0/api/campaigns/class-maybe-show-campaign.php on line 42
```

### How to test the changes in this Pull Request:

1. On `master` visit front end in an incognito browser. Make note of the `cid` in the API request.
2. In the options table, edit the transient for the current `cid`, and remove the `posts_read` array, so it looks something like this: ```{"suppressed_newsletter_campaign":false}```
3. Visit another page, observe warnings in the log file.
4. Switch to this branch, repeat the above steps. Observe no warnings.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
