### PR TITLE
Donation campaigns suppression

### DIFF
--- a/api/campaigns/class-maybe-show-campaign.php
+++ b/api/campaigns/class-maybe-show-campaign.php
@@ -155,6 +155,19 @@ class Maybe_Show_Campaign extends Lightweight_API {
 			$campaign_data['suppress_forever'] = true;
 		}
 
+		$has_donated        = count( $client_data['donations'] ) > 0;
+		$has_donation_block = $campaign->d;
+
+		// Handle suppressing a donation campaign if reader is a donor and appropriate setting is active.
+		if (
+			$has_donation_block &&
+			$settings->suppress_donation_campaigns_if_donor &&
+			$has_donated
+		) {
+			$should_display                    = false;
+			$campaign_data['suppress_forever'] = true;
+		}
+
 		if ( ! empty( array_diff( $init_campaign_data, $campaign_data ) ) ) {
 			$this->save_campaign_data( $client_id, $campaign->id, $campaign_data );
 		}

--- a/api/segmentation/class-segmentation-client-data.php
+++ b/api/segmentation/class-segmentation-client-data.php
@@ -44,7 +44,9 @@ class Segmentation_Client_Data extends Lightweight_API {
 			$client_data_update['donations'][] = $donation;
 		}
 
-		$this->save_client_data( $client_id, $client_data_update );
+		if ( ! empty( $client_data_update ) ) {
+			$this->save_client_data( $client_id, $client_data_update );
+		}
 	}
 }
 new Segmentation_Client_Data();

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -336,6 +336,7 @@ final class Newspack_Popups_Inserter {
 			'f'   => $frequency,
 			'utm' => $popup['options']['utm_suppression'],
 			'n'   => \Newspack_Popups_Model::has_newsletter_prompt( $popup ),
+			'd'   => \Newspack_Popups_Model::has_donation_block( $popup ),
 		];
 	}
 

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -436,6 +436,16 @@ final class Newspack_Popups_Model {
 	}
 
 	/**
+	 * Does the popup have a donation block?
+	 *
+	 * @param object $popup The popup object.
+	 * @return boolean True if popup has a donation block.
+	 */
+	public static function has_donation_block( $popup ) {
+		return false !== strpos( $popup['content'], 'wp:newspack-blocks/donate' );
+	}
+
+	/**
 	 * Insert amp-analytics tracking code.
 	 *
 	 * @param object $popup The popup object.

--- a/includes/class-newspack-popups-settings.php
+++ b/includes/class-newspack-popups-settings.php
@@ -51,6 +51,7 @@ class Newspack_Popups_Settings {
 		return [
 			'suppress_newsletter_campaigns'            => get_option( 'suppress_newsletter_campaigns', true ),
 			'suppress_all_newsletter_campaigns_if_one_dismissed' => get_option( 'suppress_all_newsletter_campaigns_if_one_dismissed', true ),
+			'suppress_donation_campaigns_if_donor'     => get_option( 'suppress_donation_campaigns_if_donor', false ),
 			'newspack_newsletters_non_interative_mode' => self::is_non_interactive(),
 		];
 	}

--- a/src/settings/index.js
+++ b/src/settings/index.js
@@ -60,6 +60,15 @@ const App = () => {
 					onChange={ handleSettingChange( 'suppress_all_newsletter_campaigns_if_one_dismissed' ) }
 				/>
 				<CheckboxControl
+					label={ __(
+						'Suppress all donation campaigns if the reader has donated.',
+						'newspack-popups'
+					) }
+					disabled={ inFlight }
+					checked={ settings.suppress_donation_campaigns_if_donor === '1' }
+					onChange={ handleSettingChange( 'suppress_donation_campaigns_if_donor' ) }
+				/>
+				<CheckboxControl
 					label={ __( 'Enable non-interactive mode.', 'newspack-popups' ) }
 					help={ __(
 						'Use this setting in high traffic scenarios. No API requests will be made, reducing server load. Inline campaigns will be shown to all users without dismissal buttons, and overlay campaigns will be suppressed.',

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -28,6 +28,7 @@ function _manually_load_plugin() {
 	require dirname( dirname( __FILE__ ) ) . '/newspack-popups.php';
 	require dirname( dirname( __FILE__ ) ) . '/api/campaigns/class-maybe-show-campaign.php';
 	require dirname( dirname( __FILE__ ) ) . '/api/campaigns/class-report-campaign-data.php';
+	require dirname( dirname( __FILE__ ) ) . '/api/segmentation/class-segmentation-client-data.php';
 }
 tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

The setting to hide donation campaigns for donors is off by default, because I assume some sites might want to enable repeated donation. That's open for discussion, though. 

Closes #141.

### How to test the changes in this Pull Request:

1. Create a campaign with a donation block 
2. In the plugin settings, check "Suppress all donation campaigns if the reader has donated." setting
3. Visit the site and donate using the donation block on the campaign
4. Wait for about a minute, WC has to notify the plugin about the donation

Note: you might need to disable SSL checking on a local instance:
```
add_filter(
	'http_request_args',
	function ( $r ) {
		$r['sslverify'] = false;
		return $r;
	}
);
```

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
