### PR TITLE
fix: allow only one overlay campaign per page

### DIFF
--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -80,10 +80,28 @@ final class Newspack_Popups_Inserter {
 			}
 		}
 
-		$popups_to_display = array_filter(
+		// Allow only one overlay campaign.
+		$has_overlay                     = false;
+		$popups_to_maybe_display_deduped = array_filter(
 			$popups_to_maybe_display,
+			function ( $campaign ) use ( &$has_overlay ) {
+				if ( 'inline' !== $campaign['options']['placement'] ) {
+					if ( $has_overlay ) {
+						return false;
+					} else {
+						$has_overlay = true;
+						return true;
+					}
+				}
+				return true;
+			}
+		);
+
+		$popups_to_display = array_filter(
+			$popups_to_maybe_display_deduped,
 			[ __CLASS__, 'should_display' ]
 		);
+
 		if ( ! empty( $popups_to_display ) ) {
 			return $popups_to_display;
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Recent changes to the handling of Test Mode campaigns introduced two issues related to overlays:

- If there is a sitewide default campaign a logged in user will get two instances of the same popup layered on top of each other.
- If there are multiple popups a logged in user may get two overlapping popups. 
- Anonymous users won't have either of these problems, so this is purely an issue for site editors.

This PR addresses the problem by retaining only the first overlay campaign from all candidates. This may not be a perfect solution, as an admin may see an overlay that isn't the expected one, but for now this resolves the obvious problem. 

### How to test the changes in this Pull Request:

1. On `master`, create and publish a single overlay campaign, Sitewide default.
2. View a page on the site (logged in). Observe two versions of the overlay are stacked on top of each other (you will need to click the dismissal button twice). 
3. Create a second overlay campaign assigning a Category. 
4. Visit a post in that category (logged in). Observe both popups appear.
5. Switch to this branch and repeat. Observe only one overlay appears in either case.
6. Verify no change to the test mode display of Inline campaigns. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
