### PR TITLE
Add posts read count segmentation

### DIFF
--- a/api/campaigns/class-maybe-show-campaign.php
+++ b/api/campaigns/class-maybe-show-campaign.php
@@ -168,6 +168,23 @@ class Maybe_Show_Campaign extends Lightweight_API {
 			$campaign_data['suppress_forever'] = true;
 		}
 
+		// Handle segmentation.
+		$campaign_segment = isset( $settings->all_segments->{$campaign->s} ) ? $settings->all_segments->{$campaign->s} : false;
+		if ( ! empty( $campaign_segment ) ) {
+			$client_data      = $this->get_client_data( $client_id );
+			$posts_read_count = count( $client_data['posts_read'] );
+			if (
+				$campaign_segment->min_posts > 0 && $campaign_segment->min_posts > $posts_read_count
+			) {
+				$should_display = false;
+			}
+			if (
+				$campaign_segment->max_posts > 0 && $campaign_segment->max_posts < $posts_read_count
+			) {
+				$should_display = false;
+			}
+		}
+
 		if ( ! empty( array_diff( $init_campaign_data, $campaign_data ) ) ) {
 			$this->save_campaign_data( $client_id, $campaign->id, $campaign_data );
 		}

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -353,6 +353,7 @@ final class Newspack_Popups_Inserter {
 			'id'  => $popup_id_string,
 			'f'   => $frequency,
 			'utm' => $popup['options']['utm_suppression'],
+			's'   => $popup['options']['selected_segment_id'],
 			'n'   => \Newspack_Popups_Model::has_newsletter_prompt( $popup ),
 			'd'   => \Newspack_Popups_Model::has_donation_block( $popup ),
 		];

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -166,6 +166,7 @@ final class Newspack_Popups_Model {
 					update_post_meta( $id, $key, $value );
 					break;
 				case 'utm_suppression':
+				case 'selected_segment_id':
 					update_post_meta( $id, $key, esc_attr( $value ) );
 					break;
 				default:

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -348,6 +348,7 @@ final class Newspack_Popups_Model {
 			'trigger_delay'           => get_post_meta( $id, 'trigger_delay', true ),
 			'trigger_scroll_progress' => get_post_meta( $id, 'trigger_scroll_progress', true ),
 			'utm_suppression'         => get_post_meta( $id, 'utm_suppression', true ),
+			'selected_segment_id'     => get_post_meta( $id, 'selected_segment_id', true ),
 		];
 
 		$popup = [
@@ -369,6 +370,7 @@ final class Newspack_Popups_Model {
 					'trigger_delay'           => 0,
 					'trigger_scroll_progress' => 0,
 					'utm_suppression'         => null,
+					'selected_segment_id'     => '',
 				]
 			),
 		];

--- a/includes/class-newspack-popups-segmentation.php
+++ b/includes/class-newspack-popups-segmentation.php
@@ -31,6 +31,11 @@ final class Newspack_Popups_Segmentation {
 	const NEWSPACK_SEGMENTATION_CID_LINKER_PARAM = 'ref_newspack_cid';
 
 	/**
+	 * Name of the option to store segments under.
+	 */
+	const SEGMENTS_OPTION_NAME = 'newspack_popups_segments';
+
+	/**
 	 * Main Newspack Segmentation Plugin Instance.
 	 * Ensures only one instance of Newspack Segmentation Plugin Instance is loaded or can be loaded.
 	 *
@@ -180,5 +185,64 @@ final class Newspack_Popups_Segmentation {
 		}
 	}
 
+	/**
+	 * Get all configured segments.
+	 */
+	public static function get_segments() {
+		return get_option( self::SEGMENTS_OPTION_NAME, [] );
+	}
+
+	/**
+	 * Create a segment.
+	 *
+	 * @param object $segment A segment.
+	 */
+	public static function create_segment( $segment ) {
+		$segments              = self::get_segments();
+		$segment['id']         = uniqid();
+		$segment['created_at'] = gmdate( 'Y-m-d' );
+		$segment['updated_at'] = gmdate( 'Y-m-d' );
+		$segments[]            = $segment;
+
+		update_option( self::SEGMENTS_OPTION_NAME, $segments );
+		return self::get_segments();
+	}
+
+	/**
+	 * Delete a segment.
+	 *
+	 * @param string $id A segment id.
+	 */
+	public static function delete_segment( $id ) {
+		$segments = array_values(
+			array_filter(
+				self::get_segments(),
+				function( $segment ) use ( $id ) {
+					return $segment['id'] !== $id;
+				}
+			)
+		);
+		update_option( self::SEGMENTS_OPTION_NAME, $segments );
+		return self::get_segments();
+	}
+
+	/**
+	 * Update a segment.
+	 *
+	 * @param object $segment A segment.
+	 */
+	public static function update_segment( $segment ) {
+		$segments              = self::get_segments();
+		$segment['updated_at'] = gmdate( 'Y-m-d' );
+		foreach ( $segments as &$_segment ) {
+			if ( $_segment['id'] === $segment['id'] ) {
+				$_segment['name']          = $segment['name'];
+				$_segment['configuration'] = $segment['configuration'];
+			}
+		}
+
+		update_option( self::SEGMENTS_OPTION_NAME, $segments );
+		return self::get_segments();
+	}
 }
 Newspack_Popups_Segmentation::instance();

--- a/includes/class-newspack-popups-settings.php
+++ b/includes/class-newspack-popups-settings.php
@@ -53,6 +53,14 @@ class Newspack_Popups_Settings {
 			'suppress_all_newsletter_campaigns_if_one_dismissed' => get_option( 'suppress_all_newsletter_campaigns_if_one_dismissed', true ),
 			'suppress_donation_campaigns_if_donor'     => get_option( 'suppress_donation_campaigns_if_donor', false ),
 			'newspack_newsletters_non_interative_mode' => self::is_non_interactive(),
+			'all_segments'                             => array_reduce(
+				Newspack_Popups_Segmentation::get_segments(),
+				function( $acc, $item ) {
+					$acc[ $item['id'] ] = $item['configuration'];
+					return $acc;
+				},
+				[]
+			),
 		];
 	}
 

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -232,6 +232,18 @@ final class Newspack_Popups {
 			]
 		);
 
+		\register_meta(
+			'post',
+			'selected_segment_id',
+			[
+				'object_subtype' => self::NEWSPACK_PLUGINS_CPT,
+				'show_in_rest'   => true,
+				'type'           => 'string',
+				'single'         => true,
+				'auth_callback'  => '__return_true',
+			]
+		);
+
 		// Meta field for all post types.
 		\register_meta(
 			'post',
@@ -301,6 +313,7 @@ final class Newspack_Popups {
 			'newspack_popups_data',
 			[
 				'preview_post' => $preview_post_permalink,
+				'segments'     => Newspack_Popups_Segmentation::get_segments(),
 			]
 		);
 		\wp_enqueue_style(
@@ -415,6 +428,7 @@ final class Newspack_Popups {
 		update_post_meta( $post_id, 'trigger_delay', 3 );
 		update_post_meta( $post_id, 'trigger_scroll_progress', 30 );
 		update_post_meta( $post_id, 'utm_suppression', '' );
+		update_post_meta( $post_id, 'selected_segment_id', '' );
 	}
 
 	/**

--- a/src/editor/index.js
+++ b/src/editor/index.js
@@ -21,6 +21,9 @@ import { registerPlugin } from '@wordpress/plugins';
 import { PluginDocumentSettingPanel, PluginPostStatusInfo } from '@wordpress/edit-post';
 import { ColorPaletteControl } from '@wordpress/block-editor';
 
+const segmentsList =
+	( window && window.newspack_popups_data && window.newspack_popups_data.segments ) || [];
+
 /**
  * Internal dependencies
  */
@@ -56,6 +59,7 @@ class PopupSidebar extends Component {
 			trigger_delay,
 			trigger_type,
 			utm_suppression,
+			selected_segment_id,
 			onSitewideDefaultChange,
 		} = this.props;
 		const isInline = 'inline' === placement;
@@ -79,6 +83,21 @@ class PopupSidebar extends Component {
 						} }
 					/>
 				) }
+				<SelectControl
+					label={ __( 'Segment' ) }
+					value={ selected_segment_id }
+					onChange={ value => onMetaFieldChange( 'selected_segment_id', value ) }
+					options={ [
+						{
+							value: '',
+							label: __( 'All readers', 'newspack-popups' ),
+						},
+						...segmentsList.map( segment => ( {
+							value: segment.id,
+							label: segment.name,
+						} ) ),
+					] }
+				/>
 				<SelectControl
 					label={ __( 'Placement' ) }
 					value={ placement }

--- a/src/editor/utils.js
+++ b/src/editor/utils.js
@@ -18,6 +18,7 @@ export const optionsFieldsSelector = select => {
 		trigger_delay,
 		trigger_type,
 		utm_suppression,
+		selected_segment_id,
 	} = meta || {};
 	return {
 		background_color,
@@ -34,6 +35,7 @@ export const optionsFieldsSelector = select => {
 		trigger_delay,
 		trigger_type,
 		utm_suppression,
+		selected_segment_id,
 	};
 };
 

--- a/tests/test-model.php
+++ b/tests/test-model.php
@@ -40,6 +40,7 @@ class ModelTest extends WP_UnitTestCase {
 				'trigger_delay'           => '3',
 				'trigger_scroll_progress' => 0,
 				'utm_suppression'         => null,
+				'selected_segment_id'     => '',
 			],
 			'Default options are as expected.'
 		);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #271.

### How to test the changes in this Pull Request:

1. In `newspack-plugin`, switch to `add/segmentation-ui` branch
2. Observe a new tab in the Campaigns wizard – "Segmentation"
3. Create a segment with minimum read articles count of 3 and maximum of 5
4. Create a campaign, observe a new select in the sidebar – "Segment"
5. Choose the newly created segment and publish the campaign
6. Observe that the campaign is shown only when reading the 3rd, 4th, and 5th article
7. Experiment a bit more with segments (e.g. remove a segment after a campaign was assigned one, try different configurations of min. and max. articles read count)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
