### PR TITLE
Handle MC4WP forms when assessing if campaign has newsletter form

### DIFF
--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -432,7 +432,10 @@ final class Newspack_Popups_Model {
 	 * @return boolean True if popup has a newsletter prompt.
 	 */
 	public static function has_newsletter_prompt( $popup ) {
-		return false !== strpos( $popup['content'], 'wp:jetpack/mailchimp' );
+		return (
+			false !== strpos( $popup['content'], 'wp:jetpack/mailchimp' ) ||
+			false !== strpos( $popup['content'], 'wp:mailchimp-for-wp/form' )
+		);
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a small issue

### How to test the changes in this Pull Request:

1. On `master`,
1. Create two inline campaigns with newsletter signup forms – one with MC4WP form, other with Jetpack form
2. Visit an article with the `utm_medium=email` param in URL
3. Ensure the "Suppress Newsletter campaigns if visitor is coming from email." setting is on
4. Observe that only the Jetpack-form campaign is hidden
5. Switch to this branch and observe that both campaigns are hidden

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
