### PR TITLE
Improve preview post link

### DIFF
--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -246,6 +246,34 @@ final class Newspack_Popups {
 	}
 
 	/**
+	 * Get preview post permalink.
+	 */
+	public static function preview_post_permalink() {
+		$query        = new WP_Query(
+			[
+				'posts_per_page' => 1,
+				'post_status'    => 'publish',
+				'has_password'   => false,
+				'orderby'        => 'post_date',
+				'order'          => 'DESC',
+				'meta_query'     => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+					'relation' => 'OR',
+					[
+						'key'     => 'newspack_popups_has_disabled_popups',
+						'compare' => 'NOT EXISTS',
+					],
+					[
+						'key'   => 'newspack_popups_has_disabled_popups',
+						'value' => '',
+					],
+				],
+			]
+		);
+		$recent_posts = $query->get_posts();
+		return $recent_posts && count( $recent_posts ) > 0 ? get_the_permalink( $recent_posts[0] ) : '';
+	}
+
+	/**
 	 * Load up common JS/CSS for wizards.
 	 */
 	public static function enqueue_block_editor_assets() {
@@ -274,33 +302,11 @@ final class Newspack_Popups {
 			true
 		);
 
-		$query                  = new WP_Query(
-			[
-				'posts_per_page' => 1,
-				'post_status'    => 'publish',
-				'orderby'        => 'post_date',
-				'order'          => 'DESC',
-				'meta_query'     => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
-					'relation' => 'OR',
-					[
-						'key'     => 'newspack_popups_has_disabled_popups',
-						'compare' => 'NOT EXISTS',
-					],
-					[
-						'key'   => 'newspack_popups_has_disabled_popups',
-						'value' => '',
-					],
-				],
-			]
-		);
-		$recent_posts           = $query->get_posts();
-		$preview_post_permalink = $recent_posts && count( $recent_posts ) > 0 ? get_the_permalink( $recent_posts[0] ) : '';
-
 		\wp_localize_script(
 			'newspack-popups',
 			'newspack_popups_data',
 			[
-				'preview_post' => $preview_post_permalink,
+				'preview_post' => self::preview_post_permalink(),
 			]
 		);
 		\wp_enqueue_style(


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds a password check to preview post getting. 

### How to test the changes in this Pull Request:

1. Make the most recent post password-protected
2. On `master`, observe that the campaign preview will use homepage for previews
3. Switch to this branch, observe that the campaign preview will use the most recent not-password-protected post

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
