### PR TITLE
Add above header placement option

### DIFF
--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -242,6 +242,9 @@ final class Newspack_Popups_Inserter {
 				$overlay_popups[] = $popup;
 			}
 		}
+		if ( empty( $inline_popups ) && empty( $overlay_popups ) ) {
+			return $content;
+		}
 
 		// 2. Iterate overall blocks and insert inline campaigns.
 		$pos    = 0;

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -30,9 +30,10 @@ final class Newspack_Popups_Inserter {
 	/**
 	 * Retrieve the appropriate popups for the current post.
 	 *
+	 * @param bool $skip_above_header Skip above header placement popups.
 	 * @return array Popup objects.
 	 */
-	public static function popups_for_post() {
+	public static function popups_for_post( $skip_above_header = false ) {
 		if ( ! empty( self::$popups ) ) {
 			return self::$popups;
 		}
@@ -43,10 +44,13 @@ final class Newspack_Popups_Inserter {
 		}
 
 		// 1. Get all inline, above header popups.
-		$popups_to_maybe_display = array_merge(
-			Newspack_Popups_Model::retrieve_inline_popups(),
-			Newspack_Popups_Model::retrieve_above_header_popups()
-		);
+		$popups_to_maybe_display = Newspack_Popups_Model::retrieve_inline_popups();
+		if ( false === $skip_above_header ) {
+			$popups_to_maybe_display = array_merge(
+				$popups_to_maybe_display,
+				Newspack_Popups_Model::retrieve_above_header_popups()
+			);
+		}
 
 		// 2. Get the overlay popup/s. There can be only one displayed, unless in test mode.
 
@@ -285,7 +289,7 @@ final class Newspack_Popups_Inserter {
 			return;
 		}
 
-		$popups = self::popups_for_post();
+		$popups = self::popups_for_post( true );
 
 		if ( ! empty( $popups ) ) {
 			foreach ( $popups as $popup ) {

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -43,6 +43,11 @@ final class Newspack_Popups_Inserter {
 			return [ Newspack_Popups_Model::retrieve_preview_popup( Newspack_Popups::previewed_popup_id() ) ];
 		}
 
+		// Campaigns disabled for this page.
+		if ( self::assess_has_disabled_popups() ) {
+			return [];
+		}
+
 		// 1. Get all inline, above header popups.
 		$popups_to_maybe_display = Newspack_Popups_Model::retrieve_inline_popups();
 		if ( false === $skip_above_header ) {
@@ -192,11 +197,6 @@ final class Newspack_Popups_Inserter {
 
 		// If not in the loop, ignore.
 		if ( ! in_the_loop() ) {
-			return $content;
-		}
-
-		// Campaigns disabled for this page.
-		if ( self::assess_has_disabled_popups() ) {
 			return $content;
 		}
 

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -242,6 +242,8 @@ final class Newspack_Popups_Inserter {
 				$overlay_popups[] = $popup;
 			}
 		}
+
+		// Return early if there are no popups to insert. This can happen if e.g. the only popup is an above header one.
 		if ( empty( $inline_popups ) && empty( $overlay_popups ) ) {
 			return $content;
 		}

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -11,6 +11,12 @@ defined( 'ABSPATH' ) || exit;
  * API endpoints
  */
 final class Newspack_Popups_Model {
+	/**
+	 * Possible placements of overlay popups.
+	 *
+	 * @var array
+	 */
+	protected static $overlay_placements = [ 'top', 'bottom', 'center' ];
 
 	/**
 	 * Retrieve all Popups (first 100).
@@ -31,7 +37,7 @@ final class Newspack_Popups_Model {
 		foreach ( $popups as &$popup ) {
 			// UI will not allow for setting inline as sitewide default, but there may be
 			// legacy popups from before this update.
-			if ( 'inline' !== $popup['options']['placement'] ) {
+			if ( self::is_overlay( $popup ) ) {
 				$popup['sitewide_default'] = absint( $sitewide_default_id ) === absint( $popup['id'] );
 			}
 		}
@@ -57,7 +63,7 @@ final class Newspack_Popups_Model {
 		}
 
 		// Such update will not be permitted by the UI, but it's handled just to be explicit about it.
-		if ( 'inline' === $popup['options']['placement'] ) {
+		if ( self::is_inline( $popup ) ) {
 			return new \WP_Error(
 				'newspack_popups_inline_sitewide',
 				esc_html__( 'An inline Campaign cannot be a sitewide default.', 'newspack-popups' ),
@@ -153,7 +159,7 @@ final class Newspack_Popups_Model {
 					update_post_meta( $id, $key, $value );
 					break;
 				case 'placement':
-					if ( ! in_array( $value, [ 'center', 'top', 'bottom', 'inline' ] ) ) {
+					if ( ! in_array( $value, array_merge( self::$overlay_placements, [ 'inline', 'above_header' ] ) ) ) {
 						return new \WP_Error(
 							'newspack_popups_invalid_option_value',
 							esc_html__( 'Invalid placement value.', 'newspack-popups' ),
@@ -210,8 +216,8 @@ final class Newspack_Popups_Model {
 			'meta_query'  => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 				[
 					'key'     => 'placement',
-					'value'   => 'inline',
-					'compare' => '!=',
+					'value'   => self::$overlay_placements,
+					'compare' => 'IN',
 				],
 				[
 					'key'   => 'frequency',
@@ -242,12 +248,30 @@ final class Newspack_Popups_Model {
 			'category__in'   => array_column( $post_categories, 'term_id' ),
 			'meta_key'       => 'placement',
 			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
-			'meta_value'     => 'inline',
-			'meta_compare'   => '!=',
+			'meta_value'     => self::$overlay_placements,
+			'meta_compare'   => 'IN',
 		];
 
 		$popups = self::retrieve_popups_with_query( new WP_Query( $args ) );
 		return count( $popups ) > 0 ? $popups[0] : null;
+	}
+
+	/**
+	 * Retrieve above header popups.
+	 *
+	 * @return array Popup objects.
+	 */
+	public static function retrieve_above_header_popups() {
+		$args = [
+			'post_type'    => Newspack_Popups::NEWSPACK_PLUGINS_CPT,
+			'post_status'  => 'publish',
+			'meta_key'     => 'placement',
+			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+			'meta_value'   => 'above_header',
+			'meta_compare' => '=',
+		];
+
+		return self::retrieve_popups_with_query( new WP_Query( $args ) );
 	}
 
 	/**
@@ -380,18 +404,21 @@ final class Newspack_Popups_Model {
 			return $popup;
 		}
 
-		switch ( $popup['options']['trigger_type'] ) {
-			case 'scroll':
-				$popup['options']['trigger_delay'] = 0;
-				break;
-			case 'time':
-			default:
-				$popup['options']['trigger_scroll_progress'] = 0;
-				break;
-		};
-		if ( ! in_array( $popup['options']['placement'], [ 'top', 'bottom' ], true ) ) {
-			$popup['options']['placement'] = 'center';
+		if ( self::is_overlay( $popup ) ) {
+			switch ( $popup['options']['trigger_type'] ) {
+				case 'scroll':
+					$popup['options']['trigger_delay'] = 0;
+					break;
+				case 'time':
+				default:
+					$popup['options']['trigger_scroll_progress'] = 0;
+					break;
+			};
+			if ( ! in_array( $popup['options']['placement'], [ 'top', 'bottom' ], true ) ) {
+				$popup['options']['placement'] = 'center';
+			}
 		}
+
 		return $popup;
 	}
 
@@ -422,7 +449,23 @@ final class Newspack_Popups_Model {
 	 * @return boolean True if it is an inline popup.
 	 */
 	public static function is_inline( $popup ) {
+		if ( ! isset( $popup['options'], $popup['options']['placement'] ) ) {
+			return false;
+		}
 		return 'inline' === $popup['options']['placement'];
+	}
+
+	/**
+	 * Is it an overlay popup or not.
+	 *
+	 * @param object $popup The popup object.
+	 * @return boolean True if it is an overlay popup.
+	 */
+	public static function is_overlay( $popup ) {
+		if ( ! isset( $popup['options'], $popup['options']['placement'] ) ) {
+			return false;
+		}
+		return in_array( $popup['options']['placement'], self::$overlay_placements, true );
 	}
 
 	/**
@@ -563,7 +606,7 @@ final class Newspack_Popups_Model {
 
 		$has_link                = preg_match( '/<a\s/', $body ) !== 0;
 		$has_form                = preg_match( '/<form\s/', $body ) !== 0;
-		$has_dismiss_form        = 'inline' !== $popup['options']['placement'];
+		$has_dismiss_form        = self::is_overlay( $popup );
 		$has_not_interested_form = self::get_dismiss_text( $popup );
 
 		$analytics_events = [
@@ -761,8 +804,7 @@ final class Newspack_Popups_Model {
 	 * @return string The generated markup.
 	 */
 	public static function generate_popup( $popup ) {
-
-		if ( isset( $popup['options'], $popup['options']['placement'] ) && 'inline' === $popup['options']['placement'] ) {
+		if ( ! self::is_overlay( $popup ) ) {
 			return self::generate_inline_popup( $popup );
 		}
 

--- a/src/editor/FrequencySidebar.js
+++ b/src/editor/FrequencySidebar.js
@@ -9,7 +9,7 @@ import { __ } from '@wordpress/i18n';
 import { Fragment } from '@wordpress/element';
 import { SelectControl, TextControl } from '@wordpress/components';
 
-const FrequencySidebar = ( { frequency, onMetaFieldChange, placement, utm_suppression } ) => {
+const FrequencySidebar = ( { frequency, onMetaFieldChange, isOverlay, utm_suppression } ) => {
 	return (
 		<Fragment>
 			<SelectControl
@@ -23,7 +23,7 @@ const FrequencySidebar = ( { frequency, onMetaFieldChange, placement, utm_suppre
 					{
 						value: 'always',
 						label: __( 'Every page', 'newspack-popups' ),
-						disabled: 'inline' !== placement,
+						disabled: isOverlay,
 					},
 				] }
 			/>

--- a/src/editor/Sidebar.js
+++ b/src/editor/Sidebar.js
@@ -18,11 +18,11 @@ const Sidebar = ( {
 	trigger_delay,
 	trigger_type,
 	isOverlay,
-	isInline,
+	isInlinePlacement,
 } ) => {
 	const updatePlacement = value => {
 		onMetaFieldChange( 'placement', value );
-		if ( ! isInline( value ) && frequency === 'always' ) {
+		if ( ! isInlinePlacement( value ) && frequency === 'always' ) {
 			onMetaFieldChange( 'frequency', 'once' );
 		}
 	};

--- a/src/editor/Sidebar.js
+++ b/src/editor/Sidebar.js
@@ -18,11 +18,11 @@ const Sidebar = ( {
 	trigger_delay,
 	trigger_type,
 	isOverlay,
-	canInsertOnEveryPage,
+	isInline,
 } ) => {
 	const updatePlacement = value => {
 		onMetaFieldChange( 'placement', value );
-		if ( ! canInsertOnEveryPage( value ) && frequency === 'always' ) {
+		if ( ! isInline( value ) && frequency === 'always' ) {
 			onMetaFieldChange( 'frequency', 'once' );
 		}
 	};
@@ -32,31 +32,32 @@ const Sidebar = ( {
 			<ToggleControl
 				label={ __( 'Inline Campaign', 'newspack-popups' ) }
 				checked={ ! isOverlay }
-				onChange={ value => {
-					if ( value ) {
-						return updatePlacement( 'inline' );
-					}
-					updatePlacement( 'center' );
-				} }
+				onChange={ value => updatePlacement( value ? 'inline' : 'center' ) }
 			/>
-			<ToggleControl
-				label={ __( 'Display Campaign Title', 'newspack-popups' ) }
-				checked={ display_title }
-				onChange={ value => onMetaFieldChange( 'display_title', value ) }
+			<SelectControl
+				label={ __( 'Placement' ) }
+				help={
+					isOverlay
+						? __( 'The location to display the overlay campaign.', 'newspack-popups' )
+						: __( 'The location to insert the campaign.', 'newspack-popups' )
+				}
+				value={ placement }
+				onChange={ updatePlacement }
+				options={
+					isOverlay
+						? [
+								{ value: 'center', label: __( 'Center' ) },
+								{ value: 'top', label: __( 'Top' ) },
+								{ value: 'bottom', label: __( 'Bottom' ) },
+						  ]
+						: [
+								{ value: 'inline', label: __( 'In article content' ) },
+								{ value: 'above_header', label: __( 'Above site header' ) },
+						  ]
+				}
 			/>
 			{ isOverlay && (
 				<Fragment>
-					<SelectControl
-						label={ __( 'Placement' ) }
-						help={ __( 'The location to display the campaign.', 'newspack-popups' ) }
-						value={ placement }
-						onChange={ updatePlacement }
-						options={ [
-							{ value: 'center', label: __( 'Center' ) },
-							{ value: 'top', label: __( 'Top' ) },
-							{ value: 'bottom', label: __( 'Bottom' ) },
-						] }
-					/>
 					<SelectControl
 						label={ __( 'Trigger' ) }
 						help={ __( 'The event to trigger the campaign.', 'newspack-popups' ) }
@@ -96,6 +97,11 @@ const Sidebar = ( {
 					max={ 100 }
 				/>
 			) }
+			<ToggleControl
+				label={ __( 'Display Campaign Title', 'newspack-popups' ) }
+				checked={ display_title }
+				onChange={ value => onMetaFieldChange( 'display_title', value ) }
+			/>
 		</Fragment>
 	);
 };

--- a/src/editor/index.js
+++ b/src/editor/index.js
@@ -58,11 +58,14 @@ class PopupSidebar extends Component {
 			utm_suppression,
 			onSitewideDefaultChange,
 		} = this.props;
-		const isInline = 'inline' === placement;
+		const canInsertOnEveryPage = placementValue =>
+			[ 'inline', 'above_header' ].indexOf( placementValue ) >= 0;
+
+		const isOverlay = ! canInsertOnEveryPage( placement );
 
 		const updatePlacement = value => {
 			onMetaFieldChange( 'placement', value );
-			if ( value !== 'inline' && frequency === 'always' ) {
+			if ( ! canInsertOnEveryPage( value ) && frequency === 'always' ) {
 				onMetaFieldChange( 'frequency', 'once' );
 			}
 		};
@@ -70,7 +73,7 @@ class PopupSidebar extends Component {
 		return (
 			<Fragment>
 				{ // The sitewide default option is for overlay popups only.
-				! isInline && (
+				isOverlay && (
 					<CheckboxControl
 						label={ __( 'Sitewide Default', 'newspack-popups' ) }
 						checked={ this.props.newspack_popups_is_sitewide_default }
@@ -88,9 +91,10 @@ class PopupSidebar extends Component {
 						{ value: 'top', label: __( 'Top' ) },
 						{ value: 'bottom', label: __( 'Bottom' ) },
 						{ value: 'inline', label: __( 'Inline' ) },
+						{ value: 'above_header', label: __( 'Above site header' ) },
 					] }
 				/>
-				{ ! isInline && (
+				{ isOverlay && (
 					<Fragment>
 						<RadioControl
 							label={ __( 'Trigger' ) }
@@ -122,7 +126,7 @@ class PopupSidebar extends Component {
 						) }
 					</Fragment>
 				) }
-				{ isInline && (
+				{ placement === 'inline' && (
 					<RangeControl
 						label={ __( 'Approximate position (in percent)' ) }
 						value={ trigger_scroll_progress }
@@ -143,7 +147,7 @@ class PopupSidebar extends Component {
 						{
 							value: 'always',
 							label: __( 'Every page', 'newspack-popups' ),
-							disabled: 'inline' !== placement,
+							disabled: ! canInsertOnEveryPage( placement ),
 						},
 					] }
 					help={ __(
@@ -164,7 +168,7 @@ class PopupSidebar extends Component {
 					onChange={ value => onMetaFieldChange( 'background_color', value || '#FFFFFF' ) }
 					label={ __( 'Background Color' ) }
 				/>
-				{ ! isInline && (
+				{ isOverlay && (
 					<Fragment>
 						<ColorPaletteControl
 							value={ overlay_color }

--- a/src/editor/utils.js
+++ b/src/editor/utils.js
@@ -22,10 +22,10 @@ export const optionsFieldsSelector = select => {
 		selected_segment_id,
 	} = meta || {};
 
-	const canInsertOnEveryPage = placementValue =>
+	const isInline = placementValue =>
 		[ 'inline', 'above_header' ].indexOf( placementValue ) >= 0;
 
-	const isOverlay = ! canInsertOnEveryPage( placement );
+	const isOverlay = ! isInline( placement );
 
 	return {
 		background_color,
@@ -44,7 +44,7 @@ export const optionsFieldsSelector = select => {
 		trigger_type,
 		utm_suppression,
 		selected_segment_id,
-		canInsertOnEveryPage,
+		isInline,
 		isOverlay,
 	};
 };

--- a/src/editor/utils.js
+++ b/src/editor/utils.js
@@ -22,10 +22,9 @@ export const optionsFieldsSelector = select => {
 		selected_segment_id,
 	} = meta || {};
 
-	const isInline = placementValue =>
+	const isInlinePlacement = placementValue =>
 		[ 'inline', 'above_header' ].indexOf( placementValue ) >= 0;
-
-	const isOverlay = ! isInline( placement );
+	const isOverlay = ! isInlinePlacement( placement );
 
 	return {
 		background_color,
@@ -44,7 +43,7 @@ export const optionsFieldsSelector = select => {
 		trigger_type,
 		utm_suppression,
 		selected_segment_id,
-		isInline,
+		isInlinePlacement,
 		isOverlay,
 	};
 };


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds an "above header" campaign placement, as requested in #260

Additional changes in Theme (https://github.com/Automattic/newspack-theme/pull/1131) and the plugin (https://github.com/Automattic/newspack-plugin/pull/691)

### How to test the changes in this Pull Request:

1. Create a new campaign, observe a new option in "Placement" select – "Above site header"
2. Use this option
3. Verify that the campaign is placed above site header
4. Filtering (category, tag, etc.) and everything else should work as with a regular inline campaign

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
