### PR TITLE
fix: inject campaigns into posts and pages only

### DIFF
--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -162,6 +162,15 @@ final class Newspack_Popups_Inserter {
 	 * @param bool   $enqueue_assets Whether assets should be enqueued.
 	 */
 	public static function insert_popups_in_content( $content = '', $enqueue_assets = true ) {
+		if ( ! in_array(
+			get_post_type(),
+			apply_filters(
+				'newspack_campaigns_post_types_for_campaigns',
+				[ 'post', 'page' ]
+			)
+		) ) {
+			return $content;
+		}
 		// Avoid duplicate execution.
 		if ( true === self::$the_content_has_rendered ) {
 			return $content;

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -33,6 +33,17 @@ final class Newspack_Popups_Inserter {
 	 * @return array Popup objects.
 	 */
 	public static function popups_for_post() {
+		// Inject campaigns only in posts, pages, and CPTs that explicitly opt in.
+		if ( ! in_array(
+			get_post_type(),
+			apply_filters(
+				'newspack_campaigns_post_types_for_campaigns',
+				[ 'post', 'page' ]
+			)
+		) ) {
+			return [];
+		}
+
 		if ( ! empty( self::$popups ) ) {
 			return self::$popups;
 		}
@@ -162,15 +173,6 @@ final class Newspack_Popups_Inserter {
 	 * @param bool   $enqueue_assets Whether assets should be enqueued.
 	 */
 	public static function insert_popups_in_content( $content = '', $enqueue_assets = true ) {
-		if ( ! in_array(
-			get_post_type(),
-			apply_filters(
-				'newspack_campaigns_post_types_for_campaigns',
-				[ 'post', 'page' ]
-			)
-		) ) {
-			return $content;
-		}
 		// Avoid duplicate execution.
 		if ( true === self::$the_content_has_rendered ) {
 			return $content;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The injection of Campaigns into Events single pages provided by The Events Calendar plugin causes a loop that leads to memory exhaustion, time outs and malformed markup. To resolve, this PR blocks injection into content unless the post type is `post` or `page`. This is done with a filter to allow other CPTs to opt-in for Campaign injection. 

Closes https://github.com/Automattic/newspack-popups/issues/295

### How to test the changes in this Pull Request:

1. Install [The Events Calendar](https://wordpress.org/plugins/the-events-calendar/) plugin and create/publish at least one Event. 
2. Create at least one campaign.
3. On master, view the event in the front end. Observe the page times out, or renders broken markup.
4. Switch to this branch, observe the Event page loads normally.
5. Bonus, test the filter. Add this anywhere code executes:
```
add_filter(
	'newspack_campaigns_post_types_for_campaigns',
	function( $post_types ) {
		$post_types[] = 'tribe_events';
		return $post_types;
	}
);
```
6. Retry the Event page. Observe it fails again.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
