### PR TITLE
Insert time-triggered overlay campaigns above header

### DIFF
--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -128,8 +128,7 @@ final class Newspack_Popups_Inserter {
 		add_action( 'after_header', [ $this, 'insert_popups_after_header' ] ); // This is a Newspack theme hook. When used with other themes, popups won't be inserted on archive pages.
 		add_action( 'wp_head', [ $this, 'insert_popups_amp_access' ] );
 		add_action( 'wp_head', [ $this, 'register_amp_scripts' ] );
-		add_action( 'before_header', [ $this, 'inject_timed_overlay_popups' ] );
-		add_action( 'before_header', [ $this, 'inject_above_header_popup' ] );
+		add_action( 'before_header', [ $this, 'insert_before_header' ] );
 
 		// Always enqueue scripts, since this plugin's scripts are handling pageview sending via GTAG.
 		add_action( 'wp_enqueue_scripts', [ $this, 'enqueue_scripts' ] );
@@ -293,11 +292,8 @@ final class Newspack_Popups_Inserter {
 		}
 
 		$popups = array_filter( self::popups_for_post(), [ 'Newspack_Popups_Model', 'should_be_inserted_in_page_content' ] );
-
-		if ( ! empty( $popups ) ) {
-			foreach ( $popups as $popup ) {
-				echo Newspack_Popups_Model::generate_popup( $popup ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-			}
+		foreach ( $popups as $popup ) {
+			echo Newspack_Popups_Model::generate_popup( $popup ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		}
 	}
 
@@ -305,13 +301,10 @@ final class Newspack_Popups_Inserter {
 	 * Insert time-triggered overlay popups above the header.
 	 * This way they will be visible before scrolling below the fold.
 	 */
-	public static function inject_timed_overlay_popups() {
-		$timed_overlay_popups = array_filter( self::popups_for_post(), [ 'Newspack_Popups_Model', 'should_be_inserted_above_page_header' ] );
-
-		if ( ! empty( $timed_overlay_popups ) ) {
-			foreach ( $timed_overlay_popups as $popup ) {
-				echo Newspack_Popups_Model::generate_popup( $popup ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-			}
+	public static function insert_before_header() {
+		$before_header_popups = array_filter( self::popups_for_post(), [ 'Newspack_Popups_Model', 'should_be_inserted_above_page_header' ] );
+		foreach ( $before_header_popups as $popup ) {
+			echo Newspack_Popups_Model::generate_popup( $popup ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		}
 	}
 
@@ -342,26 +335,6 @@ final class Newspack_Popups_Inserter {
 		);
 		\wp_style_add_data( 'newspack-popups-view', 'rtl', 'replace' );
 		\wp_enqueue_style( 'newspack-popups-view' );
-	}
-
-	/**
-	 * The popup shortcode function.
-	 */
-	public static function inject_above_header_popup() {
-		$previewed_popup_id = Newspack_Popups::previewed_popup_id();
-		$popups             = [];
-		if ( $previewed_popup_id ) {
-			$popups = [ Newspack_Popups_Model::retrieve_preview_popup( $previewed_popup_id ) ];
-		} else {
-			$popups = Newspack_Popups_Model::retrieve_above_header_popups();
-		}
-		if ( ! empty( $popups ) ) {
-			foreach ( $popups as $popup ) {
-				if ( $previewed_popup_id || self::should_display( $popup ) ) {
-					echo Newspack_Popups_Model::generate_popup( $popup ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-				}
-			}
-		}
 	}
 
 	/**

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -290,7 +290,6 @@ final class Newspack_Popups_Inserter {
 		if ( is_singular() ) {
 			return;
 		}
-
 		$popups = array_filter( self::popups_for_post(), [ 'Newspack_Popups_Model', 'should_be_inserted_in_page_content' ] );
 		foreach ( $popups as $popup ) {
 			echo Newspack_Popups_Model::generate_popup( $popup ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
@@ -298,8 +297,7 @@ final class Newspack_Popups_Inserter {
 	}
 
 	/**
-	 * Insert time-triggered overlay popups above the header.
-	 * This way they will be visible before scrolling below the fold.
+	 * Insert popups markup before header.
 	 */
 	public static function insert_before_header() {
 		$before_header_popups = array_filter( self::popups_for_post(), [ 'Newspack_Popups_Model', 'should_be_inserted_above_page_header' ] );

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -165,6 +165,8 @@ final class Newspack_Popups_Model {
 					}
 					update_post_meta( $id, $key, $value );
 					break;
+				case 'trigger_type':
+				case 'trigger_scroll_progress':
 				case 'utm_suppression':
 				case 'selected_segment_id':
 					update_post_meta( $id, $key, esc_attr( $value ) );
@@ -439,6 +441,26 @@ final class Newspack_Popups_Model {
 	 */
 	public static function is_inline( $popup ) {
 		return 'inline' === $popup['options']['placement'];
+	}
+
+	/**
+	 * Time-triggered overlay popups should be inserted above page header.
+	 *
+	 * @param object $popup The popup object.
+	 * @return boolean True the popup should be inserted above page header.
+	 */
+	public static function should_be_inserted_above_page_header( $popup ) {
+		return 'inline' !== $popup['options']['placement'] && 'time' === $popup['options']['trigger_type'];
+	}
+
+	/**
+	 * Time-triggered overlay popups should be inserted above page header.
+	 *
+	 * @param object $popup The popup object.
+	 * @return boolean True the popup should be inserted in page content.
+	 */
+	public static function should_be_inserted_in_page_content( $popup ) {
+		return self::should_be_inserted_above_page_header( $popup ) === false;
 	}
 
 	/**

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -19,6 +19,13 @@ final class Newspack_Popups_Model {
 	protected static $overlay_placements = [ 'top', 'bottom', 'center' ];
 
 	/**
+	 * Possible placements of inline popups.
+	 *
+	 * @var array
+	 */
+	protected static $inline_placements = [ 'inline', 'above_header' ];
+
+	/**
 	 * Retrieve all Popups (first 100).
 	 *
 	 * @param  boolean $include_unpublished Whether to include unpublished posts.
@@ -159,7 +166,7 @@ final class Newspack_Popups_Model {
 					update_post_meta( $id, $key, $value );
 					break;
 				case 'placement':
-					if ( ! in_array( $value, array_merge( self::$overlay_placements, [ 'inline', 'above_header' ] ) ) ) {
+					if ( ! in_array( $value, array_merge( self::$overlay_placements, self::$inline_placements ) ) ) {
 						return new \WP_Error(
 							'newspack_popups_invalid_option_value',
 							esc_html__( 'Invalid placement value.', 'newspack-popups' ),
@@ -197,11 +204,12 @@ final class Newspack_Popups_Model {
 	 */
 	public static function retrieve_inline_popups() {
 		$args = [
-			'post_type'   => Newspack_Popups::NEWSPACK_PLUGINS_CPT,
-			'post_status' => 'publish',
-			'meta_key'    => 'placement',
+			'post_type'    => Newspack_Popups::NEWSPACK_PLUGINS_CPT,
+			'post_status'  => 'publish',
+			'meta_key'     => 'placement',
 			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
-			'meta_value'  => 'inline',
+			'meta_value'   => self::$inline_placements,
+			'meta_compare' => 'IN',
 		];
 
 		return self::retrieve_popups_with_query( new WP_Query( $args ) );
@@ -257,24 +265,6 @@ final class Newspack_Popups_Model {
 
 		$popups = self::retrieve_popups_with_query( new WP_Query( $args ) );
 		return count( $popups ) > 0 ? $popups[0] : null;
-	}
-
-	/**
-	 * Retrieve above header popups.
-	 *
-	 * @return array Popup objects.
-	 */
-	public static function retrieve_above_header_popups() {
-		$args = [
-			'post_type'    => Newspack_Popups::NEWSPACK_PLUGINS_CPT,
-			'post_status'  => 'publish',
-			'meta_key'     => 'placement',
-			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
-			'meta_value'   => 'above_header',
-			'meta_compare' => '=',
-		];
-
-		return self::retrieve_popups_with_query( new WP_Query( $args ) );
 	}
 
 	/**
@@ -474,13 +464,17 @@ final class Newspack_Popups_Model {
 	}
 
 	/**
-	 * Time-triggered overlay popups should be inserted above page header.
+	 * Time-triggered overlay and above-header inline popups should be inserted above page header.
 	 *
 	 * @param object $popup The popup object.
 	 * @return boolean True the popup should be inserted above page header.
 	 */
 	public static function should_be_inserted_above_page_header( $popup ) {
-		return 'inline' !== $popup['options']['placement'] && 'time' === $popup['options']['trigger_type'];
+		if ( self::is_inline( $popup ) ) {
+			return 'above_header' === $popup['options']['placement'];
+		} else {
+			return 'time' === $popup['options']['trigger_type'];
+		}
 	}
 
 	/**

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -473,6 +473,8 @@ final class Newspack_Popups_Model {
 		if ( self::is_inline( $popup ) ) {
 			return 'above_header' === $popup['options']['placement'];
 		} else {
+			// Insert time-triggered overlay popups above the header, this way they will be
+			// visible before scrolling below the fold.
 			return 'time' === $popup['options']['trigger_type'];
 		}
 	}

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -464,10 +464,10 @@ final class Newspack_Popups_Model {
 	}
 
 	/**
-	 * Time-triggered overlay and above-header inline popups should be inserted above page header.
+	 * Get popups which should be inserted above page header.
 	 *
 	 * @param object $popup The popup object.
-	 * @return boolean True the popup should be inserted above page header.
+	 * @return boolean True if the popup should be inserted above page header.
 	 */
 	public static function should_be_inserted_above_page_header( $popup ) {
 		if ( self::is_inline( $popup ) ) {
@@ -480,10 +480,10 @@ final class Newspack_Popups_Model {
 	}
 
 	/**
-	 * Time-triggered overlay popups should be inserted above page header.
+	 * Get popups which should be inserted in page content.
 	 *
 	 * @param object $popup The popup object.
-	 * @return boolean True the popup should be inserted in page content.
+	 * @return boolean True if the popup should be inserted in page content.
 	 */
 	public static function should_be_inserted_in_page_content( $popup ) {
 		return self::should_be_inserted_above_page_header( $popup ) === false;

--- a/tests/test-insertion.php
+++ b/tests/test-insertion.php
@@ -29,7 +29,14 @@ class InsertionTest extends WP_UnitTestCase {
 		// Set the popup as sitewide default.
 		Newspack_Popups_Model::set_sitewide_popup( self::$popup_id );
 		// Set popup frequency from default 'test'.
-		Newspack_Popups_Model::set_popup_options( self::$popup_id, [ 'frequency' => 'once' ] );
+		Newspack_Popups_Model::set_popup_options(
+			self::$popup_id,
+			[
+				'frequency'               => 'once',
+				'trigger_type'            => 'scroll', 
+				'trigger_scroll_progress' => 0,
+			] 
+		);
 		// Reset internal duplicate-prevention.
 		Newspack_Popups_Inserter::$the_content_has_rendered = false;
 	}


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #4.

### How to test the changes in this Pull Request:

1. Create a time-triggered overlay campaign
2. On `master`, open a post with a featured image and ensure the post content area starts below the fold (is not visible when page is scrolled to top)
3. Observe the time-triggered campaign is not displayed until scrolled down (when the post content area becomes visible)
4. Switch to this branch, observe the campaign is displayed right away (after the specified delay, that is)

### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
