### PR TITLE
POC: Focus trap in non-AMP

### DIFF
--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -799,7 +799,7 @@ final class Newspack_Popups_Model {
 
 		ob_start();
 		?>
-		<amp-layout <?php echo self::get_access_attrs( $popup ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?> class="<?php echo esc_attr( implode( ' ', $classes ) ); ?>" role="button" tabindex="0" id="<?php echo esc_attr( $element_id ); ?>">
+		<amp-layout data-amp-delay="<?php echo esc_html( self::get_delay( $popup ) ); ?>" <?php echo self::get_access_attrs( $popup ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?> class="<?php echo esc_attr( implode( ' ', $classes ) ); ?>" role="button" tabindex="0" id="<?php echo esc_attr( $element_id ); ?>">
 			<div class="newspack-popup-wrapper" style="<?php echo esc_attr( self::container_style( $popup ) ); ?>">
 				<div class="newspack-popup">
 					<?php if ( ! empty( $popup['title'] ) && $display_title ) : ?>

--- a/package-lock.json
+++ b/package-lock.json
@@ -13620,6 +13620,14 @@
         "readable-stream": "^2.3.6"
       }
     },
+    "focus-trap": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-6.1.4.tgz",
+      "integrity": "sha512-jgNc+O8UkGsUpdhNXkyonwlw4i707+ESAWv1vCbyd8+29db5/Wv1BkJImDczfEWMu9O635FvM5ABOjeyqNQpEQ==",
+      "requires": {
+        "tabbable": "^5.1.3"
+      }
+    },
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -27885,6 +27893,11 @@
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true
+    },
+    "tabbable": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-5.1.3.tgz",
+      "integrity": "sha512-jqR3rOgeyNlYWDWoyjNTWuHk3+FObu3Fw4e0zjeOLBicI74TT/wGrvSbJUaFVs7FMfiY0Ee8CKM7QaJwVMT4YA=="
     },
     "table": {
       "version": "5.4.6",

--- a/package.json
+++ b/package.json
@@ -123,6 +123,7 @@
     "@wordpress/dom-ready": "^2.9.0",
     "@wordpress/element": "^2.11.0",
     "@wordpress/i18n": "^3.9.0",
+    "focus-trap": "^6.1.4",
     "newspack-components": "^1.0.5",
     "qs": "^6.9.1"
   }

--- a/src/view/index.js
+++ b/src/view/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { createFocusTrap } from 'focus-trap';
+
+/**
  * WordPress dependencies
  */
 import domReady from '@wordpress/dom-ready';
@@ -89,6 +94,25 @@ const manageForms = container => {
 	} );
 };
 
+const manageOverlays = () => {
+	[ ...document.querySelectorAll( '.newspack-lightbox' ) ].forEach( element => {
+		const wrapper = element.querySelector( '.newspack-popup-wrapper' );
+		if ( wrapper ) {
+			const observer = new MutationObserver( mutationsList => {
+				[ ...mutationsList ].forEach( mutation => {
+					const isHidden = mutation.target.hasAttribute( 'amp-access-hide' );
+					const delayValue = mutation.target.getAttribute( 'data-amp-delay' );
+					if ( ! isHidden && delayValue ) {
+						// Timeout for the animation.
+						setTimeout( () => createFocusTrap( wrapper ).activate(), parseInt( delayValue ) + 500 );
+					}
+				} );
+			} );
+			observer.observe( element, { attributes: true, subtree: false } );
+		}
+	} );
+};
+
 if ( typeof window !== 'undefined' ) {
 	domReady( () => {
 		manageAnalytics();
@@ -99,5 +123,6 @@ if ( typeof window !== 'undefined' ) {
 		campaignArray.forEach( campaign => {
 			manageForms( campaign );
 		} );
+		manageOverlays();
 	} );
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #24.

Because of lack of AMP callbacks, this focus trap is activated in a somewhat hacky way, and there's no way to _deactivate_ it – which results in a JS error being thrown after the campaign is dismissed.
Ideally, we should use the focus trap as part of the general non-AMP JS refactor (replacing AMP scripts with bespoke JS) – so this is a POC. 

### How to test the changes in this Pull Request:

1. Create an overlay campaign, view page in non-AMP mode
2. Observe the focus is trapped inside the modal by tabbing through the focusable elements

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [X] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
