### PR TITLE
Fix settings format for API; remove classname appending

### DIFF
--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -413,8 +413,17 @@ final class Newspack_Popups_Inserter {
 			);
 		}
 
+		$settings                                 = array_reduce(
+			\Newspack_Popups_Settings::get_settings(),
+			function ( $acc, $item ) {
+				$key       = $item['key'];
+				$acc->$key = $item['value'];
+				return $acc;
+			},
+			(object) []
+		);
 		$popups_access_provider['authorization'] .= '&popups=' . wp_json_encode( $popups_configs );
-		$popups_access_provider['authorization'] .= '&settings=' . wp_json_encode( \Newspack_Popups_Settings::get_settings() );
+		$popups_access_provider['authorization'] .= '&settings=' . wp_json_encode( $settings );
 		$popups_access_provider['authorization'] .= '&visit=' . wp_json_encode(
 			[
 				'post_id'    => esc_attr( get_the_ID() ),

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -645,27 +645,6 @@ final class Newspack_Popups_Model {
 	}
 
 	/**
-	 * Add "newspack-popups-content-block" class name to a block.
-	 * This way a block rendered inside of a popup can be easily told apart.
-	 * This will only work in dynamic blocks.
-	 *
-	 * @param object $block A block.
-	 * @return object Block with className appended.
-	 */
-	public static function append_class_to_block( $block ) {
-		$class_name = 'newspack-popups-content-block';
-		if ( isset( $block['attrs']['className'] ) ) {
-			$block['attrs']['className'] = $block['attrs']['className'] . ' ' . $class_name;
-		} else {
-			$block['attrs']['className'] = $class_name;
-		}
-
-		$block['innerBlocks'] = array_map( [ __CLASS__, 'append_class_to_block' ], $block['innerBlocks'] );
-
-		return $block;
-	}
-
-	/**
 	 * Canonise popups id. The id from WP will be an integer, but AMP does not play well with that and needs a string.
 	 *
 	 * @param int $popup_id Popup id.
@@ -706,7 +685,7 @@ final class Newspack_Popups_Model {
 		$blocks = parse_blocks( $popup['content'] );
 		$body   = '';
 		foreach ( $blocks as $block ) {
-			$body .= render_block( self::append_class_to_block( $block ) );
+			$body .= render_block( $block );
 		}
 		do_action( 'newspack_campaigns_after_campaign_render', $popup );
 
@@ -773,7 +752,7 @@ final class Newspack_Popups_Model {
 		$blocks = parse_blocks( $popup['content'] );
 		$body   = '';
 		foreach ( $blocks as $block ) {
-			$body .= render_block( self::append_class_to_block( $block ) );
+			$body .= render_block( $block );
 		}
 		do_action( 'newspack_campaigns_after_campaign_render', $popup );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

1. Fixes a bug introduced in #206 
2. Removes classname appending introduced in #201 – since the audience/segmentation features are now a part of this plugin, it won't be needed

### How to test the changes in this Pull Request:

1. On `master`, observe that:
2. `newspack-popups-content-block` classname is appended to dynamic (e.g. jetpack signup form) blocks inside of a campaign
2. The API endpoint is failing, so no campaigns are shown
3. Switch to this branch, observe that the classname is not being appended, and that the API endpoint is not failing

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
