### PR TITLE
Improve configuration file handling

### DIFF
--- a/api/setup.php
+++ b/api/setup.php
@@ -22,7 +22,7 @@ if ( ! defined( 'WP_DEBUG' ) ) {
 	define( 'WP_DEBUG', false );
 }
 
-require_once $wp_root_path . 'newspack-popups-config.php';
+require_once $wp_root_path . 'wp-content/newspack-popups-config.php';
 
 // phpcs:disable
 

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -43,7 +43,7 @@ final class Newspack_Popups {
 	 * Constructor.
 	 */
 	public function __construct() {
-		add_action( 'init', [ __CLASS__, 'create_lightweight_api_config' ] );
+		add_action( 'admin_init', [ __CLASS__, 'create_lightweight_api_config' ] );
 		add_action( 'admin_notices', [ __CLASS__, 'api_config_missing_notice' ] );
 		add_action( 'init', [ __CLASS__, 'register_cpt' ] );
 		add_action( 'init', [ __CLASS__, 'register_meta' ] );

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -17,7 +17,7 @@ final class Newspack_Popups {
 
 	const NEWSPACK_POPUP_PREVIEW_QUERY_PARAM = 'newspack_popups_preview_id';
 
-	const LIGHTWEIGHT_API_CONFIG_FILE_PATH = WP_CONTENT_DIR . '/../newspack-popups-config.php';
+	const LIGHTWEIGHT_API_CONFIG_FILE_PATH = WP_CONTENT_DIR . '/newspack-popups-config.php';
 
 	/**
 	 * The single instance of the class.

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -453,11 +453,12 @@ final class Newspack_Popups {
 	 * Create the config file for the API, unless it exists.
 	 */
 	public static function create_lightweight_api_config() {
-		if ( ! ( defined( 'ATOMIC_SITE_ID' ) && ATOMIC_SITE_ID ) || file_exists( self::LIGHTWEIGHT_API_CONFIG_FILE_PATH ) ) {
+		// Don't create a config file on Newspack's Atomic platform, or if there is a file already.
+		if ( defined( 'ATOMIC_SITE_ID' ) || file_exists( self::LIGHTWEIGHT_API_CONFIG_FILE_PATH ) ) {
 			return;
 		}
 		global $wpdb;
-		file_put_contents( // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_file_put_contents -- VIP will have to create a config manually
+		$new_config_file = file_put_contents( // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_file_put_contents -- VIP will have to create a config manually
 			self::LIGHTWEIGHT_API_CONFIG_FILE_PATH,
 			'<?php' .
 			// Insert these only if they are defined, but not in the as environment variables.
@@ -467,7 +468,9 @@ final class Newspack_Popups {
 			"\ndefine( 'DB_PREFIX', '" . $wpdb->prefix . "' );" .
 			"\n"
 		);
-		error_log( 'Created the config file: ' . self::LIGHTWEIGHT_API_CONFIG_FILE_PATH ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+		if ( $new_config_file ) {
+			error_log( 'Created the config file: ' . self::LIGHTWEIGHT_API_CONFIG_FILE_PATH ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+		}
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR does three things:

1. Closes #314 by moving the configuration file location to the `wp-content` directory rather than root
1. Fixes the conditional for checking whether to create a config file or not, as it wasn't actually working reliably on non-Atomic environments
1. Changes the hook used so that the plugin is not attempting to write to the disk from frontend requests, which could create performance issues

### How to test the changes in this Pull Request:

1. On a non-Atomic environment where no configuration file exists, observe there is no config file
2. Open any admin screen
3. Observe there is now a configuration file

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
