### PR TITLE
Fix: legacy config file path

### DIFF
--- a/api/setup.php
+++ b/api/setup.php
@@ -22,7 +22,15 @@ if ( ! defined( 'WP_DEBUG' ) ) {
 	define( 'WP_DEBUG', false );
 }
 
-require_once $wp_root_path . 'wp-content/newspack-popups-config.php';
+$legacy_config_path = $wp_root_path . 'newspack-popups-config.php';
+$config_path        = $wp_root_path . 'wp-content/newspack-popups-config.php';
+if ( file_exists( $legacy_config_path ) ) {
+	require_once $legacy_config_path;
+} elseif ( file_exists( $config_path ) ) {
+	require_once $config_path;
+} else {
+	die( 'missing config file' );
+}
 
 // phpcs:disable
 

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -17,7 +17,8 @@ final class Newspack_Popups {
 
 	const NEWSPACK_POPUP_PREVIEW_QUERY_PARAM = 'newspack_popups_preview_id';
 
-	const LIGHTWEIGHT_API_CONFIG_FILE_PATH = WP_CONTENT_DIR . '/newspack-popups-config.php';
+	const LIGHTWEIGHT_API_CONFIG_FILE_PATH_LEGACY = WP_CONTENT_DIR . '/../newspack-popups-config.php';
+	const LIGHTWEIGHT_API_CONFIG_FILE_PATH        = WP_CONTENT_DIR . '/newspack-popups-config.php';
 
 	/**
 	 * The single instance of the class.
@@ -454,7 +455,10 @@ final class Newspack_Popups {
 	 */
 	public static function create_lightweight_api_config() {
 		// Don't create a config file on Newspack's Atomic platform, or if there is a file already.
-		if ( defined( 'ATOMIC_SITE_ID' ) || file_exists( self::LIGHTWEIGHT_API_CONFIG_FILE_PATH ) ) {
+		if (
+			defined( 'ATOMIC_SITE_ID' ) ||
+			( file_exists( self::LIGHTWEIGHT_API_CONFIG_FILE_PATH_LEGACY ) || file_exists( self::LIGHTWEIGHT_API_CONFIG_FILE_PATH ) )
+		) {
 			return;
 		}
 		global $wpdb;

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -481,7 +481,10 @@ final class Newspack_Popups {
 	 * Add an admin notice if config is missing.
 	 */
 	public static function api_config_missing_notice() {
-		if ( file_exists( self::LIGHTWEIGHT_API_CONFIG_FILE_PATH ) ) {
+		if (
+			file_exists( self::LIGHTWEIGHT_API_CONFIG_FILE_PATH_LEGACY ) ||
+			file_exists( self::LIGHTWEIGHT_API_CONFIG_FILE_PATH )
+		) {
 			return;
 		}
 		?>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

#315 changed the config file path, but did not ensure handling of the legacy config file path. This fixes that. 

### How to test the changes in this Pull Request:

1. Follow the testing steps in #315 to ensure config is created in `wp-content` on a fresh site
2. Move the config file to the root, observe that the API is still functional

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
