### PR TITLE
Report segmentation-related data as custom dimension to GA

### DIFF
--- a/api/campaigns/class-campaign-data-utils.php
+++ b/api/campaigns/class-campaign-data-utils.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Newspack Campaigns API utils.
+ *
+ * @package Newspack
+ */
+
+/**
+ * Utils.
+ */
+class Campaign_Data_Utils {
+	/**
+	 * Is the URL from a newsletter?
+	 *
+	 * @param string $url A URL.
+	 */
+	public static function is_url_from_email( $url ) {
+		return stripos( $url, 'utm_medium=email' );
+	}
+
+	/**
+	 * Is client a donor?
+	 *
+	 * @param object $client_data Client data.
+	 */
+	public static function is_donor( $client_data ) {
+		return ! empty( $client_data['donations'] );
+	}
+
+	/**
+	 * Is client a subscriber?
+	 *
+	 * @param object $client_data Client data.
+	 * @param string $url URL.
+	 */
+	public static function is_subscriber( $client_data, $url ) {
+		// If coming from email, assume it's a subscriber.
+		return ! empty( $client_data['email_subscriptions'] ) || self::is_url_from_email( $url );
+	}
+}

--- a/api/campaigns/class-campaign-data-utils.php
+++ b/api/campaigns/class-campaign-data-utils.php
@@ -43,10 +43,10 @@ class Campaign_Data_Utils {
 	 *
 	 * @param object $campaign_segment Segment data.
 	 * @param object $client_data Client data.
-	 * @param bool   $has_utm_medium_in_url If there is UTM medium param in the URL.
+	 * @param bool   $referer_url Referrer URL.
 	 * @return bool Whether the campaign should be shown.
 	 */
-	public static function should_display_campaign( $campaign_segment, $client_data, $has_utm_medium_in_url = false ) {
+	public static function should_display_campaign( $campaign_segment, $client_data, $referer_url = '' ) {
 		$should_display   = true;
 		$posts_read_count = count( $client_data['posts_read'] );
 		$is_subscriber    = self::is_subscriber( $client_data, $referer_url );

--- a/api/campaigns/class-maybe-show-campaign.php
+++ b/api/campaigns/class-maybe-show-campaign.php
@@ -175,7 +175,7 @@ class Maybe_Show_Campaign extends Lightweight_API {
 			$should_display = Campaign_Data_Utils::should_display_campaign(
 				$campaign_segment,
 				$client_data,
-				$has_utm_medium_in_url
+				$referer_url
 			);
 
 			if (

--- a/api/campaigns/class-maybe-show-campaign.php
+++ b/api/campaigns/class-maybe-show-campaign.php
@@ -11,6 +11,7 @@
 require_once dirname( __FILE__ ) . '/../classes/class-lightweight-api.php';
 
 require_once dirname( __FILE__ ) . '/../segmentation/class-segmentation-report.php';
+require_once dirname( __FILE__ ) . '/class-campaign-data-utils.php';
 
 /**
  * GET endpoint to determine if campaign is shown or not.
@@ -121,7 +122,7 @@ class Maybe_Show_Campaign extends Lightweight_API {
 
 		$has_newsletter_prompt = $campaign->n;
 		// Suppressing based on UTM Medium parameter in the URL.
-		$has_utm_medium_in_url = stripos( $referer_url, 'utm_medium=email' );
+		$has_utm_medium_in_url = Campaign_Data_Utils::is_url_from_email( $referer_url );
 
 		// Handle referer-based conditions.
 		if ( ! empty( $referer_url ) ) {
@@ -172,9 +173,8 @@ class Maybe_Show_Campaign extends Lightweight_API {
 		$campaign_segment = isset( $settings->all_segments->{$campaign->s} ) ? $settings->all_segments->{$campaign->s} : false;
 		if ( ! empty( $campaign_segment ) ) {
 			$posts_read_count = count( $client_data['posts_read'] );
-			// If coming from email, assume it's a subscriber.
-			$is_subscriber = ! empty( $client_data['email_subscriptions'] ) || $has_utm_medium_in_url;
-			$is_donor      = ! empty( $client_data['donations'] );
+			$is_subscriber    = Campaign_Data_Utils::is_subscriber( $client_data, $referer_url );
+			$is_donor         = Campaign_Data_Utils::is_donor( $client_data );
 			if (
 				$campaign_segment->min_posts > 0 && $campaign_segment->min_posts > $posts_read_count
 			) {

--- a/api/segmentation/class-segmentation.php
+++ b/api/segmentation/class-segmentation.php
@@ -12,28 +12,6 @@ defined( 'ABSPATH' ) || exit;
  */
 class Segmentation {
 	/**
-	 * Get client's read posts.
-	 *
-	 * @param string $client_id Client ID.
-	 */
-	public static function get_client_read_posts( $client_id ) {
-		global $wpdb;
-		$events_table_name = self::get_events_table_name();
-		$clients_events    = $wpdb->get_results( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-			$wpdb->prepare( "SELECT * FROM $events_table_name WHERE client_id = %s AND type = 'post_read'", $client_id ) // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-		);
-		return array_map(
-			function ( $item ) {
-				return [
-					'post_id'      => $item->post_id,
-					'category_ids' => $item->category_ids,
-				];
-			},
-			$clients_events
-		);
-	}
-
-	/**
 	 * Get log file path.
 	 */
 	public static function get_log_file_path() {

--- a/includes/class-newspack-popups-api.php
+++ b/includes/class-newspack-popups-api.php
@@ -110,10 +110,12 @@ final class Newspack_Popups_API {
 		$client_data = $api->get_client_data( $client_id );
 
 		foreach ( $custom_dimensions as $custom_dimension ) {
+			// Strip the `ga:` prefix from gaID.
 			$dimension_id = substr( $custom_dimension['gaID'], 3 );
 			switch ( $custom_dimension['role'] ) {
 				case Newspack_Popups_Segmentation::CUSTOM_DIMENSIONS_OPTION_NAME_READER_FREQUENCY:
-					$read_count      = count( $client_data['posts_read'] );
+					$read_count = count( $client_data['posts_read'] );
+					// Tiers mimick NCI's – https://news-consumer-insights.appspot.com.
 					$read_count_tier = 'casual';
 					if ( $read_count > 1 && $read_count <= 14 ) {
 						$read_count_tier = 'loyal';

--- a/includes/class-newspack-popups-api.php
+++ b/includes/class-newspack-popups-api.php
@@ -69,6 +69,90 @@ final class Newspack_Popups_API {
 				],
 			]
 		);
+		\register_rest_route(
+			'newspack-popups/v1',
+			'analytics-config',
+			[
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => [ $this, 'get_custom_analytics_configuration' ],
+				'permission_callback' => '__return_true',
+			]
+		);
+	}
+
+	/**
+	 * Get custom Analytics config, with segmentation-related custom dimensions assigned.
+	 * The pageviews will be reported using this configuration, so it's important
+	 * to include the custom dimensions set up by the Newspack Plugin, too.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 */
+	public static function get_custom_analytics_configuration( $request ) {
+		$client_id   = $request['client_id'];
+		$ga_settings = get_option( 'googlesitekit_analytics_settings' );
+		if ( ! $client_id || ! $ga_settings || ! isset( $ga_settings['propertyID'] ) ) {
+			return [];
+		}
+
+		$custom_dimensions = [];
+		if ( class_exists( 'Newspack\Analytics_Wizard' ) ) {
+			$custom_dimensions = Newspack\Analytics_Wizard::list_configured_custom_dimensions();
+		}
+
+		// Tracking ID from Site Kit.
+		$gtag_id = $ga_settings['propertyID'];
+
+		$custom_dimensions_values = [];
+
+		require_once dirname( __FILE__ ) . '/../api/classes/class-lightweight-api.php';
+		require_once dirname( __FILE__ ) . '/../api/campaigns/class-campaign-data-utils.php';
+		$api         = new Lightweight_API();
+		$client_data = $api->get_client_data( $client_id );
+
+		foreach ( $custom_dimensions as $custom_dimension ) {
+			$dimension_id = substr( $custom_dimension['gaID'], 3 );
+			switch ( $custom_dimension['role'] ) {
+				case Newspack_Popups_Segmentation::CUSTOM_DIMENSIONS_OPTION_NAME_READER_FREQUENCY:
+					$read_count      = count( $client_data['posts_read'] );
+					$read_count_tier = 'casual';
+					if ( $read_count > 1 && $read_count <= 14 ) {
+						$read_count_tier = 'loyal';
+					} elseif ( $read_count > 14 ) {
+						$read_count_tier = 'brand_lover';
+					}
+					$custom_dimensions_values[ $dimension_id ] = $read_count_tier;
+					break;
+				case Newspack_Popups_Segmentation::CUSTOM_DIMENSIONS_OPTION_NAME_IS_SUBSCRIBER:
+					$custom_dimensions_values[ $dimension_id ] = Campaign_Data_Utils::is_subscriber( $client_data, wp_get_referer() );
+					break;
+				case Newspack_Popups_Segmentation::CUSTOM_DIMENSIONS_OPTION_NAME_IS_DONOR:
+					$custom_dimensions_values[ $dimension_id ] = Campaign_Data_Utils::is_donor( $client_data );
+					break;
+			}
+		}
+
+		$custom_dimensions_existing_values = [];
+		if ( class_exists( 'Newspack\Analytics' ) ) {
+			$custom_dimensions_existing_values = Newspack\Analytics::get_custom_dimensions_values( $request['post_id'] );
+		}
+
+		// This is an AMP Analytics-compliant configuration, which on non-AMP pages will be
+		// processed by this plugin's amp-analytics polyfill (src/view).
+		return [
+			'vars'            => [
+				'gtag_id' => $gtag_id,
+				'config'  => [
+					$gtag_id => array_merge(
+						[
+							'groups' => 'default',
+						],
+						$custom_dimensions_values,
+						$custom_dimensions_existing_values
+					),
+				],
+			],
+			'optoutElementId' => '__gaOptOutExtension',
+		];
 	}
 
 	/**

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -130,6 +130,9 @@ final class Newspack_Popups_Inserter {
 		add_action( 'wp_head', [ $this, 'insert_popups_amp_access' ] );
 		add_action( 'wp_head', [ $this, 'register_amp_scripts' ] );
 
+		// Always enqueue scripts, since this plugin's scripts are handling pageview sending via GTAG.
+		add_action( 'wp_enqueue_scripts', [ $this, 'enqueue_scripts' ] );
+
 		add_filter(
 			'newspack_newsletters_assess_has_disabled_popups',
 			function () {
@@ -276,9 +279,6 @@ final class Newspack_Popups_Inserter {
 			$output = '<!-- wp:html -->' . Newspack_Popups_Model::generate_popup( $overlay_popup ) . '<!-- /wp:html -->' . $output;
 		}
 
-		if ( $enqueue_assets ) {
-			self::enqueue_popup_assets();
-		}
 		self::$the_content_has_rendered = true;
 		return $output;
 	}
@@ -298,14 +298,13 @@ final class Newspack_Popups_Inserter {
 			foreach ( $popups as $popup ) {
 				echo Newspack_Popups_Model::generate_popup( $popup ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			}
-			self::enqueue_popup_assets();
 		}
 	}
 
 	/**
 	 * Enqueue the assets needed to display the popups.
 	 */
-	public static function enqueue_popup_assets() {
+	public static function enqueue_scripts() {
 		if ( defined( 'IS_TEST_ENV' ) && IS_TEST_ENV ) {
 			return;
 		}

--- a/includes/class-newspack-popups-segmentation.php
+++ b/includes/class-newspack-popups-segmentation.php
@@ -380,7 +380,7 @@ final class Newspack_Popups_Segmentation {
 	 * @return object Total clients amount and the amount covered by the segment.
 	 */
 	public static function get_segment_reach( $segment_config ) {
-		require_once dirname( __FILE__ ) . '/../api/campaigns/segmentation-utils.php';
+		require_once dirname( __FILE__ ) . '/../api/campaigns/class-campaign-data-utils.php';
 		require_once dirname( __FILE__ ) . '/../api/classes/class-lightweight-api.php';
 
 		$all_client_data = wp_cache_get( 'newspack_popups_all_clients_data', 'newspack-popups' );
@@ -393,7 +393,7 @@ final class Newspack_Popups_Segmentation {
 		$client_in_segment = array_filter(
 			$all_client_data,
 			function ( $client_data ) use ( $segment_config ) {
-				return newspack_segmentation_should_display_campaign(
+				return Campaign_Data_Utils::should_display_campaign(
 					$segment_config,
 					$client_data
 				);

--- a/package-lock.json
+++ b/package-lock.json
@@ -31585,9 +31585,9 @@
       "dev": true
     },
     "qs": {
-      "version": "6.9.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.1.tgz",
-      "integrity": "sha512-Cxm7/SS/y/Z3MHWSxXb8lIFqgqBowP5JMlTUFyJN88y0SGQhVmZnqFK/PeuMX9LzUyWsqqhNxIyg0jlzq946yA=="
+      "version": "6.9.4",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.4.tgz",
+      "integrity": "sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ=="
     },
     "query-string": {
       "version": "4.3.4",
@@ -36689,9 +36689,9 @@
       }
     },
     "whatwg-fetch": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
-      "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.5.0.tgz",
+      "integrity": "sha512-jXkLtsR42xhXg7akoDKvKWE40eJeI+2KZqcp2h3NsOrRnDvtWX36KcKl30dy+hxECivdk2BVUHVNrPtoMBUx6A=="
     },
     "whatwg-mimetype": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -130,6 +130,7 @@
     "@wordpress/url": "^2.19.0",
     "intersection-observer": "^0.11.0",
     "newspack-components": "^1.0.5",
-    "qs": "^6.9.1"
+    "qs": "^6.9.4",
+    "whatwg-fetch": "^3.5.0"
   }
 }

--- a/src/view/utils/index.js
+++ b/src/view/utils/index.js
@@ -1,7 +1,12 @@
 /**
  * WordPress dependencies
  */
-import { getQueryArg, removeQueryArgs } from '@wordpress/url';
+import { getQueryArg, removeQueryArgs, getQueryString } from '@wordpress/url';
+
+/**
+ * External dependencies
+ */
+import { parse, stringify } from 'qs';
 
 export const values = object => Object.keys( object ).map( key => object[ key ] );
 
@@ -38,6 +43,21 @@ export const substituteDynamicValue = value => {
 		value = getClientIDValue() || '';
 	}
 	return value;
+};
+
+/**
+ * Replace dynamic values in a URL.
+ *
+ * @param  {string} url A URL with dynamic values.
+ * @return {string} URL with the values replaced.
+ */
+export const parseDynamicURL = url => {
+	const parsed = parse( getQueryString( url ) );
+	Object.keys( parsed ).forEach( key => {
+		parsed[ key ] = substituteDynamicValue( parsed[ key ] );
+	} );
+	const withoutQuery = url.substring( 0, url.indexOf( '?' ) );
+	return `${ withoutQuery }?${ stringify( parsed ) }`;
 };
 
 /**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Allows for reporting reader frequency, donor status, subscriber status, as custom dimensions to GA. 

Note that with current implementation these custom dimensions will be reported only for pageviews (not for custom events).

Closes #259 .

### How to test the changes in this Pull Request:

1. Switch Newspack Plugin to branch `add/external-custom-dimensions` (https://github.com/Automattic/newspack-plugin/pull/685)
2. Visit the Analytics Wizard, Custom Dimensions tab
3. Observe new options in the "Role" select:

![image](https://user-images.githubusercontent.com/7383192/100472986-9b84a800-30dd-11eb-9899-2947be42daa2.png)

4. Assign some custom dimensions to the Campagins segmentation related roles (the three latter ones)
5. Visit the homepage, then a post, observe the `pageview` is reported to GA with the custom dimensions, with appropriate values
6. Repeat for both AMP and non-AMP versions of the site, the custom dimensions sent with `pageview` should be the same

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [X] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
