### PR TITLE
Prune segmentation data

### DIFF
--- a/includes/class-newspack-popups-segmentation.php
+++ b/includes/class-newspack-popups-segmentation.php
@@ -54,6 +54,11 @@ final class Newspack_Popups_Segmentation {
 	public function __construct() {
 		add_action( 'init', [ __CLASS__, 'create_database_table' ] );
 		add_action( 'wp_footer', [ __CLASS__, 'insert_amp_analytics' ], 20 );
+
+		add_action( 'newspack_popups_segmentation_data_prune', [ __CLASS__, 'prune_data' ] );
+		if ( ! wp_next_scheduled( 'newspack_popups_segmentation_data_prune' ) ) {
+			wp_schedule_event( time(), 'daily', 'newspack_popups_segmentation_data_prune' );
+		}
 	}
 
 	/**
@@ -263,6 +268,16 @@ final class Newspack_Popups_Segmentation {
 				]
 			);
 		}
+	}
+
+	/**
+	 * Only last month's worth of posts-read data is needed for segmentation features.
+	 */
+	public static function prune_data() {
+		global $wpdb;
+		$events_table_name         = Segmentation::get_events_table_name();
+		$removed_rows_count_events = $wpdb->query( $wpdb->prepare( "DELETE FROM $events_table_name WHERE type = %s AND created_at < now() - interval 30 DAY", 'post_read' ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.DirectQuery
+		error_log( 'Newspack Campaigns: Data pruning – removed ' . $removed_rows_count_events . ' rows from ' . $events_table_name . ' table.' ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 	}
 }
 Newspack_Popups_Segmentation::instance();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

For segmentation features (e.g. posts read count, category affinity), we just need 30 days worth of data about read posts. 

Closes #251 – since the segmentation-related data will be reported to GA as custom dimensions (#325), there's no need to save a condensed snapshot of the removed data. 

### How to test the changes in this Pull Request:

1. Create some events in the `wp_newspack_campaigns_events` with `created_at` dates from before 30 days ago
2. Load the site
3. Inspect the database, observe that the rows with dates older than 30 days are no more

### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
