### PR TITLE
Add/persist visit time

### DIFF
--- a/api/segmentation/class-segmentation-report.php
+++ b/api/segmentation/class-segmentation-report.php
@@ -22,7 +22,7 @@ class Segmentation_Report {
 				[
 					'post_read',
 					$payload['clientId'],
-					isset( $payload['date'] ) ? $payload['date'] : gmdate( 'Y-m-d', time() ),
+					isset( $payload['date'] ) ? $payload['date'] : gmdate( 'Y-m-d H:i:s', time() ),
 					$payload['post_id'],
 					$payload['categories'],
 				]

--- a/includes/class-newspack-popups-segmentation.php
+++ b/includes/class-newspack-popups-segmentation.php
@@ -258,7 +258,7 @@ final class Newspack_Popups_Segmentation {
 
 			$sql = "CREATE TABLE $events_table_name (
 				id bigint(20) NOT NULL AUTO_INCREMENT,
-				created_at date NOT NULL,
+				created_at datetime NOT NULL,
 				-- type of event
 				type varchar(20) NOT NULL,
 				-- Unique id of a device/browser pair
@@ -274,6 +274,8 @@ final class Newspack_Popups_Segmentation {
 
 			require_once ABSPATH . 'wp-admin/includes/upgrade.php';
 			dbDelta( $sql ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.dbDelta_dbdelta
+		} elseif ( 'date' === $wpdb->get_var( $wpdb->prepare( "SHOW COLUMNS FROM {$events_table_name} LIKE %s", 'created_at' ), 1 ) ) { // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			$wpdb->query( "ALTER TABLE {$events_table_name} CHANGE `created_at` `created_at` DATETIME NOT NULL" ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.SchemaChange, WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		}
 	}
 

--- a/tests/test-segmentation.php
+++ b/tests/test-segmentation.php
@@ -58,7 +58,7 @@ class SegmentationTest extends WP_UnitTestCase {
 			[
 				'post_read',
 				self::$post_read_payload['clientId'],
-				gmdate( 'Y-m-d', time() ),
+				gmdate( 'Y-m-d H:i:s', time() ),
 				self::$post_read_payload['post_id'],
 				self::$post_read_payload['categories'],
 			]


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds timestamp to the data stored for each visit. This will allow us to segment by current session activity (probably 45 minute period) which will allow for segments like:

- First time visitor who has viewed 5 or more posts.
- Visitor comes to the site daily, but only views one post
- Daily visitor who reads 5 or more posts each time.

### How to test the changes in this Pull Request:

1. Verify database schema is updated and `created_at` field is now `DATETIME`.
2. Verify data persisted in the log includes time, e.g. `2020-12-07 13:23:06`
3. Verify data persisted in the DB by cron task also includes time.
4. Verify this doesn't impact existing segmentation.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
