### PR TITLE
Feat/campaigns taxonomy

### DIFF
--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -207,7 +207,7 @@ final class Newspack_Popups_Inserter {
 		}
 
 		// If the current post is a Campaign, ignore.
-		if ( Newspack_Popups::NEWSPACK_PLUGINS_CPT == get_post_type() ) {
+		if ( Newspack_Popups::NEWSPACK_POPUPS_CPT == get_post_type() ) {
 			return $content;
 		}
 

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -20,7 +20,7 @@ final class Newspack_Popups_Model {
 	 */
 	public static function retrieve_popups( $include_unpublished = false ) {
 		$args = [
-			'post_type'      => Newspack_Popups::NEWSPACK_PLUGINS_CPT,
+			'post_type'      => Newspack_Popups::NEWSPACK_POPUPS_CPT,
 			'post_status'    => $include_unpublished ? [ 'publish', 'draft' ] : 'publish',
 			'posts_per_page' => 100,
 		];
@@ -189,7 +189,7 @@ final class Newspack_Popups_Model {
 	 */
 	public static function retrieve_inline_popups() {
 		$args = [
-			'post_type'   => Newspack_Popups::NEWSPACK_PLUGINS_CPT,
+			'post_type'   => Newspack_Popups::NEWSPACK_POPUPS_CPT,
 			'post_status' => 'publish',
 			'meta_key'    => 'placement',
 			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
@@ -206,7 +206,7 @@ final class Newspack_Popups_Model {
 	 */
 	public static function retrieve_overlay_test_popups() {
 		$args = [
-			'post_type'   => Newspack_Popups::NEWSPACK_PLUGINS_CPT,
+			'post_type'   => Newspack_Popups::NEWSPACK_POPUPS_CPT,
 			'post_status' => 'publish',
 			'meta_query'  => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 				[
@@ -237,7 +237,7 @@ final class Newspack_Popups_Model {
 		}
 
 		$args = [
-			'post_type'      => Newspack_Popups::NEWSPACK_PLUGINS_CPT,
+			'post_type'      => Newspack_Popups::NEWSPACK_POPUPS_CPT,
 			'posts_per_page' => 1,
 			'post_status'    => 'publish',
 			'category__in'   => array_column( $post_categories, 'term_id' ),
@@ -293,7 +293,7 @@ final class Newspack_Popups_Model {
 	 */
 	public static function retrieve_popup_by_id( $post_id, $include_drafts = false ) {
 		$args = [
-			'post_type'      => Newspack_Popups::NEWSPACK_PLUGINS_CPT,
+			'post_type'      => Newspack_Popups::NEWSPACK_POPUPS_CPT,
 			'posts_per_page' => 1,
 			'p'              => $post_id,
 		];

--- a/includes/class-newspack-popups-settings.php
+++ b/includes/class-newspack-popups-settings.php
@@ -26,7 +26,7 @@ class Newspack_Popups_Settings {
 	 */
 	public static function add_plugin_page() {
 		add_submenu_page(
-			'edit.php?post_type=' . Newspack_Popups::NEWSPACK_PLUGINS_CPT,
+			'edit.php?post_type=' . Newspack_Popups::NEWSPACK_POPUPS_CPT,
 			__( 'Campaigns Settings', 'newspack-popups' ),
 			__( 'Settings', 'newspack-popups' ),
 			'manage_options',
@@ -137,7 +137,7 @@ class Newspack_Popups_Settings {
 	public static function admin_enqueue_scripts() {
 		$screen = get_current_screen();
 
-		if ( Newspack_Popups::NEWSPACK_PLUGINS_CPT . '_page_' . self::NEWSPACK_POPUPS_SETTINGS_PAGE !== $screen->base ) {
+		if ( Newspack_Popups::NEWSPACK_POPUPS_CPT . '_page_' . self::NEWSPACK_POPUPS_SETTINGS_PAGE !== $screen->base ) {
 			return;
 		}
 

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -12,7 +12,7 @@ defined( 'ABSPATH' ) || exit;
  */
 final class Newspack_Popups {
 
-	const NEWSPACK_PLUGINS_CPT             = 'newspack_popups_cpt';
+	const NEWSPACK_POPUPS_CPT              = 'newspack_popups_cpt';
 	const NEWSPACK_POPUPS_SITEWIDE_DEFAULT = 'newspack_popups_sitewide_default';
 
 	const NEWSPACK_POPUP_PREVIEW_QUERY_PARAM = 'newspack_popups_preview_id';
@@ -51,7 +51,7 @@ final class Newspack_Popups {
 		add_action( 'enqueue_block_editor_assets', [ __CLASS__, 'enqueue_block_editor_assets' ] );
 		add_filter( 'display_post_states', [ __CLASS__, 'display_post_states' ], 10, 2 );
 		add_action( 'rest_api_init', [ __CLASS__, 'rest_api_init' ] );
-		add_action( 'save_post_' . self::NEWSPACK_PLUGINS_CPT, [ __CLASS__, 'popup_default_fields' ], 10, 3 );
+		add_action( 'save_post_' . self::NEWSPACK_POPUPS_CPT, [ __CLASS__, 'popup_default_fields' ], 10, 3 );
 
 		if ( filter_input( INPUT_GET, 'newspack_popups_preview_id', FILTER_SANITIZE_STRING ) ) {
 			add_filter( 'show_admin_bar', [ __CLASS__, 'hide_admin_bar_for_preview' ], 10, 2 ); // phpcs:ignore WordPressVIPMinimum.UserExperience.AdminBarRemoval.RemovalDetected
@@ -96,7 +96,7 @@ final class Newspack_Popups {
 			'taxonomies'   => [ 'category', 'post_tag' ],
 			'menu_icon'    => 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0Ij48cGF0aCBmaWxsPSIjYTBhNWFhIiBkPSJNMTEuOTkgMTguNTRsLTcuMzctNS43M0wzIDE0LjA3bDkgNyA5LTctMS42My0xLjI3LTcuMzggNS43NHpNMTIgMTZsNy4zNi01LjczTDIxIDlsLTktNy05IDcgMS42MyAxLjI3TDEyIDE2eiIvPjwvc3ZnPgo=',
 		];
-		\register_post_type( self::NEWSPACK_PLUGINS_CPT, $cpt_args );
+		\register_post_type( self::NEWSPACK_POPUPS_CPT, $cpt_args );
 	}
 
 	/**
@@ -107,7 +107,7 @@ final class Newspack_Popups {
 			'post',
 			'trigger_type',
 			[
-				'object_subtype' => self::NEWSPACK_PLUGINS_CPT,
+				'object_subtype' => self::NEWSPACK_POPUPS_CPT,
 				'show_in_rest'   => true,
 				'type'           => 'string',
 				'single'         => true,
@@ -118,7 +118,7 @@ final class Newspack_Popups {
 			'post',
 			'trigger_scroll_progress',
 			[
-				'object_subtype' => self::NEWSPACK_PLUGINS_CPT,
+				'object_subtype' => self::NEWSPACK_POPUPS_CPT,
 				'show_in_rest'   => true,
 				'type'           => 'integer',
 				'single'         => true,
@@ -129,7 +129,7 @@ final class Newspack_Popups {
 			'post',
 			'trigger_delay',
 			[
-				'object_subtype' => self::NEWSPACK_PLUGINS_CPT,
+				'object_subtype' => self::NEWSPACK_POPUPS_CPT,
 				'show_in_rest'   => true,
 				'type'           => 'integer',
 				'single'         => true,
@@ -141,7 +141,7 @@ final class Newspack_Popups {
 			'post',
 			'frequency',
 			[
-				'object_subtype' => self::NEWSPACK_PLUGINS_CPT,
+				'object_subtype' => self::NEWSPACK_POPUPS_CPT,
 				'show_in_rest'   => true,
 				'type'           => 'string',
 				'single'         => true,
@@ -153,7 +153,7 @@ final class Newspack_Popups {
 			'post',
 			'placement',
 			[
-				'object_subtype' => self::NEWSPACK_PLUGINS_CPT,
+				'object_subtype' => self::NEWSPACK_POPUPS_CPT,
 				'show_in_rest'   => true,
 				'type'           => 'string',
 				'single'         => true,
@@ -165,7 +165,7 @@ final class Newspack_Popups {
 			'post',
 			'utm_suppression',
 			[
-				'object_subtype' => self::NEWSPACK_PLUGINS_CPT,
+				'object_subtype' => self::NEWSPACK_POPUPS_CPT,
 				'show_in_rest'   => true,
 				'type'           => 'string',
 				'single'         => true,
@@ -177,7 +177,7 @@ final class Newspack_Popups {
 			'post',
 			'background_color',
 			[
-				'object_subtype' => self::NEWSPACK_PLUGINS_CPT,
+				'object_subtype' => self::NEWSPACK_POPUPS_CPT,
 				'show_in_rest'   => true,
 				'type'           => 'string',
 				'single'         => true,
@@ -189,7 +189,7 @@ final class Newspack_Popups {
 			'post',
 			'overlay_color',
 			[
-				'object_subtype' => self::NEWSPACK_PLUGINS_CPT,
+				'object_subtype' => self::NEWSPACK_POPUPS_CPT,
 				'show_in_rest'   => true,
 				'type'           => 'string',
 				'single'         => true,
@@ -201,7 +201,7 @@ final class Newspack_Popups {
 			'post',
 			'overlay_opacity',
 			[
-				'object_subtype' => self::NEWSPACK_PLUGINS_CPT,
+				'object_subtype' => self::NEWSPACK_POPUPS_CPT,
 				'show_in_rest'   => true,
 				'type'           => 'integer',
 				'single'         => true,
@@ -213,7 +213,7 @@ final class Newspack_Popups {
 			'post',
 			'dismiss_text',
 			[
-				'object_subtype' => self::NEWSPACK_PLUGINS_CPT,
+				'object_subtype' => self::NEWSPACK_POPUPS_CPT,
 				'show_in_rest'   => true,
 				'type'           => 'string',
 				'single'         => true,
@@ -225,7 +225,7 @@ final class Newspack_Popups {
 			'post',
 			'dismiss_text_alignment',
 			[
-				'object_subtype' => self::NEWSPACK_PLUGINS_CPT,
+				'object_subtype' => self::NEWSPACK_POPUPS_CPT,
 				'show_in_rest'   => true,
 				'type'           => 'string',
 				'single'         => true,
@@ -237,7 +237,7 @@ final class Newspack_Popups {
 			'post',
 			'display_title',
 			[
-				'object_subtype' => self::NEWSPACK_PLUGINS_CPT,
+				'object_subtype' => self::NEWSPACK_POPUPS_CPT,
 				'show_in_rest'   => true,
 				'type'           => 'boolean',
 				'single'         => true,
@@ -249,7 +249,7 @@ final class Newspack_Popups {
 			'post',
 			'selected_segment_id',
 			[
-				'object_subtype' => self::NEWSPACK_PLUGINS_CPT,
+				'object_subtype' => self::NEWSPACK_POPUPS_CPT,
 				'show_in_rest'   => true,
 				'type'           => 'string',
 				'single'         => true,
@@ -304,7 +304,7 @@ final class Newspack_Popups {
 	public static function enqueue_block_editor_assets() {
 		$screen = get_current_screen();
 
-		if ( self::NEWSPACK_PLUGINS_CPT !== $screen->post_type ) {
+		if ( self::NEWSPACK_POPUPS_CPT !== $screen->post_type ) {
 			if ( 'page' !== $screen->post_type || 'post' !== $screen->post_type ) {
 				// Script for global settings.
 				\wp_enqueue_script(
@@ -350,7 +350,7 @@ final class Newspack_Popups {
 	 * @param WP_Post $post        The current post object.
 	 */
 	public static function display_post_states( $post_states, $post ) {
-		if ( self::NEWSPACK_PLUGINS_CPT !== $post->post_type ) {
+		if ( self::NEWSPACK_POPUPS_CPT !== $post->post_type ) {
 			return $post_states;
 		}
 		$post_status_object = get_post_status_object( $post->post_status );
@@ -398,7 +398,7 @@ final class Newspack_Popups {
 	 */
 	public static function rest_api_init() {
 		register_rest_field(
-			[ self::NEWSPACK_PLUGINS_CPT ],
+			[ self::NEWSPACK_POPUPS_CPT ],
 			'newspack_popups_is_sitewide_default',
 			[
 				'get_callback'    => function( $post ) {

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -14,6 +14,7 @@ final class Newspack_Popups {
 
 	const NEWSPACK_POPUPS_CPT              = 'newspack_popups_cpt';
 	const NEWSPACK_POPUPS_SITEWIDE_DEFAULT = 'newspack_popups_sitewide_default';
+	const NEWSPACK_POPUPS_TAXONOMY         = 'newspack_popups_taxonomy';
 
 	const NEWSPACK_POPUP_PREVIEW_QUERY_PARAM = 'newspack_popups_preview_id';
 
@@ -48,6 +49,7 @@ final class Newspack_Popups {
 		add_action( 'admin_notices', [ __CLASS__, 'api_config_missing_notice' ] );
 		add_action( 'init', [ __CLASS__, 'register_cpt' ] );
 		add_action( 'init', [ __CLASS__, 'register_meta' ] );
+		add_action( 'init', [ __CLASS__, 'register_taxonomy' ] );
 		add_action( 'enqueue_block_editor_assets', [ __CLASS__, 'enqueue_block_editor_assets' ] );
 		add_filter( 'display_post_states', [ __CLASS__, 'display_post_states' ], 10, 2 );
 		add_action( 'rest_api_init', [ __CLASS__, 'rest_api_init' ] );
@@ -268,6 +270,31 @@ final class Newspack_Popups {
 				'auth_callback' => '__return_true',
 			]
 		);
+	}
+
+	/**
+	 * Register Campaigns taxonomy.
+	 */
+	public static function register_taxonomy() {
+		$taxonomy_args = [
+			'labels'        => [
+				'name'          => __( 'Campaign Groups', 'newspack-popups' ),
+				'singular_name' => __( 'Campaign Group', 'newspack-popups' ),
+				'add_new_item'  => __( 'Add Campaign Group', 'newspack-popups' ),
+			],
+			'hierarchical'  => false,
+			'public'        => false,
+			'rewrite'       => false, // phpcs:ignore Squiz.PHP.CommentedOutCode.Found [ 'hierarchical' => true, 'slug' => $prefix . '/category' ]
+			'show_in_menu'  => false,
+			'show_in_rest'  => true,
+			'show_tagcloud' => false,
+			'show_ui'       => true,
+		];
+
+		register_taxonomy( self::NEWSPACK_POPUPS_TAXONOMY, [ self::NEWSPACK_POPUPS_CPT ], $taxonomy_args );
+
+		// Better safe than sorry: https://developer.wordpress.org/reference/functions/register_taxonomy/#more-information.
+		register_taxonomy_for_object_type( self::NEWSPACK_POPUPS_TAXONOMY, [ self::NEWSPACK_POPUPS_CPT ] );
 	}
 
 	/**

--- a/tests/test-api.php
+++ b/tests/test-api.php
@@ -63,7 +63,7 @@ class APITest extends WP_UnitTestCase {
 	public static function create_test_popup( $options, $post_content = 'Faucibus placerat senectus metus molestie varius tincidunt.' ) { // phpcs:ignore Squiz.Commenting.FunctionComment.Missing
 		$popup_id = self::factory()->post->create(
 			[
-				'post_type'    => Newspack_Popups::NEWSPACK_PLUGINS_CPT,
+				'post_type'    => Newspack_Popups::NEWSPACK_POPUPS_CPT,
 				'post_title'   => 'Platea fames',
 				'post_content' => $post_content,
 			]

--- a/tests/test-insertion.php
+++ b/tests/test-insertion.php
@@ -21,7 +21,7 @@ class InsertionTest extends WP_UnitTestCase {
 		);
 		self::$popup_id = self::factory()->post->create(
 			[
-				'post_type'    => Newspack_Popups::NEWSPACK_PLUGINS_CPT,
+				'post_type'    => Newspack_Popups::NEWSPACK_POPUPS_CPT,
 				'post_title'   => 'Platea fames',
 				'post_content' => self::$popup_content,
 			]

--- a/tests/test-model.php
+++ b/tests/test-model.php
@@ -14,7 +14,7 @@ class ModelTest extends WP_UnitTestCase {
 	public static function wpSetUpBeforeClass() { // phpcs:ignore Squiz.Commenting.FunctionComment.Missing
 		self::$popup_id = self::factory()->post->create(
 			[
-				'post_type'    => Newspack_Popups::NEWSPACK_PLUGINS_CPT,
+				'post_type'    => Newspack_Popups::NEWSPACK_POPUPS_CPT,
 				'post_title'   => 'Platea fames',
 				'post_content' => 'Faucibus placerat senectus.',
 			]


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds a custom taxonomy to Campaigns, which will be used to set up groups of campaigns which can be activated and deactivated together.

This branch also corrects longstanding typo in the custom post type constant, where `NEWSPACK_POPUPS_CPT` was originally named `NEWSPACK_PLUGINS_CPT`.

Closes https://github.com/Automattic/newspack-popups/issues/332

### How to test the changes in this Pull Request:

1. Create a Campaign. Observe new taxonomy UI in the sidebar labelled "Campaign Groups."
2. Add a taxonomy, verify it sticks.
3. Verify normal Campaign creation flows, to ensure the typo was fixed globally.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
