### PR TITLE
feat: make campaign groups a hierarchical taxonomy

### DIFF
--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -282,7 +282,7 @@ final class Newspack_Popups {
 				'singular_name' => __( 'Campaign Group', 'newspack-popups' ),
 				'add_new_item'  => __( 'Add Campaign Group', 'newspack-popups' ),
 			],
-			'hierarchical'  => false,
+			'hierarchical'  => true,
 			'public'        => false,
 			'rewrite'       => false, // phpcs:ignore Squiz.PHP.CommentedOutCode.Found [ 'hierarchical' => true, 'slug' => $prefix . '/category' ]
 			'show_in_menu'  => false,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

After discussing with @thomasguillot we concluded that Campaign Groups should be a hierarchical taxonomy for clearer UI.

### How to test the changes in this Pull Request:

1. Verify Campaign Groups is now hierarchical, with checkbox UI like core Categories as opposed to Tags.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
