### PR TITLE
Add "view as segment" feature

### DIFF
--- a/api/campaigns/class-campaign-data-utils.php
+++ b/api/campaigns/class-campaign-data-utils.php
@@ -39,18 +39,41 @@ class Campaign_Data_Utils {
 	}
 
 	/**
+	 * Add default values to a segment.
+	 *
+	 * @param object $segment Segment configuration.
+	 * @return object Segment configuration with default values.
+	 */
+	public static function canonize_segment( $segment ) {
+		return (object) array_merge(
+			[
+				'min_posts'         => 0,
+				'max_posts'         => 0,
+				'is_subscribed'     => false,
+				'is_not_subscribed' => false,
+				'is_donor'          => false,
+				'is_not_donor'      => false,
+				'referrers'         => '',
+			],
+			(array) $segment
+		);
+	}
+
+	/**
 	 * Given a segment and client data, decide if the campaign should be shown.
 	 *
 	 * @param object $campaign_segment Segment data.
 	 * @param object $client_data Client data.
-	 * @param bool   $referer_url Referrer URL.
+	 * @param string $referer_url URL of the page performing the API request.
+	 * @param string $page_referrer_url URL of the referrer of the frontend page that is making the API request.
 	 * @return bool Whether the campaign should be shown.
 	 */
-	public static function should_display_campaign( $campaign_segment, $client_data, $referer_url = '' ) {
+	public static function should_display_campaign( $campaign_segment, $client_data, $referer_url = '', $page_referrer_url = '' ) {
 		$should_display   = true;
 		$posts_read_count = count( $client_data['posts_read'] );
 		$is_subscriber    = self::is_subscriber( $client_data, $referer_url );
 		$is_donor         = self::is_donor( $client_data );
+		$campaign_segment = self::canonize_segment( $campaign_segment );
 
 		if ( $campaign_segment->min_posts > 0 && $campaign_segment->min_posts > $posts_read_count ) {
 			$should_display = false;
@@ -69,6 +92,22 @@ class Campaign_Data_Utils {
 		}
 		if ( $campaign_segment->is_not_donor && $is_donor ) {
 			$should_display = false;
+		}
+
+		if ( ! empty( $campaign_segment->referrers ) ) {
+			if ( empty( $page_referrer_url ) ) {
+				$should_display = false;
+			}
+			$referer_domain = parse_url( $page_referrer_url, PHP_URL_HOST ); // phpcs:ignore WordPress.WP.AlternativeFunctions.parse_url_parse_url, WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+			// Handle the 'www' prefix – assume `www.example.com` and `example.com` referrers are the same.
+			$referer_domain_alternative = strpos( $referer_domain, 'www.' ) === 0 ? substr( $referer_domain, 4 ) : "www.$referer_domain";
+			$referrer_matches           = array_intersect(
+				[ $referer_domain, $referer_domain_alternative ],
+				array_map( 'trim', explode( ',', $campaign_segment->referrers ) )
+			);
+			if ( empty( $referrer_matches ) ) {
+				$should_display = false;
+			}
 		}
 		return $should_display;
 	}

--- a/api/campaigns/class-campaign-data-utils.php
+++ b/api/campaigns/class-campaign-data-utils.php
@@ -66,14 +66,34 @@ class Campaign_Data_Utils {
 	 * @param object $client_data Client data.
 	 * @param string $referer_url URL of the page performing the API request.
 	 * @param string $page_referrer_url URL of the referrer of the frontend page that is making the API request.
+	 * @param object $view_as_segment If using the "view as" feature, this is a segment to conform to.
 	 * @return bool Whether the campaign should be shown.
 	 */
-	public static function should_display_campaign( $campaign_segment, $client_data, $referer_url = '', $page_referrer_url = '' ) {
+	public static function should_display_campaign( $campaign_segment, $client_data, $referer_url = '', $page_referrer_url = '', $view_as_segment = false ) {
 		$should_display   = true;
 		$posts_read_count = count( $client_data['posts_read'] );
 		$is_subscriber    = self::is_subscriber( $client_data, $referer_url );
 		$is_donor         = self::is_donor( $client_data );
 		$campaign_segment = self::canonize_segment( $campaign_segment );
+
+		if ( $view_as_segment ) {
+			$view_as_segment = self::canonize_segment( $view_as_segment );
+			if ( $view_as_segment->min_posts > 0 ) {
+				$posts_read_count = $view_as_segment->min_posts;
+			}
+			if ( $view_as_segment->max_posts > 0 ) {
+				$posts_read_count = $view_as_segment->max_posts;
+			}
+			$is_subscriber = $view_as_segment->is_subscribed;
+			$is_donor      = $view_as_segment->is_donor;
+			if ( ! empty( $view_as_segment->referrers ) ) {
+				$first_referrer = array_map( 'trim', explode( ',', $campaign_segment->referrers ) )[0];
+				if ( strpos( $first_referrer, 'http' ) !== 0 ) {
+					$first_referrer = 'https://' . $first_referrer;
+				}
+				$page_referrer_url = $first_referrer;
+			}
+		}
 
 		if ( $campaign_segment->min_posts > 0 && $campaign_segment->min_posts > $posts_read_count ) {
 			$should_display = false;

--- a/api/campaigns/class-maybe-show-campaign.php
+++ b/api/campaigns/class-maybe-show-campaign.php
@@ -191,7 +191,7 @@ class Maybe_Show_Campaign extends Lightweight_API {
 
 		// Using "view as" feature.
 		$view_as_segment = false;
-		if ( $view_as_spec && $view_as_spec['segment'] ) {
+		if ( $view_as_spec && isset( $view_as_spec['segment'] ) && $view_as_spec['segment'] ) {
 			$segment_config = [];
 			if ( isset( $settings->all_segments->{$view_as_spec['segment']} ) ) {
 				$segment_config = $settings->all_segments->{$view_as_spec['segment']};

--- a/includes/class-newspack-popups-segmentation.php
+++ b/includes/class-newspack-popups-segmentation.php
@@ -181,6 +181,9 @@ final class Newspack_Popups_Segmentation {
 	 * Should tracking code be inserted?
 	 */
 	public static function is_tracking() {
+		if ( Newspack_Popups_View_As::viewing_as_spec() ) {
+			return true;
+		}
 		if ( is_admin() || self::is_admin_user() || Newspack_Popups_Settings::is_non_interactive() ) {
 			return false;
 		}

--- a/includes/class-newspack-popups-view-as.php
+++ b/includes/class-newspack-popups-view-as.php
@@ -40,8 +40,6 @@ final class Newspack_Popups_View_As {
 	 * Constructor.
 	 */
 	public function __construct() {
-		add_action( 'wp_head', [ $this, 'handle_view_as' ] );
-
 		// Register the query param.
 		add_filter(
 			'query_vars',
@@ -50,20 +48,6 @@ final class Newspack_Popups_View_As {
 				return $vars;
 			}
 		);
-	}
-
-	/**
-	 * Set cookie if query param is set.
-	 */
-	public static function handle_view_as() {
-		if ( is_user_logged_in() && current_user_can( 'edit_others_pages' ) ) {
-			$view_as_param_value = get_query_var( 'view_as' );
-			if ( ! empty( $view_as_param_value ) ) {
-				$one_day = 60 * 60 * 24;
-				// This will be used for admin users only, so setting cookies is ok.
-				setcookie( self::COOKIE_NAME, $view_as_param_value, time() + $one_day, '/' ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.cookies_setcookie
-			}
-		}
 	}
 
 	/**
@@ -78,7 +62,6 @@ final class Newspack_Popups_View_As {
 		if ( get_query_var( 'view_as' ) ) {
 			return get_query_var( 'view_as' );
 		}
-		return isset( $_COOKIE[ self::COOKIE_NAME ] ) ? esc_attr( $_COOKIE[ self::COOKIE_NAME ] ) : false; // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 	}
 }
 

--- a/includes/class-newspack-popups-view-as.php
+++ b/includes/class-newspack-popups-view-as.php
@@ -19,11 +19,6 @@ final class Newspack_Popups_View_As {
 	protected static $instance = null;
 
 	/**
-	 * Cookie name for the "view as" feature.
-	 */
-	const COOKIE_NAME = 'newspack_popups_view_as';
-
-	/**
 	 * Main Newspack Popups View As Instance.
 	 * Ensures only one instance of Newspack Popups View As Instance is loaded or can be loaded.
 	 *

--- a/includes/class-newspack-popups-view-as.php
+++ b/includes/class-newspack-popups-view-as.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * Newspack Popups View As
+ *
+ * @package Newspack
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Main Newspack Popups View As Class.
+ */
+final class Newspack_Popups_View_As {
+	/**
+	 * The single instance of the class.
+	 *
+	 * @var Newspack_Popups_View_As
+	 */
+	protected static $instance = null;
+
+	/**
+	 * Cookie name for the "view as" feature.
+	 */
+	const COOKIE_NAME = 'newspack_popups_view_as';
+
+	/**
+	 * Main Newspack Popups View As Instance.
+	 * Ensures only one instance of Newspack Popups View As Instance is loaded or can be loaded.
+	 *
+	 * @return Newspack Popups View As Instance - Main instance.
+	 */
+	public static function instance() {
+		if ( is_null( self::$instance ) ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		add_action( 'wp_head', [ $this, 'handle_view_as' ] );
+
+		// Register the query param.
+		add_filter(
+			'query_vars',
+			function ( $vars ) {
+				$vars[] = 'view_as';
+				return $vars;
+			}
+		);
+	}
+
+	/**
+	 * Set cookie if query param is set.
+	 */
+	public static function handle_view_as() {
+		if ( is_user_logged_in() && current_user_can( 'edit_others_pages' ) ) {
+			$view_as_param_value = get_query_var( 'view_as' );
+			if ( ! empty( $view_as_param_value ) ) {
+				$one_day = 60 * 60 * 24;
+				// This will be used for admin users only, so setting cookies is ok.
+				setcookie( self::COOKIE_NAME, $view_as_param_value, time() + $one_day, '/' ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.cookies_setcookie
+			}
+		}
+	}
+
+	/**
+	 * Get the "view as" feature specification.
+	 *
+	 * @return string "View as" specification.
+	 */
+	public static function viewing_as_spec() {
+		if ( ! is_user_logged_in() || ! current_user_can( 'edit_others_pages' ) ) {
+			return false;
+		}
+		if ( get_query_var( 'view_as' ) ) {
+			return get_query_var( 'view_as' );
+		}
+		return isset( $_COOKIE[ self::COOKIE_NAME ] ) ? esc_attr( $_COOKIE[ self::COOKIE_NAME ] ) : false; // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+	}
+}
+
+Newspack_Popups_View_As::instance();

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -64,6 +64,7 @@ final class Newspack_Popups {
 		include_once dirname( __FILE__ ) . '/class-newspack-popups-segmentation.php';
 		include_once dirname( __FILE__ ) . '/class-newspack-popups-parse-logs.php';
 		include_once dirname( __FILE__ ) . '/class-newspack-popups-donations.php';
+		include_once dirname( __FILE__ ) . '/class-newspack-popups-view-as.php';
 	}
 
 	/**

--- a/tests/test-api.php
+++ b/tests/test-api.php
@@ -127,6 +127,7 @@ class APITest extends WP_UnitTestCase {
 				self::$settings,
 				'',
 				'',
+				false,
 				strtotime( '+1 day 1 hour' )
 			),
 			'Assert visible after a day has passed.'
@@ -770,6 +771,98 @@ class APITest extends WP_UnitTestCase {
 		self::assertTrue(
 			self::$maybe_show_campaign->should_campaign_be_shown( $client_id, $test_popup['payload'], self::$settings ),
 			'Assert visible, since there is no such segment.'
+		);
+	}
+
+	/**
+	 * View as a segment – subscribers.
+	 */
+	public function test_view_as_segment_subscribers() {
+		$test_popup = self::create_test_popup(
+			[
+				'placement'           => 'inline',
+				'frequency'           => 'always',
+				'selected_segment_id' => 'segmentSubscribers',
+			]
+		);
+		$client_id  = 'amp-123';
+
+		self::assertFalse(
+			self::$maybe_show_campaign->should_campaign_be_shown( $client_id, $test_popup['payload'], self::$settings ),
+			'Assert not visible, as the client is not a subscriber.'
+		);
+		self::assertTrue(
+			self::$maybe_show_campaign->should_campaign_be_shown( $client_id, $test_popup['payload'], self::$settings, '', '', [ 'segment' => 'segmentSubscribers' ] ),
+			'Assert visible when viewing as a segment member.'
+		);
+	}
+
+	/**
+	 * View as a segment – posts read count.
+	 */
+	public function test_view_as_segment_read_count() {
+		$test_popup = self::create_test_popup(
+			[
+				'placement'           => 'inline',
+				'frequency'           => 'always',
+				'selected_segment_id' => 'segmentBetween3And5',
+			]
+		);
+		$client_id  = 'amp-123';
+
+		self::assertFalse(
+			self::$maybe_show_campaign->should_campaign_be_shown( $client_id, $test_popup['payload'], self::$settings ),
+			'Assert not visible, as the client does not have the appropriate read count.'
+		);
+		self::assertTrue(
+			self::$maybe_show_campaign->should_campaign_be_shown( $client_id, $test_popup['payload'], self::$settings, '', '', [ 'segment' => 'segmentBetween3And5' ] ),
+			'Assert visible when viewing as a segment member.'
+		);
+	}
+
+	/**
+	 * View as a segment – referrers.
+	 */
+	public function test_view_as_segment_referrers() {
+		$test_popup = self::create_test_popup(
+			[
+				'placement'           => 'inline',
+				'frequency'           => 'always',
+				'selected_segment_id' => 'segmentWithReferrers',
+			]
+		);
+		$client_id  = 'amp-123';
+
+		self::assertFalse(
+			self::$maybe_show_campaign->should_campaign_be_shown( $client_id, $test_popup['payload'], self::$settings ),
+			'Assert not visible, as the referrer does not match.'
+		);
+		self::assertTrue(
+			self::$maybe_show_campaign->should_campaign_be_shown( $client_id, $test_popup['payload'], self::$settings, '', 'https://newspack.pub', [ 'segment' => 'segmentWithReferrers' ] ),
+			'Assert visible when viewing as a segment member.'
+		);
+	}
+
+	/**
+	 * View as a segment – non-existent segment.
+	 */
+	public function test_view_as_segment_non_existent() {
+		$test_popup = self::create_test_popup(
+			[
+				'placement'           => 'inline',
+				'frequency'           => 'always',
+				'selected_segment_id' => 'defaultSegment',
+			]
+		);
+		$client_id  = 'amp-123';
+
+		self::assertTrue(
+			self::$maybe_show_campaign->should_campaign_be_shown( $client_id, $test_popup['payload'], self::$settings ),
+			'Assert visible, a non-existent segment is disregarded.'
+		);
+		self::assertTrue(
+			self::$maybe_show_campaign->should_campaign_be_shown( $client_id, $test_popup['payload'], self::$settings, '', '', [ 'segment' => 'not-a-segment' ] ),
+			'Assert visible, a non-existent segment is disregarded.'
 		);
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds a feature that enables admins to view site as a member of a particular segment would see it.
There's not UI for that yet – it's a 'stealth' feature. The way to control it it via a URL query param and cookies.

### How to test the changes in this Pull Request:

1. Create a bunch of campaigns, using different segments – to use all segmentation options.
2. Visit the site as a logged-in user. 
3. Observe that active campaigns are not visible, and test campaigns are – nothing new here
4. Append a `view_as` query param to the URL, with the value of `segment:<segment-id>` (e.g. `?view_as=segment:5fa056b4b94bc`). You can read the segment ID from URL in Campaigns Wizard -> Segments -> edit a segment.
5. Observe that now, as a logged in admin user, you can see the applicable active campaigns – as a member of the chosen segment would.
6. Navigate to another page ~(now the URL param will be gone) – observe the above is still the case~
7. ~Remove the `newspack_popups_view_as` cookie (Chrome devtools -> Application panel)~
8. Observe that now only test campaigns are visible on the site

Edit: 👆 removed cookie use

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
