### PR TITLE
fix: show pending and future campaigns in UI

### DIFF
--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -34,7 +34,7 @@ final class Newspack_Popups_Model {
 	public static function retrieve_popups( $include_unpublished = false ) {
 		$args = [
 			'post_type'      => Newspack_Popups::NEWSPACK_POPUPS_CPT,
-			'post_status'    => $include_unpublished ? [ 'publish', 'draft' ] : 'publish',
+			'post_status'    => $include_unpublished ? [ 'publish', 'future', 'pending', 'draft' ] : [ 'publish', 'future' ],
 			'posts_per_page' => 100,
 		];
 

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -34,7 +34,7 @@ final class Newspack_Popups_Model {
 	public static function retrieve_popups( $include_unpublished = false ) {
 		$args = [
 			'post_type'      => Newspack_Popups::NEWSPACK_POPUPS_CPT,
-			'post_status'    => $include_unpublished ? [ 'publish', 'future', 'pending', 'draft' ] : [ 'publish', 'future' ],
+			'post_status'    => $include_unpublished ? [ 'publish', 'future', 'pending', 'draft' ] : 'publish',
 			'posts_per_page' => 100,
 		];
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Current campaign UI only shows campaign posts that have `publish` and `draft` statuses. This would cause posts with the `pending` or `future` status to be dropped before being rendered in the UI.

This PR, along with https://github.com/Automattic/newspack-plugin/pull/757, shows pending drafts under the "Draft" header and scheduled campaigns under the "Inactive" header, with a corresponding "Pending review" or "Scheduled" label for each.

<img width="275" alt="Screen Shot 2020-12-18 at 3 36 46 PM" src="https://user-images.githubusercontent.com/2230142/102667542-da3ed880-4146-11eb-918f-7dda900b5c79.png">

Closes #355.

### How to test the changes in this Pull Request:

Follow instructions in https://github.com/Automattic/newspack-plugin/pull/757.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
