### PR TITLE
fix: session read count in view-as logic

### DIFF
--- a/api/campaigns/class-campaign-data-utils.php
+++ b/api/campaigns/class-campaign-data-utils.php
@@ -100,6 +100,12 @@ class Campaign_Data_Utils {
 			if ( $view_as_segment->max_posts > 0 ) {
 				$posts_read_count = $view_as_segment->max_posts;
 			}
+			if ( $view_as_segment->min_session_posts > 0 ) {
+				$posts_read_count_session = $view_as_segment->min_session_posts;
+			}
+			if ( $view_as_segment->max_session_posts > 0 ) {
+				$posts_read_count_session = $view_as_segment->max_session_posts;
+			}
 			$is_subscriber = $view_as_segment->is_subscribed;
 			$is_donor      = $view_as_segment->is_donor;
 			if ( ! empty( $view_as_segment->referrers ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Support `Articles read in session` when previewing a segment.

Closes https://github.com/Automattic/newspack-popups/issues/361

### How to test the changes in this Pull Request:

1. On `master`, create a segment with min/max values for Articles read in session.
2. Create an inline campaigns and choose the segment.
3. In the Newspack Plugin Campaigns wizard preview as the segment.
4. Observe the campaign is not shown.
5. Switch to this branch, preview again.
6. Observe the campaign is now shown.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
