### PR TITLE
fix: install composer dependencies on release job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,6 +88,9 @@ jobs:
           name: Install rsync
           command: sudo apt install rsync
       - run:
+          name: Install PHP packages
+          command: composer install --no-dev --no-scripts
+      - run:
           name: Release new version
           command: npm run release
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 commands:
-  checkout_code:
+  checkout_with_workspace:
     steps:
       - checkout
       - attach_workspace:
@@ -10,9 +10,9 @@ commands:
 jobs:
   build:
     docker:
-      - image: circleci/node:12
+      - image: circleci/php:7.2-node-browsers
     steps:
-      - checkout_code
+      - checkout_with_workspace
       - run:
           name: Install dependencies
           command: npm ci
@@ -23,9 +23,9 @@ jobs:
 
   lint-js-scss:
     docker:
-      - image: circleci/node:12
+      - image: circleci/php:7.2-node-browsers
     steps:
-      - checkout_code
+      - checkout_with_workspace
       - run:
           name: Run Linter
           command: npm run lint
@@ -38,7 +38,7 @@ jobs:
       - WP_TESTS_DIR: '/tmp/wordpress-tests-lib'
       - WP_CORE_DIR: '/tmp/wordpress/'
     steps:
-      - checkout_code
+      - checkout
       - run:
           name: Setup Environment Variables
           command: |
@@ -72,18 +72,18 @@ jobs:
 
   test-js:
     docker:
-      - image: circleci/node:12
+      - image: circleci/php:7.2-node-browsers
     steps:
-      - checkout_code
+      - checkout_with_workspace
       - run:
           name: Run JS Tests
           command: npm run test
 
   release:
     docker:
-      - image: circleci/node:12
+      - image: circleci/php:7.2-node-browsers
     steps:
-      - checkout_code
+      - checkout_with_workspace
       - run:
           name: Install rsync
           command: sudo apt install rsync
@@ -97,9 +97,9 @@ jobs:
   # Reset alpha branch after a release
   post_release:
     docker:
-      - image: circleci/node:12
+      - image: circleci/php:7.2-node-browsers
     steps:
-      - checkout_code
+      - checkout
       - run:
           name: Set tip of alpha branch on top of release and force-push it to remote
           command: |


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Includes composer dependencies in the release job, otherwise the segmentation API won't work. 

Closes #359.

### How to test the changes in this Pull Request:

1. Create an alpha release by merging this branch into the `alpha` branch.
2. In CircleCI, confirm that the alpha release job completes successfully without errors.
3. Install the alpha release package on a test site, confirm that all segmentation features are working as expected.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
