### PR TITLE
feat: manual placement

### DIFF
--- a/api/campaigns/class-maybe-show-campaign.php
+++ b/api/campaigns/class-maybe-show-campaign.php
@@ -123,6 +123,7 @@ class Maybe_Show_Campaign extends Lightweight_API {
 			case 'once':
 				$should_display = $campaign_data['count'] < 1;
 				break;
+			case 'manual':
 			case 'always':
 				$should_display = true;
 				break;

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -121,6 +121,14 @@ final class Newspack_Popups_Inserter {
 			}
 		);
 
+		// Remove manual placement campaigns.
+		$popups_to_maybe_display_deduped = array_filter(
+			$popups_to_maybe_display_deduped,
+			function( $campaign ) {
+				return 'manual' !== $campaign['options']['frequency'];
+			}
+		);
+
 		return array_filter(
 			$popups_to_maybe_display_deduped,
 			[ __CLASS__, 'should_display' ]
@@ -649,6 +657,10 @@ final class Newspack_Popups_Inserter {
 	 * @return bool Should popup be shown.
 	 */
 	public static function should_display( $popup, $skip_context_checks = false ) {
+		if ( 'manual' === $popup['options']['frequency'] ) {
+			return true;
+		}
+
 		$general_conditions = self::assess_is_post( $popup ) &&
 			self::assess_categories_filter( $popup ) &&
 			self::assess_tags_filter( $popup ) &&

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -164,7 +164,7 @@ final class Newspack_Popups_Model {
 		foreach ( $options as $key => $value ) {
 			switch ( $key ) {
 				case 'frequency':
-					if ( ! in_array( $value, [ 'test', 'never', 'once', 'daily', 'always' ] ) ) {
+					if ( ! in_array( $value, [ 'test', 'never', 'once', 'daily', 'always', 'manual' ] ) ) {
 						return new \WP_Error(
 							'newspack_popups_invalid_option_value',
 							esc_html__( 'Invalid frequency value.', 'newspack-popups' ),

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -463,6 +463,7 @@ final class Newspack_Popups {
 			return;
 		}
 		$type = isset( $_GET['placement'] ) ? sanitize_text_field( $_GET['placement'] ) : null; //phpcs:ignore
+		$frequency = 'test';
 		switch ( $type ) {
 			case 'overlay-center':
 				$placement = 'center';
@@ -476,6 +477,10 @@ final class Newspack_Popups {
 			case 'above-header':
 				$placement = 'above_header';
 				break;
+			case 'manual':
+				$placement = 'inline';
+				$frequency = 'manual';
+				break;
 			default:
 				$placement = 'inline';
 				break;
@@ -484,7 +489,7 @@ final class Newspack_Popups {
 		update_post_meta( $post_id, 'background_color', '#FFFFFF' );
 		update_post_meta( $post_id, 'display_title', false );
 		update_post_meta( $post_id, 'dismiss_text', self::get_default_dismiss_text() );
-		update_post_meta( $post_id, 'frequency', 'test' );
+		update_post_meta( $post_id, 'frequency', $frequency );
 		update_post_meta( $post_id, 'overlay_color', '#000000' );
 		update_post_meta( $post_id, 'overlay_opacity', 30 );
 		update_post_meta( $post_id, 'placement', $placement );

--- a/src/editor/FrequencySidebar.js
+++ b/src/editor/FrequencySidebar.js
@@ -25,6 +25,7 @@ const FrequencySidebar = ( { frequency, onMetaFieldChange, isOverlay, utm_suppre
 						label: __( 'Every page', 'newspack-popups' ),
 						disabled: isOverlay,
 					},
+					{ value: 'manual', label: __( 'Manual Placement', 'newspack-popups' ) },
 				] }
 			/>
 			<TextControl


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

In order to manually place an inline campaign via shortcode the campaign needs to have a normal frequency (e.g. every page) which means it will appear in posts. This will often be undesirable, if the campaign is designed exclusively for the homepage. This branch adds a new frequency option called "Manual Placement." When selected, the campaign will only show up when manually placed by shortcode. This is a bit similar to the `Manual Only` option that was originally in https://github.com/Automattic/newspack-popups/pull/321, although we ended up removing it ([my fault](https://github.com/Automattic/newspack-popups/pull/321#discussion_r532261142)!)

Closes https://github.com/Automattic/newspack-popups/issues/372

https://github.com/Automattic/newspack-plugin/pull/796 adds UI for selecting Manual Placement to the Campaigns Wizard. Strictly speaking its not necessary to test these two PRs together, but it'll be a lot easier because you can do everything from the wizard.

### How to test the changes in this Pull Request:

1. Create an inline campaign, choose `Manual Only` frequency.
2. Edit the site's homepage, manually place the campaign by adding `shortcode` block and using `[newspack-popup id="123" \]` (where 123 is the ID of the campaign created in step 1.)
3. Viewing incognito, verify the campaign appears on the homepage.
4. Navigate to other posts and verify the campaign does not appear in them.
5. Try assigning segments, make sure the segmentation logic is enforced on the homepage.
6. Try previewing in a variety of ways, make sure everything works as expected.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
