### PR TITLE
fix: remove trailing question mark from cleaned non-AMP URLs

### DIFF
--- a/src/view/index.js
+++ b/src/view/index.js
@@ -47,7 +47,7 @@ const manageAnalyticsLinkers = () => {
 			document.cookie = cookieValue;
 		}
 		if ( cleanURL ) {
-			window.history.pushState( {}, document.title, cleanURL );
+			window.history.replaceState( {}, document.title, cleanURL );
 		}
 	} );
 };

--- a/src/view/utils/index.js
+++ b/src/view/utils/index.js
@@ -104,6 +104,12 @@ export const getCookieValueFromLinker = (
 		const linkerParam = getQueryArg( url, linkerName );
 		const hasCIDCookie = documentCookie.indexOf( cookieName ) >= 0;
 		cleanURL = removeQueryArgs( url, linkerName );
+
+		// Strip trailing `?` character from clean URL.
+		if ( '?' === cleanURL.charAt( cleanURL.length - 1 ) ) {
+			cleanURL = cleanURL.slice( 0, cleanURL.length - 1 );
+		}
+
 		if ( linkerParam && ! hasCIDCookie ) {
 			// eslint-disable-next-line no-unused-vars
 			const [ version, checksum, cidName, cidValue ] = linkerParam.split( '*' );

--- a/src/view/utils/index.test.js
+++ b/src/view/utils/index.test.js
@@ -11,7 +11,7 @@ describe( 'amp-analytics linker handling', () => {
 	it( 'read linker param from URL and parse CID cookie value', () => {
 		expect( getCookieValueFromLinker( ampAnalyticsConfig, url, '' ) ).toEqual( {
 			cookieValue: 'newspack-cid=Ojmd7I5ODbwD-etNS57ApHep4q7Kn4VEUSJ7bSlhW6aUOEraIaaiYl98-AslsmDz',
-			cleanURL: 'https://example.com/lorem/?',
+			cleanURL: 'https://example.com/lorem/',
 		} );
 	} );
 	it( 'does not throw if malformed linker param is received', () => {
@@ -21,18 +21,18 @@ describe( 'amp-analytics linker handling', () => {
 				'https://example.com/lorem/?ref_newspack_cid=1*ab3otu*cid*,,,',
 				''
 			)
-		).toEqual( { cookieValue: undefined, cleanURL: 'https://example.com/lorem/?' } );
+		).toEqual( { cookieValue: undefined, cleanURL: 'https://example.com/lorem/' } );
 	} );
 	it( 'return undefined if there is no linker param in the URL', () => {
 		expect( getCookieValueFromLinker( ampAnalyticsConfig, 'https://example.com', '' ) ).toEqual( {
 			cookieValue: undefined,
-			cleanURL: 'https://example.com?',
+			cleanURL: 'https://example.com',
 		} );
 	} );
 	it( 'return undefined if cookie is already set', () => {
 		expect( getCookieValueFromLinker( ampAnalyticsConfig, url, 'newspack-cid=amp-123' ) ).toEqual( {
 			cookieValue: undefined,
-			cleanURL: 'https://example.com/lorem/?',
+			cleanURL: 'https://example.com/lorem/',
 		} );
 	} );
 } );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Due to [this clean function](https://github.com/Automattic/newspack-popups/pull/306/files#diff-961feb79bdd31646421b94dfdb35d9ea989a94b447987ea75e325e9665465241R86), when visiting a non-AMP page or post, the AMP polyfill cleans the URL of linker params but leaves a trailing `?` character at the end of the URL. It also creates extra browser history via `history.pushState`. This PR removes the trailing `?` and uses `history.replaceState` to avoid the extra browser history.

### How to test the changes in this Pull Request:

1. On `master`, visit a non-AMP post in a new Incognito window and observe that the page loads with a trailing `?` on the URL. Also observe that clicking the browser's back button after the the page loads just removes the `?` without actually going back to the prior page.
2. Check out this branch and run `npm run build`.
3. Visit the same post and observe that the trailing `?` no longer gets appended.
4. Open Dev Tools > Application > Cookies > [your test site URL] and confirm that the AMP cookie is still getting set correctly as `newspack-cid`.
5. Confirm that hitting the back button returns to the prior page as expected.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
