### PR TITLE
feat: deprecate test mode and never frequency

### DIFF
--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -659,7 +659,7 @@ final class Newspack_Popups_Inserter {
 		if ( Newspack_Popups_View_As::viewing_as_spec() ) {
 			return $general_conditions;
 		}
-		// Hide non-test mode campaigns for logged-in users.
+		// Hide campaigns for logged-in users.
 		if ( is_user_logged_in() ) {
 			return false;
 		}

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -394,6 +394,8 @@ final class Newspack_Popups_Model {
 			update_post_meta( $popup['id'], 'frequency', $popup['options']['frequency'] );
 			$popup['status'] = 'draft';
 
+			$post = get_post( $popup['id'] );
+
 			$post->post_status = 'draft';
 			wp_update_post( $post );
 

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -463,8 +463,9 @@ final class Newspack_Popups {
 		if ( $update ) {
 			return;
 		}
-		$type = isset( $_GET['placement'] ) ? sanitize_text_field( $_GET['placement'] ) : null; //phpcs:ignore
-		$frequency = 'test';
+		$type      = isset( $_GET['placement'] ) ? sanitize_text_field( $_GET['placement'] ) : null; //phpcs:ignore
+		$frequency = 'daily';
+
 		switch ( $type ) {
 			case 'overlay-center':
 				$placement = 'center';
@@ -477,6 +478,7 @@ final class Newspack_Popups {
 				break;
 			case 'above-header':
 				$placement = 'above_header';
+				$frequency = 'always';
 				break;
 			case 'manual':
 				$placement = 'inline';
@@ -484,17 +486,33 @@ final class Newspack_Popups {
 				break;
 			default:
 				$placement = 'inline';
+				$frequency = 'always';
+				break;
+		}
+
+		switch ( $type ) {
+			case 'overlay-center':
+			case 'overlay-top':
+			case 'overlay-bottom':
+				$dismiss_text = self::get_default_dismiss_text();
+				$trigger_type = 'time';
+				break;
+			case 'above-header':
+			case 'manual':
+			default:
+				$dismiss_text = null;
+				$trigger_type = 'scroll';
 				break;
 		}
 
 		update_post_meta( $post_id, 'background_color', '#FFFFFF' );
 		update_post_meta( $post_id, 'display_title', false );
-		update_post_meta( $post_id, 'dismiss_text', self::get_default_dismiss_text() );
+		update_post_meta( $post_id, 'dismiss_text', $dismiss_text );
 		update_post_meta( $post_id, 'frequency', $frequency );
 		update_post_meta( $post_id, 'overlay_color', '#000000' );
 		update_post_meta( $post_id, 'overlay_opacity', 30 );
 		update_post_meta( $post_id, 'placement', $placement );
-		update_post_meta( $post_id, 'trigger_type', 'time' );
+		update_post_meta( $post_id, 'trigger_type', $trigger_type );
 		update_post_meta( $post_id, 'trigger_delay', 3 );
 		update_post_meta( $post_id, 'trigger_scroll_progress', 30 );
 		update_post_meta( $post_id, 'utm_suppression', '' );

--- a/src/editor/FrequencySidebar.js
+++ b/src/editor/FrequencySidebar.js
@@ -17,7 +17,6 @@ const FrequencySidebar = ( { frequency, onMetaFieldChange, isOverlay, utm_suppre
 				value={ frequency }
 				onChange={ value => onMetaFieldChange( 'frequency', value ) }
 				options={ [
-					{ value: 'never', label: __( 'Never', 'newspack-popups' ) },
 					{ value: 'once', label: __( 'Once', 'newspack-popups' ) },
 					{ value: 'daily', label: __( 'Once a day', 'newspack-popups' ) },
 					{

--- a/src/editor/StatusSidebar.js
+++ b/src/editor/StatusSidebar.js
@@ -14,20 +14,18 @@ const StatusSidebar = ( {
 	isOverlay,
 	onSitewideDefaultChange,
 } ) => {
-	return (
-		isOverlay && (
-			<PluginPostStatusInfo>
-				<div className="newspack-popups__status-options">
-					<ToggleControl
-						label={ __( 'Sitewide Default', 'newspack-popups' ) }
-						help={ __( 'Sitewide default campaigns can appear on any page.', 'newspack-popups' ) }
-						checked={ newspack_popups_is_sitewide_default }
-						onChange={ value => onSitewideDefaultChange( value ) }
-					/>
-				</div>
-			</PluginPostStatusInfo>
-		)
-	);
+	return isOverlay ? (
+		<PluginPostStatusInfo>
+			<div className="newspack-popups__status-options">
+				<ToggleControl
+					label={ __( 'Sitewide Default', 'newspack-popups' ) }
+					help={ __( 'Sitewide default campaigns can appear on any page.', 'newspack-popups' ) }
+					checked={ newspack_popups_is_sitewide_default }
+					onChange={ value => onSitewideDefaultChange( value ) }
+				/>
+			</div>
+		</PluginPostStatusInfo>
+	) : null;
 };
 
 export default StatusSidebar;

--- a/src/editor/StatusSidebar.js
+++ b/src/editor/StatusSidebar.js
@@ -15,18 +15,18 @@ const StatusSidebar = ( {
 	onSitewideDefaultChange,
 } ) => {
 	return (
-		<PluginPostStatusInfo>
-			<div className="newspack-popups__status-options">
-				{ isOverlay && (
+		isOverlay && (
+			<PluginPostStatusInfo>
+				<div className="newspack-popups__status-options">
 					<ToggleControl
 						label={ __( 'Sitewide Default', 'newspack-popups' ) }
 						help={ __( 'Sitewide default campaigns can appear on any page.', 'newspack-popups' ) }
 						checked={ newspack_popups_is_sitewide_default }
 						onChange={ value => onSitewideDefaultChange( value ) }
 					/>
-				) }
-			</div>
-		</PluginPostStatusInfo>
+				</div>
+			</PluginPostStatusInfo>
+		)
 	);
 };
 

--- a/src/editor/StatusSidebar.js
+++ b/src/editor/StatusSidebar.js
@@ -10,7 +10,6 @@ import { PluginPostStatusInfo } from '@wordpress/edit-post';
 import { ToggleControl } from '@wordpress/components';
 
 const StatusSidebar = ( {
-	frequency,
 	newspack_popups_is_sitewide_default,
 	isOverlay,
 	onSitewideDefaultChange,

--- a/src/editor/StatusSidebar.js
+++ b/src/editor/StatusSidebar.js
@@ -7,55 +7,17 @@
  */
 import { __ } from '@wordpress/i18n';
 import { PluginPostStatusInfo } from '@wordpress/edit-post';
-import { useEffect } from '@wordpress/element';
 import { ToggleControl } from '@wordpress/components';
 
 const StatusSidebar = ( {
-	createNotice,
 	frequency,
 	newspack_popups_is_sitewide_default,
-	onMetaFieldChange,
 	isOverlay,
-	removeNotice,
 	onSitewideDefaultChange,
 } ) => {
-	const isTest = 'test' === frequency;
-
-	const createTestNotice = () => {
-		createNotice(
-			'warning',
-			__(
-				'Test Mode Enabled: In "Test Mode" logged-in admins will see the campaign every time, and non-admins will never see them.',
-				'newspack-popups'
-			),
-			{
-				id: 'newspack-popups__test-mode',
-				isDismissible: true,
-				type: 'default',
-			}
-		);
-	};
-
-	useEffect(() => {
-		if ( isTest ) {
-			createTestNotice();
-		} else {
-			removeNotice( 'newspack-popups__test-mode' );
-		}
-	}, [ isTest ]);
-
 	return (
 		<PluginPostStatusInfo>
 			<div className="newspack-popups__status-options">
-				<ToggleControl
-					checked={ isTest }
-					label={ __( 'Test Mode', 'newspack-popups' ) }
-					help={ __(
-						'In "Test Mode" logged-in admins will see the campaign every time, and non-admins will never see them.',
-						'newspack-popups'
-					) }
-					onChange={ value => onMetaFieldChange( 'frequency', value ? 'test' : 'once' ) }
-				/>
 				{ isOverlay && (
 					<ToggleControl
 						label={ __( 'Sitewide Default', 'newspack-popups' ) }

--- a/tests/test-insertion.php
+++ b/tests/test-insertion.php
@@ -31,11 +31,12 @@ class InsertionTest extends WP_UnitTestCase {
 				'post_content' => self::$popup_content,
 			]
 		);
-		// Set popup frequency from default 'test'.
+
 		Newspack_Popups_Model::set_popup_options(
 			self::$popup_id,
 			[
-				'frequency' => 'always',
+				'frequency'    => 'daily',
+				'dismiss_text' => Newspack_Popups::get_default_dismiss_text(),
 			]
 		);
 

--- a/tests/test-model.php
+++ b/tests/test-model.php
@@ -31,13 +31,13 @@ class ModelTest extends WP_UnitTestCase {
 			[
 				'background_color'        => '#FFFFFF',
 				'display_title'           => false,
-				'dismiss_text'            => Newspack_Popups::get_default_dismiss_text(),
+				'dismiss_text'            => '',
 				'dismiss_text_alignment'  => 'center',
-				'frequency'               => 'test',
+				'frequency'               => 'always',
 				'overlay_color'           => '#000000',
 				'overlay_opacity'         => '30',
 				'placement'               => 'inline',
-				'trigger_type'            => 'time',
+				'trigger_type'            => 'scroll',
 				'trigger_delay'           => '3',
 				'trigger_scroll_progress' => '30',
 				'utm_suppression'         => null,
@@ -68,7 +68,8 @@ class ModelTest extends WP_UnitTestCase {
 		Newspack_Popups_Model::set_popup_options(
 			self::$popup_id,
 			[
-				'placement' => 'center',
+				'placement'    => 'center',
+				'trigger_type' => 'time',
 			]
 		);
 
@@ -94,6 +95,7 @@ class ModelTest extends WP_UnitTestCase {
 			get_post( self::$popup_id ),
 			false,
 			[
+				'placement'    => 'center',
 				'trigger_type' => 'scroll',
 			]
 		);
@@ -112,6 +114,7 @@ class ModelTest extends WP_UnitTestCase {
 			get_post( self::$popup_id ),
 			false,
 			[
+				'placement'               => 'center',
 				'trigger_type'            => 'scroll',
 				'trigger_scroll_progress' => 42,
 			]


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

### Changes proposed in this Pull Request:

Test with https://github.com/Automattic/newspack-plugin/pull/809.

Replaces https://github.com/Automattic/newspack-popups/pull/365

### How to test the changes in this Pull Request:

Full testing instructions in https://github.com/Automattic/newspack-plugin/pull/809

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
