### PR TITLE
Segmentation: category affinity fixes

### DIFF
--- a/api/campaigns/class-maybe-show-campaign.php
+++ b/api/campaigns/class-maybe-show-campaign.php
@@ -199,26 +199,6 @@ class Maybe_Show_Campaign extends Lightweight_API {
 				// Save suppression for this campaign.
 				$campaign_data['suppress_forever'] = true;
 			}
-			if ( isset( $campaign_segment->favorite_categories ) && count( $campaign_segment->favorite_categories ) > 0 ) {
-				$categories_read_counts = array_reduce(
-					$client_data['posts_read'],
-					function ( $read_counts, $read_post ) {
-						foreach ( explode( ',', $read_post['category_ids'] ) as $cat_id ) {
-							if ( isset( $read_counts[ $cat_id ] ) ) {
-								$read_counts[ $cat_id ]++;
-							} else {
-								$read_counts[ $cat_id ] = 1;
-							}
-						}
-						return $read_counts;
-					}
-				);
-				arsort( $categories_read_counts );
-				$favorite_category_matches_segment = in_array( key( $categories_read_counts ), $campaign_segment->favorite_categories );
-				if ( ! $favorite_category_matches_segment ) {
-					$should_display = false;
-				}
-			}
 		}
 
 		if ( ! $view_as_spec && ! empty( array_diff( $init_campaign_data, $campaign_data ) ) ) {


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes two issues with category affinity segmentation.

### How to test the changes in this Pull Request:

1. On `master`, create a segment using category affinity criterion and assign it to a campaign
2. Observe the segment size ("This segment would reach…") not changing, always at 100%
3. Use the preview feature to view site as the segment member, observe that the relevant campaign is not displayed
4. Switch to this branch
5. Observe the segment size updated when as expected in the segment editor
6. Observe the preview feature working as expected

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [X] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
