### PR TITLE
Disregard frequency with view-as; handle 'all' in view-as spec

### DIFF
--- a/api/campaigns/class-maybe-show-campaign.php
+++ b/api/campaigns/class-maybe-show-campaign.php
@@ -32,7 +32,12 @@ class Maybe_Show_Campaign extends Lightweight_API {
 		$response  = [];
 		$client_id = $_REQUEST['cid']; // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 
-		if ( $visit['is_post'] && defined( 'ENABLE_CAMPAIGN_EVENT_LOGGING' ) && ENABLE_CAMPAIGN_EVENT_LOGGING ) {
+		$view_as_spec = [];
+		if ( ! empty( $_REQUEST['view_as'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$view_as_spec = Segmentation::parse_view_as( json_decode( $_REQUEST['view_as'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		}
+
+		if ( empty( $view_as_spec ) && $visit['is_post'] && defined( 'ENABLE_CAMPAIGN_EVENT_LOGGING' ) && ENABLE_CAMPAIGN_EVENT_LOGGING ) {
 			// Update the cache.
 			$posts_read        = $this->get_client_data( $client_id )['posts_read'];
 			$already_read_post = count(
@@ -66,12 +71,6 @@ class Maybe_Show_Campaign extends Lightweight_API {
 					$visit
 				)
 			);
-		}
-
-
-		$view_as_spec = [];
-		if ( ! empty( $_REQUEST['view_as'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			$view_as_spec = Segmentation::parse_view_as( json_decode( $_REQUEST['view_as'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		}
 
 		$page_referer_url = isset( $_REQUEST['ref'] ) ? $_REQUEST['ref'] : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
@@ -201,15 +200,16 @@ class Maybe_Show_Campaign extends Lightweight_API {
 			}
 		}
 
-		if ( ! $view_as_spec && ! empty( array_diff( $init_campaign_data, $campaign_data ) ) ) {
-			$this->save_campaign_data( $client_id, $campaign->id, $campaign_data );
-		}
-
-		if ( 'once' === $frequency && $campaign_data['count'] >= 1 ) {
-			$should_display = false;
-		}
-		if ( 'daily' === $frequency && $campaign_data['last_viewed'] >= strtotime( '-1 day', $now ) ) {
-			$should_display = false;
+		if ( ! $view_as_spec ) {
+			if ( ! empty( array_diff( $init_campaign_data, $campaign_data ) ) ) {
+				$this->save_campaign_data( $client_id, $campaign->id, $campaign_data );
+			}
+			if ( 'once' === $frequency && $campaign_data['count'] >= 1 ) {
+				$should_display = false;
+			}
+			if ( 'daily' === $frequency && $campaign_data['last_viewed'] >= strtotime( '-1 day', $now ) ) {
+				$should_display = false;
+			}
 		}
 
 		return $should_display;

--- a/api/segmentation/class-segmentation.php
+++ b/api/segmentation/class-segmentation.php
@@ -47,8 +47,12 @@ class Segmentation {
 		return array_reduce(
 			explode( ';', $raw_spec ),
 			function( $acc, $item ) {
-				$parts            = explode( ':', $item );
-				$acc[ $parts[0] ] = $parts[1];
+				$parts = explode( ':', $item );
+				if ( 1 === count( $parts ) ) {
+					$acc[ $parts[0] ] = true;
+				} else {
+					$acc[ $parts[0] ] = $parts[1];
+				}
 				return $acc;
 			},
 			[]

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -681,8 +681,8 @@ final class Newspack_Popups_Inserter {
 		$is_not_test_mode   = 'test' !== $popup['options']['frequency'];
 
 		// When using "view as" feature, discard test mode campaigns.
-		if ( $general_conditions && Newspack_Popups_View_As::viewing_as_spec() ) {
-			return $is_not_test_mode;
+		if ( Newspack_Popups_View_As::viewing_as_spec() ) {
+			return $general_conditions && $is_not_test_mode;
 		}
 		// Hide non-test mode campaigns for logged-in users.
 		if ( is_user_logged_in() && $is_not_test_mode ) {

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -587,7 +587,7 @@ final class Newspack_Popups_Model {
 	 */
 	protected static function insert_event_tracking( $popup, $body, $element_id ) {
 		if (
-			Newspack_Popups::previewed_popup_id() ||
+			Newspack_Popups::is_preview_request() ||
 			'test' === $popup['options']['frequency'] ||
 			Newspack_Popups_Settings::is_non_interactive()
 		) {
@@ -660,7 +660,7 @@ final class Newspack_Popups_Model {
 	 * @param string $element_id The id of the popup element.
 	 */
 	protected static function get_analytics_events( $popup, $body, $element_id ) {
-		if ( Newspack_Popups::previewed_popup_id() ) {
+		if ( Newspack_Popups::is_preview_request() ) {
 			return [];
 		}
 

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -16,8 +16,7 @@ final class Newspack_Popups {
 	const NEWSPACK_POPUPS_SITEWIDE_DEFAULT      = 'newspack_popups_sitewide_default';
 	const NEWSPACK_POPUPS_TAXONOMY              = 'newspack_popups_taxonomy';
 	const NEWSPACK_POPUPS_ACTIVE_CAMPAIGN_GROUP = 'newspack_popups_active_campaign_group';
-
-	const NEWSPACK_POPUP_PREVIEW_QUERY_PARAM = 'newspack_popups_preview_id';
+	const NEWSPACK_POPUP_PREVIEW_QUERY_PARAM    = 'newspack_popups_preview_id';
 
 	const LIGHTWEIGHT_API_CONFIG_FILE_PATH_LEGACY = WP_CONTENT_DIR . '/../newspack-popups-config.php';
 	const LIGHTWEIGHT_API_CONFIG_FILE_PATH        = WP_CONTENT_DIR . '/newspack-popups-config.php';
@@ -392,34 +391,31 @@ final class Newspack_Popups {
 	}
 
 	/**
-	 * Hide admin bar if previewing the popup.
+	 * Should admin bar be shown.
 	 *
 	 * @return boolean Whether admin bar should be shown.
 	 */
 	public static function show_admin_bar() {
+		return ! self::is_preview_request();
+	}
+
+	/**
+	 * Is it a preview request – a single popup preview or using "view as" feature.
+	 *
+	 * @return boolean Whether it's a preview request.
+	 */
+	public static function is_preview_request() {
 		$view_as_spec = Newspack_Popups_View_As::viewing_as_spec();
-		return ! self::previewed_popup_id() && false === $view_as_spec;
+		return self::previewed_popup_id() || false !== $view_as_spec;
 	}
 
 	/**
 	 * Get previewed popup id from the URL.
 	 *
-	 * @param string $url URL, if available.
 	 * @return number|null Popup id, if found in the URL
 	 */
-	public static function previewed_popup_id( $url = null ) {
-		if ( $url ) {
-			$query_params = [];
-			$parsed_url   = wp_parse_url( $url );
-			parse_str(
-				isset( $parsed_url['query'] ) ? $parsed_url['query'] : '',
-				$query_params
-			);
-			$param = self::NEWSPACK_POPUP_PREVIEW_QUERY_PARAM;
-			return isset( $query_params[ $param ] ) ? $query_params[ $param ] : false;
-		} else {
-			return filter_input( INPUT_GET, self::NEWSPACK_POPUP_PREVIEW_QUERY_PARAM, FILTER_SANITIZE_STRING );
-		}
+	public static function previewed_popup_id() {
+		return filter_input( INPUT_GET, self::NEWSPACK_POPUP_PREVIEW_QUERY_PARAM, FILTER_SANITIZE_STRING );
 	}
 
 	/**

--- a/tests/test-api.php
+++ b/tests/test-api.php
@@ -1097,4 +1097,47 @@ class APITest extends WP_UnitTestCase {
 			'Assert visible, a non-existent segment is disregarded.'
 		);
 	}
+
+	/**
+	 * Serializing a popup object to be sent to the API.
+	 */
+	public function test_popup_object_api_serialization() {
+		$default_payload = self::create_test_popup( [] )['payload'];
+		self::assertArraySubset(
+			(array) [
+				'f'   => 'test',
+				'utm' => null,
+				's'   => '',
+				'n'   => false,
+				'd'   => false,
+			],
+			(array) $default_payload,
+			false,
+			'API payload for the default test popup is correct.'
+		);
+
+		self::assertRegExp(
+			'/id_\d/',
+			$default_payload->id,
+			'The id in the payload is the popup id prefixed with "id_"'
+		);
+
+		self::assertArraySubset(
+			(array) [
+				'f'   => 'once',
+				'utm' => null,
+				's'   => '',
+				'n'   => false,
+				'd'   => false,
+			],
+			(array) self::create_test_popup(
+				[
+					'frequency' => 'always',
+					'placement' => 'top',
+				]
+			)['payload'],
+			false,
+			'An overlay popup with "always" frequency has it corrected to "once".'
+		);
+	}
 }

--- a/tests/test-insertion.php
+++ b/tests/test-insertion.php
@@ -9,9 +9,12 @@
  * Insertion test case.
  */
 class InsertionTest extends WP_UnitTestCase {
-	private static $post_id       = false; // phpcs:ignore Squiz.Commenting.VariableComment.Missing
-	private static $popup_content = 'Faucibus placerat senectus metus molestie varius tincidunt.'; // phpcs:ignore Squiz.Commenting.VariableComment.Missing
-	private static $popup_id      = false; // phpcs:ignore Squiz.Commenting.VariableComment.Missing
+	private static $post_id          = false; // phpcs:ignore Squiz.Commenting.VariableComment.Missing
+	private static $popup_content    = 'The popup content.'; // phpcs:ignore Squiz.Commenting.VariableComment.Missing
+	private static $popup_id         = false; // phpcs:ignore Squiz.Commenting.VariableComment.Missing
+	private static $raw_post_content = 'The post content.'; // phpcs:ignore Squiz.Commenting.VariableComment.Missing
+	private static $post_content     = false; // phpcs:ignore Squiz.Commenting.VariableComment.Missing
+	private static $dom_xpath        = false; // phpcs:ignore Squiz.Commenting.VariableComment.Missing
 
 	public function setUp() { // phpcs:ignore Squiz.Commenting.FunctionComment.Missing
 		// Remove any popups (from previous tests).
@@ -21,13 +24,13 @@ class InsertionTest extends WP_UnitTestCase {
 
 		self::$post_id  = self::factory()->post->create(
 			[
-				'post_content' => 'Elit platea a convallis dolor id mollis ultricies sociosqu dapibus.',
+				'post_content' => self::$raw_post_content,
 			]
 		);
 		self::$popup_id = self::factory()->post->create(
 			[
 				'post_type'    => Newspack_Popups::NEWSPACK_POPUPS_CPT,
-				'post_title'   => 'Platea fames',
+				'post_title'   => 'Popup title',
 				'post_content' => self::$popup_content,
 			]
 		);
@@ -35,30 +38,39 @@ class InsertionTest extends WP_UnitTestCase {
 		Newspack_Popups_Model::set_popup_options(
 			self::$popup_id,
 			[
+				'placement' => 'inline',
 				'frequency' => 'always',
 			]
 		);
+	}
 
+	/**
+	 * Trigger post rendering with popups in it.
+	 *
+	 * @param string $url_query Query to append to URL.
+	 */
+	public function render_post( $url_query = '' ) {
 		// Navigate to post.
-		self::go_to( get_permalink( self::$post_id ) );
+		self::go_to( get_permalink( self::$post_id ) . '&' . $url_query );
 		global $wp_query, $post;
 		$wp_query->in_the_loop = true;
 		setup_postdata( $post );
 
 		// Reset internal duplicate-prevention.
 		Newspack_Popups_Inserter::$the_content_has_rendered = false;
+
+		self::$post_content = apply_filters( 'the_content', get_post( self::$post_id )->post_content );
+		$dom                = new DomDocument();
+		@$dom->loadHTML( self::$post_content ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+		self::$dom_xpath = new DOMXpath( $dom );
 	}
 
 	/**
 	 * Test popup insertion into a post.
 	 */
 	public function test_insertion() {
-		$post_content = apply_filters( 'the_content', get_post( self::$post_id )->post_content );
-
-		$dom = new DomDocument();
-		@$dom->loadHTML( $post_content ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
-		$xpath               = new DOMXpath( $dom );
-		$amp_layout_elements = $xpath->query( '//amp-layout' );
+		self::render_post();
+		$amp_layout_elements = self::$dom_xpath->query( '//amp-layout' );
 		$popup_text_content  = $amp_layout_elements->item( 0 )->textContent;
 
 		self::assertContains(
@@ -72,9 +84,55 @@ class InsertionTest extends WP_UnitTestCase {
 			'Includes the dismissal text.'
 		);
 		self::assertContains(
-			$post_content,
-			$post_content,
+			self::$raw_post_content,
+			self::$post_content,
 			'Includes the original post content.'
+		);
+	}
+
+	/**
+	 * Tracking.
+	 */
+	public function test_insertion_analytics() {
+		self::render_post();
+		$amp_analytics_elements = self::$dom_xpath->query( '//amp-analytics' );
+
+		self::assertEquals(
+			$amp_analytics_elements->length,
+			1,
+			'Includes tracking by default.'
+		);
+
+		$user_id = $this->factory->user->create();
+		wp_set_current_user( $user_id );
+
+		self::render_post( 'view_as=all' );
+		self::assertEquals(
+			self::$dom_xpath->query( '//amp-analytics' )->length,
+			0,
+			'Does not include tracking when a user is logged in.'
+		);
+	}
+
+	/**
+	 * With view-as feature.
+	 */
+	public function test_insertion_view_as() {
+		self::render_post( 'view_as=all' );
+		self::assertEquals(
+			self::$dom_xpath->query( '//amp-analytics' )->length,
+			1,
+			'Includes tracking with "view as", since there is no logged in user.'
+		);
+
+		$user_id = $this->factory->user->create();
+		wp_set_current_user( $user_id );
+
+		self::render_post( 'view_as=all' );
+		self::assertEquals(
+			self::$dom_xpath->query( '//amp-analytics' )->length,
+			0,
+			'Does not include tracking when a user is logged in.'
 		);
 	}
 
@@ -92,14 +150,13 @@ class InsertionTest extends WP_UnitTestCase {
 		);
 
 		update_option( 'newspack_newsletters_non_interative_mode', true );
-
-		$post_content = apply_filters( 'the_content', get_post( self::$post_id )->post_content );
-
+		self::render_post();
 		self::assertNotContains(
 			self::$popup_content,
-			$post_content,
+			self::$post_content,
 			'Does not include the popup content, since it is an overlay campaign.'
 		);
+		update_option( 'newspack_newsletters_non_interative_mode', false );
 	}
 
 	/**
@@ -107,18 +164,17 @@ class InsertionTest extends WP_UnitTestCase {
 	 */
 	public function test_non_interactive_inline() {
 		update_option( 'newspack_newsletters_non_interative_mode', true );
-
-		$post_content = apply_filters( 'the_content', get_post( self::$post_id )->post_content );
-
+		self::render_post();
 		self::assertContains(
 			self::$popup_content,
-			$post_content,
+			self::$post_content,
 			'Does include the popup content.'
 		);
 		self::assertNotContains(
 			Newspack_Popups::get_default_dismiss_text(),
-			$post_content,
+			self::$post_content,
 			'Does not include the dismissal text.'
 		);
+		update_option( 'newspack_newsletters_non_interative_mode', false );
 	}
 }

--- a/tests/test-segmentation.php
+++ b/tests/test-segmentation.php
@@ -188,6 +188,14 @@ class SegmentationTest extends WP_UnitTestCase {
 		);
 
 		self::assertEquals(
+			Segmentation::parse_view_as( 'all' ),
+			[
+				'all' => true,
+			],
+			'Spec is parsed with the "all" value'
+		);
+
+		self::assertEquals(
 			Segmentation::parse_view_as( '' ),
 			[],
 			'Empty array is returned if there is no spec.'


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes two issues with "view as" feature.

### How to test the changes in this Pull Request:

1. On `master`, visit the Campaigns Wizard, "Preview" tab
2. Observe that when "Default (no segment)" is selected (with no groups), the preview will display test campaigns
3. Observe that when previewing a campaign with `once` frequency, it will not be displayed on subsequent preview
4. Switch to this branch, and `fix/view-as` branch on `newspack-plugin`
5. Observe the issues not reproducible anymore

### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [X] Have you written new tests for your changes, as applicable?
* [X] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
