### PR TITLE
Replace logged-in check with admin check

### DIFF
--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -76,7 +76,7 @@ final class Newspack_Popups_Inserter {
 			// 2. Get the overlay popup/s. There can be only one displayed, unless in test mode.
 
 			// Any overlay test popups, if the user is logged in.
-			if ( is_user_logged_in() ) {
+			if ( Newspack_Popups::is_user_admin() ) {
 				$popups_to_maybe_display = array_merge(
 					$popups_to_maybe_display,
 					Newspack_Popups_Model::retrieve_overlay_test_popups()
@@ -612,7 +612,7 @@ final class Newspack_Popups_Inserter {
 	 */
 	public static function assess_test_mode( $popup ) {
 		if ( 'test' === $popup['options']['frequency'] ) {
-			return is_user_logged_in() && ( current_user_can( 'edit_others_pages' ) || Newspack_Popups::previewed_popup_id() );
+			return Newspack_Popups::is_user_admin() && Newspack_Popups::previewed_popup_id();
 		}
 		return true;
 	}
@@ -684,12 +684,12 @@ final class Newspack_Popups_Inserter {
 		if ( $general_conditions && Newspack_Popups_View_As::viewing_as_spec() ) {
 			return $is_not_test_mode;
 		}
-		// Hide non-test mode campaigns for logged-in users.
-		if ( is_user_logged_in() && $is_not_test_mode ) {
+		// Hide non-test mode campaigns for admin users.
+		if ( Newspack_Popups::is_user_admin() && $is_not_test_mode ) {
 			return false;
 		}
-		// Hide overlay campaigns in non-interactive mode, for non-logged-in users.
-		if ( ! is_user_logged_in() && Newspack_Popups_Settings::is_non_interactive() && ! Newspack_Popups_Model::is_inline( $popup ) ) {
+		// Hide overlay campaigns in non-interactive mode, for non-admin users.
+		if ( ! Newspack_Popups::is_user_admin() && Newspack_Popups_Settings::is_non_interactive() && ! Newspack_Popups_Model::is_inline( $popup ) ) {
 			return false;
 		}
 		if ( ! self::assess_test_mode( $popup ) ) {

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -768,8 +768,7 @@ final class Newspack_Popups_Model {
 		}
 		if (
 			( 'test' === $popup['options']['frequency'] || Newspack_Popups::previewed_popup_id() ) &&
-			is_user_logged_in() &&
-			current_user_can( 'edit_others_pages' )
+			Newspack_Popups::is_user_admin()
 		) {
 			return '';
 		}

--- a/includes/class-newspack-popups-view-as.php
+++ b/includes/class-newspack-popups-view-as.php
@@ -37,7 +37,7 @@ final class Newspack_Popups_View_As {
 	 * @return string "View as" specification.
 	 */
 	public static function viewing_as_spec() {
-		if ( ! is_user_logged_in() || ! current_user_can( 'edit_others_pages' ) ) {
+		if ( ! Newspack_Popups::is_user_admin() ) {
 			return false;
 		}
 		if ( isset( $_GET['view_as'] ) && $_GET['view_as'] ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -549,5 +549,13 @@ final class Newspack_Popups {
 			</div>
 		<?php
 	}
+
+	/**
+	 * Is the user an admin user?
+	 */
+	public static function is_user_admin() {
+		return is_user_logged_in() && current_user_can( 'edit_others_pages' );
+	}
+
 }
 Newspack_Popups::instance();


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Not all logged-in users are admin users. This PR simplifies the condition for checking if the user can see test popups etc, and removes some repetition.

### How to test the changes in this Pull Request:

1. Insert an inline popup using a shortcode, on a page (not post)
2. Visit the site as a logged-in, non-admin user – observe that the popup is visible
3. Switch to `master`, observe the popup is not visible

### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [X] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
