### PR TITLE
fix: in preview tab, allow previewing without choosing groups

### DIFF
--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -62,33 +62,34 @@ final class Newspack_Popups_Inserter {
 
 		$view_as_spec             = Segmentation::parse_view_as( Newspack_Popups_View_As::viewing_as_spec() );
 		$view_as_spec_groups      = isset( $view_as_spec['groups'] ) ? $view_as_spec['groups'] : false;
-		$view_as_spec_campaigns   = isset( $view_as_spec['campaigns'] ) ? $view_as_spec['campaigns'] : false;
 		$view_as_spec_all         = ! empty( $view_as_spec['all'] ) ? true : false;
 		$view_as_spec_segment     = isset( $view_as_spec['segment'] ) ? $view_as_spec['segment'] : false;
 		$view_as_spec_unpublished = isset( $view_as_spec['show_unpublished'] ) && 'true' === $view_as_spec['show_unpublished'] ? true : false;
 
-		if ( $view_as_spec_groups ) { // If previewing specific groups.
+		if ( $view_as_spec_groups ) {
+			// If previewing specific groups.
 			$popups_to_maybe_display = Newspack_Popups_Model::retrieve_group_popups( explode( ',', $view_as_spec['groups'] ), $view_as_spec_unpublished );
-		} elseif ( $view_as_spec_campaigns ) { // If previewing a specific set of campaigns.
-			$popups_to_maybe_display = Newspack_Popups_Model::retrieve_popups_by_ids( explode( ',', $view_as_spec['campaigns'] ), $view_as_spec_unpublished );
-		} elseif ( $view_as_spec_all || $view_as_spec_segment ) { // If previewing and groups and campaigns are unspecified, but 'all' or a segment is specified, retrieve all campaigns.
+		} elseif ( $view_as_spec_all || $view_as_spec_segment ) {
+			// If previewing and no groups are specified, but 'all' or a segment is specified, retrieve all campaigns.
 			$popups_to_maybe_display = Newspack_Popups_Model::retrieve_popups( $view_as_spec_unpublished );
-		} else { // Retrieve campaigns for front-end display.
-			// 1. Get all inline popups.
-			$popups_to_maybe_display = Newspack_Popups_Model::retrieve_inline_popups( $view_as_spec_unpublished );
+		} else {
+			// Retrieve campaigns for front-end display.
 
-			// 2. Get the overlay popup/s. There can be only one displayed, unless in test mode.
+			// 1. Get all inline popups.
+			$popups_to_maybe_display = Newspack_Popups_Model::retrieve_inline_popups();
+
+			// 2. Get the overlay popups. There can be only one displayed, unless in test mode.
 
 			// Any overlay test popups, if the user is logged in.
 			if ( is_user_logged_in() ) {
 				$popups_to_maybe_display = array_merge(
 					$popups_to_maybe_display,
-					Newspack_Popups_Model::retrieve_overlay_test_popups( $view_as_spec_unpublished )
+					Newspack_Popups_Model::retrieve_overlay_test_popups()
 				);
 			}
 
 			// Check if there's an overlay popup with matching category.
-			$category_overlay_popup = Newspack_Popups_Model::retrieve_category_overlay_popup( $view_as_spec_unpublished );
+			$category_overlay_popup = Newspack_Popups_Model::retrieve_category_overlay_popup();
 			if ( $category_overlay_popup && self::should_display( $category_overlay_popup ) ) {
 				array_push(
 					$popups_to_maybe_display,
@@ -98,7 +99,7 @@ final class Newspack_Popups_Inserter {
 				// If there's no category-matching popup, get the sitewide pop-up.
 				$sitewide_default = get_option( Newspack_Popups::NEWSPACK_POPUPS_SITEWIDE_DEFAULT, null );
 				if ( $sitewide_default ) {
-					$found_popup = Newspack_Popups_Model::retrieve_popup_by_id( $sitewide_default, $view_as_spec_unpublished );
+					$found_popup = Newspack_Popups_Model::retrieve_popup_by_id( $sitewide_default );
 					if (
 						$found_popup &&
 						// Prevent non-overlay sitewide default from being added.
@@ -114,21 +115,26 @@ final class Newspack_Popups_Inserter {
 		}
 
 		// Allow only one overlay campaign.
-		$has_overlay                     = false;
-		$popups_to_maybe_display_deduped = array_filter(
-			$popups_to_maybe_display,
-			function ( $campaign ) use ( &$has_overlay ) {
-				if ( Newspack_Popups_Model::is_overlay( $campaign ) ) {
-					if ( $has_overlay ) {
-						return false;
-					} else {
-						$has_overlay = true;
-						return true;
+		if ( empty( $view_as_spec ) ) {
+			$has_overlay                     = false;
+			$popups_to_maybe_display_deduped = array_filter(
+				$popups_to_maybe_display,
+				function ( $campaign ) use ( &$has_overlay ) {
+					if ( Newspack_Popups_Model::is_overlay( $campaign ) ) {
+						if ( $has_overlay ) {
+							return false;
+						} else {
+							$has_overlay = true;
+							return true;
+						}
 					}
+					return true;
 				}
-				return true;
-			}
-		);
+			);
+		} else {
+			// If previewing, allow all matching overlay campaigns to be displayed.
+			$popups_to_maybe_display_deduped = $popups_to_maybe_display;
+		}
 
 		// Remove manual placement campaigns.
 		$popups_to_maybe_display_deduped = array_filter(

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -34,7 +34,7 @@ final class Newspack_Popups_Model {
 	public static function retrieve_popups( $include_unpublished = false ) {
 		$args = [
 			'post_type'      => Newspack_Popups::NEWSPACK_POPUPS_CPT,
-			'post_status'    => $include_unpublished ? [ 'publish', 'draft' ] : 'publish',
+			'post_status'    => $include_unpublished ? [ 'draft', 'pending', 'future', 'publish' ] : 'publish',
 			'posts_per_page' => 100,
 		];
 
@@ -211,12 +211,13 @@ final class Newspack_Popups_Model {
 	/**
 	 * Retrieve all inline popups.
 	 *
+	 * @param  boolean $include_unpublished Whether to include unpublished posts.
 	 * @return array Inline popup objects.
 	 */
-	public static function retrieve_inline_popups() {
+	public static function retrieve_inline_popups( $include_unpublished = false ) {
 		$args = [
 			'post_type'    => Newspack_Popups::NEWSPACK_POPUPS_CPT,
-			'post_status'  => 'publish',
+			'post_status'  => $include_unpublished ? [ 'draft', 'pending', 'future', 'publish' ] : 'publish',
 			'meta_key'     => 'placement',
 			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
 			'meta_value'   => self::$inline_placements,
@@ -269,12 +270,13 @@ final class Newspack_Popups_Model {
 	/**
 	 * Get overlay test popups.
 	 *
+	 * @param  boolean $include_unpublished Whether to include unpublished posts.
 	 * @return array Overlay test popup objects.
 	 */
-	public static function retrieve_overlay_test_popups() {
+	public static function retrieve_overlay_test_popups( $include_unpublished = false ) {
 		$args = [
 			'post_type'   => Newspack_Popups::NEWSPACK_POPUPS_CPT,
-			'post_status' => 'publish',
+			'post_status' => $include_unpublished ? [ 'draft', 'pending', 'future', 'publish' ] : 'publish',
 			'meta_query'  => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 				[
 					'key'     => 'placement',
@@ -294,9 +296,10 @@ final class Newspack_Popups_Model {
 	/**
 	 * Retrieve first overlay popup matching post categries.
 	 *
+	 * @param  boolean $include_unpublished Whether to include unpublished posts.
 	 * @return object|null Popup object.
 	 */
-	public static function retrieve_category_overlay_popup() {
+	public static function retrieve_category_overlay_popup( $include_unpublished = false ) {
 		$post_categories = get_the_category();
 
 		if ( empty( $post_categories ) ) {
@@ -306,7 +309,7 @@ final class Newspack_Popups_Model {
 		$args = [
 			'post_type'      => Newspack_Popups::NEWSPACK_POPUPS_CPT,
 			'posts_per_page' => 1,
-			'post_status'    => 'publish',
+			'post_status'    => $include_unpublished ? [ 'draft', 'pending', 'future', 'publish' ] : 'publish',
 			'category__in'   => array_column( $post_categories, 'term_id' ),
 			'meta_key'       => 'placement',
 			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -211,13 +211,12 @@ final class Newspack_Popups_Model {
 	/**
 	 * Retrieve all inline popups.
 	 *
-	 * @param  boolean $include_unpublished Whether to include unpublished posts.
 	 * @return array Inline popup objects.
 	 */
-	public static function retrieve_inline_popups( $include_unpublished = false ) {
+	public static function retrieve_inline_popups() {
 		$args = [
 			'post_type'    => Newspack_Popups::NEWSPACK_POPUPS_CPT,
-			'post_status'  => $include_unpublished ? [ 'draft', 'pending', 'future', 'publish' ] : 'publish',
+			'post_status'  => 'publish',
 			'meta_key'     => 'placement',
 			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
 			'meta_value'   => self::$inline_placements,
@@ -253,13 +252,12 @@ final class Newspack_Popups_Model {
 	/**
 	 * Get overlay test popups.
 	 *
-	 * @param  boolean $include_unpublished Whether to include unpublished posts.
 	 * @return array Overlay test popup objects.
 	 */
-	public static function retrieve_overlay_test_popups( $include_unpublished = false ) {
+	public static function retrieve_overlay_test_popups() {
 		$args = [
 			'post_type'   => Newspack_Popups::NEWSPACK_POPUPS_CPT,
-			'post_status' => $include_unpublished ? [ 'draft', 'pending', 'future', 'publish' ] : 'publish',
+			'post_status' => 'publish',
 			'meta_query'  => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 				[
 					'key'     => 'placement',
@@ -279,10 +277,9 @@ final class Newspack_Popups_Model {
 	/**
 	 * Retrieve first overlay popup matching post categries.
 	 *
-	 * @param  boolean $include_unpublished Whether to include unpublished posts.
 	 * @return object|null Popup object.
 	 */
-	public static function retrieve_category_overlay_popup( $include_unpublished = false ) {
+	public static function retrieve_category_overlay_popup() {
 		$post_categories = get_the_category();
 
 		if ( empty( $post_categories ) ) {
@@ -292,7 +289,7 @@ final class Newspack_Popups_Model {
 		$args = [
 			'post_type'      => Newspack_Popups::NEWSPACK_POPUPS_CPT,
 			'posts_per_page' => 1,
-			'post_status'    => $include_unpublished ? [ 'draft', 'pending', 'future', 'publish' ] : 'publish',
+			'post_status'    => 'publish',
 			'category__in'   => array_column( $post_categories, 'term_id' ),
 			'meta_key'       => 'placement',
 			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -251,23 +251,6 @@ final class Newspack_Popups_Model {
 	}
 
 	/**
-	 * Retrieve popups by IDs.
-	 *
-	 * @param  array   $ids array Array of popup IDs.
-	 * @param  boolean $include_unpublished Whether to include unpublished posts.
-	 * @return array Array of popup objects.
-	 */
-	public static function retrieve_popups_by_ids( $ids, $include_unpublished = false ) {
-		$args = [
-			'post_type'   => Newspack_Popups::NEWSPACK_POPUPS_CPT,
-			'post_status' => $include_unpublished ? [ 'draft', 'pending', 'future', 'publish' ] : 'publish',
-			'post__in'    => $ids,
-		];
-
-		return self::retrieve_popups_with_query( new WP_Query( $args ) );
-	}
-
-	/**
 	 * Get overlay test popups.
 	 *
 	 * @param  boolean $include_unpublished Whether to include unpublished posts.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Previews created from the preview tab does should be able to show any campaigns that match the selected segment, even if no groups are selected.

This PR can replace #356 as it contains all changes in that branch (required for properly testing that the Preview tab works with both published and unpublished campaigns). Leaving #356 open for now so that it can be tested separately if necessary.

### How to test the changes in this Pull Request:

1. On `master`, go to the Preview tab and select any segment while leaving the Groups field empty.
2. Observe that only published campaigns are displayed in the preview modal (basically only what can appear on the front-end rather than what matches the `view_as` param).
3. Check out this branch.
4. Select any segment while leaving Groups empty and "Show unpublished campaigns" OFF. Confirm that all published campaigns matching the selected segment, regardless of group, are shown in the preview modal.
5. Toggle "Show unpublished campaigns" ON, and confirm that all published and draft campaigns matching the selected segment, regardless of group, are shown in the preview modal.
6. Go back to the Campaigns tab and filter by All Campaigns (no group selected). Repeat steps 4-5 using the same segment you tested with in the Preview tab, and confirm that the campaigns you see are the same when previewing from both tabs.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
