### PR TITLE
fix: remove inline class for above header campaigns

### DIFF
--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -801,6 +801,7 @@ final class Newspack_Popups_Model {
 		$dismiss_text_alignment = self::get_dismiss_text_alignment( $popup );
 		$is_newsletter_prompt   = self::has_newsletter_prompt( $popup );
 		$classes                = [];
+		$classes[]              = 'above_header' === $popup['options']['placement'] ? 'newspack-above-header-popup' : null;
 		$classes[]              = 'inline' === $popup['options']['placement'] ? 'newspack-inline-popup' : null;
 		$classes[]              = ( ! empty( $popup['title'] ) && $display_title ) ? 'newspack-lightbox-has-title' : null;
 		$classes[]              = $is_newsletter_prompt ? 'newspack-newsletter-prompt-inline' : null;

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -800,7 +800,8 @@ final class Newspack_Popups_Model {
 		$dismiss_text           = self::get_dismiss_text( $popup );
 		$dismiss_text_alignment = self::get_dismiss_text_alignment( $popup );
 		$is_newsletter_prompt   = self::has_newsletter_prompt( $popup );
-		$classes                = array( 'newspack-inline-popup' );
+		$classes                = [];
+		$classes[]              = 'inline' === $popup['options']['placement'] ? 'newspack-inline-popup' : null;
 		$classes[]              = ( ! empty( $popup['title'] ) && $display_title ) ? 'newspack-lightbox-has-title' : null;
 		$classes[]              = $is_newsletter_prompt ? 'newspack-newsletter-prompt-inline' : null;
 

--- a/src/view/style.scss
+++ b/src/view/style.scss
@@ -207,8 +207,19 @@ $color__secondary-variation: darken( $color__secondary, 10% );
 	}
 }
 
+.newspack-above-header-popup {
+	display: block;
+	clear: both;
+	padding: 0.75em 0;
+
+	&:focus {
+		outline: none;
+	}
+}
+
 .newspack-lightbox,
-.newspack-inline-popup {
+.newspack-inline-popup,
+.newspack-above-header-popup {
 	.popup-not-interested-form {
 		display: flex;
 		justify-content: center;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds `newspack-above-header-popup` instead of `newspack-inline-popup` class to Above Header campaigns, causing them to bleed to the left/right edges. 

<img width="1350" alt="Screen Shot 2021-01-19 at 12 01 35 PM" src="https://user-images.githubusercontent.com/1477002/105067806-1b7c1e00-5a4e-11eb-8a76-d147ab8d9294.png">

### How to test the changes in this Pull Request:

1. Create an Above Header campaign and an Inline campaign.
2. View in front end. Verify the inline campaign appears normal, and the above header bleeds to the left/right edges.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
