### PR TITLE
fix: remove dismiss button preview when empty

### DIFF
--- a/src/editor/EditorAdditions.js
+++ b/src/editor/EditorAdditions.js
@@ -30,7 +30,7 @@ const EditorAdditions = () => {
 
 		if ( ! dismiss_text ) {
 			if ( dismissButtonPreview ) {
-				dismissButtonPreview.remove();
+				dismissButtonPreview.parentNode.removeChild( dismissButtonPreview );
 			}
 			return;
 		}

--- a/src/editor/EditorAdditions.js
+++ b/src/editor/EditorAdditions.js
@@ -24,15 +24,18 @@ const EditorAdditions = () => {
 
 	// Render a preview of the dismiss button at the end of the block content area.
 	useEffect(() => {
+		let dismissButtonPreview = document.querySelector(
+			'.newspack-popups__not-interested-button-preview'
+		);
+
 		if ( ! dismiss_text ) {
+			if ( dismissButtonPreview ) {
+				dismissButtonPreview.remove();
+			}
 			return;
 		}
 
 		const alignClass = 'has-text-align-' + ( dismiss_text_alignment || 'center' );
-
-		let dismissButtonPreview = document.querySelector(
-			'.newspack-popups__not-interested-button-preview'
-		);
 
 		if ( ! dismissButtonPreview ) {
 			const rootContainer = document.querySelector(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

When the dismiss button label is cleared out by the editor, the preview of the text remains on screen. This PR corrects this.

### How to test the changes in this Pull Request:

1. On `master`, create a new campaign, open `Dismiss Button Settings`, delete all text. Observe it is impossible to completely clear the text. 
2. Switch to this branch, observe the issue is resolved.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
