### PR TITLE
fix: corrected logic for above header display

### DIFF
--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -512,7 +512,7 @@ final class Newspack_Popups_Model {
 		if ( ! isset( $popup['options'], $popup['options']['placement'] ) ) {
 			return false;
 		}
-		return in_array( $popup['options']['placement'], [ 'inline', 'above_header' ] );
+		return in_array( $popup['options']['placement'], self::$inline_placements );
 	}
 
 	/**

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -512,7 +512,7 @@ final class Newspack_Popups_Model {
 		if ( ! isset( $popup['options'], $popup['options']['placement'] ) ) {
 			return false;
 		}
-		return 'inline' === $popup['options']['placement'];
+		return in_array( $popup['options']['placement'], [ 'inline', 'above_header' ] );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

There's currently a bug where Above Header campaigns will only be shown if they happen to have a timer trigger, which is an unused feature for this type of campaign. This corrects the issue.

### How to test the changes in this Pull Request:

1. On `master`, create a new campaign. Switch it to be an overlay, and set the trigger to scroll progress. Switch Inline back on, and set placement to Above Site Header.
2. Observe the campaign will not display in previews or front end. 
3. Switch to this branch, observe the campaign displays normally.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
