### PR TITLE
fix: view-as-segment should always take min count values

### DIFF
--- a/api/campaigns/class-campaign-data-utils.php
+++ b/api/campaigns/class-campaign-data-utils.php
@@ -124,7 +124,7 @@ class Campaign_Data_Utils {
 			$is_subscriber = $view_as_segment->is_subscribed;
 			$is_donor      = $view_as_segment->is_donor;
 			if ( ! empty( $view_as_segment->referrers ) ) {
-				$first_referrer = array_map( 'trim', explode( ',', $campaign_segment->referrers ) )[0];
+				$first_referrer = array_map( 'trim', explode( ',', $view_as_segment->referrers ) )[0];
 				if ( strpos( $first_referrer, 'http' ) !== 0 ) {
 					$first_referrer = 'https://' . $first_referrer;
 				}

--- a/api/campaigns/class-campaign-data-utils.php
+++ b/api/campaigns/class-campaign-data-utils.php
@@ -116,18 +116,11 @@ class Campaign_Data_Utils {
 		 */
 		if ( $view_as_segment ) {
 			$view_as_segment = self::canonize_segment( $view_as_segment );
-			if ( $view_as_segment->min_posts > 0 ) {
-				$posts_read_count = $view_as_segment->min_posts;
-			}
-			if ( $view_as_segment->max_posts > 0 ) {
-				$posts_read_count = $view_as_segment->max_posts;
-			}
-			if ( $view_as_segment->min_session_posts > 0 ) {
-				$posts_read_count_session = $view_as_segment->min_session_posts;
-			}
-			if ( $view_as_segment->max_session_posts > 0 ) {
-				$posts_read_count_session = $view_as_segment->max_session_posts;
-			}
+
+			$posts_read_count = intval( $view_as_segment->min_posts );
+
+			$posts_read_count_session = intval( $view_as_segment->min_session_posts );
+
 			$is_subscriber = $view_as_segment->is_subscribed;
 			$is_donor      = $view_as_segment->is_donor;
 			if ( ! empty( $view_as_segment->referrers ) ) {

--- a/api/campaigns/class-campaign-data-utils.php
+++ b/api/campaigns/class-campaign-data-utils.php
@@ -133,6 +133,8 @@ class Campaign_Data_Utils {
 			if ( count( $view_as_segment->favorite_categories ) ) {
 				$diff_count                        = count( array_diff( $view_as_segment->favorite_categories, $campaign_segment->favorite_categories ) );
 				$favorite_category_matches_segment = 0 === $diff_count;
+			} else {
+				$favorite_category_matches_segment = false;
 			}
 		}
 

--- a/tests/test-api.php
+++ b/tests/test-api.php
@@ -43,6 +43,9 @@ class APITest extends WP_UnitTestCase {
 				'segmentWithReferrers'                => (object) [
 					'referrers' => 'foobar.com, newspack.pub',
 				],
+				'anotherSegmentWithReferrers'                => (object) [
+					'referrers' => 'bar.com',
+				],
 				'segmentFavCategory42'                => (object) [
 					'favorite_categories' => [ 42 ],
 				],
@@ -1081,11 +1084,19 @@ class APITest extends WP_UnitTestCase {
 
 		self::assertFalse(
 			self::$maybe_show_campaign->should_campaign_be_shown( self::$client_id, $test_popup['payload'], self::$settings ),
-			'Assert not visible, as the referrer does not match.'
+			'Assert not visible without referrer.'
+		);
+		self::assertTrue(
+			self::$maybe_show_campaign->should_campaign_be_shown( self::$client_id, $test_popup['payload'], self::$settings, '', '', [ 'segment' => 'segmentWithReferrers' ] ),
+			'Assert visible when viewing as a segment member.'
 		);
 		self::assertTrue(
 			self::$maybe_show_campaign->should_campaign_be_shown( self::$client_id, $test_popup['payload'], self::$settings, '', 'https://newspack.pub', [ 'segment' => 'segmentWithReferrers' ] ),
-			'Assert visible when viewing as a segment member.'
+			'Assert visible when viewing as a segment member, with a referrer.'
+		);
+		self::assertFalse(
+			self::$maybe_show_campaign->should_campaign_be_shown( self::$client_id, $test_popup['payload'], self::$settings, '', 'https://twitter.com', [ 'segment' => 'anotherSegmentWithReferrers' ] ),
+			'Assert not visible when viewing as a different segment with a referrer.'
 		);
 	}
 

--- a/tests/test-api.php
+++ b/tests/test-api.php
@@ -43,7 +43,7 @@ class APITest extends WP_UnitTestCase {
 				'segmentWithReferrers'                => (object) [
 					'referrers' => 'foobar.com, newspack.pub',
 				],
-				'anotherSegmentWithReferrers'                => (object) [
+				'anotherSegmentWithReferrers'         => (object) [
 					'referrers' => 'bar.com',
 				],
 				'segmentFavCategory42'                => (object) [
@@ -1035,16 +1035,29 @@ class APITest extends WP_UnitTestCase {
 			self::$client_id,
 			[
 				'posts_read' => [
-					self::create_read_post( 1 ),
-					self::create_read_post( 2 ),
-					self::create_read_post( 3 ),
+					self::create_read_post( 1, false, '42' ),
+					self::create_read_post( 2, false, '42' ),
+					self::create_read_post( 3, false, '42' ),
 				],
 			]
 		);
 
 		self::assertFalse(
 			self::$maybe_show_campaign->should_campaign_be_shown( self::$client_id, $test_popup['payload'], self::$settings, '', '', [ 'segment' => 'segmentWithReferrers' ] ),
-			'Assert not visible when viewing as a different segment.'
+			'Assert campaign with read count not visible when viewing as a different segment.'
+		);
+
+		$test_popup_2 = self::create_test_popup(
+			[
+				'placement'           => 'inline',
+				'frequency'           => 'always',
+				'selected_segment_id' => 'segmentFavCategory42',
+			]
+		);
+
+		self::assertFalse(
+			self::$maybe_show_campaign->should_campaign_be_shown( self::$client_id, $test_popup_2['payload'], self::$settings, '', '', [ 'segment' => 'segmentWithReferrers' ] ),
+			'Assert campaign with fav. categories segment not visible when viewing as a different segment.'
 		);
 	}
 

--- a/tests/test-api.php
+++ b/tests/test-api.php
@@ -1015,6 +1015,37 @@ class APITest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * View as a segment – ignoring client data.
+	 */
+	public function test_view_as_segment_client_data_ignoring() {
+		$api = new Lightweight_API();
+
+		$test_popup = self::create_test_popup(
+			[
+				'placement'           => 'inline',
+				'frequency'           => 'always',
+				'selected_segment_id' => 'segmentBetween3And5',
+			]
+		);
+
+		$api->save_client_data(
+			self::$client_id,
+			[
+				'posts_read' => [
+					self::create_read_post( 1 ),
+					self::create_read_post( 2 ),
+					self::create_read_post( 3 ),
+				],
+			]
+		);
+
+		self::assertFalse(
+			self::$maybe_show_campaign->should_campaign_be_shown( self::$client_id, $test_popup['payload'], self::$settings, '', '', [ 'segment' => 'segmentWithReferrers' ] ),
+			'Assert not visible when viewing as a different segment.'
+		);
+	}
+
+	/**
 	 * View as a segment – posts read count.
 	 */
 	public function test_view_as_segment_read_count() {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

When using view-as-segment for a segment that has 0 values for read counts, the logic will not take these values from the segment and instead falls back to any legitimate views that have been logged in the current browser. This leads to confusing, sometimes incorrect results where previewing may work correctly for some users and incorrectly for other based on their history of viewing the site. This branch resolves the issue by always adopting the `min_posts` and `min_session_posts` verbatim from the segment, regardless of whether they are zero or not. `max_posts` and `max_session_posts` are ignored, since being precisely at the min values is sufficient for matching the segment.

A separate question this raises is whether segments with 0 counts should even be allowed, but that's for later.

### How to test the changes in this Pull Request:

1. Switch to `master`, open an incognito window, log in to test site. 
2. Create several segments with no counts (e.g. set a referrer only, or check one of the Donor checkboxes) and one with a read count min 1.
3. Create a few campaigns and assign to one of the non read-count segments. Assign one campaign to the read count 1 segment
4. Preview each segment, observe the campaigns are shown correctly.
5. Log out of WordPress and view several pages on the site.
6. Log back in and preview each segment. This time, observe that you see the campaign assigned to the read count 1 segment when previewing any segment, which is incorrect.
7. Switch to this branch, repeat step 6, and verify that you see only the campaigns you'd expect to see with each segment.
8. Test a variety of other segments and campaigns to ensure view-as-segment is working properly.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
