### PR TITLE
fix: bug that causes admin bar to be hidden

### DIFF
--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -406,7 +406,7 @@ final class Newspack_Popups {
 	 */
 	public static function is_preview_request() {
 		$view_as_spec = Newspack_Popups_View_As::viewing_as_spec();
-		return self::previewed_popup_id() || false !== $view_as_spec;
+		return self::previewed_popup_id() || false != $view_as_spec;
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The admin bar is meant to be hidden while previewing campaigns, but a small bug causes it to be hidden always. This PR corrects the issue.

### How to test the changes in this Pull Request:

1. On `master` verify the admin bar is not visible when viewing the site while as a logged in admin.
2. Switch to this branch, verify the admin bar is now hidden properly.
3. Preview several campaigns, verify the admin bar is NOT shown in the preview window.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
