### PR TITLE
fix: admin bar shown on front end logged out

### DIFF
--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -393,10 +393,14 @@ final class Newspack_Popups {
 	/**
 	 * Should admin bar be shown.
 	 *
+	 * @param bool $show Whether to show admin bar.
 	 * @return boolean Whether admin bar should be shown.
 	 */
-	public static function show_admin_bar() {
-		return ! self::is_preview_request();
+	public static function show_admin_bar( $show ) {
+		if ( $show ) {
+			return ! self::is_preview_request();
+		}
+		return $show;
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

https://github.com/Automattic/newspack-popups/pull/349 introduced a regression that causes the admin bar to be shown (empty) on the front end to logged out users. This doesn't happen on all sites (probably) because some are running plugins that use the `show_admin_bar` filter with a higher priority than 10, which effectively overrides this bug.  

### How to test the changes in this Pull Request:

1. On `master` view a page on the front end, logged out. You _may_ see the admin bar. If you don't, manually edit https://github.com/Automattic/newspack-popups/blob/master/includes/class-newspack-popups.php#L58 and change the priority from 10 to a much higher number. This should cause the admin bar to display.
2. Switch to this branch, verify the admin bar is no longer visible. (If you changed the priority in step 1 you should also change it in the new branch, to make sure you're authentically replicating the issue)
3. View a front end page while logged in, verify the admin bar _is_ visible. 
4. In Newspack->Campaigns, preview an individual campaign. Verify the admin bar is not visible.
5. In Newspack->Campaigns, preview as a segment, also verify the admin bar is not visible.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
