### PR TITLE
fix: set segment id to null if segment doesn't exist

### DIFF
--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -440,6 +440,9 @@ final class Newspack_Popups_Model {
 				]
 			),
 		];
+		if ( $popup['options']['selected_segment_id'] && ! in_array( $popup['options']['selected_segment_id'], Newspack_Popups_Segmentation::get_segment_ids() ) ) {
+			$popup['options']['selected_segment_id'] = null;
+		}
 		if ( $include_categories ) {
 			$popup['categories']      = get_the_category( $id );
 			$popup['campaign_groups'] = get_the_terms( $id, Newspack_Popups::NEWSPACK_POPUPS_TAXONOMY );

--- a/includes/class-newspack-popups-segmentation.php
+++ b/includes/class-newspack-popups-segmentation.php
@@ -313,6 +313,18 @@ final class Newspack_Popups_Segmentation {
 	}
 
 	/**
+	 * Get segment IDs.
+	 */
+	public static function get_segment_ids() {
+		return array_map(
+			function( $segment ) {
+				return $segment['id'];
+			},
+			self::get_segments()
+		);
+	}
+
+	/**
 	 * Create a segment.
 	 *
 	 * @param object $segment A segment.

--- a/tests/test-api.php
+++ b/tests/test-api.php
@@ -14,45 +14,66 @@ class APITest extends WP_UnitTestCase {
 	private static $report_campaign_data = null; // phpcs:ignore Squiz.Commenting.VariableComment.Missing
 	private static $report_client_data   = null; // phpcs:ignore Squiz.Commenting.VariableComment.Missing
 	private static $client_id            = 'abc-123'; // phpcs:ignore Squiz.Commenting.VariableComment.Missing
+	private static $segment_ids          = []; // phpcs:ignore Squiz.Commenting.VariableComment.Missing
 
 	public static function wpSetUpBeforeClass() { // phpcs:ignore Squiz.Commenting.FunctionComment.Missing
 		self::$maybe_show_campaign  = new Maybe_Show_Campaign();
 		self::$report_campaign_data = new Report_Campaign_Data();
 		self::$report_client_data   = new Segmentation_Client_Data();
 
+		$test_segments = [
+			'defaultSegment'                      => [],
+			'segmentBetween3And5'                 => [
+				'min_posts' => 2,
+				'max_posts' => 3,
+			],
+			'segmentSessionReadCountBetween3And5' => [
+				'min_session_posts' => 2,
+				'max_session_posts' => 3,
+			],
+			'segmentSubscribers'                  => [
+				'is_subscribed' => true,
+			],
+			'segmentNonSubscribers'               => [
+				'is_not_subscribed' => true,
+			],
+			'segmentWithReferrers'                => [
+				'referrers' => 'foobar.com, newspack.pub',
+			],
+			'anotherSegmentWithReferrers'         => [
+				'referrers' => 'bar.com',
+			],
+			'segmentWithNegativeReferrer'         => [
+				'referrers_not' => 'baz.com',
+			],
+			'segmentFavCategory42'                => [
+				'favorite_categories' => [ 42 ],
+			],
+		];
+
+		foreach ( $test_segments as $key => $value ) {
+			$segments = Newspack_Popups_Segmentation::create_segment(
+				[
+					'name'          => $key,
+					'configuration' => $value,
+				]
+			);
+
+			self::$segment_ids[ $key ] = end( $segments )['id'];
+		}
+
 		self::$settings = (object) [ // phpcs:ignore Squiz.Commenting.VariableComment.Missing
 			'suppress_newsletter_campaigns'        => true,
 			'suppress_all_newsletter_campaigns_if_one_dismissed' => true,
 			'suppress_donation_campaigns_if_donor' => true,
-			'all_segments'                         => (object) [
-				'defaultSegment'                      => (object) [],
-				'segmentBetween3And5'                 => (object) [
-					'min_posts' => 2,
-					'max_posts' => 3,
-				],
-				'segmentSessionReadCountBetween3And5' => (object) [
-					'min_session_posts' => 2,
-					'max_session_posts' => 3,
-				],
-				'segmentSubscribers'                  => (object) [
-					'is_subscribed' => true,
-				],
-				'segmentNonSubscribers'               => (object) [
-					'is_not_subscribed' => true,
-				],
-				'segmentWithReferrers'                => (object) [
-					'referrers' => 'foobar.com, newspack.pub',
-				],
-				'anotherSegmentWithReferrers'         => (object) [
-					'referrers' => 'bar.com',
-				],
-				'segmentWithNegativeReferrer'         => (object) [
-					'referrers_not' => 'baz.com',
-				],
-				'segmentFavCategory42'                => (object) [
-					'favorite_categories' => [ 42 ],
-				],
-			],
+			'all_segments'                         => (object) array_reduce(
+				Newspack_Popups_Segmentation::get_segments(),
+				function( $acc, $item ) {
+					$acc[ $item['id'] ] = $item['configuration'];
+					return $acc;
+				},
+				[]
+			),
 		];
 	}
 
@@ -586,7 +607,7 @@ class APITest extends WP_UnitTestCase {
 			[
 				'placement'           => 'inline',
 				'frequency'           => 'always',
-				'selected_segment_id' => 'segmentSubscribers',
+				'selected_segment_id' => self::$segment_ids['segmentSubscribers'],
 			]
 		);
 
@@ -625,7 +646,7 @@ class APITest extends WP_UnitTestCase {
 			[
 				'placement'           => 'inline',
 				'frequency'           => 'always',
-				'selected_segment_id' => 'segmentNonSubscribers',
+				'selected_segment_id' => self::$segment_ids['segmentNonSubscribers'],
 			]
 		);
 
@@ -682,7 +703,7 @@ class APITest extends WP_UnitTestCase {
 			[
 				'placement'           => 'inline',
 				'frequency'           => 'always',
-				'selected_segment_id' => 'segmentBetween3And5',
+				'selected_segment_id' => self::$segment_ids['segmentBetween3And5'],
 			]
 		);
 
@@ -734,7 +755,7 @@ class APITest extends WP_UnitTestCase {
 			[
 				'placement'           => 'inline',
 				'frequency'           => 'once',
-				'selected_segment_id' => 'segmentBetween3And5',
+				'selected_segment_id' => self::$segment_ids['segmentBetween3And5'],
 			]
 		);
 
@@ -781,7 +802,7 @@ class APITest extends WP_UnitTestCase {
 			[
 				'placement'           => 'inline',
 				'frequency'           => 'daily',
-				'selected_segment_id' => 'segmentBetween3And5',
+				'selected_segment_id' => self::$segment_ids['segmentBetween3And5'],
 			]
 		);
 
@@ -828,7 +849,7 @@ class APITest extends WP_UnitTestCase {
 			[
 				'placement'           => 'inline',
 				'frequency'           => 'always',
-				'selected_segment_id' => 'segmentSessionReadCountBetween3And5',
+				'selected_segment_id' => self::$segment_ids['segmentSessionReadCountBetween3And5'],
 			]
 		);
 
@@ -909,7 +930,7 @@ class APITest extends WP_UnitTestCase {
 			[
 				'placement'           => 'inline',
 				'frequency'           => 'always',
-				'selected_segment_id' => 'segmentWithReferrers',
+				'selected_segment_id' => self::$segment_ids['segmentWithReferrers'],
 			]
 		);
 
@@ -943,7 +964,7 @@ class APITest extends WP_UnitTestCase {
 			[
 				'placement'           => 'inline',
 				'frequency'           => 'always',
-				'selected_segment_id' => 'segmentWithNegativeReferrer',
+				'selected_segment_id' => self::$segment_ids['segmentWithNegativeReferrer'],
 			]
 		);
 
@@ -973,7 +994,7 @@ class APITest extends WP_UnitTestCase {
 			[
 				'placement'           => 'inline',
 				'frequency'           => 'always',
-				'selected_segment_id' => 'segmentFavCategory42',
+				'selected_segment_id' => self::$segment_ids['segmentFavCategory42'],
 			]
 		);
 
@@ -1040,7 +1061,7 @@ class APITest extends WP_UnitTestCase {
 			[
 				'placement'           => 'inline',
 				'frequency'           => 'always',
-				'selected_segment_id' => 'segmentSubscribers',
+				'selected_segment_id' => self::$segment_ids['segmentSubscribers'],
 			]
 		);
 
@@ -1049,7 +1070,7 @@ class APITest extends WP_UnitTestCase {
 			'Assert not visible, as the client is not a subscriber.'
 		);
 		self::assertTrue(
-			self::$maybe_show_campaign->should_campaign_be_shown( self::$client_id, $test_popup['payload'], self::$settings, '', '', [ 'segment' => 'segmentSubscribers' ] ),
+			self::$maybe_show_campaign->should_campaign_be_shown( self::$client_id, $test_popup['payload'], self::$settings, '', '', [ 'segment' => self::$segment_ids['segmentSubscribers'] ] ),
 			'Assert visible when viewing as a segment member.'
 		);
 	}
@@ -1064,7 +1085,7 @@ class APITest extends WP_UnitTestCase {
 			[
 				'placement'           => 'inline',
 				'frequency'           => 'always',
-				'selected_segment_id' => 'segmentBetween3And5',
+				'selected_segment_id' => self::$segment_ids['segmentBetween3And5'],
 			]
 		);
 
@@ -1080,7 +1101,7 @@ class APITest extends WP_UnitTestCase {
 		);
 
 		self::assertFalse(
-			self::$maybe_show_campaign->should_campaign_be_shown( self::$client_id, $test_popup['payload'], self::$settings, '', '', [ 'segment' => 'segmentWithReferrers' ] ),
+			self::$maybe_show_campaign->should_campaign_be_shown( self::$client_id, $test_popup['payload'], self::$settings, '', '', [ 'segment' => self::$segment_ids['segmentWithReferrers'] ] ),
 			'Assert campaign with read count not visible when viewing as a different segment.'
 		);
 
@@ -1088,12 +1109,12 @@ class APITest extends WP_UnitTestCase {
 			[
 				'placement'           => 'inline',
 				'frequency'           => 'always',
-				'selected_segment_id' => 'segmentFavCategory42',
+				'selected_segment_id' => self::$segment_ids['segmentFavCategory42'],
 			]
 		);
 
 		self::assertFalse(
-			self::$maybe_show_campaign->should_campaign_be_shown( self::$client_id, $test_popup_2['payload'], self::$settings, '', '', [ 'segment' => 'segmentWithReferrers' ] ),
+			self::$maybe_show_campaign->should_campaign_be_shown( self::$client_id, $test_popup_2['payload'], self::$settings, '', '', [ 'segment' => self::$segment_ids['segmentWithReferrers'] ] ),
 			'Assert campaign with fav. categories segment not visible when viewing as a different segment.'
 		);
 	}
@@ -1106,7 +1127,7 @@ class APITest extends WP_UnitTestCase {
 			[
 				'placement'           => 'inline',
 				'frequency'           => 'always',
-				'selected_segment_id' => 'segmentBetween3And5',
+				'selected_segment_id' => self::$segment_ids['segmentBetween3And5'],
 			]
 		);
 
@@ -1115,7 +1136,7 @@ class APITest extends WP_UnitTestCase {
 			'Assert not visible, as the client does not have the appropriate read count.'
 		);
 		self::assertTrue(
-			self::$maybe_show_campaign->should_campaign_be_shown( self::$client_id, $test_popup['payload'], self::$settings, '', '', [ 'segment' => 'segmentBetween3And5' ] ),
+			self::$maybe_show_campaign->should_campaign_be_shown( self::$client_id, $test_popup['payload'], self::$settings, '', '', [ 'segment' => self::$segment_ids['segmentBetween3And5'] ] ),
 			'Assert visible when viewing as a segment member.'
 		);
 	}
@@ -1128,7 +1149,7 @@ class APITest extends WP_UnitTestCase {
 			[
 				'placement'           => 'inline',
 				'frequency'           => 'always',
-				'selected_segment_id' => 'segmentWithReferrers',
+				'selected_segment_id' => self::$segment_ids['segmentWithReferrers'],
 			]
 		);
 
@@ -1137,15 +1158,15 @@ class APITest extends WP_UnitTestCase {
 			'Assert not visible without referrer.'
 		);
 		self::assertTrue(
-			self::$maybe_show_campaign->should_campaign_be_shown( self::$client_id, $test_popup['payload'], self::$settings, '', '', [ 'segment' => 'segmentWithReferrers' ] ),
+			self::$maybe_show_campaign->should_campaign_be_shown( self::$client_id, $test_popup['payload'], self::$settings, '', '', [ 'segment' => self::$segment_ids['segmentWithReferrers'] ] ),
 			'Assert visible when viewing as a segment member.'
 		);
 		self::assertTrue(
-			self::$maybe_show_campaign->should_campaign_be_shown( self::$client_id, $test_popup['payload'], self::$settings, '', 'https://newspack.pub', [ 'segment' => 'segmentWithReferrers' ] ),
+			self::$maybe_show_campaign->should_campaign_be_shown( self::$client_id, $test_popup['payload'], self::$settings, '', 'https://newspack.pub', [ 'segment' => self::$segment_ids['segmentWithReferrers'] ] ),
 			'Assert visible when viewing as a segment member, with a referrer.'
 		);
 		self::assertFalse(
-			self::$maybe_show_campaign->should_campaign_be_shown( self::$client_id, $test_popup['payload'], self::$settings, '', 'https://twitter.com', [ 'segment' => 'anotherSegmentWithReferrers' ] ),
+			self::$maybe_show_campaign->should_campaign_be_shown( self::$client_id, $test_popup['payload'], self::$settings, '', 'https://twitter.com', [ 'segment' => self::$segment_ids['anotherSegmentWithReferrers'] ] ),
 			'Assert not visible when viewing as a different segment with a referrer.'
 		);
 	}
@@ -1158,7 +1179,7 @@ class APITest extends WP_UnitTestCase {
 			[
 				'placement'           => 'inline',
 				'frequency'           => 'always',
-				'selected_segment_id' => 'segmentWithNegativeReferrer',
+				'selected_segment_id' => self::$segment_ids['segmentWithNegativeReferrer'],
 			]
 		);
 
@@ -1167,11 +1188,11 @@ class APITest extends WP_UnitTestCase {
 			'Assert visible without referrer.'
 		);
 		self::assertTrue(
-			self::$maybe_show_campaign->should_campaign_be_shown( self::$client_id, $test_popup['payload'], self::$settings, '', '', [ 'segment' => 'segmentWithNegativeReferrer' ] ),
+			self::$maybe_show_campaign->should_campaign_be_shown( self::$client_id, $test_popup['payload'], self::$settings, '', '', [ 'segment' => self::$segment_ids['segmentWithNegativeReferrer'] ] ),
 			'Assert visible when viewing as a segment member.'
 		);
 		self::assertTrue(
-			self::$maybe_show_campaign->should_campaign_be_shown( self::$client_id, $test_popup['payload'], self::$settings, '', 'https://newspack.pub', [ 'segment' => 'segmentWithNegativeReferrer' ] ),
+			self::$maybe_show_campaign->should_campaign_be_shown( self::$client_id, $test_popup['payload'], self::$settings, '', 'https://newspack.pub', [ 'segment' => self::$segment_ids['segmentWithNegativeReferrer'] ] ),
 			'Assert visible when viewing as a segment member, with a referrer.'
 		);
 	}
@@ -1184,12 +1205,12 @@ class APITest extends WP_UnitTestCase {
 			[
 				'placement'           => 'inline',
 				'frequency'           => 'always',
-				'selected_segment_id' => 'segmentFavCategory42',
+				'selected_segment_id' => self::$segment_ids['segmentFavCategory42'],
 			]
 		);
 
 		self::assertTrue(
-			self::$maybe_show_campaign->should_campaign_be_shown( self::$client_id, $test_popup['payload'], self::$settings, '', '', [ 'segment' => 'segmentFavCategory42' ] ),
+			self::$maybe_show_campaign->should_campaign_be_shown( self::$client_id, $test_popup['payload'], self::$settings, '', '', [ 'segment' => self::$segment_ids['segmentFavCategory42'] ] ),
 			'Assert visible when viewing as a segment member.'
 		);
 	}

--- a/tests/test-api.php
+++ b/tests/test-api.php
@@ -685,7 +685,7 @@ class APITest extends WP_UnitTestCase {
 			[
 				'placement'           => 'inline',
 				'frequency'           => 'always',
-				'selected_segment_id' => 'defaultSegment',
+				'selected_segment_id' => self::$segment_ids['defaultSegment'],
 			]
 		);
 
@@ -1223,7 +1223,7 @@ class APITest extends WP_UnitTestCase {
 			[
 				'placement'           => 'inline',
 				'frequency'           => 'always',
-				'selected_segment_id' => 'defaultSegment',
+				'selected_segment_id' => self::$segment_ids['defaultSegment'],
 			]
 		);
 
@@ -1277,6 +1277,24 @@ class APITest extends WP_UnitTestCase {
 			)['payload'],
 			false,
 			'An overlay popup with "always" frequency has it corrected to "once".'
+		);
+	}
+
+	/**
+	 * Test missing segment.
+	 */
+	public function test_missing_segment() {
+		$test_popup = self::create_test_popup(
+			[
+				'placement'           => 'inline',
+				'frequency'           => 'always',
+				'selected_segment_id' => 'garbagio',
+			]
+		);
+
+		self::assertNull(
+			$test_popup['payload']->s,
+			'Returns null if segment is missing.'
 		);
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This addresses an edge case where a prompt (formerly "campaign") has been assigned a segment which was later deleted. This change caused segmentation tests to fail, so these have been refactored slightly to create real segments with unique IDs.

### How to test the changes in this Pull Request:

1. On `master`, create a segment, then create a campaign and assign the segment.
2. Navigate to Campaigns Wizard, observe results of the `newspack/v1/wizard/newspack-popups-wizard` API request. 
3. The campaign should have `options.selected_segment_id` set to the ID of the segment.
4. Delete the segment.
5. Navigate back to Campaigns Wizard, observe the API results still has the ID even though it doesn't exist.
6. Switch to this branch, refresh Campaigns Wizard. 
7. Observe `options.selected_segment_id` is `null`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
