### PR TITLE
feat: specify group and segment in url for new campaigns

### DIFF
--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -464,6 +464,8 @@ final class Newspack_Popups {
 			return;
 		}
 		$type      = isset( $_GET['placement'] ) ? sanitize_text_field( $_GET['placement'] ) : null; //phpcs:ignore
+		$segment   = isset( $_GET['segment'] ) ? sanitize_text_field( $_GET['segment'] ) : ''; //phpcs:ignore
+		$group     = isset( $_GET['group'] ) ? absint( $_GET['group'] ) : null; //phpcs:ignore
 		$frequency = 'daily';
 
 		switch ( $type ) {
@@ -516,7 +518,11 @@ final class Newspack_Popups {
 		update_post_meta( $post_id, 'trigger_delay', 3 );
 		update_post_meta( $post_id, 'trigger_scroll_progress', 30 );
 		update_post_meta( $post_id, 'utm_suppression', '' );
-		update_post_meta( $post_id, 'selected_segment_id', '' );
+		update_post_meta( $post_id, 'selected_segment_id', $segment );
+
+		if ( $group ) {
+			wp_set_post_terms( $post_id, [ $group ], self::NEWSPACK_POPUPS_TAXONOMY );
+		}
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds the option to specify campaign group and segment as query parameters when creating a new campaign. 

### How to test the changes in this Pull Request:

1. Create at least one campaign group and segment. Note the ID of the segment and the term_id of the group.
2. Go directly to a URL like this: `/wp-admin/post-new.php?post_type=newspack_popups_cpt&group={term_id}&segment={segment_id}`
3. Verify the new campaign has the correct group and segment assignments.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
