### PR TITLE
fix: add cache control headers

### DIFF
--- a/api/classes/class-lightweight-api.php
+++ b/api/classes/class-lightweight-api.php
@@ -105,6 +105,7 @@ class Lightweight_API {
 		}
 		header( 'Access-Control-Allow-Origin: https://' . parse_url( $_SERVER['HTTP_REFERER'] )['host'], false ); // phpcs:ignore
 		header( 'Access-Control-Allow-Credentials: true', false );
+		header( 'Cache-Control: no-store, no-cache, must-revalidate' );
 		http_response_code( 200 );
 		print json_encode( $this->response ); // phpcs:ignore
 		exit;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds `no-store`, `no-cache`, and `must-revalidate` headers to the lightweight API.

Closes https://github.com/Automattic/newspack-popups/issues/433

### How to test the changes in this Pull Request:

1. Verify the headers are present on API responses.
2. Verify the issue described in https://github.com/Automattic/newspack-popups/issues/433
, then create a build of the plugin from this branch and temporarily deploy it to the production site. Verify the fix resolves the issue.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
