### PR TITLE
Campaigns Wizard: mark draft prompts in preview

### DIFF
--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -783,6 +783,7 @@ final class Newspack_Popups_Model {
 		$classes                = [];
 		$classes[]              = 'above_header' === $popup['options']['placement'] ? 'newspack-above-header-popup' : null;
 		$classes[]              = 'inline' === $popup['options']['placement'] ? 'newspack-inline-popup' : null;
+		$classes[]              = 'draft' === $popup['status'] ? 'newspack-draft-popup' : null;
 		$classes[]              = ( ! empty( $popup['title'] ) && $display_title ) ? 'newspack-lightbox-has-title' : null;
 		$classes[]              = $is_newsletter_prompt ? 'newspack-newsletter-prompt-inline' : null;
 
@@ -854,6 +855,8 @@ final class Newspack_Popups_Model {
 		$classes                = array( 'newspack-lightbox', 'newspack-lightbox-placement-' . $popup['options']['placement'] );
 		$classes[]              = ( ! empty( $popup['title'] ) && $display_title ) ? 'newspack-lightbox-has-title' : null;
 		$classes[]              = $is_newsletter_prompt ? 'newspack-newsletter-prompt-overlay' : null;
+		$wrapper_classes        = [ 'newspack-popup-wrapper' ];
+		$wrapper_classes[]      = 'draft' === $popup['status'] ? 'newspack-draft-popup' : null;
 		$is_scroll_triggered    = 'scroll' === $popup['options']['trigger_type'];
 
 		add_filter(
@@ -866,7 +869,7 @@ final class Newspack_Popups_Model {
 		ob_start();
 		?>
 		<amp-layout <?php echo self::get_access_attrs( $popup ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?> class="<?php echo esc_attr( implode( ' ', $classes ) ); ?>" role="button" tabindex="0" id="<?php echo esc_attr( $element_id ); ?>">
-			<div class="newspack-popup-wrapper" style="<?php echo esc_attr( self::container_style( $popup ) ); ?>">
+			<div class="<?php echo esc_attr( implode( ' ', $wrapper_classes ) ); ?>" style="<?php echo esc_attr( self::container_style( $popup ) ); ?>">
 				<div class="newspack-popup">
 					<?php if ( ! empty( $popup['title'] ) && $display_title ) : ?>
 						<h1 class="newspack-popup-title"><?php echo esc_html( $popup['title'] ); ?></h1>

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -747,12 +747,23 @@ final class Newspack_Popups_Model {
 		if ( Newspack_Popups_Settings::is_non_interactive() ) {
 			return '';
 		}
-		if ( Newspack_Popups::previewed_popup_id() &&
-			Newspack_Popups::is_user_admin()
-		) {
+		if ( Newspack_Popups::previewed_popup_id() && Newspack_Popups::is_user_admin() ) {
 			return '';
 		}
 		return 'amp-access="popups.' . esc_attr( self::canonize_popup_id( $popup['id'] ) ) . '" amp-access-hide ';
+	}
+
+	/**
+	 * Get data-popup-status attribute for use in previews, if viewing as an admin.
+	 *
+	 * @param object $popup Popup.
+	 */
+	public static function get_data_status_preview_attrs( $popup ) {
+		if ( ! Newspack_Popups::is_user_admin() ) {
+			return '';
+		}
+		$status = 'future' === $popup['status'] ? __( 'scheduled', 'newspack-popups' ) : $popup['status'];
+		return 'data-popup-status="' . esc_attr( $status ) . '" ';
 	}
 
 	/**
@@ -782,7 +793,7 @@ final class Newspack_Popups_Model {
 		$classes                = [];
 		$classes[]              = 'above_header' === $popup['options']['placement'] ? 'newspack-above-header-popup' : null;
 		$classes[]              = 'inline' === $popup['options']['placement'] ? 'newspack-inline-popup' : null;
-		$classes[]              = 'draft' === $popup['status'] ? 'newspack-draft-popup' : null;
+		$classes[]              = 'publish' !== $popup['status'] ? 'newspack-inactive-popup-status' : null;
 		$classes[]              = ( ! empty( $popup['title'] ) && $display_title ) ? 'newspack-lightbox-has-title' : null;
 		$classes[]              = $is_newsletter_prompt ? 'newspack-newsletter-prompt-inline' : null;
 
@@ -799,7 +810,15 @@ final class Newspack_Popups_Model {
 		ob_start();
 		?>
 			<?php self::insert_event_tracking( $popup, $body, $element_id ); ?>
-			<amp-layout <?php echo self::get_access_attrs( $popup ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?> class="<?php echo esc_attr( implode( ' ', $classes ) ); ?>" role="button" tabindex="0" style="<?php echo esc_attr( self::container_style( $popup ) ); ?>" id="<?php echo esc_attr( $element_id ); ?>">
+			<amp-layout
+				<?php echo self::get_access_attrs( $popup ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+				<?php echo self::get_data_status_preview_attrs( $popup ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+				class="<?php echo esc_attr( implode( ' ', $classes ) ); ?>"
+				role="button"
+				tabindex="0"
+				style="<?php echo esc_attr( self::container_style( $popup ) ); ?>"
+				id="<?php echo esc_attr( $element_id ); ?>"
+			>
 						<?php if ( ! empty( $popup['title'] ) && $display_title ) : ?>
 					<h1 class="newspack-popup-title"><?php echo esc_html( $popup['title'] ); ?></h1>
 				<?php endif; ?>
@@ -855,7 +874,7 @@ final class Newspack_Popups_Model {
 		$classes[]              = ( ! empty( $popup['title'] ) && $display_title ) ? 'newspack-lightbox-has-title' : null;
 		$classes[]              = $is_newsletter_prompt ? 'newspack-newsletter-prompt-overlay' : null;
 		$wrapper_classes        = [ 'newspack-popup-wrapper' ];
-		$wrapper_classes[]      = 'draft' === $popup['status'] ? 'newspack-draft-popup' : null;
+		$wrapper_classes[]      = 'publish' !== $popup['status'] ? 'newspack-inactive-popup-status' : null;
 		$is_scroll_triggered    = 'scroll' === $popup['options']['trigger_type'];
 
 		add_filter(
@@ -867,8 +886,15 @@ final class Newspack_Popups_Model {
 
 		ob_start();
 		?>
-		<amp-layout <?php echo self::get_access_attrs( $popup ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?> class="<?php echo esc_attr( implode( ' ', $classes ) ); ?>" role="button" tabindex="0" id="<?php echo esc_attr( $element_id ); ?>">
-			<div class="<?php echo esc_attr( implode( ' ', $wrapper_classes ) ); ?>" style="<?php echo esc_attr( self::container_style( $popup ) ); ?>">
+		<amp-layout
+			<?php echo self::get_access_attrs( $popup ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+			<?php echo self::get_data_status_preview_attrs( $popup ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+			class="<?php echo esc_attr( implode( ' ', $classes ) ); ?>"
+			role="button"
+			tabindex="0"
+			id="<?php echo esc_attr( $element_id ); ?>"
+		>
+			<div class="<?php echo esc_attr( implode( ' ', $wrapper_classes ) ); ?>" data-popup-status="<?php echo esc_attr( $popup['status'] ); ?>" style="<?php echo esc_attr( self::container_style( $popup ) ); ?>">
 				<div class="newspack-popup">
 					<?php if ( ! empty( $popup['title'] ) && $display_title ) : ?>
 						<h1 class="newspack-popup-title"><?php echo esc_html( $popup['title'] ); ?></h1>

--- a/src/view/style.scss
+++ b/src/view/style.scss
@@ -2,6 +2,10 @@
 $color__secondary: #555;
 $color__secondary-variation: darken( $color__secondary, 10% );
 
+// System Font
+$font__system: -apple-system, blinkmacsystemfont, 'Segoe UI', roboto, oxygen, ubuntu, cantarell,
+	'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
+
 .newspack-lightbox {
 	align-items: center;
 	bottom: 0;
@@ -208,33 +212,19 @@ $color__secondary-variation: darken( $color__secondary, 10% );
 }
 
 .newspack-draft-popup {
-	&::after,
 	&::before {
-		position: absolute;
-		z-index: 1;
-	}
-	&::after {
+		background: black;
+		color: white;
 		content: 'INACTIVE';
-		top: 2px;
-		left: 2px;
-		padding: 0 4px;
-		font-size: 0.6em;
-		background: white;
-		border: 1px solid rgba( black, 0.2 );
-	}
-	&::before {
-		content: '';
-		top: 0;
-		left: 0;
-		width: 100%;
-		height: 100%;
-		background: repeating-linear-gradient(
-			45deg,
-			transparent,
-			transparent 10px,
-			rgba( black, 0.1 ) 10px,
-			rgba( black, 0.1 ) 20px
-		);
+		font-family: $font__system;
+		font-size: 0.8em;
+		font-weight: bold;
+		left: 6px;
+		line-height: 1.5;
+		padding: 0 0.25em;
+		position: absolute;
+		top: 6px;
+		z-index: 1;
 	}
 }
 

--- a/src/view/style.scss
+++ b/src/view/style.scss
@@ -207,6 +207,37 @@ $color__secondary-variation: darken( $color__secondary, 10% );
 	}
 }
 
+.newspack-draft-popup {
+	&::after,
+	&::before {
+		position: absolute;
+		z-index: 1;
+	}
+	&::after {
+		content: 'INACTIVE';
+		top: 2px;
+		left: 2px;
+		padding: 0 4px;
+		font-size: 0.6em;
+		background: white;
+		border: 1px solid rgba( black, 0.2 );
+	}
+	&::before {
+		content: '';
+		top: 0;
+		left: 0;
+		width: 100%;
+		height: 100%;
+		background: repeating-linear-gradient(
+			45deg,
+			transparent,
+			transparent 10px,
+			rgba( black, 0.1 ) 10px,
+			rgba( black, 0.1 ) 20px
+		);
+	}
+}
+
 .newspack-above-header-popup {
 	display: block;
 	clear: both;

--- a/src/view/style.scss
+++ b/src/view/style.scss
@@ -211,14 +211,15 @@ $font__system: -apple-system, blinkmacsystemfont, 'Segoe UI', roboto, oxygen, ub
 	}
 }
 
-.newspack-draft-popup {
+.newspack-inactive-popup-status {
 	&::before {
 		background: black;
 		color: white;
-		content: 'INACTIVE';
+		content: attr( data-popup-status );
 		font-family: $font__system;
 		font-size: 0.8em;
 		font-weight: bold;
+		text-transform: uppercase;
 		left: 6px;
 		line-height: 1.5;
 		padding: 0 0.25em;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

When previewing, a user might be confused as to what will actually be visible for the reader. In this PR, styling for inactive (draft) prompts is introduced in the preview window.

### How to test the changes in this Pull Request:

1. Visit the Campaigns Wizard
2. Preview a segment
3. Observe that inactive (draft) prompts are marked with striped overlay and a label in top-left corner

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
