### PR TITLE
fix: preview functionality by campaign/group

### DIFF
--- a/api/campaigns/class-maybe-show-campaign.php
+++ b/api/campaigns/class-maybe-show-campaign.php
@@ -204,6 +204,10 @@ class Maybe_Show_Campaign extends Lightweight_API {
 		if ( $view_as_spec ) {
 			$should_display = true;
 			if ( isset( $view_as_spec['segment'] ) && $view_as_spec['segment'] ) {
+				// If previewing the "Everyone" segment, only show prompts with no segment.
+				if ( 'everyone' === $view_as_spec['segment'] && ! empty( $campaign->s ) ) {
+					return false;
+				}
 				$segment_config = [];
 				if ( isset( $settings->all_segments->{$view_as_spec['segment']} ) ) {
 					$segment_config = $settings->all_segments->{$view_as_spec['segment']};

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -60,25 +60,23 @@ final class Newspack_Popups_Inserter {
 		}
 
 		$view_as_spec             = Segmentation::parse_view_as( Newspack_Popups_View_As::viewing_as_spec() );
-		$view_as_spec_groups      = isset( $view_as_spec['groups'] ) ? $view_as_spec['groups'] : false;
+		$view_as_spec_campaign    = isset( $view_as_spec['campaign'] ) ? $view_as_spec['campaign'] : false;
 		$view_as_spec_unpublished = isset( $view_as_spec['show_unpublished'] ) && 'true' === $view_as_spec['show_unpublished'] ? true : false;
 
 		// Retrieve all prompts eligible for display.
-		// 1. If previewing specific groups, only get popups that match those groups.
-		$group_slugs = $view_as_spec_groups ? explode( ',', $view_as_spec['groups'] ) : false;
 
-		// 2. Get all inline popups.
-		$popups_to_maybe_display = Newspack_Popups_Model::retrieve_inline_popups( $view_as_spec_unpublished, $group_slugs );
+		// 1. Get all inline popups.
+		$popups_to_maybe_display = Newspack_Popups_Model::retrieve_inline_popups( $view_as_spec_unpublished, $view_as_spec_campaign );
 
-		// 3. Check if there are any overlay popups with matching category.
-		$category_overlay_popups = Newspack_Popups_Model::retrieve_category_overlay_popups( $view_as_spec_unpublished, $group_slugs );
+		// 2. Check if there are any overlay popups with matching category.
+		$category_overlay_popups = Newspack_Popups_Model::retrieve_category_overlay_popups( $view_as_spec_unpublished, $view_as_spec_campaign );
 
-		// 4. If there are matching category overlays, use those. Otherwise, get all valid overlay popups.
+		// 3. If there are matching category overlays, use those. Otherwise, get all valid overlay popups.
 		$overlay_popups = ! empty( $category_overlay_popups ) ?
 			$category_overlay_popups :
-			Newspack_Popups_Model::retrieve_overlay_popups( $view_as_spec_unpublished, $group_slugs );
+			Newspack_Popups_Model::retrieve_overlay_popups( $view_as_spec_unpublished, $view_as_spec_campaign );
 
-		// 5. Add overlay popups to array.
+		// 4. Add overlay popups to array.
 		if ( ! empty( $overlay_popups ) ) {
 			$popups_to_maybe_display = array_merge(
 				$popups_to_maybe_display,
@@ -86,7 +84,7 @@ final class Newspack_Popups_Inserter {
 			);
 		}
 
-		// 6. Remove manual placement prompts.
+		// 5. Remove manual placement prompts.
 		$popups_to_maybe_display = array_filter(
 			$popups_to_maybe_display,
 			function( $popup ) {

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -149,11 +149,11 @@ final class Newspack_Popups_Model {
 	/**
 	 * Retrieve all overlay popups.
 	 *
-	 * @param  boolean       $include_unpublished Whether to include unpublished posts.
-	 * @param  array|boolean $group_slugs array Array of group slugs, or false to ignore groups.
+	 * @param  boolean     $include_unpublished Whether to include unpublished prompts.
+	 * @param  int|boolean $campaign_id Campaign term ID, or false to ignore campaign.
 	 * @return array Overlay popup objects.
 	 */
-	public static function retrieve_overlay_popups( $include_unpublished = false, $group_slugs = false ) {
+	public static function retrieve_overlay_popups( $include_unpublished = false, $campaign_id = false ) {
 		$args = [
 			'post_type'    => Newspack_Popups::NEWSPACK_POPUPS_CPT,
 			'post_status'  => $include_unpublished ? [ 'draft', 'pending', 'future', 'publish' ] : 'publish',
@@ -163,15 +163,18 @@ final class Newspack_Popups_Model {
 			'meta_compare' => 'IN',
 		];
 
-		// If previewing specific groups.
-		if ( ! empty( $group_slugs ) ) {
-			$args['tax_query'] = [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
-				[
-					'taxonomy' => Newspack_Popups::NEWSPACK_POPUPS_TAXONOMY,
-					'field'    => 'term_id',
-					'terms'    => $group_slugs,
-				],
-			];
+		// If previewing specific campaign.
+		if ( ! empty( $campaign_id ) ) {
+			$tax_query = [ 'taxonomy' => Newspack_Popups::NEWSPACK_POPUPS_TAXONOMY ];
+
+			if ( -1 === (int) $campaign_id ) {
+				$tax_query['operator'] = 'NOT EXISTS';
+			} else {
+				$tax_query['field'] = 'term_id';
+				$tax_query['terms'] = [ $campaign_id ];
+			}
+
+			$args['tax_query'] = [ $tax_query ]; // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
 		}
 
 		return self::retrieve_popups_with_query( new WP_Query( $args ) );
@@ -180,11 +183,11 @@ final class Newspack_Popups_Model {
 	/**
 	 * Retrieve all inline prompts.
 	 *
-	 * @param  boolean       $include_unpublished Whether to include unpublished posts.
-	 * @param  array|boolean $group_slugs array Array of group slugs, or false to ignore groups.
+	 * @param  boolean     $include_unpublished Whether to include unpublished prompts.
+	 * @param  int|boolean $campaign_id Campaign term ID, or false to ignore campaign.
 	 * @return array Inline popup objects.
 	 */
-	public static function retrieve_inline_popups( $include_unpublished = false, $group_slugs = false ) {
+	public static function retrieve_inline_popups( $include_unpublished = false, $campaign_id = false ) {
 		$args = [
 			'post_type'    => Newspack_Popups::NEWSPACK_POPUPS_CPT,
 			'post_status'  => $include_unpublished ? [ 'draft', 'pending', 'future', 'publish' ] : 'publish',
@@ -194,15 +197,18 @@ final class Newspack_Popups_Model {
 			'meta_compare' => 'IN',
 		];
 
-		// If previewing specific groups.
-		if ( ! empty( $group_slugs ) ) {
-			$args['tax_query'] = [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
-				[
-					'taxonomy' => Newspack_Popups::NEWSPACK_POPUPS_TAXONOMY,
-					'field'    => 'term_id',
-					'terms'    => $group_slugs,
-				],
-			];
+		// If previewing specific campaign.
+		if ( ! empty( $campaign_id ) ) {
+			$tax_query = [ 'taxonomy' => Newspack_Popups::NEWSPACK_POPUPS_TAXONOMY ];
+
+			if ( -1 === (int) $campaign_id ) {
+				$tax_query['operator'] = 'NOT EXISTS';
+			} else {
+				$tax_query['field'] = 'term_id';
+				$tax_query['terms'] = [ $campaign_id ];
+			}
+
+			$args['tax_query'] = [ $tax_query ]; // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
 		}
 
 		return self::retrieve_popups_with_query( new WP_Query( $args ) );
@@ -211,11 +217,11 @@ final class Newspack_Popups_Model {
 	/**
 	 * Retrieve overlay popups matching post categories.
 	 *
-	 * @param  boolean       $include_unpublished Whether to include unpublished posts.
-	 * @param  array|boolean $group_slugs array Array of group slugs, or false to ignore groups.
+	 * @param  boolean     $include_unpublished Whether to include unpublished prompts.
+	 * @param  int|boolean $campaign_id Campaign term ID, or false to ignore campaign.
 	 * @return array|null Array of popup objects.
 	 */
-	public static function retrieve_category_overlay_popups( $include_unpublished = false, $group_slugs = false ) {
+	public static function retrieve_category_overlay_popups( $include_unpublished = false, $campaign_id = false ) {
 		$post_categories = get_the_category();
 
 		if ( empty( $post_categories ) ) {
@@ -233,15 +239,18 @@ final class Newspack_Popups_Model {
 			'meta_compare'   => 'IN',
 		];
 
-		// If previewing specific groups.
-		if ( ! empty( $group_slugs ) ) {
-			$args['tax_query'] = [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
-				[
-					'taxonomy' => Newspack_Popups::NEWSPACK_POPUPS_TAXONOMY,
-					'field'    => 'term_id',
-					'terms'    => $group_slugs,
-				],
-			];
+		// If previewing specific campaign.
+		if ( ! empty( $campaign_id ) ) {
+			$tax_query = [ 'taxonomy' => Newspack_Popups::NEWSPACK_POPUPS_TAXONOMY ];
+
+			if ( -1 === (int) $campaign_id ) {
+				$tax_query['operator'] = 'NOT EXISTS';
+			} else {
+				$tax_query['field'] = 'term_id';
+				$tax_query['terms'] = [ $campaign_id ];
+			}
+
+			$args['tax_query'] = [ $tax_query ]; // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
 		}
 
 		$popups = self::retrieve_popups_with_query( new WP_Query( $args ) );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Along with https://github.com/Automattic/newspack-plugin/pull/856, fixes previewing logic when previewing prompts within a single campaign, when previewing active prompts, or when previewing unassigned prompts.

### How to test the changes in this Pull Request:

Follow testing instructions in https://github.com/Automattic/newspack-plugin/pull/856.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
