### PR TITLE
fix: prevent category overlays from being fetched erroneously

### DIFF
--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -168,6 +168,8 @@ final class Newspack_Popups_Model {
 			'operator' => 'NOT EXISTS',
 		];
 
+		$args['tax_query'] = [ $tax_query ]; // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
+
 		// If previewing specific campaign.
 		if ( ! empty( $campaign_id ) ) {
 			$campaign_tax_query = [ 'taxonomy' => Newspack_Popups::NEWSPACK_POPUPS_TAXONOMY ];
@@ -179,10 +181,8 @@ final class Newspack_Popups_Model {
 				$campaign_tax_query['terms'] = [ $campaign_id ];
 			}
 
-			$tax_query[] = $campaign_tax_query;
+			$args['tax_query'][] = $campaign_tax_query;
 		}
-
-		$args['tax_query'] = [ $tax_query ]; // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
 
 		if ( ! empty( $campaign_id ) ) {
 			$args['tax_query']['relation'] = 'AND';

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -163,15 +163,24 @@ final class Newspack_Popups_Model {
 			'meta_compare' => 'IN',
 		];
 
+		$tax_query = [
+			'taxonomy' => 'category',
+			'operator' => 'NOT EXISTS',
+		];
+
 		// If previewing specific groups.
 		if ( ! empty( $group_slugs ) ) {
-			$args['tax_query'] = [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
-				[
-					'taxonomy' => Newspack_Popups::NEWSPACK_POPUPS_TAXONOMY,
-					'field'    => 'term_id',
-					'terms'    => $group_slugs,
-				],
+			$tax_query[] = [
+				'taxonomy' => Newspack_Popups::NEWSPACK_POPUPS_TAXONOMY,
+				'field'    => 'term_id',
+				'terms'    => $group_slugs,
 			];
+		}
+
+		$args['tax_query'] = [ $tax_query ]; // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
+
+		if ( ! empty( $group_slugs ) ) {
+			$args['tax_query']['relation'] = 'AND';
 		}
 
 		return self::retrieve_popups_with_query( new WP_Query( $args ) );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes overlay insertion so that category overlays are never displayed on non-matching pages or posts.

### How to test the changes in this Pull Request:

1. On `master`, create an overlay and assign a category. Make sure it's the only published overlay and it's in a segment that would be matched by new readers.
2. In an incognito session, visit the site front-end on the homepage or a post without a matching category. Observe that the overlay is shown even though its category doesn't match the page.
3. Check out this branch.
4. Visit the site in a new incognito session. This time confirm that the overlay only appears when visiting a post with a matching category.
5. Publish a second overlay in the same segment and don't assign a category to it.
6. Visit the site in a new incognito session. Confirm that on posts with a category that matches the category-enabled overlay, that overlay appears, but on all other pages, the second overlay appears.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
