### PR TITLE
Simplify prompt retrieval

### DIFF
--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -59,30 +59,12 @@ final class Newspack_Popups_Inserter {
 			return [];
 		}
 
-		$view_as_spec             = Segmentation::parse_view_as( Newspack_Popups_View_As::viewing_as_spec() );
-		$view_as_spec_campaign    = isset( $view_as_spec['campaign'] ) ? $view_as_spec['campaign'] : false;
-		$view_as_spec_unpublished = isset( $view_as_spec['show_unpublished'] ) && 'true' === $view_as_spec['show_unpublished'] ? true : false;
+		$view_as_spec        = Segmentation::parse_view_as( Newspack_Popups_View_As::viewing_as_spec() );
+		$campaign_id         = isset( $view_as_spec['campaign'] ) ? $view_as_spec['campaign'] : false;
+		$include_unpublished = isset( $view_as_spec['show_unpublished'] ) && 'true' === $view_as_spec['show_unpublished'] ? true : false;
 
 		// Retrieve all prompts eligible for display.
-
-		// 1. Get all inline popups.
-		$popups_to_maybe_display = Newspack_Popups_Model::retrieve_inline_popups( $view_as_spec_unpublished, $view_as_spec_campaign );
-
-		// 2. Check if there are any overlay popups with matching category.
-		$category_overlay_popups = Newspack_Popups_Model::retrieve_category_overlay_popups( $view_as_spec_unpublished, $view_as_spec_campaign );
-
-		// 3. If there are matching category overlays, use those. Otherwise, get all valid overlay popups.
-		$overlay_popups = ! empty( $category_overlay_popups ) ?
-			$category_overlay_popups :
-			Newspack_Popups_Model::retrieve_overlay_popups( $view_as_spec_unpublished, $view_as_spec_campaign );
-
-		// 4. Add overlay popups to array.
-		if ( ! empty( $overlay_popups ) ) {
-			$popups_to_maybe_display = array_merge(
-				$popups_to_maybe_display,
-				$overlay_popups
-			);
-		}
+		$popups_to_maybe_display = Newspack_Popups_Model::retrieve_eligible_popups( $include_unpublished, $campaign_id );
 
 		return array_filter(
 			$popups_to_maybe_display,
@@ -712,26 +694,25 @@ final class Newspack_Popups_Inserter {
 			return true;
 		}
 
-		$general_conditions = self::assess_is_post( $popup ) &&
-			self::assess_categories_filter( $popup ) &&
-			self::assess_tags_filter( $popup );
-
-		// When using "view as" feature, discard test mode popups.
+		// When using "view as" feature, disregard most conditions.
 		if ( Newspack_Popups_View_As::viewing_as_spec() ) {
-			return $skip_context_checks ? true : $general_conditions;
+			return $skip_context_checks ? true : self::assess_is_post( $popup );
 		}
-		// Hide prompts for logged-in users.
+		// Hide prompts for admin users.
 		if ( Newspack_Popups::is_user_admin() ) {
 			return false;
 		}
-		// Hide overlay prompts in non-interactive mode, for non-logged-in users.
+		// Hide overlay prompts in non-interactive mode, for non-admin users.
 		if ( ! Newspack_Popups::is_user_admin() && Newspack_Popups_Settings::is_non_interactive() && ! Newspack_Popups_Model::is_inline( $popup ) ) {
 			return false;
 		}
+
 		if ( $skip_context_checks ) {
 			return true;
 		}
-		return $general_conditions;
+		return self::assess_is_post( $popup ) &&
+			self::assess_categories_filter( $popup ) &&
+			self::assess_tags_filter( $popup );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

With the changes in #416, separate retrieval of overlay and inline prompts is not necessary anymore, since the multiple overlays are allowed to be rendered on the page (API logic decides which is shown). 
Handling of the category condition was redundant, since categorised prompts are filtered out by `should_display` method.

This is mostly a refactor, with one user-facing change: the preview is now disregarding the category. Before, segment previews would not display a categorised prompt, unless the preview post had matching category (which could happen by chance). With changes here, all prompts tied to a campaign and/or segment will be displayed in the preview.

### How to test the changes in this Pull Request:

Mostly a refactor/performance improvement, so verify that everything works as expected

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
