### PR TITLE
feat: allow multiple segments per prompt

### DIFF
--- a/api/campaigns/class-campaign-data-utils.php
+++ b/api/campaigns/class-campaign-data-utils.php
@@ -73,6 +73,7 @@ class Campaign_Data_Utils {
 				'is_not_donor'        => false,
 				'referrers'           => '',
 				'favorite_categories' => [],
+				'priority'            => PHP_INT_MAX,
 			],
 			(array) $segment
 		);

--- a/api/campaigns/class-maybe-show-campaign.php
+++ b/api/campaigns/class-maybe-show-campaign.php
@@ -79,6 +79,15 @@ class Maybe_Show_Campaign extends Lightweight_API {
 		$overlay_to_maybe_display      = null;
 		$above_header_to_maybe_display = null;
 
+		/**
+		 * When previewing, spoof client ID so that user actions performed outside the preview window don't affect prompt display.
+		 * If a `cid` param is passed as part of the view_as spec, use that so it will persist across page loads within the preview session.
+		 * Otherwise, generate a unique ID for the current page view only.
+		 */
+		if ( ! empty( $view_as_spec ) ) {
+			$client_id = isset( $view_as_spec['cid'] ) ? $view_as_spec['cid'] : uniqid( 'view_as_client_' );
+		}
+
 		if ( $settings ) {
 			$settings->best_priority_segment = $this->get_best_priority_segment( $all_segments, $client_id, $referer_url, $page_referer_url, $view_as_spec );
 			$this->debug['matching_segment'] = $settings->best_priority_segment;

--- a/api/campaigns/class-maybe-show-campaign.php
+++ b/api/campaigns/class-maybe-show-campaign.php
@@ -265,6 +265,7 @@ class Maybe_Show_Campaign extends Lightweight_API {
 				}
 			}
 		} elseif ( ! empty( $campaign_segment_ids ) ) {
+			// $settings->best_priority_segment_id should always be present, but in case it's not (e.g. in a unit test), we can fetch it here.
 			$best_priority_segment_id = isset( $settings->best_priority_segment_id ) ?
 				$settings->best_priority_segment_id :
 				$this->get_best_priority_segment_id( $settings->all_segments, $client_id, $referer_url, $page_referer_url, $view_as_spec );

--- a/api/campaigns/class-maybe-show-campaign.php
+++ b/api/campaigns/class-maybe-show-campaign.php
@@ -89,8 +89,8 @@ class Maybe_Show_Campaign extends Lightweight_API {
 		}
 
 		if ( $settings ) {
-			$settings->best_priority_segment = $this->get_best_priority_segment( $all_segments, $client_id, $referer_url, $page_referer_url, $view_as_spec );
-			$this->debug['matching_segment'] = $settings->best_priority_segment;
+			$settings->best_priority_segment_id = $this->get_best_priority_segment_id( $all_segments, $client_id, $referer_url, $page_referer_url, $view_as_spec );
+			$this->debug['matching_segment']    = $settings->best_priority_segment_id;
 		}
 
 		// Check each matching campaign against other global factors.
@@ -151,15 +151,15 @@ class Maybe_Show_Campaign extends Lightweight_API {
 	 *
 	 * @return string|null ID of the best matching segment, or null if the client matches no segment.
 	 */
-	public function get_best_priority_segment( $all_segments = [], $client_id, $referer_url = '', $page_referer_url = '', $view_as_spec = false ) {
+	public function get_best_priority_segment_id( $all_segments = [], $client_id, $referer_url = '', $page_referer_url = '', $view_as_spec = false ) {
 		// If using "view as" feature, automatically make that the matching segment. Otherwise, find the matching segment with the best priority.
 		if ( $view_as_spec && isset( $view_as_spec['segment'] ) ) {
 			return $view_as_spec['segment'];
 		}
 
-		$client_data           = $this->get_client_data( $client_id );
-		$best_segment_priority = PHP_INT_MAX;
-		$best_priority_segment = null;
+		$client_data              = $this->get_client_data( $client_id );
+		$best_segment_priority    = PHP_INT_MAX;
+		$best_priority_segment_id = null;
 
 		foreach ( $all_segments as $segment_id => $segment ) {
 			// Determine whether the client matches the segment criteria.
@@ -173,12 +173,12 @@ class Maybe_Show_Campaign extends Lightweight_API {
 
 			// Find the matching segment with the best priority.
 			if ( $client_matches_segment && $segment->priority < $best_segment_priority ) {
-				$best_segment_priority = $segment->priority;
-				$best_priority_segment = $segment_id;
+				$best_segment_priority    = $segment->priority;
+				$best_priority_segment_id = $segment_id;
 			}
 		}
 
-		return $best_priority_segment;
+		return $best_priority_segment_id;
 	}
 
 	/**
@@ -260,14 +260,14 @@ class Maybe_Show_Campaign extends Lightweight_API {
 		$campaign_segment_ids = ! empty( $campaign->s ) ? explode( ',', $campaign->s ) : [];
 
 		if ( ! empty( $campaign_segment_ids ) ) {
-			$best_priority_segment = isset( $settings->best_priority_segment ) ?
-				$settings->best_priority_segment :
-				$this->get_best_priority_segment( $settings->all_segments, $client_id, $referer_url, $page_referer_url, $view_as_spec );
+			$best_priority_segment_id = isset( $settings->best_priority_segment_id ) ?
+				$settings->best_priority_segment_id :
+				$this->get_best_priority_segment_id( $settings->all_segments, $client_id, $referer_url, $page_referer_url, $view_as_spec );
 
 			// Only factor in the best=priority segment.
-			$is_best_priority = ! empty( $best_priority_segment ) ? in_array( $best_priority_segment, $campaign_segment_ids ) : false;
+			$is_best_priority = ! empty( $best_priority_segment_id ) ? in_array( $best_priority_segment_id, $campaign_segment_ids ) : false;
 			$campaign_segment = $is_best_priority ?
-				$settings->all_segments->{$best_priority_segment} :
+				$settings->all_segments->{$best_priority_segment_id} :
 				[];
 
 			$campaign_segment = Campaign_Data_Utils::canonize_segment( $campaign_segment );

--- a/api/campaigns/class-maybe-show-campaign.php
+++ b/api/campaigns/class-maybe-show-campaign.php
@@ -306,7 +306,7 @@ class Maybe_Show_Campaign extends Lightweight_API {
 			$should_display = false;
 			if ( isset( $view_as_spec['segment'] ) && $view_as_spec['segment'] ) {
 				// Show prompts with a matching segment, or "everyone". Don't show any prompts that don't match the previewed segment.
-				if ( $view_as_spec['segment'] === $campaign->s || empty( $campaign->s ) ) {
+				if ( in_array( $view_as_spec['segment'], $campaign_segment_ids ) || empty( $campaign->s ) ) {
 					$should_display = true;
 				}
 

--- a/api/campaigns/class-maybe-show-campaign.php
+++ b/api/campaigns/class-maybe-show-campaign.php
@@ -190,7 +190,6 @@ class Maybe_Show_Campaign extends Lightweight_API {
 	 * @param string $page_referer_url URL of the referrer of the frontend page that is making the API request.
 	 * @param object $view_as_spec "View As" specification.
 	 * @param string $now Current timestamp.
-	 * @param bool   $check_segment Whether to check if the client matches the prompt's segment. If false, the client is assumed to match the segment.
 	 * @return bool Whether prompt should be shown.
 	 */
 	public function should_campaign_be_shown( $client_id, $campaign, $settings, $referer_url = '', $page_referer_url = '', $view_as_spec = false, $now = false ) {

--- a/api/campaigns/class-maybe-show-campaign.php
+++ b/api/campaigns/class-maybe-show-campaign.php
@@ -191,7 +191,7 @@ class Maybe_Show_Campaign extends Lightweight_API {
 		$campaign_data      = $this->get_campaign_data( $client_id, $campaign->id );
 		$init_campaign_data = $campaign_data;
 
-		if ( $view_as_spec && $campaign_data['suppress_forever'] ) {
+		if ( ! $view_as_spec && $campaign_data['suppress_forever'] ) {
 			return false;
 		}
 

--- a/api/campaigns/class-maybe-show-campaign.php
+++ b/api/campaigns/class-maybe-show-campaign.php
@@ -272,7 +272,7 @@ class Maybe_Show_Campaign extends Lightweight_API {
 			$campaign_segment = Campaign_Data_Utils::canonize_segment( $campaign_segment );
 
 			// Check whether client matches the prompt's segment.
-			$should_display = ( empty( $campaign->s ) || $is_best_priority ) && Campaign_Data_Utils::does_client_match_segment(
+			$should_display = $is_best_priority && Campaign_Data_Utils::does_client_match_segment(
 				$campaign_segment,
 				$client_data,
 				$referer_url,

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -155,12 +155,13 @@ final class Newspack_Popups_Model {
 	 */
 	public static function retrieve_overlay_popups( $include_unpublished = false, $campaign_id = false ) {
 		$args = [
-			'post_type'    => Newspack_Popups::NEWSPACK_POPUPS_CPT,
-			'post_status'  => $include_unpublished ? [ 'draft', 'pending', 'future', 'publish' ] : 'publish',
-			'meta_key'     => 'placement',
+			'post_type'      => Newspack_Popups::NEWSPACK_POPUPS_CPT,
+			'post_status'    => $include_unpublished ? [ 'draft', 'pending', 'future', 'publish' ] : 'publish',
+			'meta_key'       => 'placement',
 			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
-			'meta_value'   => self::$overlay_placements,
-			'meta_compare' => 'IN',
+			'meta_value'     => self::$overlay_placements,
+			'meta_compare'   => 'IN',
+			'posts_per_page' => 100,
 		];
 
 		$tax_query = [
@@ -200,12 +201,13 @@ final class Newspack_Popups_Model {
 	 */
 	public static function retrieve_inline_popups( $include_unpublished = false, $campaign_id = false ) {
 		$args = [
-			'post_type'    => Newspack_Popups::NEWSPACK_POPUPS_CPT,
-			'post_status'  => $include_unpublished ? [ 'draft', 'pending', 'future', 'publish' ] : 'publish',
-			'meta_key'     => 'placement',
+			'post_type'      => Newspack_Popups::NEWSPACK_POPUPS_CPT,
+			'post_status'    => $include_unpublished ? [ 'draft', 'pending', 'future', 'publish' ] : 'publish',
+			'meta_key'       => 'placement',
 			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
-			'meta_value'   => self::$inline_placements,
-			'meta_compare' => 'IN',
+			'meta_value'     => self::$inline_placements,
+			'meta_compare'   => 'IN',
+			'posts_per_page' => 100,
 		];
 
 		// If previewing specific campaign.
@@ -248,6 +250,7 @@ final class Newspack_Popups_Model {
 			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
 			'meta_value'     => self::$overlay_placements,
 			'meta_compare'   => 'IN',
+			'posts_per_page' => 100,
 		];
 
 		// If previewing specific campaign.

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -434,7 +434,8 @@ final class Newspack_Popups_Model {
 				]
 			),
 		];
-		if ( $popup['options']['selected_segment_id'] && ! in_array( $popup['options']['selected_segment_id'], Newspack_Popups_Segmentation::get_segment_ids() ) ) {
+		$assigned_segments = explode( ',', $popup['options']['selected_segment_id'] );
+		if ( $popup['options']['selected_segment_id'] && 0 === count( array_intersect( $assigned_segments, Newspack_Popups_Segmentation::get_segment_ids() ) ) ) {
 			$popup['options']['selected_segment_id'] = null;
 		}
 		if ( $include_categories ) {

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -430,6 +430,7 @@ final class Newspack_Popups_Model {
 				]
 			),
 		];
+
 		$assigned_segments = explode( ',', $popup['options']['selected_segment_id'] );
 		if ( $popup['options']['selected_segment_id'] && 0 === count( array_intersect( $assigned_segments, Newspack_Popups_Segmentation::get_segment_ids() ) ) ) {
 			$popup['options']['selected_segment_id'] = null;

--- a/src/editor/SegmentationSidebar.js
+++ b/src/editor/SegmentationSidebar.js
@@ -31,6 +31,7 @@ const SegmentationSidebar = ( { onMetaFieldChange, selected_segment_id } ) => {
 	return (
 		<Fragment>
 			<BaseControl
+				className="newspack-popups__segmentation-sidebar"
 				help={
 					! selected_segment_id
 						? __( 'The prompt will be shown to all readers.', 'newspack-popups' )

--- a/src/editor/SegmentationSidebar.js
+++ b/src/editor/SegmentationSidebar.js
@@ -5,39 +5,93 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
-import { Fragment } from '@wordpress/element';
-import { ExternalLink, SelectControl } from '@wordpress/components';
+import { __, _x, sprintf } from '@wordpress/i18n';
+import { Fragment, useEffect, useState } from '@wordpress/element';
+import { BaseControl, CheckboxControl, ExternalLink, FormTokenField } from '@wordpress/components';
+
+const defaultSegment = [ { id: '', name: __( 'Everyone', 'newspack-popups' ) } ];
 
 const segmentsList =
-	( window && window.newspack_popups_data && window.newspack_popups_data.segments ) || [];
+	( window &&
+		window.newspack_popups_data &&
+		window.newspack_popups_data.segments.concat( defaultSegment ) ) ||
+	defaultSegment;
 
 const SegmentationSidebar = ( { onMetaFieldChange, selected_segment_id } ) => {
+	const [ assignedSegments, setAssignedSegments ] = useState( [] );
+
+	useEffect(() => {
+		if ( selected_segment_id ) {
+			setAssignedSegments( selected_segment_id.split( ',' ) );
+		} else {
+			setAssignedSegments( [] );
+		}
+	}, [ selected_segment_id ]);
+
 	return (
 		<Fragment>
-			<SelectControl
-				label={ __( 'Segment' ) }
+			<BaseControl
 				help={
 					! selected_segment_id
 						? __( 'The prompt will be shown to all readers.', 'newspack-popups' )
-						: __(
-								'The prompt will be shown only to readers who match the selected segment.',
-								'newspack-popups'
+						: sprintf(
+								__(
+									'The prompt will be shown only to readers who match the selected segment%s.',
+									'newspack-popups'
+								),
+								1 === assignedSegments.length
+									? ''
+									: _x( 's', 'plural modifier for segment', 'newspack-popups' )
 						  )
 				}
-				value={ selected_segment_id }
-				onChange={ value => onMetaFieldChange( 'selected_segment_id', value ) }
-				options={ [
-					{
-						value: '',
-						label: __( 'Default (no segment)', 'newspack-popups' ),
-					},
-					...segmentsList.map( segment => ( {
-						value: segment.id,
-						label: segment.name,
-					} ) ),
-				] }
-			/>
+			>
+				{ 0 < segmentsList.length && (
+					<FormTokenField
+						value={ [] }
+						onChange={ _segment => {
+							const segmentToAssign = segmentsList.find(
+								segment => segment.name === _segment[ 0 ]
+							);
+
+							if ( ! segmentToAssign.id ) {
+								return onMetaFieldChange( 'selected_segment_id', '' );
+							}
+
+							assignedSegments.push( segmentToAssign.id );
+							return onMetaFieldChange( 'selected_segment_id', assignedSegments.join( ',' ) );
+						} }
+						suggestions={ segmentsList
+							.filter( segment => -1 === assignedSegments.indexOf( segment.id ) )
+							.map( segment => segment.name ) }
+						label={ __( 'Search Segments', 'newspack-popups' ) }
+					/>
+				) }
+				{ segmentsList.map( segment => {
+					const segmentIndex = assignedSegments.indexOf( segment.id );
+					const segmentIsAssigned = segmentIndex > -1;
+					return (
+						<CheckboxControl
+							key={ segment.id }
+							value={ segment.id }
+							label={ segment.name }
+							onChange={ () => {
+								if ( ! segment.id ) {
+									return onMetaFieldChange( 'selected_segment_id', '' );
+								}
+
+								if ( segmentIsAssigned ) {
+									assignedSegments.splice( segmentIndex, 1 );
+								} else {
+									assignedSegments.push( segment.id );
+								}
+
+								return onMetaFieldChange( 'selected_segment_id', assignedSegments.join( ',' ) );
+							} }
+							checked={ segment.id ? segmentIsAssigned : 0 === assignedSegments.length }
+						/>
+					);
+				} ) }
+			</BaseControl>
 			<ExternalLink
 				href="/wp-admin/admin.php?page=newspack-popups-wizard#/segments"
 				key="segmentation-link"

--- a/src/editor/SegmentationSidebar.js
+++ b/src/editor/SegmentationSidebar.js
@@ -54,6 +54,10 @@ const SegmentationSidebar = ( { onMetaFieldChange, selected_segment_id } ) => {
 								segment => segment.name === _segment[ 0 ]
 							);
 
+							if ( ! segmentToAssign ) {
+								return;
+							}
+
 							if ( ! segmentToAssign.id ) {
 								return onMetaFieldChange( 'selected_segment_id', '' );
 							}

--- a/src/editor/style.scss
+++ b/src/editor/style.scss
@@ -21,4 +21,10 @@
 		font-size: 0.7em;
 		text-decoration: underline;
 	}
+
+	&__segmentation-sidebar {
+		.components-form-token-field__help {
+			display: none;
+		}
+	}
 }

--- a/tests/test-api.php
+++ b/tests/test-api.php
@@ -26,28 +26,36 @@ class APITest extends WP_UnitTestCase {
 			'segmentBetween3And5'                 => [
 				'min_posts' => 2,
 				'max_posts' => 3,
+				'priority'  => 0,
 			],
 			'segmentSessionReadCountBetween3And5' => [
 				'min_session_posts' => 2,
 				'max_session_posts' => 3,
+				'priority'          => 1,
 			],
 			'segmentSubscribers'                  => [
 				'is_subscribed' => true,
+				'priority'      => 2,
 			],
 			'segmentNonSubscribers'               => [
 				'is_not_subscribed' => true,
+				'priority'          => 3,
 			],
 			'segmentWithReferrers'                => [
 				'referrers' => 'foobar.com, newspack.pub',
+				'priority'  => 4,
 			],
 			'anotherSegmentWithReferrers'         => [
 				'referrers' => 'bar.com',
+				'priority'  => 5,
 			],
 			'segmentWithNegativeReferrer'         => [
 				'referrers_not' => 'baz.com',
+				'priority'      => 6,
 			],
 			'segmentFavCategory42'                => [
 				'favorite_categories' => [ 42 ],
+				'priority'            => 7,
 			],
 		];
 
@@ -688,7 +696,7 @@ class APITest extends WP_UnitTestCase {
 			[
 				'placement'           => 'inline',
 				'frequency'           => 'always',
-				'selected_segment_id' => self::$segment_ids['defaultSegment'],
+				'selected_segment_id' => '',
 			]
 		);
 
@@ -937,6 +945,8 @@ class APITest extends WP_UnitTestCase {
 			]
 		);
 
+		self::$settings->best_priority_segment = self::$segment_ids['segmentWithReferrers'];
+
 		self::assertTrue(
 			self::$maybe_show_campaign->should_campaign_be_shown( self::$client_id, $test_popup_with_segment['payload'], self::$settings, '', 'http://foobar.com' ),
 			'Assert visible if first referrer matches.'
@@ -971,6 +981,8 @@ class APITest extends WP_UnitTestCase {
 			]
 		);
 
+		self::$settings->best_priority_segment = self::$segment_ids['segmentWithNegativeReferrer'];
+
 		self::assertTrue(
 			self::$maybe_show_campaign->should_campaign_be_shown( self::$client_id, $test_popup_with_segment['payload'], self::$settings ),
 			'Assert visible without referrer.'
@@ -1000,6 +1012,8 @@ class APITest extends WP_UnitTestCase {
 				'selected_segment_id' => self::$segment_ids['segmentFavCategory42'],
 			]
 		);
+
+		self::$settings->best_priority_segment = self::$segment_ids['segmentFavCategory42'];
 
 		self::assertFalse(
 			self::$maybe_show_campaign->should_campaign_be_shown( self::$client_id, $test_popup['payload'], self::$settings ),
@@ -1186,6 +1200,8 @@ class APITest extends WP_UnitTestCase {
 			]
 		);
 
+		self::$settings->best_priority_segment = self::$segment_ids['segmentWithNegativeReferrer'];
+
 		self::assertTrue(
 			self::$maybe_show_campaign->should_campaign_be_shown( self::$client_id, $test_popup['payload'], self::$settings ),
 			'Assert visible without referrer.'
@@ -1226,7 +1242,7 @@ class APITest extends WP_UnitTestCase {
 			[
 				'placement'           => 'inline',
 				'frequency'           => 'always',
-				'selected_segment_id' => self::$segment_ids['defaultSegment'],
+				'selected_segment_id' => '',
 			]
 		);
 

--- a/tests/test-api.php
+++ b/tests/test-api.php
@@ -1011,7 +1011,7 @@ class APITest extends WP_UnitTestCase {
 			]
 		);
 
-		self::$settings->best_priority_segment = self::$segment_ids['segmentWithReferrers'];
+		self::$settings->best_priority_segment_id = self::$segment_ids['segmentWithReferrers'];
 
 		self::assertTrue(
 			self::$maybe_show_campaign->should_campaign_be_shown( self::$client_id, $test_popup_with_segment['payload'], self::$settings, '', 'http://foobar.com' ),
@@ -1047,7 +1047,7 @@ class APITest extends WP_UnitTestCase {
 			]
 		);
 
-		self::$settings->best_priority_segment = self::$segment_ids['segmentWithNegativeReferrer'];
+		self::$settings->best_priority_segment_id = self::$segment_ids['segmentWithNegativeReferrer'];
 
 		self::assertTrue(
 			self::$maybe_show_campaign->should_campaign_be_shown( self::$client_id, $test_popup_with_segment['payload'], self::$settings ),
@@ -1079,7 +1079,7 @@ class APITest extends WP_UnitTestCase {
 			]
 		);
 
-		self::$settings->best_priority_segment = self::$segment_ids['segmentFavCategory42'];
+		self::$settings->best_priority_segment_id = self::$segment_ids['segmentFavCategory42'];
 
 		self::assertFalse(
 			self::$maybe_show_campaign->should_campaign_be_shown( self::$client_id, $test_popup['payload'], self::$settings ),
@@ -1266,7 +1266,7 @@ class APITest extends WP_UnitTestCase {
 			]
 		);
 
-		self::$settings->best_priority_segment = self::$segment_ids['segmentWithNegativeReferrer'];
+		self::$settings->best_priority_segment_id = self::$segment_ids['segmentWithNegativeReferrer'];
 
 		self::assertTrue(
 			self::$maybe_show_campaign->should_campaign_be_shown( self::$client_id, $test_popup['payload'], self::$settings ),

--- a/tests/test-api.php
+++ b/tests/test-api.php
@@ -150,6 +150,37 @@ class APITest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test comparing prompts with different-priority segments.
+	 */
+	public function test_segment_priority() {
+		$test_overlay_a = self::create_test_popup(
+			[
+				'placement'           => 'center',
+				'frequency'           => 'daily',
+				'selected_segment_id' => self::$segment_ids['segmentBetween3And5'],
+			]
+		);
+		$test_overlay_b = self::create_test_popup(
+			[
+				'placement'           => 'center',
+				'frequency'           => 'daily',
+				'selected_segment_id' => self::$segment_ids['segmentNonSubscribers'],
+			]
+		);
+
+		$higher_priority = self::$maybe_show_campaign->get_higher_priority_item(
+			$test_overlay_a['payload'],
+			$test_overlay_b['payload'],
+			self::$settings->all_segments
+		);
+
+		self::assertTrue(
+			$higher_priority->id === $test_overlay_a['payload']->id,
+			'Assert the prompt with the highest priority is shown.'
+		);
+	}
+
+	/**
 	 * Suppression caused by "once" frequency.
 	 */
 	public function test_once_frequency() {

--- a/tests/test-api.php
+++ b/tests/test-api.php
@@ -115,6 +115,41 @@ class APITest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test multiple segments assigned per prompt.
+	 */
+	public function test_multiple_segments() {
+		$segments   = [ self::$segment_ids['segmentBetween3And5'], self::$segment_ids['segmentSubscribers'] ];
+		$test_popup = self::create_test_popup(
+			[
+				'placement'           => 'inline',
+				'frequency'           => 'always',
+				'selected_segment_id' => implode( ',', $segments ),
+			]
+		);
+
+		self::assertFalse(
+			self::$maybe_show_campaign->should_campaign_be_shown( self::$client_id, $test_popup['payload'], self::$settings ),
+			'Assert not shown if client matches no assigned segments.'
+		);
+
+		// Report 2 articles read.
+		self::$maybe_show_campaign->save_client_data(
+			self::$client_id,
+			[
+				'posts_read' => [
+					self::create_read_post( 1 ),
+					self::create_read_post( 2 ),
+				],
+			]
+		);
+
+		self::assertTrue(
+			self::$maybe_show_campaign->should_campaign_be_shown( self::$client_id, $test_popup['payload'], self::$settings ),
+			'Assert shown if client’s highest-priority matching segment is assigned.'
+		);
+	}
+
+	/**
 	 * Suppression caused by "once" frequency.
 	 */
 	public function test_once_frequency() {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Along with https://github.com/Automattic/newspack-plugin/pull/874, allows multiple segments to be assigned to each prompt. When deciding whether to show a particular prompt to a reader, all assigned segments are taken into account and the prompt is shown if one of the assigned segments is the reader's highest-priority matching segment.

Depends on #432.

Closes #442.

### How to test the changes in this Pull Request:

Follow testing instructions in https://github.com/Automattic/newspack-plugin/pull/874.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
