### PR TITLE
feat: validate segmentation sort operations

### DIFF
--- a/includes/class-newspack-popups-segmentation.php
+++ b/includes/class-newspack-popups-segmentation.php
@@ -337,7 +337,6 @@ final class Newspack_Popups_Segmentation {
 	 */
 	public static function get_segments() {
 		$segments                  = get_option( self::SEGMENTS_OPTION_NAME, [] );
-
 		$segments_without_priority = array_filter(
 			$segments,
 			function( $segment ) {

--- a/includes/class-newspack-popups-segmentation.php
+++ b/includes/class-newspack-popups-segmentation.php
@@ -522,7 +522,7 @@ final class Newspack_Popups_Segmentation {
 		if ( ! $is_valid ) {
 			return new WP_Error(
 				'invalid_segment_sort',
-				__( 'Failed to sort due to outdated segment data. Please refresh and try again.' )
+				__( 'Failed to sort due to outdated segment data. Please refresh and try again.', 'newspack-popups'  )
 			);
 		}
 

--- a/includes/class-newspack-popups-segmentation.php
+++ b/includes/class-newspack-popups-segmentation.php
@@ -332,9 +332,12 @@ final class Newspack_Popups_Segmentation {
 
 	/**
 	 * Get all configured segments.
+	 *
+	 * @return array Array of segments.
 	 */
 	public static function get_segments() {
 		$segments                  = get_option( self::SEGMENTS_OPTION_NAME, [] );
+
 		$segments_without_priority = array_filter(
 			$segments,
 			function( $segment ) {
@@ -510,11 +513,57 @@ final class Newspack_Popups_Segmentation {
 	/**
 	 * Sort all segments by relative priority.
 	 *
-	 * @param object $segments Array of segments, sorted by priority property.
+	 * @param array $segment_ids Array of segment IDs, in order of desired priority.
+	 * @return array Array of sorted segments.
 	 */
-	public static function sort_segments( $segments ) {
-		update_option( self::SEGMENTS_OPTION_NAME, self::reindex_segments( $segments ) );
+	public static function sort_segments( $segment_ids ) {
+		$segments = get_option( self::SEGMENTS_OPTION_NAME, [] );
+		$is_valid = self::validate_segment_ids( $segment_ids, $segments );
+
+		if ( ! $is_valid ) {
+			return new WP_Error(
+				'invalid_segment_sort',
+				__( 'Failed to sort due to outdated segment data. Please refresh and try again.' )
+			);
+		}
+
+		$sorted_segments = array_map(
+			function( $segment_id ) use ( $segments ) {
+				$segment = array_filter(
+					$segments,
+					function( $segment ) use ( $segment_id ) {
+						return $segment['id'] === $segment_id;
+					}
+				);
+
+				return reset( $segment );
+			},
+			$segment_ids
+		);
+
+		$sorted_segments = self::reindex_segments( $sorted_segments );
+		update_option( self::SEGMENTS_OPTION_NAME, $sorted_segments );
 		return self::get_segments();
+	}
+
+	/**
+	 * Validate an array of segment IDs against the existing segment IDs in the options table.
+	 * When re-sorting segments, the IDs passed should all exist, albeit in a different order,
+	 * so if there are any differences, validation will fail.
+	 *
+	 * @param array $segment_ids Array of segment IDs to validate.
+	 * @param array $segments    Array of existing segments to validate against.
+	 * @return boolean Whether $segment_ids is valid.
+	 */
+	public static function validate_segment_ids( $segment_ids, $segments ) {
+		$existing_ids = array_map(
+			function( $segment ) {
+				return $segment['id'];
+			},
+			$segments
+		);
+
+		return array_diff( $segment_ids, $existing_ids ) === array_diff( $existing_ids, $segment_ids );
 	}
 
 	/**

--- a/includes/class-newspack-popups-segmentation.php
+++ b/includes/class-newspack-popups-segmentation.php
@@ -522,7 +522,7 @@ final class Newspack_Popups_Segmentation {
 		if ( ! $is_valid ) {
 			return new WP_Error(
 				'invalid_segment_sort',
-				__( 'Failed to sort due to outdated segment data. Please refresh and try again.', 'newspack-popups'  )
+				__( 'Failed to sort due to outdated segment data. Please refresh and try again.', 'newspack-popups' )
 			);
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Along with https://github.com/Automattic/newspack-plugin/pull/886, adds server-side validation of segmentation sort request params. Halts operation and returns an error if the passed segment IDs don't match segment IDs that exist in the options table.

Closes https://github.com/Automattic/newspack-plugin/issues/882.

### How to test the changes in this Pull Request:

Follow testing instructions in https://github.com/Automattic/newspack-plugin/pull/886.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
