### PR TITLE
Handle visit data also in previews

### DIFF
--- a/api/campaigns/class-maybe-show-campaign.php
+++ b/api/campaigns/class-maybe-show-campaign.php
@@ -37,7 +37,7 @@ class Maybe_Show_Campaign extends Lightweight_API {
 			$view_as_spec = Segmentation::parse_view_as( json_decode( $_REQUEST['view_as'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		}
 
-		if ( empty( $view_as_spec ) && $visit['is_post'] && defined( 'ENABLE_CAMPAIGN_EVENT_LOGGING' ) && ENABLE_CAMPAIGN_EVENT_LOGGING ) {
+		if ( $visit['is_post'] && defined( 'ENABLE_CAMPAIGN_EVENT_LOGGING' ) && ENABLE_CAMPAIGN_EVENT_LOGGING ) {
 			// Update the cache.
 			$posts_read        = $this->get_client_data( $client_id )['posts_read'];
 			$already_read_post = count(
@@ -141,7 +141,7 @@ class Maybe_Show_Campaign extends Lightweight_API {
 		$campaign_data      = $this->get_campaign_data( $client_id, $campaign->id );
 		$init_campaign_data = $campaign_data;
 
-		if ( ! $view_as_spec && $campaign_data['suppress_forever'] ) {
+		if ( $campaign_data['suppress_forever'] ) {
 			return false;
 		}
 
@@ -238,16 +238,14 @@ class Maybe_Show_Campaign extends Lightweight_API {
 			}
 		}
 
-		if ( ! $view_as_spec ) {
-			if ( ! empty( array_diff( $init_campaign_data, $campaign_data ) ) ) {
-				$this->save_campaign_data( $client_id, $campaign->id, $campaign_data );
-			}
-			if ( 'once' === $frequency && $campaign_data['count'] >= 1 ) {
-				$should_display = false;
-			}
-			if ( 'daily' === $frequency && $campaign_data['last_viewed'] >= strtotime( '-1 day', $now ) ) {
-				$should_display = false;
-			}
+		if ( ! empty( array_diff( $init_campaign_data, $campaign_data ) ) ) {
+			$this->save_campaign_data( $client_id, $campaign->id, $campaign_data );
+		}
+		if ( 'once' === $frequency && $campaign_data['count'] >= 1 ) {
+			$should_display = false;
+		}
+		if ( 'daily' === $frequency && $campaign_data['last_viewed'] >= strtotime( '-1 day', $now ) ) {
+			$should_display = false;
 		}
 
 		return $should_display;

--- a/api/classes/class-lightweight-api.php
+++ b/api/classes/class-lightweight-api.php
@@ -253,11 +253,16 @@ class Lightweight_API {
 		$events_table_name   = Segmentation::get_events_table_name();
 		$all_client_ids_rows = $wpdb->get_results( "SELECT DISTINCT client_id FROM $events_table_name" ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		$api                 = new Lightweight_API();
-		return array_map(
-			function ( $row ) use ( $api ) {
-				return $api->get_client_data( $row->client_id, true );
+		return array_reduce(
+			$all_client_ids_rows,
+			function ( $acc, $row ) use ( $api ) {
+				// Disregard client data created during previewing.
+				if ( false === strpos( $row->client_id, 'preview' ) ) {
+					$acc[] = $api->get_client_data( $row->client_id, true );
+				}
+				return $acc;
 			},
-			$all_client_ids_rows
+			[]
 		);
 	}
 

--- a/includes/class-newspack-popups-segmentation.php
+++ b/includes/class-newspack-popups-segmentation.php
@@ -235,7 +235,7 @@ final class Newspack_Popups_Segmentation {
 			$initial_client_report_url_params['mc_cid'] = sanitize_text_field( $_GET['mc_cid'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			$initial_client_report_url_params['mc_eid'] = sanitize_text_field( $_GET['mc_eid'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		}
-		if ( is_user_logged_in() ) {
+		if ( is_user_logged_in() && ! Newspack_Popups::is_preview_request() ) {
 			if ( function_exists( 'wc_get_orders' ) ) {
 				$user_orders = wc_get_orders( [ 'customer_id' => get_current_user_id() ] );
 				if ( count( $user_orders ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Enable cookie spoofing when previewing.

TODO/Question: this would spam the logs and DB with the preview-generated data – perhaps it should be removed in a CRON job?

### How to test the changes in this Pull Request:

Follow instructions in https://github.com/Automattic/newspack-plugin/pull/891

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [X] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
