### PR TITLE
feat: enable visit logging by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ define( 'DB_PREFIX', 'wp_' );
 
 ## Segmentation features
 
+The segmentation features rely on visit logging. This is on by default, but can be turned off by setting the `DISABLE_CAMPAIGN_EVENT_LOGGING` flag in the aforementioned file:
+
+```
+define( 'DISABLE_CAMPAIGN_EVENT_LOGGING', true );
+```
+
 The segmentation feature causes amp-access to be added to all pages whether or not prompts are present. To override this behavior use the `newspack_popups_suppress_insert_amp_access` filter. The filter receives an array of prompts for the current page. To suppress, return true, for example:
 
 ```

--- a/README.md
+++ b/README.md
@@ -18,12 +18,6 @@ define( 'DB_PREFIX', 'wp_' );
 
 ## Segmentation features
 
-The segmentation features rely on visit logging. This is currently opt-in, managed by the `ENABLE_CAMPAIGN_EVENT_LOGGING` flag defined in the aforementioned file:
-
-```
-define( 'ENABLE_CAMPAIGN_EVENT_LOGGING', true );
-```
-
 The segmentation feature causes amp-access to be added to all pages whether or not prompts are present. To override this behavior use the `newspack_popups_suppress_insert_amp_access` filter. The filter receives an array of prompts for the current page. To suppress, return true, for example:
 
 ```

--- a/api/campaigns/class-maybe-show-campaign.php
+++ b/api/campaigns/class-maybe-show-campaign.php
@@ -37,7 +37,7 @@ class Maybe_Show_Campaign extends Lightweight_API {
 			$view_as_spec = Segmentation::parse_view_as( json_decode( $_REQUEST['view_as'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		}
 
-		if ( empty( $view_as_spec ) && $visit['is_post'] ) {
+		if ( empty( $view_as_spec ) && $visit['is_post'] && ( ! defined( 'DISABLE_CAMPAIGN_EVENT_LOGGING' ) || true !== DISABLE_CAMPAIGN_EVENT_LOGGING ) ) {
 			// Update the cache.
 			$posts_read        = $this->get_client_data( $client_id )['posts_read'];
 			$already_read_post = count(

--- a/api/campaigns/class-maybe-show-campaign.php
+++ b/api/campaigns/class-maybe-show-campaign.php
@@ -37,7 +37,7 @@ class Maybe_Show_Campaign extends Lightweight_API {
 			$view_as_spec = Segmentation::parse_view_as( json_decode( $_REQUEST['view_as'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		}
 
-		if ( empty( $view_as_spec ) && $visit['is_post'] && defined( 'ENABLE_CAMPAIGN_EVENT_LOGGING' ) && ENABLE_CAMPAIGN_EVENT_LOGGING ) {
+		if ( empty( $view_as_spec ) && $visit['is_post'] ) {
 			// Update the cache.
 			$posts_read        = $this->get_client_data( $client_id )['posts_read'];
 			$already_read_post = count(

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -33,7 +33,6 @@ function _manually_load_plugin() {
 tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
 
 define( 'IS_TEST_ENV', 1 );
-define( 'ENABLE_CAMPAIGN_EVENT_LOGGING', 1 );
 
 // Start up the WP testing environment.
 require $_tests_dir . '/includes/bootstrap.php';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Removes the requirement for the `ENABLE_CAMPAIGN_EVENT_LOGGING` constant to be present and `true` in order to enable visit logging for segmentation purposes. This requirement results in new sites installing the plugin for the first time getting only half-functional segmentation features until the constant is added.

Now that segmentation features have been live for some time without major issues, in order to better support new sites, it might be time to flip the condition: if the `DISABLE_CAMPAIGN_EVENT_LOGGING` is defined and `true`, then visit logging is disabled. Otherwise, it is enabled by default.

Closes #459.

### How to test the changes in this Pull Request:

1. Create a new site and install/setup the Newspack plugin and this plugin.
2. If it isn't created automatically, create the `newspack-popups-config.php` file as [described in the readme](https://github.com/Automattic/newspack-popups/blob/master/README.md), but **don't** set the `ENABLE_CAMPAIGN_EVENT_LOGGING` or `DISABLE_CAMPAIGN_EVENT_LOGGING` constants. If it is created automatically, make sure these constants are not set.
3. For ease of testing, enable debug mode by defining `define( 'NEWSPACK_POPUPS_DEBUG', true );` in the config file.
4. Debug the client visit data by adding `$this->debug['client_data'] = $client_data;` after [this line](https://github.com/Automattic/newspack-popups/blob/master/api/campaigns/class-maybe-show-campaign.php#L176).
5. Create and activate at least one prompt. Segment doesn't matter for purposes of this test, but if you want to go above and beyond, then create a segment that relies on a minimum number of articles read, and assign it to the prompt.
6. Visit several articles in a new incognito session and in the Dev Tools > Network tab, filter XHR requests by `api/campaigns` and inspect the response. In the `debug` object, confirm that the `client_id` property correctly logs the read posts as `posts_read`. If you created and assigned the test segment, confirm that the prompt is displayed only after the minimum number of read posts has been logged.
7. Edit the `newspack-popups-config.php` file and add `define( 'DISABLE_CAMPAIGN_EVENT_LOGGING', true );`.
8. In the same Incognito session, view several other (previously unread) articles and confirm that the debug `client_id` property is no longer updated.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
