### PR TITLE
Prevent segmentation-derived custom dimensions reporting in non-interaction mode

### DIFF
--- a/includes/class-newspack-popups-segmentation.php
+++ b/includes/class-newspack-popups-segmentation.php
@@ -55,9 +55,8 @@ final class Newspack_Popups_Segmentation {
 		add_action( 'init', [ __CLASS__, 'create_database_table' ] );
 		add_action( 'wp_footer', [ __CLASS__, 'insert_amp_analytics' ], 20 );
 
+		add_filter( 'newspack_custom_dimensions', [ __CLASS__, 'register_custom_dimensions' ] );
 		if ( ! Newspack_Popups_Settings::is_non_interactive() && ( ! defined( 'NEWSPACK_POPUPS_DISABLE_REPORTING_CUSTOM_DIMENSIONS' ) || true !== NEWSPACK_POPUPS_DISABLE_REPORTING_CUSTOM_DIMENSIONS ) ) {
-			add_filter( 'newspack_custom_dimensions', [ __CLASS__, 'register_custom_dimensions' ] );
-
 			// Sending pageviews with segmentation-related custom dimensions.
 			// 1. Disable pageview sending from Site Kit's GTAG implementation. The custom events sent using Site Kit's
 			// GTAG will not contain the segmentation-related custom dimensions.

--- a/includes/class-newspack-popups-segmentation.php
+++ b/includes/class-newspack-popups-segmentation.php
@@ -55,15 +55,17 @@ final class Newspack_Popups_Segmentation {
 		add_action( 'init', [ __CLASS__, 'create_database_table' ] );
 		add_action( 'wp_footer', [ __CLASS__, 'insert_amp_analytics' ], 20 );
 
-		add_filter( 'newspack_custom_dimensions', [ __CLASS__, 'register_custom_dimensions' ] );
+		if ( ! Newspack_Popups_Settings::is_non_interactive() && ( ! defined( 'NEWSPACK_POPUPS_DISABLE_REPORTING_CUSTOM_DIMENSIONS' ) || true !== NEWSPACK_POPUPS_DISABLE_REPORTING_CUSTOM_DIMENSIONS ) ) {
+			add_filter( 'newspack_custom_dimensions', [ __CLASS__, 'register_custom_dimensions' ] );
 
-		// Sending pageviews with segmentation-related custom dimensions.
-		// 1. Disable pageview sending from Site Kit's GTAG implementation. The custom events sent using Site Kit's
-		// GTAG will not contain the segmentation-related custom dimensions.
-		add_filter( 'googlesitekit_gtag_opt', [ __CLASS__, 'remove_pageview_reporting' ] );
-		add_filter( 'googlesitekit_amp_gtag_opt', [ __CLASS__, 'remove_pageview_reporting_amp' ] );
-		// 2. Add an amp-analytics tag which will send the PV with custom dimensions attached.
-		add_action( 'wp_footer', [ __CLASS__, 'insert_gtag_amp_analytics' ] );
+			// Sending pageviews with segmentation-related custom dimensions.
+			// 1. Disable pageview sending from Site Kit's GTAG implementation. The custom events sent using Site Kit's
+			// GTAG will not contain the segmentation-related custom dimensions.
+			add_filter( 'googlesitekit_gtag_opt', [ __CLASS__, 'remove_pageview_reporting' ] );
+			add_filter( 'googlesitekit_amp_gtag_opt', [ __CLASS__, 'remove_pageview_reporting_amp' ] );
+			// 2. Add an amp-analytics tag which will send the PV with custom dimensions attached.
+			add_action( 'wp_footer', [ __CLASS__, 'insert_gtag_amp_analytics' ] );
+		}
 
 		add_action( 'newspack_popups_segmentation_data_prune', [ __CLASS__, 'prune_data' ] );
 		if ( ! wp_next_scheduled( 'newspack_popups_segmentation_data_prune' ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Ensures non-interaction mode sticks to the promise of disabling API calls.

### How to test the changes in this Pull Request:

1. On `master`, verify that when non-interaction mode is on, a call is made to the API on page load, and that segmentation-derived custom dimensions are reported*
2. Switch to this branch, observe the above is not true anymore
3. Turn off the non-interaction mode and verify that segmentation-derived custom dimensions are reported
4. Add a `NEWSPACK_POPUPS_DISABLE_REPORTING_CUSTOM_DIMENSIONS` flag of value `true` to `wp-config.php`
5. Observe that the API calls for prompts are made, but not for custom GA config, and that the segmentation-derived custom dimensions are not reported. This flag is for additional debugging purposes.

\* look for `collect' calls in network tab. The custom dimensions have to be configured in the Analytics wizard

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
