### PR TITLE
fix: prompt insertion with slideshows

### DIFF
--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -247,7 +247,13 @@ final class Newspack_Popups_Inserter {
 		$output = '';
 		foreach ( parse_blocks( $content ) as $block ) {
 			$block_content = render_block( $block );
-			$pos          += strlen( $block_content );
+			$block_length  = strlen( $block_content );
+
+			if ( $block_length > 2 * strlen( $block['innerHTML'] ) ) {
+				$block_length = strlen( $block['innerHTML'] );
+			}
+
+			$pos += $block_length;
 			foreach ( $inline_popups as &$inline_popup ) {
 				if ( ! $inline_popup['is_inserted'] && $pos > $inline_popup['precise_position'] ) {
 					$output .= '<!-- wp:shortcode -->[newspack-popup id="' . $inline_popup['id'] . '"]<!-- /wp:shortcode -->';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fix for a strange issue related to prompt insertion when a post contains Jetpack Slideshow blocks. This fix treats the symptom, but doesn't really solve the root issue, which is elusive.

Addresses #465, but perhaps doesn't close it. This is kind of a workaround which just checks whether the block's rendered content is much longer than expected based on its `innerHTML` attribute, and if it is, updates the inserter logic's internal position marker based on `innerHTML` instead of the usual rendered content. A potentially more ideal but much more involved solution is mentioned in the issue.

### How to test the changes in this Pull Request:

This is nearly impossible to replicate locally, in my experience. For this reason, I created a clone of the site that reported the issue, where the issue can be replicated reliably. The clone of the offending page is [here](https://mississippitoday.newspackstaging.com/2021/02/26/food-thats-going-to-stick-to-your-ribs-the-significance-of-soul-food-in-yalobusha-county/), but it can be replicated on any post on the test site that contains a slideshow block. DM me if you need the password to access the test site.

1. Ensure that the test site has the [latest production release](https://github.com/Automattic/newspack-popups/releases/tag/v1.26.0) of this plugin installed and active.
2. In a new incognito session, visit https://mississippitoday.newspackstaging.com/2021/02/26/food-thats-going-to-stick-to-your-ribs-the-significance-of-soul-food-in-yalobusha-county/ or any post that contains a slideshow block, in AMP mode (slideshow blocks [currently don't work in non-AMP mode with the Campaigns plugin active](https://github.com/Automattic/newspack-popups/issues/170), a known issue).  
3. Observe that the three prompts are displayed as described in #465. Also visit several other posts that don't contain a slideshow, and note the insertion locations for the prompts.
4. From this branch, run `npm run release:archive` to build the plugin code. Install and activate this plugin version on the test site.
5. Refresh the offending post. Confirm that the prompts are now be inserted in much more logical places, especially the "Donate" prompt, which should always appear at the end of the content.
6. Visit other posts on the test site and confirm that the prompts are inserted where you might expect, with or without slideshow blocks present, and with and without AMP enabled.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
