### PR TITLE
feat: custom placements

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -43,7 +43,6 @@ node_modules
 .git
 .github
 .circleci
-/src
 /tests
 /bin
 /release

--- a/api/campaigns/class-maybe-show-campaign.php
+++ b/api/campaigns/class-maybe-show-campaign.php
@@ -127,11 +127,17 @@ class Maybe_Show_Campaign extends Lightweight_API {
 
 			// Handle custom placements: Only one prompt should be shown per placement block.
 			// "Everyone" prompts should only be shown if the reader doesn't match any segments.
-			if ( ! empty( $campaign->c ) ) {
-				if ( $campaign_should_be_shown && ! isset( $custom_placements_displayed[ $campaign->c ] ) ) {
-					$custom_placements_displayed[ $campaign->c ] = $campaign->id;
+			if ( $campaign_should_be_shown && ! empty( $campaign->c ) ) {
+				if ( ! isset( $custom_placements_displayed[ $campaign->c ] ) ) {
+					$custom_placements_displayed[ $campaign->c ] = $campaign;
 				} else {
-					$campaign_should_be_shown = false;
+					$previous_item        = $custom_placements_displayed[ $campaign->c ];
+					$higher_priority_item = self::get_higher_priority_item( $previous_item, $campaign, $all_segments );
+
+					// If the previous prompt in this custom placement already has a higher priority, only show that one. Otherwise, show this one instead.
+					$response[ $previous_item->id ]              = $previous_item->id === $higher_priority_item->id;
+					$campaign_should_be_shown                    = $campaign->id === $higher_priority_item->id;
+					$custom_placements_displayed[ $campaign->c ] = $higher_priority_item;
 				}
 			}
 

--- a/api/campaigns/class-maybe-show-campaign.php
+++ b/api/campaigns/class-maybe-show-campaign.php
@@ -78,6 +78,7 @@ class Maybe_Show_Campaign extends Lightweight_API {
 		$all_segments                  = isset( $settings->all_segments ) ? $settings->all_segments : [];
 		$overlay_to_maybe_display      = null;
 		$above_header_to_maybe_display = null;
+		$custom_placements_displayed   = [];
 
 		if ( $settings ) {
 			$settings->best_priority_segment_id = $this->get_best_priority_segment_id( $all_segments, $client_id, $referer_url, $page_referer_url, $view_as_spec );
@@ -121,6 +122,16 @@ class Maybe_Show_Campaign extends Lightweight_API {
 					$response[ $above_header_to_maybe_display->id ] = $above_header_to_maybe_display->id === $higher_priority_item->id;
 					$campaign_should_be_shown                       = $campaign->id === $higher_priority_item->id;
 					$above_header_to_maybe_display                  = $higher_priority_item;
+				}
+			}
+
+			// Handle custom placements: Only one prompt should be shown per placement block.
+			// "Everyone" prompts should only be shown if the reader doesn't match any segments.
+			if ( ! empty( $campaign->c ) ) {
+				if ( $campaign_should_be_shown && ! isset( $custom_placements_displayed[ $campaign->c ] ) ) {
+					$custom_placements_displayed[ $campaign->c ] = $campaign->id;
+				} else {
+					$campaign_should_be_shown = false;
 				}
 			}
 

--- a/includes/class-newspack-popups-custom-placements.php
+++ b/includes/class-newspack-popups-custom-placements.php
@@ -71,5 +71,18 @@ final class Newspack_Popups_Custom_Placements {
 	public static function get_custom_placement_values() {
 		return array_keys( self::get_custom_placements() );
 	}
+
+	/**
+	 * Determine whether the given prompt should be displayed via custom placement.
+	 *
+	 * @param object $prompt The prompt to assess.
+	 * @return boolean Whether or not the prompt has a custom placement.
+	 */
+	public static function is_custom_placement( $prompt ) {
+		return (
+			'manual' === $prompt['options']['frequency'] ||
+			in_array( $prompt['options']['frequency'], self::get_custom_placement_values() )
+		);
+	}
 }
 Newspack_Popups_Custom_Placements::instance();

--- a/includes/class-newspack-popups-custom-placements.php
+++ b/includes/class-newspack-popups-custom-placements.php
@@ -114,24 +114,8 @@ final class Newspack_Popups_Custom_Placements {
 				'methods'             => \WP_REST_Server::READABLE,
 				'callback'            => [ __CLASS__, 'api_get_prompts_for_custom_placement' ],
 				'permission_callback' => '__return_true',
-				'args'                => [
-					'custom_placement' => [
-						'validate_callback' => [ __CLASS__, 'validate_custom_placement' ],
-						'sanitize_callback' => 'esc_attr',
-					],
-				],
 			]
 		);
-	}
-
-	/**
-	 * Validate a custom placement slug.
-	 *
-	 * @param string $slug The slug of the custom placement to check.
-	 * @return boolean Whether the slug is a valid custom placement.
-	 */
-	public static function validate_custom_placement( $slug ) {
-		return in_array( $slug, self::get_custom_placement_values() );
 	}
 
 	/**

--- a/includes/class-newspack-popups-custom-placements.php
+++ b/includes/class-newspack-popups-custom-placements.php
@@ -10,18 +10,18 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Main Newspack Placements Plugin Class.
  */
-final class Newspack_Popups_Placements {
+final class Newspack_Popups_Custom_Placements {
 	/**
 	 * The single instance of the class.
 	 *
-	 * @var Newspack_Popups_Placements
+	 * @var Newspack_Popups_Custom_Placements
 	 */
 	protected static $instance = null;
 
 	/**
 	 * Name of the option to store placements under.
 	 */
-	const PLACEMENTS_OPTION_NAME = 'newspack_popups_placements';
+	const PLACEMENTS_OPTION_NAME = 'newspack_popups_custom_placements';
 
 	/**
 	 * Main Newspack Placements Plugin Instance.
@@ -45,7 +45,7 @@ final class Newspack_Popups_Placements {
 	/**
 	 * Get default placements that exist for all sites.
 	 */
-	public static function get_default_placements() {
+	public static function get_default_custom_placements() {
 		return [
 			'custom1' => __( 'Custom Placement 1' ),
 			'custom2' => __( 'Custom Placement 2' ),
@@ -58,9 +58,18 @@ final class Newspack_Popups_Placements {
 	 *
 	 * @return array Array of placements.
 	 */
-	public static function get_placements() {
+	public static function get_custom_placements() {
 		$placements = get_option( self::PLACEMENTS_OPTION_NAME, [] );
-		return array_merge( $placements, self::get_default_placements() );
+		return array_merge( self::get_default_custom_placements(), $placements );
+	}
+
+	/**
+	 * Get a simple array of placement values.
+	 *
+	 * @return array Array of placement values.
+	 */
+	public static function get_custom_placement_values() {
+		return array_keys( self::get_custom_placements() );
 	}
 }
-Newspack_Popups_Placements::instance();
+Newspack_Popups_Custom_Placements::instance();

--- a/includes/class-newspack-popups-custom-placements.php
+++ b/includes/class-newspack-popups-custom-placements.php
@@ -160,11 +160,13 @@ final class Newspack_Popups_Custom_Placements {
 	/**
 	 * Query for prompts with the given custom placements.
 	 *
-	 * @param array  $custom_placement_ids Array of IDs for custom placements to look up.
-	 * @param string $fields Field values to return in response: 'all' or 'ids'.
+	 * @param array         $custom_placement_ids Array of IDs for custom placements to look up.
+	 * @param string        $fields Field values to return in response: 'all' or 'ids'.
+	 * @param array|boolean $categories Array of category IDs to filter by, empty array if fetching only uncategorized prompts, or false to ignore categories.
+	 *
 	 * @return array Array of prompt posts matching the custom placement.
 	 */
-	public static function get_prompts_for_custom_placement( $custom_placement_ids, $fields = 'all' ) {
+	public static function get_prompts_for_custom_placement( $custom_placement_ids, $fields = 'all', $categories = false ) {
 		$args  = [
 			'posts_per_page' => 100,
 			'post_status'    => 'publish',
@@ -175,6 +177,19 @@ final class Newspack_Popups_Custom_Placements {
 			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
 			'meta_value'     => $custom_placement_ids,
 		];
+
+		if ( ! empty( $categories ) ) {
+			$args['category__in'] = $categories;
+		} elseif ( is_array( $categories ) ) {
+			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
+			$args['tax_query'] = [
+				[
+					'taxonomy' => 'category',
+					'operator' => 'NOT EXISTS',
+				],
+			];
+		}
+
 		$query = new \WP_Query( $args );
 
 		if ( $query->have_posts() ) {

--- a/includes/class-newspack-popups-custom-placements.php
+++ b/includes/class-newspack-popups-custom-placements.php
@@ -279,7 +279,7 @@ final class Newspack_Popups_Custom_Placements {
 	public static function is_custom_placement( $prompt ) {
 		return (
 			'manual' === $prompt['options']['frequency'] ||
-			in_array( $prompt['options']['frequency'], self::get_custom_placement_values() )
+			in_array( $prompt['options']['placement'], self::get_custom_placement_values() )
 		);
 	}
 }

--- a/includes/class-newspack-popups-custom-placements.php
+++ b/includes/class-newspack-popups-custom-placements.php
@@ -167,7 +167,7 @@ final class Newspack_Popups_Custom_Placements {
 	 * @return array Array of prompt posts matching the custom placement.
 	 */
 	public static function get_prompts_for_custom_placement( $custom_placement_ids, $fields = 'all', $categories = false ) {
-		$args  = [
+		$args = [
 			'posts_per_page' => 100,
 			'post_status'    => 'publish',
 			'post_type'      => Newspack_Popups::NEWSPACK_POPUPS_CPT,

--- a/includes/class-newspack-popups-custom-placements.php
+++ b/includes/class-newspack-popups-custom-placements.php
@@ -153,11 +153,19 @@ final class Newspack_Popups_Custom_Placements {
 
 					if ( $segment_ids ) {
 						$segment_ids = explode( ',', $segment_ids );
-						$segments    = array_map(
-							function( $segment_id ) {
-								return Newspack_Popups_Segmentation::get_segment( $segment_id );
+						$segments    = array_reduce(
+							$segment_ids,
+							function( $acc, $segment_id ) {
+								$segment = Newspack_Popups_Segmentation::get_segment( $segment_id );
+
+								// Only return segments that exist (result can be null if a segment has been deleted).
+								if ( $segment ) {
+									$acc[] = $segment;
+								}
+
+								return $acc;
 							},
-							$segment_ids
+							[]
 						);
 					}
 

--- a/includes/class-newspack-popups-custom-placements.php
+++ b/includes/class-newspack-popups-custom-placements.php
@@ -146,7 +146,7 @@ final class Newspack_Popups_Custom_Placements {
 					$segment_ids = get_post_meta( $post->ID, 'selected_segment_id', true );
 					$segments    = [
 						[
-							'name'     => 'Everyone else',
+							'name'     => 'Everyone',
 							'priority' => PHP_INT_MAX,
 						],
 					];

--- a/includes/class-newspack-popups-custom-placements.php
+++ b/includes/class-newspack-popups-custom-placements.php
@@ -42,6 +42,7 @@ final class Newspack_Popups_Custom_Placements {
 	public function __construct() {
 		add_action( 'enqueue_block_editor_assets', [ __CLASS__, 'manage_editor_assets' ] );
 		add_action( 'init', [ __CLASS__, 'manage_view_assets' ] );
+		add_action( 'rest_api_init', [ __CLASS__, 'rest_api_init' ] );
 	}
 
 	/**
@@ -63,6 +64,15 @@ final class Newspack_Popups_Custom_Placements {
 				'custom_placements' => self::get_custom_placements(),
 			]
 		);
+
+		\wp_register_style(
+			'newspack-popups-blocks',
+			plugins_url( '../dist/blocks.css', __FILE__ ),
+			[],
+			filemtime( dirname( NEWSPACK_POPUPS_PLUGIN_FILE ) . '/dist/blocks.css' )
+		);
+		wp_style_add_data( 'newspack-popups-blocks', 'rtl', 'replace' );
+		wp_enqueue_style( 'newspack-popups-blocks' );
 	}
 
 	/**
@@ -93,6 +103,46 @@ final class Newspack_Popups_Custom_Placements {
 		}
 	}
 
+	/**
+	 * Initialise REST API endpoints.
+	 */
+	public static function rest_api_init() {
+		\register_rest_route(
+			'newspack-popups/v1',
+			'custom-placement',
+			[
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => [ __CLASS__, 'api_get_prompts_for_custom_placement' ],
+				'permission_callback' => '__return_true',
+				'args'                => [
+					'custom_placement' => [
+						'validate_callback' => [ __CLASS__, 'validate_custom_placement' ],
+						'sanitize_callback' => 'esc_attr',
+					],
+				],
+			]
+		);
+	}
+
+	/**
+	 * Validate a custom placement slug.
+	 *
+	 * @param string $slug The slug of the custom placement to check.
+	 * @return boolean Whether the slug is a valid custom placement.
+	 */
+	public static function validate_custom_placement( $slug ) {
+		return in_array( $slug, self::get_custom_placement_values() );
+	}
+
+	/**
+	 * Get prompts assigned to a given custom placement.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response.
+	 */
+	public static function api_get_prompts_for_custom_placement( $request ) {
+		return [];
+	}
 
 	/**
 	 * Get default placements that exist for all sites.

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -429,8 +429,8 @@ final class Newspack_Popups_Inserter {
 		);
 
 		// Get prompts for custom placements.
-		$custom_placement_ids      = self::get_custom_placement_ids( get_the_content() );
-		$custom_placement_popups   = array_reduce(
+		$custom_placement_ids    = self::get_custom_placement_ids( get_the_content() );
+		$custom_placement_popups = array_reduce(
 			Newspack_Popups_Custom_Placements::get_prompts_for_custom_placement( $custom_placement_ids ),
 			function ( $acc, $custom_placement_popup ) {
 				if ( $custom_placement_popup ) {

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -88,7 +88,10 @@ final class Newspack_Popups_Inserter {
 		$popups_to_maybe_display = array_filter(
 			$popups_to_maybe_display,
 			function( $popup ) {
-				return 'manual' !== $popup['options']['frequency'];
+				return (
+					'manual' !== $popup['options']['frequency'] &&
+					! in_array( $popup['options']['frequency'], Newspack_Popups_Custom_Placements::get_custom_placement_values() )
+				);
 			}
 		);
 

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -88,10 +88,7 @@ final class Newspack_Popups_Inserter {
 		$popups_to_maybe_display = array_filter(
 			$popups_to_maybe_display,
 			function( $popup ) {
-				return (
-					'manual' !== $popup['options']['frequency'] &&
-					! in_array( $popup['options']['frequency'], Newspack_Popups_Custom_Placements::get_custom_placement_values() )
-				);
+				return ! Newspack_Popups_Custom_Placements::is_custom_placement( $popup );
 			}
 		);
 
@@ -351,7 +348,7 @@ final class Newspack_Popups_Inserter {
 			! $found_popup ||
 			// Bail if it's a non-preview popup which should not be displayed.
 			( ! self::should_display( $found_popup, true ) && ! Newspack_Popups::previewed_popup_id() ) ||
-			// Only inline popups can be inserted via the  shortcode.
+			// Only inline popups can be inserted via the shortcode.
 			! Newspack_Popups_Model::is_inline( $found_popup )
 		) {
 			return;
@@ -633,7 +630,7 @@ final class Newspack_Popups_Inserter {
 	 * @return bool Should popup be shown.
 	 */
 	public static function should_display( $popup, $skip_context_checks = false ) {
-		if ( 'manual' === $popup['options']['frequency'] ) {
+		if ( Newspack_Popups_Custom_Placements::is_custom_placement( $popup ) ) {
 			return true;
 		}
 

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -429,24 +429,15 @@ final class Newspack_Popups_Inserter {
 		);
 
 		// Get prompts for custom placements.
-		$custom_placement_segments = [];
 		$custom_placement_ids      = self::get_custom_placement_ids( get_the_content() );
 		$custom_placement_popups   = array_reduce(
 			Newspack_Popups_Custom_Placements::get_prompts_for_custom_placement( $custom_placement_ids ),
 			function ( $acc, $custom_placement_popup ) use ( $custom_placement_segments ) {
 				if ( $custom_placement_popup ) {
 					$popup_object = Newspack_Popups_Model::create_popup_object( $custom_placement_popup );
-					$segment_id   = $popup_object['options']['selected_segment_id'] ? $popup_object['options']['selected_segment_id'] : 'everyone';
-					$placement    = $popup_object['options']['placement'];
-
-					// Only show one prompt per segment, per custom placement.
-					if ( empty( $custom_placement_segments[ $placement ] ) ) {
-						$custom_placement_segments[ $placement ] = [];
-					}
 
 					if ( $popup_object && ! in_array( $segment_id, $custom_placement_segments[ $placement ] ) ) {
-						$custom_placement_segments[ $placement ] = $segment_id;
-						$acc[]                                   = $popup_object;
+						$acc[] = $popup_object;
 					}
 				}
 				return $acc;

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -432,11 +432,11 @@ final class Newspack_Popups_Inserter {
 		$custom_placement_ids      = self::get_custom_placement_ids( get_the_content() );
 		$custom_placement_popups   = array_reduce(
 			Newspack_Popups_Custom_Placements::get_prompts_for_custom_placement( $custom_placement_ids ),
-			function ( $acc, $custom_placement_popup ) use ( $custom_placement_segments ) {
+			function ( $acc, $custom_placement_popup ) {
 				if ( $custom_placement_popup ) {
 					$popup_object = Newspack_Popups_Model::create_popup_object( $custom_placement_popup );
 
-					if ( $popup_object && ! in_array( $segment_id, $custom_placement_segments[ $placement ] ) ) {
+					if ( $popup_object ) {
 						$acc[] = $popup_object;
 					}
 				}

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -381,7 +381,7 @@ final class Newspack_Popups_Inserter {
 			$type = 'a';
 		}
 
-		return [
+		$popup_payload = [
 			'id'  => $popup_id_string,
 			'f'   => $frequency,
 			'utm' => $popup['options']['utm_suppression'],
@@ -390,6 +390,12 @@ final class Newspack_Popups_Inserter {
 			'd'   => \Newspack_Popups_Model::has_donation_block( $popup ),
 			't'   => $type,
 		];
+
+		if ( Newspack_Popups_Custom_Placements::is_custom_placement( $popup ) ) {
+			$popup_payload['c'] = $popup['options']['placement'];
+		}
+
+		return $popup_payload;
 	}
 
 	/**

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -413,7 +413,7 @@ final class Newspack_Popups_Inserter {
 		);
 
 		// Get shortcoded prompts.
-		$shortcoded_popups    = array_reduce(
+		$shortcoded_popups = array_reduce(
 			$shortcoded_popup_ids,
 			function ( $acc, $id ) {
 				$popup_post = get_post( $id );

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -84,14 +84,6 @@ final class Newspack_Popups_Inserter {
 			);
 		}
 
-		// 5. Remove manual placement prompts.
-		$popups_to_maybe_display = array_filter(
-			$popups_to_maybe_display,
-			function( $popup ) {
-				return ! Newspack_Popups_Custom_Placements::is_custom_placement( $popup );
-			}
-		);
-
 		return array_filter(
 			$popups_to_maybe_display,
 			[ __CLASS__, 'should_display' ]

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -114,7 +114,12 @@ final class Newspack_Popups_Model {
 					update_post_meta( $id, $key, $value );
 					break;
 				case 'placement':
-					if ( ! in_array( $value, array_merge( self::$overlay_placements, self::$inline_placements ) ) ) {
+					$valid_placements = array_merge(
+						self::$overlay_placements,
+						self::$inline_placements,
+						array_keys( Newspack_Popups_Placements::get_placements() )
+					);
+					if ( ! in_array( $value, $valid_placements ) ) {
 						return new \WP_Error(
 							'newspack_popups_invalid_option_value',
 							esc_html__( 'Invalid placement value.', 'newspack-popups' ),

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -521,7 +521,10 @@ final class Newspack_Popups_Model {
 		if ( ! isset( $popup['options'], $popup['options']['placement'] ) ) {
 			return false;
 		}
-		return in_array( $popup['options']['placement'], self::$inline_placements );
+		return in_array(
+			$popup['options']['placement'],
+			array_merge( self::$inline_placements, Newspack_Popups_Custom_Placements::get_custom_placement_values() )
+		);
 	}
 
 	/**

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -367,18 +367,27 @@ final class Newspack_Popups_Model {
 	protected static function deprecate_test_never( $popup, $published_only ) {
 		$frequency = $popup['options']['frequency'];
 		$placement = $popup['options']['placement'];
-		if ( in_array( $frequency, [ 'never', 'test' ] ) ) {
+		if ( in_array( $frequency, [ 'never', 'test', 'manual' ] ) ) {
 			if ( in_array( $placement, [ 'inline', 'above_header' ] ) ) {
 				$popup['options']['frequency'] = 'always';
 			} else {
 				$popup['options']['frequency'] = 'daily';
 			}
 			update_post_meta( $popup['id'], 'frequency', $popup['options']['frequency'] );
-			$popup['status'] = 'draft';
 
 			$post = get_post( $popup['id'] );
 
-			$post->post_status = 'draft';
+			// Update 'manual' prompts to a default custom placement.
+			if ( 'manual' === $frequency ) {
+				$popup['options']['placement'] = 'custom1';
+			}
+
+			// Set 'never' and 'test' prompts to draft status.
+			if ( in_array( $frequency, [ 'never', 'test' ] ) ) {
+				$popup['status']   = 'draft';
+				$post->post_status = 'draft';
+			}
+
 			wp_update_post( $post );
 
 			if ( $published_only ) {

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -380,6 +380,7 @@ final class Newspack_Popups_Model {
 			// Update 'manual' prompts to a default custom placement.
 			if ( 'manual' === $frequency ) {
 				$popup['options']['placement'] = 'custom1';
+				update_post_meta( $popup['id'], 'placement', $popup['options']['placement'] );
 			}
 
 			// Set 'never' and 'test' prompts to draft status.

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -835,7 +835,7 @@ final class Newspack_Popups_Model {
 		$is_newsletter_prompt   = self::has_newsletter_prompt( $popup );
 		$classes                = [];
 		$classes[]              = 'above_header' === $popup['options']['placement'] ? 'newspack-above-header-popup' : null;
-		$classes[]              = 'inline' === $popup['options']['placement'] ? 'newspack-inline-popup' : null;
+		$classes[]              = ! self::is_above_header( $popup ) ? 'newspack-inline-popup' : null;
 		$classes[]              = 'publish' !== $popup['status'] ? 'newspack-inactive-popup-status' : null;
 		$classes[]              = ( ! empty( $popup['title'] ) && $display_title ) ? 'newspack-lightbox-has-title' : null;
 		$classes[]              = $is_newsletter_prompt ? 'newspack-newsletter-prompt-inline' : null;

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -117,7 +117,7 @@ final class Newspack_Popups_Model {
 					$valid_placements = array_merge(
 						self::$overlay_placements,
 						self::$inline_placements,
-						array_keys( Newspack_Popups_Placements::get_placements() )
+						Newspack_Popups_Custom_Placements::get_custom_placement_values()
 					);
 					if ( ! in_array( $value, $valid_placements ) ) {
 						return new \WP_Error(

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -346,7 +346,7 @@ final class Newspack_Popups_Model {
 					get_post( get_the_ID() ),
 					$include_categories
 				);
-				$popup = self::deprecate_test_never( $popup, 'publish' === $query->get( 'post_status', null ) );
+				$popup = self::deprecate_test_never_manual( $popup, 'publish' === $query->get( 'post_status', null ) );
 
 				if ( $popup ) {
 					$popups[] = $popup;
@@ -358,13 +358,13 @@ final class Newspack_Popups_Model {
 	}
 
 	/**
-	 * Deprecate Test Mode and Never frequency.
+	 * Deprecate Test Mode and Never/Manual frequencies.
 	 *
 	 * @param object $popup The popup.
 	 * @param bool   $published_only Whether the result must be a published post.
 	 * @return object|null Popup object or null.
 	 */
-	protected static function deprecate_test_never( $popup, $published_only ) {
+	protected static function deprecate_test_never_manual( $popup, $published_only ) {
 		$frequency = $popup['options']['frequency'];
 		$placement = $popup['options']['placement'];
 		if ( in_array( $frequency, [ 'never', 'test', 'manual' ] ) ) {
@@ -390,7 +390,7 @@ final class Newspack_Popups_Model {
 
 			wp_update_post( $post );
 
-			if ( $published_only ) {
+			if ( $published_only && 'publish' !== $popup['status'] ) {
 				$popup = null;
 			}
 		}

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -101,7 +101,7 @@ final class Newspack_Popups_Model {
 		foreach ( $options as $key => $value ) {
 			switch ( $key ) {
 				case 'frequency':
-					if ( ! in_array( $value, [ 'once', 'daily', 'always', 'manual' ] ) ) {
+					if ( ! in_array( $value, [ 'once', 'daily', 'always' ] ) ) {
 						return new \WP_Error(
 							'newspack_popups_invalid_option_value',
 							esc_html__( 'Invalid frequency value.', 'newspack-popups' ),

--- a/includes/class-newspack-popups-placements.php
+++ b/includes/class-newspack-popups-placements.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Newspack Placements Plugin
+ *
+ * @package Newspack
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Main Newspack Placements Plugin Class.
+ */
+final class Newspack_Popups_Placements {
+	/**
+	 * The single instance of the class.
+	 *
+	 * @var Newspack_Popups_Placements
+	 */
+	protected static $instance = null;
+
+	/**
+	 * Name of the option to store placements under.
+	 */
+	const PLACEMENTS_OPTION_NAME = 'newspack_popups_placements';
+
+	/**
+	 * Main Newspack Placements Plugin Instance.
+	 * Ensures only one instance of Newspack Placements Plugin Instance is loaded or can be loaded.
+	 *
+	 * @return Newspack Placements Plugin Instance - Main instance.
+	 */
+	public static function instance() {
+		if ( is_null( self::$instance ) ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+	}
+
+	/**
+	 * Get default placements that exist for all sites.
+	 */
+	public static function get_default_placements() {
+		return [
+			'custom1' => __( 'Custom Placement 1' ),
+			'custom2' => __( 'Custom Placement 2' ),
+			'custom3' => __( 'Custom Placement 3' ),
+		];
+	}
+
+	/**
+	 * Get all configured placements.
+	 *
+	 * @return array Array of placements.
+	 */
+	public static function get_placements() {
+		$placements = get_option( self::PLACEMENTS_OPTION_NAME, [] );
+		return array_merge( $placements, self::get_default_placements() );
+	}
+}
+Newspack_Popups_Placements::instance();

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -61,6 +61,7 @@ final class Newspack_Popups {
 		include_once dirname( __FILE__ ) . '/class-newspack-popups-api.php';
 		include_once dirname( __FILE__ ) . '/class-newspack-popups-settings.php';
 		include_once dirname( __FILE__ ) . '/class-newspack-popups-segmentation.php';
+		include_once dirname( __FILE__ ) . '/class-newspack-popups-placements.php';
 		include_once dirname( __FILE__ ) . '/class-newspack-popups-parse-logs.php';
 		include_once dirname( __FILE__ ) . '/class-newspack-popups-donations.php';
 		include_once dirname( __FILE__ ) . '/class-newspack-popups-view-as.php';
@@ -358,6 +359,7 @@ final class Newspack_Popups {
 			[
 				'preview_post' => self::preview_post_permalink(),
 				'segments'     => Newspack_Popups_Segmentation::get_segments(),
+				'placements'   => Newspack_Popups_Placements::get_placements(),
 				'taxonomy'     => self::NEWSPACK_POPUPS_TAXONOMY,
 			]
 		);

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -461,9 +461,9 @@ final class Newspack_Popups {
 				$placement = 'above_header';
 				$frequency = 'always';
 				break;
-			case 'manual':
-				$placement = 'inline';
-				$frequency = 'manual';
+			case 'custom':
+				$placement = 'custom1';
+				$frequency = 'always';
 				break;
 			default:
 				$placement = 'inline';
@@ -479,7 +479,7 @@ final class Newspack_Popups {
 				$trigger_type = 'time';
 				break;
 			case 'above-header':
-			case 'manual':
+			case 'custom':
 			default:
 				$dismiss_text = null;
 				$trigger_type = 'scroll';

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -61,7 +61,7 @@ final class Newspack_Popups {
 		include_once dirname( __FILE__ ) . '/class-newspack-popups-api.php';
 		include_once dirname( __FILE__ ) . '/class-newspack-popups-settings.php';
 		include_once dirname( __FILE__ ) . '/class-newspack-popups-segmentation.php';
-		include_once dirname( __FILE__ ) . '/class-newspack-popups-placements.php';
+		include_once dirname( __FILE__ ) . '/class-newspack-popups-custom-placements.php';
 		include_once dirname( __FILE__ ) . '/class-newspack-popups-parse-logs.php';
 		include_once dirname( __FILE__ ) . '/class-newspack-popups-donations.php';
 		include_once dirname( __FILE__ ) . '/class-newspack-popups-view-as.php';
@@ -357,10 +357,10 @@ final class Newspack_Popups {
 			'newspack-popups',
 			'newspack_popups_data',
 			[
-				'preview_post' => self::preview_post_permalink(),
-				'segments'     => Newspack_Popups_Segmentation::get_segments(),
-				'placements'   => Newspack_Popups_Placements::get_placements(),
-				'taxonomy'     => self::NEWSPACK_POPUPS_TAXONOMY,
+				'preview_post'      => self::preview_post_permalink(),
+				'segments'          => Newspack_Popups_Segmentation::get_segments(),
+				'custom_placements' => Newspack_Popups_Custom_Placements::get_custom_placements(),
+				'taxonomy'          => self::NEWSPACK_POPUPS_TAXONOMY,
 			]
 		);
 		\wp_enqueue_style(

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -361,6 +361,7 @@ final class Newspack_Popups {
 				'segments'          => Newspack_Popups_Segmentation::get_segments(),
 				'custom_placements' => Newspack_Popups_Custom_Placements::get_custom_placements(),
 				'taxonomy'          => self::NEWSPACK_POPUPS_TAXONOMY,
+				'is_prompt'         => self::NEWSPACK_POPUPS_CPT == get_post_type(),
 			]
 		);
 		\wp_enqueue_style(

--- a/src/blocks/custom-placement/block.json
+++ b/src/blocks/custom-placement/block.json
@@ -1,0 +1,10 @@
+{
+	"name": "newspack-popups/custom-placement",
+	"category": "newspack",
+	"attributes": {
+		"customPlacement": {
+			"type": "string",
+			"default": ""
+		}
+	}
+}

--- a/src/blocks/custom-placement/edit.js
+++ b/src/blocks/custom-placement/edit.js
@@ -63,8 +63,8 @@ export const CustomPlacementEditor = ( { attributes, setAttributes } ) => {
 	return (
 		<Placeholder
 			className="newspack-popups__custom-placement-placeholder"
-			label={ __( 'Newspack Campaigns: Custom Placement', 'newspack-popups' ) }
-			icon={ <CallToActionIcon /> }
+			label={ __( 'Custom Placement', 'newspack-popups' ) }
+			icon={ <CallToActionIcon style={ { color: '#36f' } } /> }
 		>
 			<SelectControl
 				id="newspack-popups__custom-placement-select"

--- a/src/blocks/custom-placement/edit.js
+++ b/src/blocks/custom-placement/edit.js
@@ -1,0 +1,48 @@
+/**
+ * WordPress dependencies.
+ */
+import { __ } from '@wordpress/i18n';
+import { Placeholder, SelectControl } from '@wordpress/components';
+
+/**
+ * External dependencies.
+ */
+import CallToActionIcon from '@material-ui/icons/CallToAction';
+
+/**
+ * Internal dependencies
+ */
+
+export const CustomPlacementEditor = ( { attributes, setAttributes } ) => {
+	const { customPlacement } = attributes;
+	const customPlacements = window.newspack_popups_blocks_data?.custom_placements || {};
+	const customPlacementOptions = [
+		{
+			label: __( 'Choose a custom placement', 'newspack-popups' ),
+			value: '',
+			disabled: true,
+		},
+	].concat(
+		Object.keys( customPlacements ).map( key => ( {
+			value: key,
+			label: customPlacements[ key ],
+		} ) )
+	);
+
+	return (
+		<Placeholder
+			className="newspack-popups__custom-placement-placeholder"
+			label={ __( 'Newspack Campaigns: Custom Placement', 'newspack-popups' ) }
+			icon={ <CallToActionIcon /> }
+		>
+			<SelectControl
+				id="newspack-popups__custom-placement-select"
+				onChange={ _customPlacement => setAttributes( { _customPlacement } ) }
+				value={
+					-1 < Object.keys( customPlacements ).indexOf( customPlacement ) ? customPlacement : ''
+				}
+				options={ customPlacementOptions }
+			/>
+		</Placeholder>
+	);
+};

--- a/src/blocks/custom-placement/edit.js
+++ b/src/blocks/custom-placement/edit.js
@@ -1,19 +1,21 @@
 /**
  * WordPress dependencies.
  */
+import apiFetch from '@wordpress/api-fetch';
 import { __ } from '@wordpress/i18n';
-import { Placeholder, SelectControl } from '@wordpress/components';
+import { Notice, Placeholder, SelectControl, Spinner } from '@wordpress/components';
+import { useEffect, useState } from '@wordpress/element';
+import { addQueryArgs } from '@wordpress/url';
 
 /**
  * External dependencies.
  */
 import CallToActionIcon from '@material-ui/icons/CallToAction';
 
-/**
- * Internal dependencies
- */
-
 export const CustomPlacementEditor = ( { attributes, setAttributes } ) => {
+	const [ loading, setLoading ] = useState( false );
+	const [ prompts, setPrompts ] = useState( null );
+	const [ error, setError ] = useState( null );
 	const { customPlacement } = attributes;
 	const customPlacements = window.newspack_popups_blocks_data?.custom_placements || {};
 	const customPlacementOptions = [
@@ -29,6 +31,35 @@ export const CustomPlacementEditor = ( { attributes, setAttributes } ) => {
 		} ) )
 	);
 
+	const getPrompts = async () => {
+		setError( null );
+		setLoading( true );
+
+		try {
+			const response = await apiFetch( {
+				path: addQueryArgs( '/newspack-popups/v1/custom-placement/', {
+					custom_placement: customPlacement,
+				} ),
+				method: 'GET',
+			} );
+
+			setPrompts( response );
+			setLoading( false );
+		} catch ( e ) {
+			setError(
+				e.message ||
+					__( 'There was an error fetching prompts for this custom placement.', 'newspack-popups' )
+			);
+			setLoading( false );
+		}
+	};
+
+	useEffect(() => {
+		if ( customPlacement ) {
+			getPrompts();
+		}
+	}, [ customPlacement ]);
+
 	return (
 		<Placeholder
 			className="newspack-popups__custom-placement-placeholder"
@@ -37,12 +68,29 @@ export const CustomPlacementEditor = ( { attributes, setAttributes } ) => {
 		>
 			<SelectControl
 				id="newspack-popups__custom-placement-select"
-				onChange={ _customPlacement => setAttributes( { _customPlacement } ) }
+				onChange={ _customPlacement => setAttributes( { customPlacement: _customPlacement } ) }
 				value={
 					-1 < Object.keys( customPlacements ).indexOf( customPlacement ) ? customPlacement : ''
 				}
 				options={ customPlacementOptions }
 			/>
+
+			{ loading && <Spinner /> }
+
+			{ error && (
+				<div className="newspack-popups__custom-placement-prompts">
+					<Notice status="error" isDismissible={ false }>
+						{ error }
+					</Notice>
+				</div>
+			) }
+
+			{ ! loading && ! error && Array.isArray( prompts ) && (
+				<div className="newspack-popups__custom-placement-prompts">
+					{ 0 === prompts.length &&
+						__( 'No prompts found for this custom placement.', 'newspack-popups' ) }
+				</div>
+			) }
 		</Placeholder>
 	);
 };

--- a/src/blocks/custom-placement/edit.js
+++ b/src/blocks/custom-placement/edit.js
@@ -60,6 +60,27 @@ export const CustomPlacementEditor = ( { attributes, setAttributes } ) => {
 		}
 	}, [ customPlacement ]);
 
+	const segments = {};
+
+	if ( prompts ) {
+		prompts.forEach( prompt => {
+			const assignedSegments = prompt.segments || [];
+
+			assignedSegments.forEach( segment => {
+				const segmentName = segment?.name || 'Everyone else';
+
+				if ( ! segments[ segmentName ] ) {
+					segments[ segmentName ] = {
+						id: segment.id || null,
+						prompts: [],
+					};
+				}
+
+				segments[ segmentName ].prompts.push( { id: prompt.id, title: prompt.title } );
+			} );
+		} );
+	}
+
 	return (
 		<Placeholder
 			className="newspack-popups__custom-placement-placeholder"
@@ -97,21 +118,49 @@ export const CustomPlacementEditor = ( { attributes, setAttributes } ) => {
 							<p>
 								{ sprintf(
 									__(
-										'This custom placement contains the following active prompt%s:',
+										'This custom placement will display at most one of the following active prompt%s, depending on the reader’s top-priority segment:',
 										'newspack-popups'
 									),
 									1 < prompts.length ? 's' : ''
 								) }
 							</p>
-							<ul>
-								{ prompts.map( prompt => (
-									<li key={ prompt.id }>
-										<ExternalLink href={ `/wp-admin/post.php?post=${ prompt.id }&action=edit` }>
-											{ prompt.title }
-										</ExternalLink>
-									</li>
-								) ) }
-							</ul>
+							{ Object.keys( segments ).map( segmentName => (
+								<>
+									<h4>
+										{ segments[ segmentName ].id && (
+											<ExternalLink
+												href={ `/wp-admin/admin.php?page=newspack-popups-wizard#/segments/${
+													segments[ segmentName ].id
+												}` }
+											>
+												{ sprintf(
+													__( '%s%s', 'newspack-popup' ),
+													'Everyone else' !== segmentName ? 'Segment: ' : '',
+													segmentName
+												) }
+											</ExternalLink>
+										) }
+										{ ! segments[ segmentName ].id && (
+											<>
+												{ sprintf(
+													__( '%s%s', 'newspack-popup' ),
+													'Everyone else' !== segmentName ? 'Segment: ' : '',
+													segmentName
+												) }
+											</>
+										) }
+									</h4>
+									<ul>
+										{ segments[ segmentName ].prompts.map( prompt => (
+											<li key={ prompt.id }>
+												<ExternalLink href={ `/wp-admin/post.php?post=${ prompt.id }&action=edit` }>
+													{ prompt.title }
+												</ExternalLink>
+											</li>
+										) ) }
+									</ul>
+								</>
+							) ) }
 						</>
 					) }
 				</div>

--- a/src/blocks/custom-placement/edit.js
+++ b/src/blocks/custom-placement/edit.js
@@ -2,8 +2,8 @@
  * WordPress dependencies.
  */
 import apiFetch from '@wordpress/api-fetch';
-import { __ } from '@wordpress/i18n';
-import { Notice, Placeholder, SelectControl, Spinner } from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
+import { ExternalLink, Notice, Placeholder, SelectControl, Spinner } from '@wordpress/components';
 import { useEffect, useState } from '@wordpress/element';
 import { addQueryArgs } from '@wordpress/url';
 
@@ -87,8 +87,33 @@ export const CustomPlacementEditor = ( { attributes, setAttributes } ) => {
 
 			{ ! loading && ! error && Array.isArray( prompts ) && (
 				<div className="newspack-popups__custom-placement-prompts">
-					{ 0 === prompts.length &&
-						__( 'No prompts found for this custom placement.', 'newspack-popups' ) }
+					{ 0 === prompts.length && (
+						<Notice status="warning" isDismissible={ false }>
+							{ __( 'No prompts found for this custom placement.', 'newspack-popups' ) }
+						</Notice>
+					) }
+					{ 0 < prompts.length && (
+						<>
+							<p>
+								{ sprintf(
+									__(
+										'This custom placement contains the following active prompt%s:',
+										'newspack-popups'
+									),
+									1 < prompts.length ? 's' : ''
+								) }
+							</p>
+							<ul>
+								{ prompts.map( prompt => (
+									<li key={ prompt.id }>
+										<ExternalLink href={ `/wp-admin/post.php?post=${ prompt.id }&action=edit` }>
+											{ prompt.title }
+										</ExternalLink>
+									</li>
+								) ) }
+							</ul>
+						</>
+					) }
 				</div>
 			) }
 		</Placeholder>

--- a/src/blocks/custom-placement/edit.js
+++ b/src/blocks/custom-placement/edit.js
@@ -110,7 +110,7 @@ export const CustomPlacementEditor = ( { attributes, setAttributes } ) => {
 				<div className="newspack-popups__custom-placement-prompts">
 					{ 0 === prompts.length && (
 						<Notice status="warning" isDismissible={ false }>
-							{ __( 'No prompts found for this custom placement.', 'newspack-popups' ) }
+							{ __( 'No active prompts found for this custom placement.', 'newspack-popups' ) }
 						</Notice>
 					) }
 					{ 0 < prompts.length && (
@@ -118,9 +118,10 @@ export const CustomPlacementEditor = ( { attributes, setAttributes } ) => {
 							<p>
 								{ sprintf(
 									__(
-										'This custom placement will display at most one of the following active prompt%s, depending on the reader’s top-priority segment:',
+										'This custom placement will display at most %sthe following active prompt%s, depending on the reader’s top-priority segment:',
 										'newspack-popups'
 									),
+									1 < prompts.length ? 'one of ' : '',
 									1 < prompts.length ? 's' : ''
 								) }
 							</p>
@@ -133,19 +134,18 @@ export const CustomPlacementEditor = ( { attributes, setAttributes } ) => {
 													segments[ segmentName ].id
 												}` }
 											>
-												{ sprintf(
-													__( '%s%s', 'newspack-popup' ),
-													'Everyone else' !== segmentName ? 'Segment: ' : '',
-													segmentName
-												) }
+												{ sprintf( __( 'Segment: %s', 'newspack-popup' ), segmentName ) }
 											</ExternalLink>
 										) }
 										{ ! segments[ segmentName ].id && (
 											<>
 												{ sprintf(
-													__( '%s%s', 'newspack-popup' ),
-													'Everyone else' !== segmentName ? 'Segment: ' : '',
-													segmentName
+													__( '%s%s%s', 'newspack-popup' ),
+													'Everyone' !== segmentName ? 'Segment: ' : '',
+													segmentName,
+													'Everyone' === segmentName && 1 < Object.keys( segments ).length
+														? __( ' else', 'newspack-popups' )
+														: ''
 												) }
 											</>
 										) }

--- a/src/blocks/custom-placement/editor.scss
+++ b/src/blocks/custom-placement/editor.scss
@@ -2,5 +2,21 @@
 	&__custom-placement-prompts {
 		margin-top: 1rem;
 		width: 100%;
+
+		.components-notice {
+			margin-left: 0;
+			margin-right: 0;
+		}
+
+		.editor-styles-wrapper & p {
+			font-size: inherit;
+			margin-bottom: 1rem;
+			margin-top: 0;
+		}
+		.editor-styles-wrapper & ul {
+			list-style: none;
+			margin: 0;
+			padding: 0;
+		}
 	}
 }

--- a/src/blocks/custom-placement/editor.scss
+++ b/src/blocks/custom-placement/editor.scss
@@ -1,0 +1,6 @@
+.newspack-popups {
+	&__custom-placement-prompts {
+		margin-top: 1rem;
+		width: 100%;
+	}
+}

--- a/src/blocks/custom-placement/editor.scss
+++ b/src/blocks/custom-placement/editor.scss
@@ -3,9 +3,17 @@
 		margin-top: 1rem;
 		width: 100%;
 
+		.components-external-link svg {
+			display: none;
+		}
+
 		.components-notice {
 			margin-left: 0;
 			margin-right: 0;
+		}
+
+		.editor-styles-wrapper & h4 {
+			margin-bottom: 0;
 		}
 
 		.editor-styles-wrapper & p {

--- a/src/blocks/custom-placement/index.js
+++ b/src/blocks/custom-placement/index.js
@@ -12,6 +12,7 @@ import CallToActionIcon from '@material-ui/icons/CallToAction';
 /**
  * Internal dependencies.
  */
+import './editor.scss';
 import metadata from './block.json';
 const { attributes, category, name } = metadata;
 import { CustomPlacementEditor } from './edit';

--- a/src/blocks/custom-placement/index.js
+++ b/src/blocks/custom-placement/index.js
@@ -1,0 +1,38 @@
+/**
+ * WordPress dependencies.
+ */
+import { __ } from '@wordpress/i18n';
+import { registerBlockType } from '@wordpress/blocks';
+
+/**
+ * External dependencies.
+ */
+import CallToActionIcon from '@material-ui/icons/CallToAction';
+
+/**
+ * Internal dependencies.
+ */
+import metadata from './block.json';
+const { attributes, category, name } = metadata;
+import { CustomPlacementEditor } from './edit';
+
+export const registerCustomPlacementBlock = () => {
+	registerBlockType( name, {
+		title: __( 'Newspack Campaigns: Custom Placement', 'newspack-listing' ),
+		icon: <CallToActionIcon />,
+		category,
+		keywords: [
+			__( 'newspack', 'newspack-popups' ),
+			__( 'campaigns', 'newspack-popups' ),
+			__( 'campaign', 'newspack-popups' ),
+			__( 'prompt', 'newspack-popups' ),
+			__( 'custom', 'newspack-popups' ),
+			__( 'placement', 'newspack-popups' ),
+		],
+
+		attributes,
+
+		edit: CustomPlacementEditor,
+		save: () => null, // uses view.php
+	} );
+};

--- a/src/blocks/custom-placement/index.js
+++ b/src/blocks/custom-placement/index.js
@@ -18,6 +18,13 @@ const { attributes, category, name } = metadata;
 import { CustomPlacementEditor } from './edit';
 
 export const registerCustomPlacementBlock = () => {
+	const isPrompt = Boolean( window.newspack_popups_data?.is_prompt );
+
+	// No prompts inside prompts.
+	if ( isPrompt ) {
+		return null;
+	}
+
 	registerBlockType( name, {
 		title: __( 'Newspack Campaigns: Custom Placement', 'newspack-listing' ),
 		icon: <CallToActionIcon />,

--- a/src/blocks/custom-placement/index.js
+++ b/src/blocks/custom-placement/index.js
@@ -27,7 +27,7 @@ export const registerCustomPlacementBlock = () => {
 
 	registerBlockType( name, {
 		title: __( 'Newspack Campaigns: Custom Placement', 'newspack-listing' ),
-		icon: <CallToActionIcon />,
+		icon: <CallToActionIcon style={ { color: '#36f' } } />,
 		category,
 		keywords: [
 			__( 'newspack', 'newspack-popups' ),

--- a/src/blocks/custom-placement/view.php
+++ b/src/blocks/custom-placement/view.php
@@ -58,17 +58,9 @@ function render_block( $attributes ) {
 		if ( defined( 'WP_NEWSPACK_DEBUG' ) && WP_NEWSPACK_DEBUG ) {
 			$content .= '<!-- Newspack Campaigns: Start custom placement ' . $custom_placement_id . '-->';
 		}
-		$segments = [];
 		foreach ( $prompts as $prompt_id ) {
-			$segment_ids = explode( ',', get_post_meta( $prompt_id, 'selected_segment_id', true ) );
-
-			// Only render one prompt per segment and category for each custom placement.
-			if ( 0 === count( array_intersect( $segments, $segment_ids ) ) ) {
-				$segments = array_unique( array_merge( $segments, $segment_ids ) );
-				$content .= '<!-- wp:shortcode -->[newspack-popup id="' . $prompt_id . '"]<!-- /wp:shortcode -->';
-			}
+			$content .= '<!-- wp:shortcode -->[newspack-popup id="' . $prompt_id . '"]<!-- /wp:shortcode -->';
 		}
-
 		if ( defined( 'WP_NEWSPACK_DEBUG' ) && WP_NEWSPACK_DEBUG ) {
 			$content .= '<!-- Newspack Campaigns: End custom placement ' . $custom_placement_id . '-->';
 		}

--- a/src/blocks/custom-placement/view.php
+++ b/src/blocks/custom-placement/view.php
@@ -55,7 +55,9 @@ function render_block( $attributes ) {
 	}
 
 	if ( ! empty( $prompts ) ) {
-		$content .= '<!-- start custom placement: ' . $custom_placement_id . '-->';
+		if ( defined( 'WP_NEWSPACK_DEBUG' ) && WP_NEWSPACK_DEBUG ) {
+			$content .= '<!-- Newspack Campaigns: Start custom placement ' . $custom_placement_id . '-->';
+		}
 		$segments = [];
 		foreach ( $prompts as $prompt_id ) {
 			$segment_ids = explode( ',', get_post_meta( $prompt_id, 'selected_segment_id', true ) );
@@ -67,7 +69,9 @@ function render_block( $attributes ) {
 			}
 		}
 
-		$content .= '<!-- end custom placement: ' . $custom_placement_id . '-->';
+		if ( defined( 'WP_NEWSPACK_DEBUG' ) && WP_NEWSPACK_DEBUG ) {
+			$content .= '<!-- Newspack Campaigns: End custom placement ' . $custom_placement_id . '-->';
+		}
 	}
 
 	return $content;

--- a/src/blocks/custom-placement/view.php
+++ b/src/blocks/custom-placement/view.php
@@ -32,7 +32,29 @@ function register_block() {
  * @param array $attributes Block attributes.
  */
 function render_block( $attributes ) {
-	$content = '<div class="newspack-popups__custom-placement">Custom Placement!!</div>';
+	$content             = '';
+	$custom_placement_id = \Newspack_Popups_Custom_Placements::validate_custom_placement_id( $attributes['customPlacement'] );
+
+	if ( empty( $custom_placement_id ) ) {
+		return $content;
+	}
+
+	// Get prompts for the custom placement.
+	$prompts = \Newspack_Popups_Custom_Placements::get_prompts_for_custom_placement( [ $custom_placement_id ], 'ids' );
+
+	if ( ! empty( $prompts ) ) {
+		$segments = [];
+		foreach ( $prompts as $prompt_id ) {
+			$segment_id = get_post_meta( $prompt_id, 'selected_segment_id', true );
+
+			// Only show one prompt per segment for each custom placement.
+			if ( ! in_array( $segment_id, $segments ) ) {
+				$segments[] = $segment_id;
+				$content   .= '<!-- wp:shortcode -->[newspack-popup id="' . $prompt_id . '"]<!-- /wp:shortcode -->';
+			}
+		}
+	}
+
 	return $content;
 }
 

--- a/src/blocks/custom-placement/view.php
+++ b/src/blocks/custom-placement/view.php
@@ -39,20 +39,35 @@ function render_block( $attributes ) {
 		return $content;
 	}
 
-	// Get prompts for the custom placement.
-	$prompts = \Newspack_Popups_Custom_Placements::get_prompts_for_custom_placement( [ $custom_placement_id ], 'ids' );
+	$post_categories = array_map(
+		function( $term ) {
+			return $term->term_id;
+		},
+		get_the_category()
+	);
+
+	// Get category-matching prompts for the custom placement.
+	$prompts = \Newspack_Popups_Custom_Placements::get_prompts_for_custom_placement( [ $custom_placement_id ], 'ids', $post_categories );
+
+	// If no category-matching prompts, get uncategorized prompts.
+	if ( empty( $prompts ) ) {
+		$prompts = \Newspack_Popups_Custom_Placements::get_prompts_for_custom_placement( [ $custom_placement_id ], 'ids', [] );
+	}
 
 	if ( ! empty( $prompts ) ) {
+		$content .= '<!-- start custom placement: ' . $custom_placement_id . '-->';
 		$segments = [];
 		foreach ( $prompts as $prompt_id ) {
 			$segment_id = get_post_meta( $prompt_id, 'selected_segment_id', true );
 
-			// Only show one prompt per segment for each custom placement.
+			// Only render one prompt per segment and category for each custom placement.
 			if ( ! in_array( $segment_id, $segments ) ) {
 				$segments[] = $segment_id;
 				$content   .= '<!-- wp:shortcode -->[newspack-popup id="' . $prompt_id . '"]<!-- /wp:shortcode -->';
 			}
 		}
+
+		$content .= '<!-- end custom placement: ' . $custom_placement_id . '-->';
 	}
 
 	return $content;

--- a/src/blocks/custom-placement/view.php
+++ b/src/blocks/custom-placement/view.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Front-end render functions for the Custom Placement block.
+ *
+ * @package Newspack_Popups
+ */
+
+namespace Newspack_Popups\Custom_Placement_Block;
+
+/**
+ * Dynamic block registration.
+ */
+function register_block() {
+	// Listings block attributes.
+	$block_json = json_decode(
+		file_get_contents( __DIR__ . '/block.json' ), // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+		true
+	);
+
+	register_block_type(
+		$block_json['name'],
+		[
+			'attributes'      => $block_json['attributes'],
+			'render_callback' => __NAMESPACE__ . '\render_block',
+		]
+	);
+}
+
+/**
+ * Block render callback.
+ *
+ * @param array $attributes Block attributes.
+ */
+function render_block( $attributes ) {
+	$content = '<div class="newspack-popups__custom-placement">Custom Placement!!</div>';
+	return $content;
+}
+
+register_block();

--- a/src/blocks/custom-placement/view.php
+++ b/src/blocks/custom-placement/view.php
@@ -58,12 +58,12 @@ function render_block( $attributes ) {
 		$content .= '<!-- start custom placement: ' . $custom_placement_id . '-->';
 		$segments = [];
 		foreach ( $prompts as $prompt_id ) {
-			$segment_id = get_post_meta( $prompt_id, 'selected_segment_id', true );
+			$segment_ids = explode( ',', get_post_meta( $prompt_id, 'selected_segment_id', true ) );
 
 			// Only render one prompt per segment and category for each custom placement.
-			if ( ! in_array( $segment_id, $segments ) ) {
-				$segments[] = $segment_id;
-				$content   .= '<!-- wp:shortcode -->[newspack-popup id="' . $prompt_id . '"]<!-- /wp:shortcode -->';
+			if ( 0 === count( array_intersect( $segments, $segment_ids ) ) ) {
+				$segments = array_unique( array_merge( $segments, $segment_ids ) );
+				$content .= '<!-- wp:shortcode -->[newspack-popup id="' . $prompt_id . '"]<!-- /wp:shortcode -->';
 			}
 		}
 

--- a/src/blocks/custom-placement/view.php
+++ b/src/blocks/custom-placement/view.php
@@ -11,7 +11,7 @@ namespace Newspack_Popups\Custom_Placement_Block;
  * Dynamic block registration.
  */
 function register_block() {
-	// Listings block attributes.
+	// Custom Placement block attributes.
 	$block_json = json_decode(
 		file_get_contents( __DIR__ . '/block.json' ), // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 		true

--- a/src/blocks/index.js
+++ b/src/blocks/index.js
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies.
+ */
+import { registerCustomPlacementBlock } from './custom-placement';
+
+// Register the Custom Placement block.
+registerCustomPlacementBlock();

--- a/src/editor/DismissSidebar.js
+++ b/src/editor/DismissSidebar.js
@@ -22,7 +22,7 @@ const DismissSidebar = ( { dismiss_text, dismiss_text_alignment, onMetaFieldChan
 				onChange={ value => onMetaFieldChange( 'dismiss_text', value ) }
 			/>
 			<SelectControl
-				label={ __( 'Alignment', 'newspack-listings' ) }
+				label={ __( 'Alignment', 'newspack-popups' ) }
 				id="newspack-popups-dimiss-button-alignment"
 				onChange={ value => onMetaFieldChange( 'dismiss_text_alignment', value ) }
 				value={ dismiss_text_alignment }

--- a/src/editor/FrequencySidebar.js
+++ b/src/editor/FrequencySidebar.js
@@ -24,7 +24,6 @@ const FrequencySidebar = ( { frequency, onMetaFieldChange, isOverlay, utm_suppre
 						label: __( 'Until dismissed', 'newspack-popups' ),
 						disabled: isOverlay,
 					},
-					{ value: 'manual', label: __( 'Manual Placement', 'newspack-popups' ) },
 				] }
 			/>
 			<TextControl

--- a/src/editor/SegmentationSidebar.js
+++ b/src/editor/SegmentationSidebar.js
@@ -101,7 +101,7 @@ const SegmentationSidebar = ( { onMetaFieldChange, selected_segment_id } ) => {
 				href="/wp-admin/admin.php?page=newspack-popups-wizard#/segments"
 				key="segmentation-link"
 			>
-				{ __( 'Manage segments' ) }
+				{ __( 'Manage segments', 'newspack-popups' ) }
 			</ExternalLink>
 		</Fragment>
 	);

--- a/src/editor/Sidebar.js
+++ b/src/editor/Sidebar.js
@@ -26,7 +26,7 @@ const Sidebar = ( {
 			onMetaFieldChange( 'frequency', 'once' );
 		}
 	};
-	const customPlacements = window.newspack_popups_data?.placements || {};
+	const customPlacements = window.newspack_popups_data?.custom_placements || {};
 
 	return (
 		<Fragment>

--- a/src/editor/Sidebar.js
+++ b/src/editor/Sidebar.js
@@ -26,6 +26,7 @@ const Sidebar = ( {
 			onMetaFieldChange( 'frequency', 'once' );
 		}
 	};
+	const customPlacements = window.newspack_popups_data?.placements || {};
 
 	return (
 		<Fragment>
@@ -53,7 +54,12 @@ const Sidebar = ( {
 						: [
 								{ value: 'inline', label: __( 'In article content' ) },
 								{ value: 'above_header', label: __( 'Above site header' ) },
-						  ]
+						  ].concat(
+								Object.keys( customPlacements ).map( key => ( {
+									value: key,
+									label: customPlacements[ key ],
+								} ) )
+						  )
 				}
 			/>
 			{ isOverlay && (

--- a/src/editor/utils.js
+++ b/src/editor/utils.js
@@ -23,7 +23,7 @@ export const optionsFieldsSelector = select => {
 	} = meta || {};
 
 	const isInlinePlacement = placementValue =>
-		[ 'inline', 'above_header' ].indexOf( placementValue ) >= 0;
+		-1 === [ 'top', 'bottom', 'center' ].indexOf( placementValue );
 	const isOverlay = ! isInlinePlacement( placement );
 
 	return {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -26,6 +26,7 @@ function _manually_load_plugin() {
 	$_SERVER['HTTP_REFERER'] = 'https://' . $_SERVER['HTTP_HOST']; // phpcs:ignore
 
 	require dirname( dirname( __FILE__ ) ) . '/newspack-popups.php';
+	require dirname( dirname( __FILE__ ) ) . '/src/blocks/custom-placement/view.php';
 	require dirname( dirname( __FILE__ ) ) . '/api/campaigns/class-maybe-show-campaign.php';
 	require dirname( dirname( __FILE__ ) ) . '/api/campaigns/class-report-campaign-data.php';
 	require dirname( dirname( __FILE__ ) ) . '/api/segmentation/class-segmentation-client-data.php';

--- a/tests/test-blocks.php
+++ b/tests/test-blocks.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Class Blocks Test
+ *
+ * @package Newspack_Popups
+ */
+
+/**
+ * Blocks test case.
+ */
+class BlocksTest extends WP_UnitTestCase {
+	public function setUp() { // phpcs:ignore Squiz.Commenting.FunctionComment.Missing
+		// Remove any popups (from previous tests).
+		foreach ( Newspack_Popups_Model::retrieve_popups() as $popup ) {
+			wp_delete_post( $popup['id'] );
+		}
+	}
+
+	/**
+	 * Create a popup.
+	 *
+	 * @param object $options Popup options.
+	 */
+	private function create_popup( $options = [] ) {
+		$popup_id = self::factory()->post->create(
+			[
+				'post_type'    => Newspack_Popups::NEWSPACK_POPUPS_CPT,
+				'post_title'   => 'Popup title',
+				'post_content' => 'Hello, world.',
+			]
+		);
+		Newspack_Popups_Model::set_popup_options( $popup_id, $options );
+		return $popup_id;
+	}
+
+	/**
+	 * Basic Block rendering.
+	 */
+	public function test_block_rendering() {
+		$custom_placement_id = 'custom1';
+		$popup_id            = self::create_popup( [ 'placement' => $custom_placement_id ] );
+		$block_content       = Newspack_Popups\Custom_Placement_Block\render_block( [ 'customPlacement' => $custom_placement_id ] );
+
+		self::assertEquals(
+			$block_content,
+			'<!-- wp:shortcode -->[newspack-popup id="' . $popup_id . '"]<!-- /wp:shortcode -->',
+			'Includes popup shortcode.'
+		);
+	}
+
+	/**
+	 * Block rendering with conflicting popups.
+	 */
+	public function test_block_rendering_with_conflict() {
+		$custom_placement_id = 'custom1';
+		$popup_id_first      = self::create_popup( [ 'placement' => $custom_placement_id ] );
+		sleep( 1 ); // Ensure the creation dates are not the same.
+		$popup_id_second = self::create_popup( [ 'placement' => $custom_placement_id ] );
+		$block_content   = Newspack_Popups\Custom_Placement_Block\render_block( [ 'customPlacement' => $custom_placement_id ] );
+
+		self::assertEquals(
+			$block_content,
+			'<!-- wp:shortcode -->[newspack-popup id="' . $popup_id_second . '"]<!-- /wp:shortcode --><!-- wp:shortcode -->[newspack-popup id="' . $popup_id_first . '"]<!-- /wp:shortcode -->',
+			'Includes all popup shortcodes in case of a conflict, since the API will decide what to show.'
+		);
+	}
+}

--- a/tests/test-insertion.php
+++ b/tests/test-insertion.php
@@ -47,9 +47,10 @@ class InsertionTest extends WP_UnitTestCase {
 	/**
 	 * Trigger post rendering with popups in it.
 	 *
-	 * @param string $url_query Query to append to URL.
+	 * @param string      $url_query Query to append to URL.
+	 * @param null|string $content Raw string to render as post content.
 	 */
-	public function render_post( $url_query = '' ) {
+	public function render_post( $url_query = '', $content = null ) {
 		// Navigate to post.
 		self::go_to( get_permalink( self::$post_id ) . '&' . $url_query );
 		global $wp_query, $post;
@@ -59,7 +60,11 @@ class InsertionTest extends WP_UnitTestCase {
 		// Reset internal duplicate-prevention.
 		Newspack_Popups_Inserter::$the_content_has_rendered = false;
 
-		self::$post_content = apply_filters( 'the_content', get_post( self::$post_id )->post_content );
+		if ( ! $content ) {
+			$content = get_post( self::$post_id )->post_content;
+		}
+
+		self::$post_content = apply_filters( 'the_content', $content );
 		$dom                = new DomDocument();
 		@$dom->loadHTML( self::$post_content ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
 		self::$dom_xpath = new DOMXpath( $dom );
@@ -194,6 +199,13 @@ class InsertionTest extends WP_UnitTestCase {
 			self::$popup_content,
 			self::$post_content,
 			'Does not include the popup content, since it is a custom placement campaign.'
+		);
+
+		self::render_post( '', '<!-- wp:newspack-popups/custom-placement {"customPlacement":"custom1"} /-->' );
+		self::assertContains(
+			self::$popup_content,
+			self::$post_content,
+			'Includes the popup content when the custom placement is present in post content.'
 		);
 	}
 }

--- a/tests/test-insertion.php
+++ b/tests/test-insertion.php
@@ -176,4 +176,24 @@ class InsertionTest extends WP_UnitTestCase {
 		);
 		update_option( 'newspack_popups_non_interative_mode', false );
 	}
+
+	/**
+	 * Test custom placement campaigns.
+	 */
+	public function test_custom_placement_prompt() {
+		Newspack_Popups_Model::set_popup_options(
+			self::$popup_id,
+			[
+				'placement' => 'custom1',
+				'frequency' => 'always',
+			]
+		);
+
+		self::render_post();
+		self::assertNotContains(
+			self::$popup_content,
+			self::$post_content,
+			'Does not include the popup content, since it is a custom placement campaign.'
+		);
+	}
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,6 +16,7 @@ const editor = path.join( __dirname, 'src', 'editor' );
 const view = path.join( __dirname, 'src', 'view' );
 const documentSettings = path.join( __dirname, 'src', 'document-settings' );
 const settings = path.join( __dirname, 'src', 'settings' );
+const blocks = path.join( __dirname, 'src', 'blocks' );
 
 const webpackConfig = getBaseWebpackConfig(
 	{ WP: true },
@@ -25,6 +26,7 @@ const webpackConfig = getBaseWebpackConfig(
 			view,
 			documentSettings,
 			settings,
+			blocks,
 		},
 		'output-path': path.join( __dirname, 'dist' ),
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Along with https://github.com/Automattic/newspack-plugin/pull/898, creates a new system for placing prompts manually in post or page content. Prompts assigned to a custom placement will be rendered on the page and displayed according to segmentation rules (one prompt per segment per block).

This MVP provides three custom placements that can be placed in post content via a new Custom Placement block. Could be extended to allow editors to create and update their own custom placements, too, but this isn't included yet.

Closes #444.

### How to test the changes in this Pull Request:

Follow testing instructions in https://github.com/Automattic/newspack-plugin/pull/898.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
