### PR TITLE
Fix placement computation

### DIFF
--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -221,7 +221,13 @@ final class Newspack_Popups_Inserter {
 			$content = scaip_maybe_insert_shortcode( $content );
 		}
 
-		$total_length = strlen( $content );
+		// Dynamic blocks might render an arbitrary amount of content, so the length of the content string is
+		// not an accurate representation of the content length.
+		$total_length = 0;
+		foreach ( parse_blocks( $content ) as $block ) {
+			$block_content = render_block( $block );
+			$total_length += strlen( wp_strip_all_tags( $block_content ) );
+		}
 
 		// 1. Separate prompts into inline and overlay.
 		$inline_popups  = [];
@@ -247,7 +253,7 @@ final class Newspack_Popups_Inserter {
 		$output = '';
 		foreach ( parse_blocks( $content ) as $block ) {
 			$block_content = render_block( $block );
-			$pos          += strlen( $block_content );
+			$pos          += strlen( wp_strip_all_tags( $block_content ) );
 			foreach ( $inline_popups as &$inline_popup ) {
 				if ( ! $inline_popup['is_inserted'] && $pos > $inline_popup['precise_position'] ) {
 					$output .= '<!-- wp:shortcode -->[newspack-popup id="' . $inline_popup['id'] . '"]<!-- /wp:shortcode -->';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #465, supersedes #466

### How to test the changes in this Pull Request:

1. Create a post with a _massive_ jetpack slideshow block* at the top followed by at least five other blocks
2. Create five inline prompts, each at a position of 25% more than the last one
3. On `master`, observe the prompts are rendered at the top of the post content
4. Switch to this branch, observe the prompts are rendered at intended placements

\* Mine had about 80 images, beat that

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
