### PR TITLE
fix: no amp-access auth check for inactive prompts

### DIFF
--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -423,7 +423,7 @@ final class Newspack_Popups_Inserter {
 				$popup_post = get_post( $id );
 				if ( $popup_post ) {
 					$popup_object = Newspack_Popups_Model::create_popup_object( $popup_post );
-					if ( $popup_object ) {
+					if ( $popup_object && 'publish' === $popup_object['status'] ) {
 						$acc[] = $popup_object;
 					}
 				}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

There's no need to poll the AMP Access API for prompts that aren't published/active. This fixes a bug where prompts that are inserted via shortcode (either in widgets or directly in post content) are checked against AMP Access authorization even if they're not published, which could result in unnecessary client data logging and DB writes even if the authorization result is `false`.

### How to test the changes in this Pull Request:

1. On `master`, create a draft prompt and assign to any segment.
2. Insert the prompt via shortcode into any post or page using `[newspack-popup id="<PROMPT ID>"]`.
3. Visit the post in a new incognito session. In Dev Tools > Network, filter XHR requests by `api/campaigns` and inspect the request. Observe that the response [includes the ID of your draft prompt](https://d.pr/i/h814fj), indicating that it's being checked via AMP Access.
4. Check out this branch and refresh the page.
5. Now confirm that the response no longer includes the draft prompt's ID.
6. Publish the prompt and refresh the page once more. Now confirm that the response once again includes the prompt's ID.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
