### PR TITLE
feat: do not log client data if site has no prompts

### DIFF
--- a/includes/class-newspack-popups-segmentation.php
+++ b/includes/class-newspack-popups-segmentation.php
@@ -56,7 +56,7 @@ final class Newspack_Popups_Segmentation {
 		add_action( 'wp_footer', [ __CLASS__, 'insert_amp_analytics' ], 20 );
 
 		add_filter( 'newspack_custom_dimensions', [ __CLASS__, 'register_custom_dimensions' ] );
-		if ( ! Newspack_Popups_Settings::is_non_interactive() && ( ! defined( 'NEWSPACK_POPUPS_DISABLE_REPORTING_CUSTOM_DIMENSIONS' ) || true !== NEWSPACK_POPUPS_DISABLE_REPORTING_CUSTOM_DIMENSIONS ) ) {
+		if ( ! Newspack_Popups::is_empty() && ! Newspack_Popups_Settings::is_non_interactive() && ( ! defined( 'NEWSPACK_POPUPS_DISABLE_REPORTING_CUSTOM_DIMENSIONS' ) || true !== NEWSPACK_POPUPS_DISABLE_REPORTING_CUSTOM_DIMENSIONS ) ) {
 			// Sending pageviews with segmentation-related custom dimensions.
 			// 1. Disable pageview sending from Site Kit's GTAG implementation. The custom events sent using Site Kit's
 			// GTAG will not contain the segmentation-related custom dimensions.
@@ -185,7 +185,7 @@ final class Newspack_Popups_Segmentation {
 		if ( Newspack_Popups_View_As::viewing_as_spec() ) {
 			return true;
 		}
-		if ( is_admin() || self::is_admin_user() || Newspack_Popups_Settings::is_non_interactive() ) {
+		if ( is_admin() || self::is_admin_user() || Newspack_Popups_Settings::is_non_interactive() || Newspack_Popups::is_empty() ) {
 			return false;
 		}
 		return true;

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -403,6 +403,25 @@ final class Newspack_Popups {
 	}
 
 	/**
+	 * Site has no active prompts. Lets us skip client data logging when not needed.
+	 *
+	 * @return boolean True if the site has no active prompts.
+	 */
+	public static function is_empty() {
+		$active_prompts = new \WP_Query(
+			[
+				'post_type'      => self::NEWSPACK_POPUPS_CPT,
+				'post_status'    => 'publish',
+				'posts_per_page' => 1,
+				'no_found_rows'  => true,
+				'fields'         => 'ids',
+			]
+		);
+
+		return ! $active_prompts->have_posts();
+	}
+
+	/**
 	 * Is it a preview request – a single popup preview or using "view as" feature.
 	 *
 	 * @return boolean Whether it's a preview request.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

I'm not sure if this would cause more harm than help, because of the extra query. But this adds a check of whether there's at least one active prompt before injecting the GA tracking code (which in turn calls the segmentation API and logs client data such as posts read, dismissals, etc.).

The intention here is to avoid writing client data to the DB as well as creating and updating transients for each reader who visits the site if the site isn't serving any prompts. Presumably there's no need to track this client data if the site has no need to segment readers for prompt display logic.

Note: #474 fixes an unrelated bug where shortcoded but unpublished prompts can also trigger the `save_client_data` request and therefore write client data even with the changes in this PR. 

Closes #473.

### How to test the changes in this Pull Request:

1. On `master`, with non-interactive mode OFF, unpublish or delete any active prompts.
2. In a new incognito session, visit the site front-end and in Dev Tools > Network, filter XHR requests by `api/segmentation`. Observe that a call is made that looks something like this (this is the API request that triggers writing client data to the DB):

```
https://<SITE URL>.com/wp-content/plugins/newspack-popups/api/segmentation/index.php?client_id=amp-QIR_V0fHXR8I-Km7G-eSIA&post_id=1259795&custom_dimensions={%220%22:{%22role%22:%22category%22,%22option%22:{%22value%22:%22category%22,%22label%22:%22Category%22},%22gaID%22:%22ga:dimension2%22},%221%22:{%22role%22:%22author%22,%22option%22:{%22value%22:%22author%22,%22label%22:%22Author%22},%22gaID%22:%22ga:dimension1%22},%223%22:{%22role%22:%22publish_date%22,%22option%22:{%22value%22:%22publish_date%22,%22label%22:%22Publish%20date%22},%22gaID%22:%22ga:dimension4%22}}&custom_dimensions_existing_values={%22dimension1%22:%22adminnewspack%22,%22dimension4%22:%222020-11-13%2012:03%22}&__amp_source_origin=https%3A%2F%2F<SITE URL>
```

3. To double-verify, you can `error_log` at [this line](https://github.com/Automattic/newspack-popups/blob/master/api/classes/class-lightweight-api.php#L286) and observe that the `save_client_data` function (which actually writes the transient with client data) is executed.
4. Check out this branch. Visit the site front-end and confirm that the `/segmentation` API request is no longer made.
5. (Note: only with #474 as well) Confirm via your `error_log` that the `save_client_data` function is never executed.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
