### PR TITLE
Process custom dimensions' values as strings

### DIFF
--- a/api/segmentation/class-segmentation-custom-ga-config.php
+++ b/api/segmentation/class-segmentation-custom-ga-config.php
@@ -67,10 +67,10 @@ class Segmentation_Custom_GA_Config extends Lightweight_API {
 					$custom_dimensions_values[ $dimension_id ] = $read_count_tier;
 					break;
 				case Segmentation::CUSTOM_DIMENSIONS_OPTION_NAME_IS_SUBSCRIBER:
-					$custom_dimensions_values[ $dimension_id ] = Campaign_Data_Utils::is_subscriber( $client_data, wp_get_referer() );
+					$custom_dimensions_values[ $dimension_id ] = Campaign_Data_Utils::is_subscriber( $client_data, wp_get_referer() ) ? 'true' : 'false';
 					break;
 				case Segmentation::CUSTOM_DIMENSIONS_OPTION_NAME_IS_DONOR:
-					$custom_dimensions_values[ $dimension_id ] = Campaign_Data_Utils::is_donor( $client_data );
+					$custom_dimensions_values[ $dimension_id ] = Campaign_Data_Utils::is_donor( $client_data ) ? 'true' : 'false';
 					break;
 			}
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #461.

### How to test the changes in this Pull Request:

1. Ensure Campaigns-related custom dimensions are configured
2. Visit the site as a non-logged-in user
3. Observe the return value of the request to `/wp-content/plugins/newspack-popups/api/segmentation/index.php` - the campaigns-related custom dimensions' values should be returned as strings, no booleans

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
