### PR TITLE
Remove default category on prompt activation

### DIFF
--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -593,14 +593,6 @@ final class Newspack_Popups_Inserter {
 		$post_categories  = get_the_category();
 		$popup_categories = get_the_category( $popup['id'] );
 
-		// Filter out "Uncategorized" category which is automatically added to uncategorized posts on publish.
-		$popup_categories = array_filter(
-			$popup_categories,
-			function( $popup_category ) {
-				return 'uncategorized' !== $popup_category->slug;
-			}
-		);
-
 		if ( $post_categories && count( $post_categories ) && $popup_categories && count( $popup_categories ) ) {
 			return array_intersect(
 				array_column( $post_categories, 'term_id' ),

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -649,7 +649,7 @@ final class Newspack_Popups {
 	 * @param bool   $post Post.
 	 */
 	public static function remove_default_category( $new_status, $old_status, $post ) {
-		if ( self::NEWSPACK_POPUPS_CPT === $post->post_type && 'publish' === $new_status ) {
+		if ( self::NEWSPACK_POPUPS_CPT === $post->post_type && 'publish' !== $old_status && 'publish' === $new_status ) {
 			$default_category_id = (int) get_option( 'default_category', false );
 			$popup_has_category  = has_category( $default_category_id, $post->ID );
 			if ( $popup_has_category ) {

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -53,6 +53,7 @@ final class Newspack_Popups {
 		add_action( 'enqueue_block_editor_assets', [ __CLASS__, 'enqueue_block_editor_assets' ] );
 		add_filter( 'display_post_states', [ __CLASS__, 'display_post_states' ], 10, 2 );
 		add_action( 'save_post_' . self::NEWSPACK_POPUPS_CPT, [ __CLASS__, 'popup_default_fields' ], 10, 3 );
+		add_action( 'transition_post_status', [ __CLASS__, 'remove_default_category' ], 10, 3 );
 
 		add_filter( 'show_admin_bar', [ __CLASS__, 'show_admin_bar' ], 10, 2 ); // phpcs:ignore WordPressVIPMinimum.UserExperience.AdminBarRemoval.RemovalDetected
 
@@ -638,6 +639,23 @@ final class Newspack_Popups {
 	 */
 	public static function archive_campaign( $id, $status ) {
 		update_term_meta( $id, self::NEWSPACK_POPUPS_TAXONOMY_STATUS, $status ? 'archive' : '' );
+	}
+
+	/**
+	 * Prevent setting the default category when publishing.
+	 *
+	 * @param string $new_status New status.
+	 * @param string $old_status Old status.
+	 * @param bool   $post Post.
+	 */
+	public static function remove_default_category( $new_status, $old_status, $post ) {
+		if ( self::NEWSPACK_POPUPS_CPT === $post->post_type && 'publish' === $new_status ) {
+			$default_category_id = (int) get_option( 'default_category', false );
+			$popup_has_category  = has_category( $default_category_id, $post->ID );
+			if ( $popup_has_category ) {
+				wp_remove_object_terms( $post->ID, $default_category_id, 'category' );
+			}
+		}
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #447.

### How to test the changes in this Pull Request:

1. On `master`, raname your default category to something else than "Uncategorized"
2. Visit the Campaigns wizard, observe that the prompts have the default category assigned on activation
3. Switch to this branch; deactivate & activate a prompt - observe it does not have the default category assigned
4. In Campaign Wizard, assign the default category via the category filtering options (![image](https://user-images.githubusercontent.com/7383192/111289683-aee46080-8645-11eb-8bc7-2895ecc06711.png)), observe the category filtering is applied
5. Edit a prompt, assign the default category via the editor sidebar, observe the category is applied

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
