### PR TITLE
fix: render_block causes Homepage Posts to render wrong post

### DIFF
--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -225,7 +225,7 @@ final class Newspack_Popups_Inserter {
 		// not an accurate representation of the content length.
 		$total_length = 0;
 		foreach ( parse_blocks( $content ) as $block ) {
-			$block_content = render_block( $block );
+			$block_content = $block['innerHTML'];
 			$total_length += strlen( wp_strip_all_tags( $block_content ) );
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Potential fix for a bug that causes Homepage Posts to sometimes render the wrong posts.

### How to test the changes in this Pull Request:

1. Visit https://abq-debug.newspackstaging.com in two separate browser sessions: one logged in and the other not logged in. Observe that while logged in, the first Homepage Posts block shows the correct post—the most recently published post—while the other session seems to skip that post and show the next most recently published post.
2. View several articles and note the positions of inline prompts.
3. Temporarily disable the `newspack-popups-release` plugin and install/activate the plugin from this branch.
4. Refresh the homepage in both sessions and confirm that all Homepage Posts blocks are showing the same posts, now.
5. View several articles and confirm that the inline prompts are still injected in the same positions in the article content.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
