### PR TITLE
Allow filters to suppress popups better

### DIFF
--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -121,7 +121,7 @@ final class Newspack_Popups_Inserter {
 		add_action( 'delete_widget', [ $this, 'remove_widgets_shortcoded_popup_ids' ] );
 
 		add_filter(
-			'newspack_newsletters_assess_has_disabled_popups',
+			'newspack_popups_assess_has_disabled_popups',
 			function ( $disabled ) {
 				if ( get_post_meta( get_the_ID(), 'newspack_popups_has_disabled_popups', true ) ) {
 					return true;
@@ -134,11 +134,24 @@ final class Newspack_Popups_Inserter {
 		// Suppress popups on product pages.
 		// Until the popups non-AMP refactoring happens, they will break Add to Cart buttons.
 		add_filter(
-			'newspack_newsletters_assess_has_disabled_popups',
+			'newspack_popups_assess_has_disabled_popups',
 			function( $disabled ) {
 				if ( function_exists( 'is_product' ) && is_product() ) {
 					return true;
 				}
+				return $disabled;
+			}
+		);
+
+		// The suppress filter used to be named 'newspack_newsletters_assess_has_disabled_popups'.
+		// Maintain that filter for backwards compatibility.
+		add_filter(
+			'newspack_popups_assess_has_disabled_popups',
+			function( $disabled ) {
+				if ( apply_filters( 'newspack_newsletters_assess_has_disabled_popups', false ) ) {
+					return true;
+				}
+
 				return $disabled;
 			}
 		);
@@ -507,7 +520,7 @@ final class Newspack_Popups_Inserter {
 	 * @return bool True if popups should be disabled for current page.
 	 */
 	public static function assess_has_disabled_popups() {
-		return apply_filters( 'newspack_newsletters_assess_has_disabled_popups', false );
+		return apply_filters( 'newspack_popups_assess_has_disabled_popups', false );
 	}
 
 	/**

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -122,8 +122,12 @@ final class Newspack_Popups_Inserter {
 
 		add_filter(
 			'newspack_newsletters_assess_has_disabled_popups',
-			function () {
-				return get_post_meta( get_the_ID(), 'newspack_popups_has_disabled_popups', true );
+			function ( $disabled ) {
+				if ( get_post_meta( get_the_ID(), 'newspack_popups_has_disabled_popups', true ) ) {
+					return true;
+				}
+
+				return $disabled;
 			}
 		);
 
@@ -503,7 +507,7 @@ final class Newspack_Popups_Inserter {
 	 * @return bool True if popups should be disabled for current page.
 	 */
 	public static function assess_has_disabled_popups() {
-		return apply_filters( 'newspack_newsletters_assess_has_disabled_popups', [] );
+		return apply_filters( 'newspack_newsletters_assess_has_disabled_popups', false );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR fixes a few small issues with the `newspack_newsletters_assess_has_disabled_popups` filter:

1. [The logic in the `get_post_meta( get_the_ID(), 'newspack_popups_has_disabled_popups', true )` check](https://github.com/Automattic/newspack-popups/blob/master/includes/class-newspack-popups-inserter.php#L123-L128) would override anything which hooked into the filter before that check. Best practices around filters are that a filter should only modify the return value if it is different than the default return value; that will correctly ensure that any other plugin is able to modify the return value. See the testing instructions for a more clear example of why this is an issue.
2. [The default return value in `::assess_has_disabled_popups` was `[]`](https://github.com/Automattic/newspack-popups/blob/master/includes/class-newspack-popups-inserter.php#L506) which technically works because it evaluates to `false` but isn't strictly correct. I've modified it to return a boolean.
3. The filter name was `newspack_newsletters_assess_has_disabled_popups`, which would be a great filter name if only it was located in Newspack Newsletters. :) I've modified it to `newspack_popups_assess_has_disabled_popups` and added backwards compatibility for the old hook name.

### How to test the changes in this Pull Request:

1. Add and activate the following plugin to your site, and name it `aaaaa.php`:

```
<?php
/**
 * Plugin Name: AAAAAAAAA
 * Description: AAAAAAAAAAAAAAAAAAAAAAAAAAAA!
 * Version: 1.0.0
 * Author: Automattic
 * Author URI: https://newspack.pub/
 * License: GPL2
 */

// Disable those popups!
add_filter( 'newspack_newsletters_assess_has_disabled_popups', function( $disabled ) {
	return true;
} );
```

2. Before applying this PR, create a prompt and view it on a post. With the above plugin active, you'd expect it to be suppressed, but it's not. This is because `aaaaa` is loaded before `newspack-popups` in WordPress (because of the alphabet), so the `get_post_meta` check in Newspack Campaigns runs after the filter in AAAAAAAAA.

<img width="1159" alt="Screen Shot 2021-03-14 at 11 28 09 AM" src="https://user-images.githubusercontent.com/7317227/111080330-36ea2f00-84bb-11eb-9217-a6e3c97c1935.png">


3. Apply this PR. Now the prompt should correctly get suppressed:

<img width="1150" alt="Screen Shot 2021-03-14 at 11 29 44 AM" src="https://user-images.githubusercontent.com/7317227/111080420-a2cc9780-84bb-11eb-93c5-868133f28cdc.png">

4. Deactivate AAAAAAAAA to verify the default prompt behavior still works:

<img width="1159" alt="Screen Shot 2021-03-14 at 11 28 09 AM" src="https://user-images.githubusercontent.com/7317227/111080453-cbed2800-84bb-11eb-9585-aac29a858715.png">

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
