### PR TITLE
refactor: custom db table for campaign transients

### DIFF
--- a/api/classes/class-lightweight-api.php
+++ b/api/classes/class-lightweight-api.php
@@ -164,9 +164,8 @@ class Lightweight_API {
 		$table_name       = Segmentation::get_transients_table_name();
 		$name             = '_transient_' . $name;
 		$serialized_value = maybe_serialize( $value );
-		$autoload         = 'no';
 		wp_cache_set( $name, $serialized_value, 'newspack-popups' );
-		$result           = $wpdb->query( $wpdb->prepare( "INSERT INTO `$table_name` (`option_name`, `option_value`, `autoload`) VALUES (%s, %s, %s) ON DUPLICATE KEY UPDATE `option_name` = VALUES(`option_name`), `option_value` = VALUES(`option_value`), `autoload` = VALUES(`autoload`)", $name, $serialized_value, $autoload ) ); // phpcs:ignore
+		$result           = $wpdb->query( $wpdb->prepare( "INSERT INTO `$table_name` (`option_name`, `option_value`) VALUES (%s, %s) ON DUPLICATE KEY UPDATE `option_name` = VALUES(`option_name`), `option_value` = VALUES(`option_value`)", $name, $serialized_value ) ); // phpcs:ignore
 
 		$this->debug['write_query_count'] += 1;
 	}

--- a/api/classes/class-lightweight-api.php
+++ b/api/classes/class-lightweight-api.php
@@ -140,7 +140,7 @@ class Lightweight_API {
 		} elseif ( false === $value ) {
 			$this->debug['read_query_count'] += 1;
 
-			$value = $wpdb->get_var( $wpdb->prepare( "SELECT option_value FROM `$table_name` WHERE option_name = %s LIMIT 1", $name ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching;
+			$value = $wpdb->get_var( $wpdb->prepare( "SELECT option_value FROM `$table_name` WHERE option_name = %s LIMIT 1", $name ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared;
 			if ( $value ) {
 				wp_cache_set( $name, $value, 'newspack-popups' );
 			} else {

--- a/api/classes/class-lightweight-api.php
+++ b/api/classes/class-lightweight-api.php
@@ -130,16 +130,17 @@ class Lightweight_API {
 	 */
 	public function get_transient( $name ) {
 		global $wpdb;
-		$name = '_transient_' . $name;
-
-		$value = wp_cache_get( $name, 'newspack-popups' );
+		$name       = '_transient_' . $name;
+		$table_name = Segmentation::get_transients_table_name();
+		$value      = wp_cache_get( $name, 'newspack-popups' );
 		if ( -1 === $value ) {
 			$this->debug['read_empty_transients'] += 1;
 			$this->debug['cache_count']           += 1;
 			return null;
 		} elseif ( false === $value ) {
 			$this->debug['read_query_count'] += 1;
-			$value                            = $this->get_option( $name );
+
+			$value = $wpdb->get_var( $wpdb->prepare( 'SELECT option_value FROM %s WHERE option_name = %s LIMIT 1', $table_name, $name ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching;
 			if ( $value ) {
 				wp_cache_set( $name, $value, 'newspack-popups' );
 			} else {
@@ -160,11 +161,12 @@ class Lightweight_API {
 	 */
 	public function set_transient( $name, $value ) {
 		global $wpdb;
+		$table_name       = Segmentation::get_transients_table_name();
 		$name             = '_transient_' . $name;
 		$serialized_value = maybe_serialize( $value );
 		$autoload         = 'no';
 		wp_cache_set( $name, $serialized_value, 'newspack-popups' );
-		$result           = $wpdb->query( $wpdb->prepare( "INSERT INTO `$wpdb->options` (`option_name`, `option_value`, `autoload`) VALUES (%s, %s, %s) ON DUPLICATE KEY UPDATE `option_name` = VALUES(`option_name`), `option_value` = VALUES(`option_value`), `autoload` = VALUES(`autoload`)", $name, $serialized_value, $autoload ) ); // phpcs:ignore
+		$result           = $wpdb->query( $wpdb->prepare( "INSERT INTO `$table_name` (`option_name`, `option_value`, `autoload`) VALUES (%s, %s, %s) ON DUPLICATE KEY UPDATE `option_name` = VALUES(`option_name`), `option_value` = VALUES(`option_value`), `autoload` = VALUES(`autoload`)", $name, $serialized_value, $autoload ) ); // phpcs:ignore
 
 		$this->debug['write_query_count'] += 1;
 	}

--- a/api/classes/class-lightweight-api.php
+++ b/api/classes/class-lightweight-api.php
@@ -140,7 +140,7 @@ class Lightweight_API {
 		} elseif ( false === $value ) {
 			$this->debug['read_query_count'] += 1;
 
-			$value = $wpdb->get_var( $wpdb->prepare( "SELECT option_value FROM `$table_name` WHERE option_name = %s LIMIT 1", $name ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared;
+			$value = $wpdb->get_var( $wpdb->prepare( "SELECT option_value FROM `$table_name` WHERE option_name = %s LIMIT 1", $name ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 			if ( $value ) {
 				wp_cache_set( $name, $value, 'newspack-popups' );
 			} else {

--- a/api/classes/class-lightweight-api.php
+++ b/api/classes/class-lightweight-api.php
@@ -140,7 +140,7 @@ class Lightweight_API {
 		} elseif ( false === $value ) {
 			$this->debug['read_query_count'] += 1;
 
-			$value = $wpdb->get_var( $wpdb->prepare( 'SELECT option_value FROM `$table_name` WHERE option_name = %s LIMIT 1', $name ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching;
+			$value = $wpdb->get_var( $wpdb->prepare( "SELECT option_value FROM `$table_name` WHERE option_name = %s LIMIT 1", $name ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching;
 			if ( $value ) {
 				wp_cache_set( $name, $value, 'newspack-popups' );
 			} else {

--- a/api/classes/class-lightweight-api.php
+++ b/api/classes/class-lightweight-api.php
@@ -140,7 +140,7 @@ class Lightweight_API {
 		} elseif ( false === $value ) {
 			$this->debug['read_query_count'] += 1;
 
-			$value = $wpdb->get_var( $wpdb->prepare( 'SELECT option_value FROM %s WHERE option_name = %s LIMIT 1', $table_name, $name ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching;
+			$value = $wpdb->get_var( $wpdb->prepare( 'SELECT option_value FROM `$table_name` WHERE option_name = %s LIMIT 1', $name ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching;
 			if ( $value ) {
 				wp_cache_set( $name, $value, 'newspack-popups' );
 			} else {

--- a/api/segmentation/class-segmentation.php
+++ b/api/segmentation/class-segmentation.php
@@ -35,6 +35,14 @@ class Segmentation {
 	}
 
 	/**
+	 * Get transients table name.
+	 */
+	public static function get_transients_table_name() {
+		global $wpdb;
+		return $wpdb->prefix . 'newspack_campaigns_transients';
+	}
+
+	/**
 	 * Parse "view as" spec.
 	 *
 	 * @param string $raw_spec Raw spec.

--- a/includes/class-newspack-popups-segmentation.php
+++ b/includes/class-newspack-popups-segmentation.php
@@ -302,8 +302,8 @@ final class Newspack_Popups_Segmentation {
 	 */
 	public static function create_database_table() {
 		global $wpdb;
-		$events_table_name = Segmentation::get_events_table_name();
-
+		$events_table_name     = Segmentation::get_events_table_name();
+		$transients_table_name = Segmentation::get_transients_table_name();
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 		if ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $events_table_name ) ) != $events_table_name ) {
 			$charset_collate = $wpdb->get_charset_collate();
@@ -326,6 +326,23 @@ final class Newspack_Popups_Segmentation {
 
 			require_once ABSPATH . 'wp-admin/includes/upgrade.php';
 			dbDelta( $sql ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.dbDelta_dbdelta
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		} elseif ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $transients_table_name ) ) != $transients_table_name ) {
+			$charset_collate = $wpdb->get_charset_collate();
+
+			$sql = "CREATE TABLE $transients_table_name (
+				option_id bigint(20) unsigned NOT NULL auto_increment,
+				option_name varchar(191) NOT NULL default '',
+				option_value longtext NOT NULL,
+				autoload varchar(20) NOT NULL default 'yes',
+				PRIMARY KEY  (option_id),
+				UNIQUE KEY option_name (option_name),
+				KEY autoload (autoload)
+			) $charset_collate;";
+
+			require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+			dbDelta( $sql ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.dbDelta_dbdelta
+			$wpdb->query( $wpdb->prepare( "INSERT INTO `{$transients_table_name}` (option_name, option_value) SELECT option_name, option_value FROM `{$wpdb->options}` WHERE option_name LIKE %s", "_transient%-popup%" ) ); // phpcs:ignore
 		} elseif ( 'date' === $wpdb->get_var( $wpdb->prepare( "SHOW COLUMNS FROM {$events_table_name} LIKE %s", 'created_at' ), 1 ) ) { // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 			$wpdb->query( "ALTER TABLE {$events_table_name} CHANGE `created_at` `created_at` DATETIME NOT NULL" ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.SchemaChange, WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		}

--- a/includes/class-newspack-popups-segmentation.php
+++ b/includes/class-newspack-popups-segmentation.php
@@ -326,8 +326,12 @@ final class Newspack_Popups_Segmentation {
 
 			require_once ABSPATH . 'wp-admin/includes/upgrade.php';
 			dbDelta( $sql ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.dbDelta_dbdelta
+		} elseif ( 'date' === $wpdb->get_var( $wpdb->prepare( "SHOW COLUMNS FROM {$events_table_name} LIKE %s", 'created_at' ), 1 ) ) { // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			$wpdb->query( "ALTER TABLE {$events_table_name} CHANGE `created_at` `created_at` DATETIME NOT NULL" ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.SchemaChange, WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		}
+
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-		} elseif ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $transients_table_name ) ) != $transients_table_name ) {
+		if ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $transients_table_name ) ) != $transients_table_name ) {
 			$charset_collate = $wpdb->get_charset_collate();
 
 			$sql = "CREATE TABLE $transients_table_name (
@@ -343,8 +347,6 @@ final class Newspack_Popups_Segmentation {
 			require_once ABSPATH . 'wp-admin/includes/upgrade.php';
 			dbDelta( $sql ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.dbDelta_dbdelta
 			$wpdb->query( $wpdb->prepare( "INSERT INTO `{$transients_table_name}` (option_name, option_value) SELECT option_name, option_value FROM `{$wpdb->options}` WHERE option_name LIKE %s", "_transient%-popup%" ) ); // phpcs:ignore
-		} elseif ( 'date' === $wpdb->get_var( $wpdb->prepare( "SHOW COLUMNS FROM {$events_table_name} LIKE %s", 'created_at' ), 1 ) ) { // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-			$wpdb->query( "ALTER TABLE {$events_table_name} CHANGE `created_at` `created_at` DATETIME NOT NULL" ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.SchemaChange, WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		}
 	}
 

--- a/includes/class-newspack-popups-segmentation.php
+++ b/includes/class-newspack-popups-segmentation.php
@@ -338,10 +338,8 @@ final class Newspack_Popups_Segmentation {
 				option_id bigint(20) unsigned NOT NULL auto_increment,
 				option_name varchar(191) NOT NULL default '',
 				option_value longtext NOT NULL,
-				autoload varchar(20) NOT NULL default 'yes',
 				PRIMARY KEY  (option_id),
-				UNIQUE KEY option_name (option_name),
-				KEY autoload (autoload)
+				UNIQUE KEY option_name (option_name)
 			) $charset_collate;";
 
 			require_once ABSPATH . 'wp-admin/includes/upgrade.php';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

The Campaigns plugin sets a transient for each prompt/user combination, which on a high traffic site is a source of significant options table bloat, causing performance issues. https://github.com/Automattic/newspack-popups/issues/478 lists a number of ways this can be optimized. This PR addresses one of these, creating a custom database table for Campaigns transients, taking the burden off the WordPress options table. At the moment when the table is created, all existing Campaigns transients are copied over. I opted not to delete the transients in the options table as this would be a potentially destructive action. We can manually prune the options tables of production sites on a case-by-case basis.

### How to test the changes in this Pull Request:

1. With this branch checked on, go to any wp-admin page. Observe a new database table is created named `{prefix}_newspack_campaigns_transients`. Observe all existing campaign transients are copied to the new table. 
2. Verify prompt display logic works normally, respecting frequency settings, permanent dismissal etc.
3. Verify new transients are created in the custom table, not options.
4. Try deleting the table and switching back to `master`. Dismiss a prompt, then switch to this branch. Verify the correct behavior occurs before and after the switch, demonstrating that the transients were seamlessly migrated to the new table.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
