### PR TITLE
fix: introduce blacklisted blocks to ignore when inserting prompts

### DIFF
--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -223,7 +223,7 @@ final class Newspack_Popups_Inserter {
 
 		// For certain types of blocks, their innerHTML is not a good representation of the length of their content.
 		// For example, slideshows may have an arbitrary amount of slide content, but only show one slide at a time.
-		// Don't insert prompts adjacent to these.
+		// For these blocks, let's ignore their length for purposes of inserting prompts.
 		$blacklisted_blocks = [ 'jetpack/slideshow', 'newspack-blocks/carousel' ];
 		$parsed_blocks      = parse_blocks( $content );
 		$total_length       = 0;

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -224,14 +224,17 @@ final class Newspack_Popups_Inserter {
 		// For certain types of blocks, their innerHTML is not a good representation of the length of their content.
 		// For example, slideshows may have an arbitrary amount of slide content, but only show one slide at a time.
 		// Don't insert prompts adjacent to these.
-		$override_blocks = [ 'jetpack/slideshow', 'newspack-blocks/carousel' ];
-		$parsed_blocks   = parse_blocks( $content );
-		$total_length    = 0;
+		$blacklisted_blocks = [ 'jetpack/slideshow', 'newspack-blocks/carousel' ];
+		$parsed_blocks      = parse_blocks( $content );
+		$total_length       = 0;
 
 		foreach ( $parsed_blocks as $block ) {
-			if ( ! in_array( $block['blockName'], $override_blocks ) ) {
+			if ( ! in_array( $block['blockName'], $blacklisted_blocks ) ) {
 				$block_content = $block['innerHTML'];
 				$total_length += strlen( wp_strip_all_tags( $block_content ) );
+			} else {
+				// Give blacklisted blocks a length so that prompts at 0% can still be inserted before them.
+				$total_length++;
 			}
 		}
 
@@ -259,12 +262,13 @@ final class Newspack_Popups_Inserter {
 		$output = '';
 
 		foreach ( $parsed_blocks as $block ) {
-			if ( ! in_array( $block['blockName'], $override_blocks ) ) {
+			if ( ! in_array( $block['blockName'], $blacklisted_blocks ) ) {
 				$pos += strlen( wp_strip_all_tags( $block['innerHTML'] ) );
+			} else {
+				$pos++;
 			}
 			foreach ( $inline_popups as &$inline_popup ) {
 				if (
-					! in_array( $block['blockName'], $override_blocks ) &&
 					! $inline_popup['is_inserted'] &&
 					$pos > $inline_popup['precise_position']
 				) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

#466 and #468 tweaked the inline prompt insertion logic to account for slideshows, but it wasn't enough to truly fix the insertion logic in posts with slideshows. This PR introduces the concept of ignoring certain types of blocks for purposes of inline prompt insertion; these blocks may contain a massive amount of block content but will only take up a small amount of visual space in the post content, so their content length shouldn't be used for purposes of inline prompt insertion.

The new feature lets us designate any block to be ignored by adding it to the `$blacklisted_blocks` array in `class-newspack-popups-inserter.php`. At time of PR, only `jetpack/slideshow` and `newspack-blocks/carousel` are designated as such, but more can be added if they're found to cause similar issues with inline prompt insertion.

Closes #465 (again).

### How to test the changes in this Pull Request:

1. Create a post with 10 very short paragraphs, perhaps a sentence or two each.
2. At the top of the post, insert a Jetpack slideshow block with a truly massive number of slides (at least 20, preferably with captions, the more the better to inflate the size of its `innerHTML`).
3. Create and publish several inline prompts at various insertion points try (0%, 25%, 50%, 75%, and 100%).
4. On `master`, view the post while not logged in and observe that several of the inline prompts appear bunched together toward the top of the post.
5. Check out this branch and refresh the post. Now confirm that the prompts appear more evenly spaced throughout the short paragraphs.
6. Edit the post and replace the slideshow with a Newspack posts carousel block. Make sure the block is set to a large number of posts (20+).
7. Repeat steps 4-5 and confirm the same issue on `master`, and a similar result on this branch.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
