### PR TITLE
refactor: minimize transients written to one per reader

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
   test-php:
     docker:
       - image: circleci/php:7.2
-      - image: circleci/mysql:5.6
+      - image: circleci/mysql:5.6.50
     environment:
       - WP_TESTS_DIR: '/tmp/wordpress-tests-lib'
       - WP_CORE_DIR: '/tmp/wordpress/'

--- a/api/campaigns/class-maybe-show-campaign.php
+++ b/api/campaigns/class-maybe-show-campaign.php
@@ -149,7 +149,6 @@ class Maybe_Show_Campaign extends Lightweight_API {
 		}
 
 		$client_data              = $this->get_client_data( $client_id );
-		$this->debug[ $client_id ] = $client_data;
 		$best_segment_priority    = PHP_INT_MAX;
 		$best_priority_segment_id = null;
 

--- a/api/campaigns/class-maybe-show-campaign.php
+++ b/api/campaigns/class-maybe-show-campaign.php
@@ -149,6 +149,7 @@ class Maybe_Show_Campaign extends Lightweight_API {
 		}
 
 		$client_data              = $this->get_client_data( $client_id );
+		$this->debug[ $client_id ] = $client_data;
 		$best_segment_priority    = PHP_INT_MAX;
 		$best_priority_segment_id = null;
 

--- a/api/campaigns/class-maybe-show-campaign.php
+++ b/api/campaigns/class-maybe-show-campaign.php
@@ -299,7 +299,12 @@ class Maybe_Show_Campaign extends Lightweight_API {
 		// Handle frequency.
 		$frequency = $campaign->f;
 		if ( ! empty( array_diff( $init_campaign_data, $campaign_data ) ) ) {
-			$this->save_campaign_data( $client_id, $campaign->id, $campaign_data );
+			$updated_campaign_data = [
+				'prompts' => [
+					"$campaign->id" => $campaign_data,
+				],
+			];
+			$this->save_client_data( $client_id, $updated_campaign_data );
 		}
 		if ( 'once' === $frequency && $campaign_data['count'] >= 1 ) {
 			$should_display = false;

--- a/api/campaigns/class-report-campaign-data.php
+++ b/api/campaigns/class-report-campaign-data.php
@@ -68,8 +68,9 @@ class Report_Campaign_Data extends Lightweight_API {
 			];
 		}
 
+		// Update prompts data.
+		$client_data_update['prompts'] = [ "$campaign_id" => $campaign_data ];
 		$this->save_client_data( $client_id, $client_data_update );
-		$this->save_campaign_data( $client_id, $campaign_id, $campaign_data );
 	}
 }
 new Report_Campaign_Data();

--- a/api/classes/class-lightweight-api.php
+++ b/api/classes/class-lightweight-api.php
@@ -318,7 +318,7 @@ class Lightweight_API {
 	 * @param string $client_data_update Client data.
 	 */
 	public function save_client_data( $client_id, $client_data_update ) {
-		$existing_client_data                       = $this->get_client_data( $client_id, true );
+		$existing_client_data = $this->get_client_data( $client_id, true );
 
 		// Update prompts data: new data should replace existing data.
 		if ( isset( $client_data_update['prompts'] ) && ! empty( $existing_client_data['prompts'] ) ) {

--- a/api/classes/class-lightweight-api.php
+++ b/api/classes/class-lightweight-api.php
@@ -198,14 +198,7 @@ class Lightweight_API {
 	 * @return object Prompt data.
 	 */
 	public function get_campaign_data_legacy( $client_id, $campaign_id ) {
-		$data = $this->get_transient( $this->get_transient_name_legacy( $client_id, $campaign_id ) );
-		return [
-			'count'            => ! empty( $data['count'] ) ? (int) $data['count'] : 0,
-			'last_viewed'      => ! empty( $data['last_viewed'] ) ? (int) $data['last_viewed'] : 0,
-			// Primarily caused by permanent dismissal, but also by email signup
-			// (on a newsletter prompt) or a UTM param suppression.
-			'suppress_forever' => ! empty( $data['suppress_forever'] ) ? (int) $data['suppress_forever'] : false,
-		];
+		return $this->get_transient( $this->get_transient_name_legacy( $client_id, $campaign_id ) );
 	}
 
 	/**
@@ -292,21 +285,18 @@ class Lightweight_API {
 
 		$this->save_client_data(
 			$client_id,
-			array_merge(
-				$this->client_data_blueprint,
-				[
-					'posts_read' => array_map(
-						function ( $item ) {
-							return [
-								'post_id'      => $item->post_id,
-								'category_ids' => $item->category_ids,
-								'created_at'   => $item->created_at,
-							];
-						},
-						$client_post_read_events
-					),
-				]
-			)
+			[
+				'posts_read' => array_map(
+					function ( $item ) {
+						return [
+							'post_id'      => $item->post_id,
+							'category_ids' => $item->category_ids,
+							'created_at'   => $item->created_at,
+						];
+					},
+					$client_post_read_events
+				),
+			]
 		);
 
 		return $this->get_transient( $client_id );

--- a/api/classes/class-lightweight-api.php
+++ b/api/classes/class-lightweight-api.php
@@ -36,6 +36,7 @@ class Lightweight_API {
 		'donations'                      => [],
 		'email_subscriptions'            => [],
 		'user_id'                        => false,
+		'prompts'                        => [],
 	];
 
 	/**
@@ -50,6 +51,7 @@ class Lightweight_API {
 		$this->debug = [
 			'read_query_count'       => 0,
 			'write_query_count'      => 0,
+			'delete_query_count'     => 0,
 			'cache_count'            => 0,
 			'read_empty_transients'  => 0,
 			'write_empty_transients' => 0,
@@ -77,12 +79,13 @@ class Lightweight_API {
 	}
 
 	/**
+	 * LEGACY FORMAT - one transient per reader per prompt.
 	 * Get transient name.
 	 *
 	 * @param string $client_id Client ID.
 	 * @param string $popup_id Popup ID.
 	 */
-	public function get_transient_name( $client_id, $popup_id = null ) {
+	public function get_transient_name_legacy( $client_id, $popup_id = null ) {
 		if ( null === $popup_id ) {
 			// For data about popups in general.
 			return sprintf( '%s-popups', $client_id );
@@ -130,25 +133,24 @@ class Lightweight_API {
 	 */
 	public function get_transient( $name ) {
 		global $wpdb;
-		$name = '_transient_' . $name;
-
+		$name  = '_transient_' . $name;
 		$value = wp_cache_get( $name, 'newspack-popups' );
-		if ( -1 === $value ) {
-			$this->debug['read_empty_transients'] += 1;
-			$this->debug['cache_count']           += 1;
-			return null;
-		} elseif ( false === $value ) {
+
+		if ( false === $value ) {
 			$this->debug['read_query_count'] += 1;
 			$value                            = $this->get_option( $name );
+
 			if ( $value ) {
+				// Transient found; cache value.
 				wp_cache_set( $name, $value, 'newspack-popups' );
 			} else {
-				$this->debug['write_empty_transients'] += 1;
-				wp_cache_set( $name, -1, 'newspack-popups' );
+				// No transient and no DB entry found.
+				return null;
 			}
 		} else {
 			$this->debug['cache_count'] += 1;
 		}
+
 		return maybe_unserialize( $value );
 	}
 
@@ -170,6 +172,43 @@ class Lightweight_API {
 	}
 
 	/**
+	 * Delete transient.
+	 *
+	 * @param string $name The transient's name.
+	 */
+	public function delete_transient( $name ) {
+		global $wpdb;
+		$name = '_transient_' . $name;
+
+		wp_cache_delete( $name );
+		$wpdb->delete( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
+			$wpdb->options,
+			[ 'option_name' => $name ]
+		);
+
+		$this->debug['delete_query_count'] += 1;
+	}
+
+	/**
+	 * LEGACY FORMAT - one row per reader per prompt.
+	 * Retrieve prompt data.
+	 *
+	 * @param string $client_id Client ID.
+	 * @param string $campaign_id Prompt ID.
+	 * @return object Prompt data.
+	 */
+	public function get_campaign_data_legacy( $client_id, $campaign_id ) {
+		$data = $this->get_transient( $this->get_transient_name_legacy( $client_id, $campaign_id ) );
+		return [
+			'count'            => ! empty( $data['count'] ) ? (int) $data['count'] : 0,
+			'last_viewed'      => ! empty( $data['last_viewed'] ) ? (int) $data['last_viewed'] : 0,
+			// Primarily caused by permanent dismissal, but also by email signup
+			// (on a newsletter prompt) or a UTM param suppression.
+			'suppress_forever' => ! empty( $data['suppress_forever'] ) ? (int) $data['suppress_forever'] : false,
+		];
+	}
+
+	/**
 	 * Retrieve prompt data.
 	 *
 	 * @param string $client_id Client ID.
@@ -177,13 +216,24 @@ class Lightweight_API {
 	 * @return object Prompt data.
 	 */
 	public function get_campaign_data( $client_id, $campaign_id ) {
-		$data = $this->get_transient( $this->get_transient_name( $client_id, $campaign_id ) );
+		$prompt = [];
+		$data   = $this->get_transient( $client_id );
+
+		if ( $data && isset( $data['prompts'] ) && isset( $data['prompts'][ $campaign_id ] ) ) {
+			// NEW FORMAT - one row per reader.
+			$prompt = $data['prompts'][ $campaign_id ];
+		} else {
+			// LEGACY FORMAT - one row per reader per prompt.
+			$prompt = $this->get_campaign_data_legacy( $client_id, $campaign_id );
+			$this->delete_transient( $this->get_transient_name_legacy( $client_id, $campaign_id ) ); // Clean up legacy data.
+		}
+
 		return [
-			'count'            => ! empty( $data['count'] ) ? (int) $data['count'] : 0,
-			'last_viewed'      => ! empty( $data['last_viewed'] ) ? (int) $data['last_viewed'] : 0,
+			'count'            => ! empty( $prompt['count'] ) ? (int) $prompt['count'] : 0,
+			'last_viewed'      => ! empty( $prompt['last_viewed'] ) ? (int) $prompt['last_viewed'] : 0,
 			// Primarily caused by permanent dismissal, but also by email signup
 			// (on a newsletter prompt) or a UTM param suppression.
-			'suppress_forever' => ! empty( $data['suppress_forever'] ) ? (int) $data['suppress_forever'] : false,
+			'suppress_forever' => ! empty( $prompt['suppress_forever'] ) ? (int) $prompt['suppress_forever'] : false,
 		];
 	}
 
@@ -195,7 +245,10 @@ class Lightweight_API {
 	 * @param string $campaign_data Prompt data.
 	 */
 	public function save_campaign_data( $client_id, $campaign_id, $campaign_data ) {
-		return $this->set_transient( $this->get_transient_name( $client_id, $campaign_id ), $campaign_data );
+		$client_data                            = $this->get_client_data( $client_id, true );
+		$client_data['prompts'][ $campaign_id ] = $campaign_data;
+
+		return $this->set_transient( $client_id, $client_data );
 	}
 
 	/**
@@ -205,7 +258,14 @@ class Lightweight_API {
 	 * @param bool   $do_not_rebuild Whether to rebuild cache if not found.
 	 */
 	public function get_client_data( $client_id, $do_not_rebuild = false ) {
-		$data = $this->get_transient( $this->get_transient_name( $client_id ) );
+		$data = $this->get_transient( $client_id );
+
+		// If no client data found, try the legacy transient name.
+		if ( empty( $data ) ) {
+			$data = $this->get_transient( $this->get_transient_name_legacy( $client_id ) );
+			$this->delete_transient( $this->get_transient_name_legacy( $client_id ) );
+		}
+
 		if ( $data ) {
 			// Handle legacy data which might not have some default keys.
 			return array_merge(
@@ -213,6 +273,7 @@ class Lightweight_API {
 				$data
 			);
 		}
+
 		if ( $do_not_rebuild ) {
 			return $this->client_data_blueprint;
 		}
@@ -224,23 +285,31 @@ class Lightweight_API {
 			$wpdb->prepare( "SELECT * FROM $events_table_name WHERE client_id = %s AND type = 'post_read'", $client_id ) // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		);
 
+		// If client hasn't read any posts yet, don't write any data.
+		if ( 0 === count( $client_post_read_events ) ) {
+			return $this->client_data_blueprint;
+		}
+
 		$this->save_client_data(
 			$client_id,
-			[
-				'posts_read' => array_map(
-					function ( $item ) {
-						return [
-							'post_id'      => $item->post_id,
-							'category_ids' => $item->category_ids,
-							'created_at'   => $item->created_at,
-						];
-					},
-					$client_post_read_events
-				),
-			]
+			array_merge(
+				$this->client_data_blueprint,
+				[
+					'posts_read' => array_map(
+						function ( $item ) {
+							return [
+								'post_id'      => $item->post_id,
+								'category_ids' => $item->category_ids,
+								'created_at'   => $item->created_at,
+							];
+						},
+						$client_post_read_events
+					),
+				]
+			)
 		);
 
-		return $this->get_transient( $this->get_transient_name( $client_id ) );
+		return $this->get_transient( $client_id );
 	}
 
 	/**
@@ -285,7 +354,7 @@ class Lightweight_API {
 			$updated_client_data['user_id'] = $client_data_update['user_id'];
 		}
 		return $this->set_transient(
-			$this->get_transient_name( $client_id ),
+			$client_id,
 			$updated_client_data
 		);
 	}

--- a/api/classes/class-lightweight-api.php
+++ b/api/classes/class-lightweight-api.php
@@ -178,11 +178,12 @@ class Lightweight_API {
 	 */
 	public function delete_transient( $name ) {
 		global $wpdb;
-		$name = '_transient_' . $name;
+		$name       = '_transient_' . $name;
+		$table_name = Segmentation::get_transients_table_name();
 
 		wp_cache_delete( $name );
 		$wpdb->delete( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
-			$wpdb->options,
+			$table_name,
 			[ 'option_name' => $name ]
 		);
 

--- a/api/classes/class-lightweight-api.php
+++ b/api/classes/class-lightweight-api.php
@@ -319,7 +319,18 @@ class Lightweight_API {
 	 */
 	public function save_client_data( $client_id, $client_data_update ) {
 		$existing_client_data                       = $this->get_client_data( $client_id, true );
-		$updated_client_data                        = array_replace_recursive(
+
+		// Update prompts data: new data should replace existing data.
+		if ( isset( $client_data_update['prompts'] ) && ! empty( $existing_client_data['prompts'] ) ) {
+			$client_data_update['prompts']   = array_replace_recursive(
+				$existing_client_data['prompts'],
+				$client_data_update['prompts']
+			);
+			$existing_client_data['prompts'] = []; // Unset old client data to avoid data duplication on array_merge_recursive below.
+		}
+
+		// Update client data: merge data so we don't lose historical read, subscription, or donation data.
+		$updated_client_data                        = array_merge_recursive(
 			$existing_client_data,
 			$client_data_update
 		);

--- a/api/classes/class-lightweight-api.php
+++ b/api/classes/class-lightweight-api.php
@@ -231,20 +231,6 @@ class Lightweight_API {
 	}
 
 	/**
-	 * Save prompt data.
-	 *
-	 * @param string $client_id Client ID.
-	 * @param string $campaign_id Prompt ID.
-	 * @param string $campaign_data Prompt data.
-	 */
-	public function save_campaign_data( $client_id, $campaign_id, $campaign_data ) {
-		$client_data                            = $this->get_client_data( $client_id, true );
-		$client_data['prompts'][ $campaign_id ] = $campaign_data;
-
-		return $this->set_transient( $client_id, $client_data );
-	}
-
-	/**
 	 * Retrieve client data.
 	 *
 	 * @param string $client_id Client ID.
@@ -333,7 +319,7 @@ class Lightweight_API {
 	 */
 	public function save_client_data( $client_id, $client_data_update ) {
 		$existing_client_data                       = $this->get_client_data( $client_id, true );
-		$updated_client_data                        = array_merge_recursive(
+		$updated_client_data                        = array_replace_recursive(
 			$existing_client_data,
 			$client_data_update
 		);

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -225,7 +225,7 @@ final class Newspack_Popups_Inserter {
 		// not an accurate representation of the content length.
 		$total_length = 0;
 		foreach ( parse_blocks( $content ) as $block ) {
-			$block_content = render_block( $block );
+			$block_content = $block['innerHTML'];
 			$total_length += strlen( wp_strip_all_tags( $block_content ) );
 		}
 

--- a/tests/test-api.php
+++ b/tests/test-api.php
@@ -652,7 +652,7 @@ class APITest extends WP_UnitTestCase {
 		self::assertEquals(
 			$api->get_campaign_data( $client_id, $popup_id ),
 			$expected_popup_data,
-			'Returns prompt data only.'
+			'Returns prompt data.'
 		);
 
 		// Report another view of the same prompt.
@@ -668,18 +668,10 @@ class APITest extends WP_UnitTestCase {
 			'suppress_forever' => false,
 		];
 		self::assertEquals(
-			$api->get_client_data( $client_id )['prompts'],
-			[
-				"$popup_id" => $expected_popup_data,
-			],
-			'Returns data with prompt data after a prompt is reported.'
-		);
-		self::assertEquals(
 			$api->get_campaign_data( $client_id, $popup_id ),
 			$expected_popup_data,
-			'Returns prompt data only.'
+			'Returns prompt data.'
 		);
-
 		self::assertEquals(
 			$api->get_client_data( $client_id ),
 			[
@@ -690,6 +682,40 @@ class APITest extends WP_UnitTestCase {
 				'user_id'                        => false,
 				'prompts'                        => [
 					"$popup_id" => $expected_popup_data,
+				],
+			],
+			'Returns data in expected shape.'
+		);
+
+		// Report another view of a diffrent prompt.
+		$new_popup_id            = Newspack_Popups_Model::canonize_popup_id( uniqid() );
+		$expected_new_popup_data = [
+			'count'            => 1,
+			'last_viewed'      => time(),
+			'suppress_forever' => false,
+		];
+		self::$report_campaign_data->report_campaign(
+			[
+				'cid'      => $client_id,
+				'popup_id' => $new_popup_id,
+			]
+		);
+		self::assertEquals(
+			$api->get_campaign_data( $client_id, $new_popup_id ),
+			$expected_new_popup_data,
+			'Returns prompt data.'
+		);
+		self::assertEquals(
+			$api->get_client_data( $client_id ),
+			[
+				'suppressed_newsletter_campaign' => false,
+				'posts_read'                     => [],
+				'email_subscriptions'            => [],
+				'donations'                      => [],
+				'user_id'                        => false,
+				'prompts'                        => [
+					"$popup_id"     => $expected_popup_data,
+					"$new_popup_id" => $expected_new_popup_data,
 				],
 			],
 			'Returns data in expected shape.'

--- a/tests/test-api.php
+++ b/tests/test-api.php
@@ -627,11 +627,9 @@ class APITest extends WP_UnitTestCase {
 		self::assertEquals(
 			$api->get_campaign_data( self::$client_id, 'foo' ),
 			[
-				'foo' => [
-					'count'            => 1,
-					'last_viewed'      => 0,
-					'suppress_forever' => true,
-				],
+				'count'            => 1,
+				'last_viewed'      => 0,
+				'suppress_forever' => true,
 			],
 			'Returns prompt data only.'
 		);
@@ -673,6 +671,8 @@ class APITest extends WP_UnitTestCase {
 			]
 		);
 
+		$prompt_data = $api->get_campaign_data( self::$client_id, Newspack_Popups_Model::canonize_popup_id( $test_popup_with_subscription_block['id'] ) );
+
 		self::assertEquals(
 			self::$report_campaign_data->get_client_data( self::$client_id ),
 			[
@@ -685,7 +685,7 @@ class APITest extends WP_UnitTestCase {
 					],
 				],
 				'user_id'                        => false,
-				'prompts'                        => [],
+				'prompts'                        => $prompt_data,
 			],
 			'The client data after a subscription contains the provided email address.'
 		);

--- a/tests/test-api.php
+++ b/tests/test-api.php
@@ -538,6 +538,7 @@ class APITest extends WP_UnitTestCase {
 				'email_subscriptions'            => [],
 				'donations'                      => [],
 				'user_id'                        => false,
+				'prompts'                        => [],
 			],
 			'Returns expected data blueprint in absence of saved data.'
 		);
@@ -564,6 +565,7 @@ class APITest extends WP_UnitTestCase {
 				'email_subscriptions'            => [],
 				'donations'                      => [],
 				'user_id'                        => false,
+				'prompts'                        => [],
 			],
 			'Returns data with saved post after an article reading was reported.'
 		);
@@ -584,8 +586,54 @@ class APITest extends WP_UnitTestCase {
 				'some_other_data'                => 42,
 				'donations'                      => [],
 				'user_id'                        => false,
+				'prompts'                        => [],
 			],
 			'Returns data without overwriting the existing data.'
+		);
+
+		$api->save_client_data(
+			self::$client_id,
+			[
+				'prompts' => [
+					'foo' => [
+						'count'            => 1,
+						'last_viewed'      => 0,
+						'suppress_forever' => true,
+					],
+				],
+			]
+		);
+
+		self::assertEquals(
+			$api->get_client_data( self::$client_id ),
+			[
+				'suppressed_newsletter_campaign' => false,
+				'posts_read'                     => $posts_read,
+				'email_subscriptions'            => [],
+				'some_other_data'                => 42,
+				'donations'                      => [],
+				'user_id'                        => false,
+				'prompts'                        => [
+					'foo' => [
+						'count'            => 1,
+						'last_viewed'      => 0,
+						'suppress_forever' => true,
+					],
+				],
+			],
+			'Returns data with prompt data after a prompt is reported.'
+		);
+
+		self::assertEquals(
+			$api->get_campaign_data( self::$client_id, 'foo' ),
+			[
+				'foo' => [
+					'count'            => 1,
+					'last_viewed'      => 0,
+					'suppress_forever' => true,
+				],
+			],
+			'Returns prompt data only.'
 		);
 	}
 
@@ -609,6 +657,7 @@ class APITest extends WP_UnitTestCase {
 				'email_subscriptions'            => [],
 				'donations'                      => [],
 				'user_id'                        => false,
+				'prompts'                        => [],
 			],
 			'The initial client data has expected shape.'
 		);
@@ -636,6 +685,7 @@ class APITest extends WP_UnitTestCase {
 					],
 				],
 				'user_id'                        => false,
+				'prompts'                        => [],
 			],
 			'The client data after a subscription contains the provided email address.'
 		);

--- a/tests/test-api.php
+++ b/tests/test-api.php
@@ -930,7 +930,6 @@ class APITest extends WP_UnitTestCase {
 	 * Suppression caused by a read count segment.
 	 */
 	public function test_segment_read_count_range() {
-		$api                     = new Lightweight_API();
 		$test_popup_with_segment = self::create_test_popup(
 			[
 				'placement'           => 'inline',
@@ -945,13 +944,12 @@ class APITest extends WP_UnitTestCase {
 		);
 
 		// Report 2 articles read.
-		$api->save_client_data(
+		self::$maybe_show_campaign->save_client_data(
 			self::$client_id,
 			[
 				'posts_read' => [
 					self::create_read_post( 1 ),
 					self::create_read_post( 2 ),
-					self::create_read_post( 3 ),
 				],
 			]
 		);
@@ -962,10 +960,11 @@ class APITest extends WP_UnitTestCase {
 		);
 
 		// Report more than 5 articles read.
-		$api->save_client_data(
+		self::$maybe_show_campaign->save_client_data(
 			self::$client_id,
 			[
 				'posts_read' => [
+					self::create_read_post( 3 ),
 					self::create_read_post( 4 ),
 					self::create_read_post( 5 ),
 					self::create_read_post( 6 ),
@@ -983,7 +982,6 @@ class APITest extends WP_UnitTestCase {
 	 * Suppression caused by a read count segment, with a 'once' frequency cap.
 	 */
 	public function test_segment_read_count_range_with_once_frequency() {
-		$api                     = new Lightweight_API();
 		$test_popup_with_segment = self::create_test_popup(
 			[
 				'placement'           => 'inline',
@@ -998,13 +996,12 @@ class APITest extends WP_UnitTestCase {
 		);
 
 		// Report 2 articles read.
-		$api->save_client_data(
+		self::$maybe_show_campaign->save_client_data(
 			self::$client_id,
 			[
 				'posts_read' => [
 					self::create_read_post( 1 ),
 					self::create_read_post( 2 ),
-					self::create_read_post( 3 ),
 				],
 			]
 		);
@@ -1079,7 +1076,6 @@ class APITest extends WP_UnitTestCase {
 	 * Suppression caused by a session read count segment.
 	 */
 	public function test_segment_session_read_count() {
-		$api                     = new Lightweight_API();
 		$test_popup_with_segment = self::create_test_popup(
 			[
 				'placement'           => 'inline',
@@ -1094,7 +1090,7 @@ class APITest extends WP_UnitTestCase {
 		);
 
 		// Ensure legacy post read data format is handled gracefully.
-		$api->save_client_data(
+		self::$maybe_show_campaign->save_client_data(
 			self::$client_id,
 			[
 				'posts_read' => [
@@ -1107,7 +1103,7 @@ class APITest extends WP_UnitTestCase {
 		);
 
 		// Report 2 articles read before current session.
-		$api->save_client_data(
+		self::$maybe_show_campaign->save_client_data(
 			self::$client_id,
 			[
 				'posts_read' => [
@@ -1123,13 +1119,12 @@ class APITest extends WP_UnitTestCase {
 		);
 
 		// Report 2 articles read in the session.
-		$api->save_client_data(
+		self::$maybe_show_campaign->save_client_data(
 			self::$client_id,
 			[
 				'posts_read' => [
 					self::create_read_post( 1 ),
 					self::create_read_post( 2 ),
-					self::create_read_post( 3 ),
 				],
 			]
 		);
@@ -1140,10 +1135,11 @@ class APITest extends WP_UnitTestCase {
 		);
 
 		// Report more than 5 articles read in the session.
-		$api->save_client_data(
+		self::$maybe_show_campaign->save_client_data(
 			self::$client_id,
 			[
 				'posts_read' => [
+					self::create_read_post( 3 ),
 					self::create_read_post( 4 ),
 					self::create_read_post( 5 ),
 					self::create_read_post( 6 ),

--- a/tests/test-api.php
+++ b/tests/test-api.php
@@ -671,6 +671,7 @@ class APITest extends WP_UnitTestCase {
 			]
 		);
 
+		$api         = new Lightweight_API();
 		$prompt_data = $api->get_campaign_data( self::$client_id, Newspack_Popups_Model::canonize_popup_id( $test_popup_with_subscription_block['id'] ) );
 
 		self::assertEquals(

--- a/tests/test-api.php
+++ b/tests/test-api.php
@@ -930,6 +930,7 @@ class APITest extends WP_UnitTestCase {
 	 * Suppression caused by a read count segment.
 	 */
 	public function test_segment_read_count_range() {
+		$api                     = new Lightweight_API();
 		$test_popup_with_segment = self::create_test_popup(
 			[
 				'placement'           => 'inline',
@@ -944,7 +945,7 @@ class APITest extends WP_UnitTestCase {
 		);
 
 		// Report 2 articles read.
-		self::$maybe_show_campaign->save_client_data(
+		$api->save_client_data(
 			self::$client_id,
 			[
 				'posts_read' => [
@@ -961,7 +962,7 @@ class APITest extends WP_UnitTestCase {
 		);
 
 		// Report more than 5 articles read.
-		self::$maybe_show_campaign->save_client_data(
+		$api->save_client_data(
 			self::$client_id,
 			[
 				'posts_read' => [
@@ -982,6 +983,7 @@ class APITest extends WP_UnitTestCase {
 	 * Suppression caused by a read count segment, with a 'once' frequency cap.
 	 */
 	public function test_segment_read_count_range_with_once_frequency() {
+		$api                     = new Lightweight_API();
 		$test_popup_with_segment = self::create_test_popup(
 			[
 				'placement'           => 'inline',
@@ -996,12 +998,13 @@ class APITest extends WP_UnitTestCase {
 		);
 
 		// Report 2 articles read.
-		self::$maybe_show_campaign->save_client_data(
+		$api->save_client_data(
 			self::$client_id,
 			[
 				'posts_read' => [
 					self::create_read_post( 1 ),
 					self::create_read_post( 2 ),
+					self::create_read_post( 3 ),
 				],
 			]
 		);
@@ -1076,6 +1079,7 @@ class APITest extends WP_UnitTestCase {
 	 * Suppression caused by a session read count segment.
 	 */
 	public function test_segment_session_read_count() {
+		$api                     = new Lightweight_API();
 		$test_popup_with_segment = self::create_test_popup(
 			[
 				'placement'           => 'inline',
@@ -1090,7 +1094,7 @@ class APITest extends WP_UnitTestCase {
 		);
 
 		// Ensure legacy post read data format is handled gracefully.
-		self::$maybe_show_campaign->save_client_data(
+		$api->save_client_data(
 			self::$client_id,
 			[
 				'posts_read' => [
@@ -1103,7 +1107,7 @@ class APITest extends WP_UnitTestCase {
 		);
 
 		// Report 2 articles read before current session.
-		self::$maybe_show_campaign->save_client_data(
+		$api->save_client_data(
 			self::$client_id,
 			[
 				'posts_read' => [
@@ -1119,12 +1123,13 @@ class APITest extends WP_UnitTestCase {
 		);
 
 		// Report 2 articles read in the session.
-		self::$maybe_show_campaign->save_client_data(
+		$api->save_client_data(
 			self::$client_id,
 			[
 				'posts_read' => [
 					self::create_read_post( 1 ),
 					self::create_read_post( 2 ),
+					self::create_read_post( 3 ),
 				],
 			]
 		);
@@ -1135,11 +1140,10 @@ class APITest extends WP_UnitTestCase {
 		);
 
 		// Report more than 5 articles read in the session.
-		self::$maybe_show_campaign->save_client_data(
+		$api->save_client_data(
 			self::$client_id,
 			[
 				'posts_read' => [
-					self::create_read_post( 3 ),
 					self::create_read_post( 4 ),
 					self::create_read_post( 5 ),
 					self::create_read_post( 6 ),

--- a/tests/test-api.php
+++ b/tests/test-api.php
@@ -618,7 +618,7 @@ class APITest extends WP_UnitTestCase {
 				'user_id'                        => false,
 				'prompts'                        => [],
 			],
-			'Returns expected data blueprint in absence of saved data.'
+			'Returns expected data based on events table.'
 		);
 	}
 
@@ -715,11 +715,6 @@ class APITest extends WP_UnitTestCase {
 				'donation'  => $donation,
 			]
 		);
-		self::assertEquals(
-			$api->get_client_data( $client_id )['donations'],
-			[ $donation ],
-			'Returns data with donation data after a donation is reported.'
-		);
 
 		self::assertEquals(
 			$api->get_client_data( $client_id ),
@@ -731,7 +726,7 @@ class APITest extends WP_UnitTestCase {
 				'user_id'                        => false,
 				'prompts'                        => [],
 			],
-			'Returns data in expected shape.'
+			'Returns data with donation data after a donation is reported.'
 		);
 	}
 

--- a/tests/test-api.php
+++ b/tests/test-api.php
@@ -661,18 +661,21 @@ class APITest extends WP_UnitTestCase {
 		);
 
 		$email_address = 'foo@bar.com';
+		$prompt_id     = Newspack_Popups_Model::canonize_popup_id( $test_popup_with_subscription_block['id'] );
+
 		// Report a subscription.
 		self::$report_campaign_data->report_campaign(
 			[
 				'cid'                 => self::$client_id,
-				'popup_id'            => Newspack_Popups_Model::canonize_popup_id( $test_popup_with_subscription_block['id'] ),
+				'popup_id'            => $prompt_id,
 				'mailing_list_status' => 'subscribed',
 				'email'               => $email_address,
 			]
 		);
 
-		$api         = new Lightweight_API();
-		$prompt_data = $api->get_campaign_data( self::$client_id, Newspack_Popups_Model::canonize_popup_id( $test_popup_with_subscription_block['id'] ) );
+		$api                       = new Lightweight_API();
+		$prompt_data               = [];
+		$prompt_data[ $prompt_id ] = $api->get_campaign_data( self::$client_id, $prompt_id );
 
 		self::assertEquals(
 			self::$report_campaign_data->get_client_data( self::$client_id ),

--- a/tests/test-api.php
+++ b/tests/test-api.php
@@ -950,6 +950,7 @@ class APITest extends WP_UnitTestCase {
 				'posts_read' => [
 					self::create_read_post( 1 ),
 					self::create_read_post( 2 ),
+					self::create_read_post( 3 ),
 				],
 			]
 		);
@@ -964,7 +965,6 @@ class APITest extends WP_UnitTestCase {
 			self::$client_id,
 			[
 				'posts_read' => [
-					self::create_read_post( 3 ),
 					self::create_read_post( 4 ),
 					self::create_read_post( 5 ),
 					self::create_read_post( 6 ),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Taking inspiration from #478, makes two changes to the way the plugin handles writing transients:

a. Transients are not written for unrecognized readers who do not have any ~read-posts~ recorded history (this should avoid writing new empty client data rows for bounced readers), and
b. Writes a maximum of one row per client, with all prompt-related data collected in that row.

Does not do anything to add expiration logic to transients (let's save that for another PR to keep this testable).

Since the transient name and data format differ slightly, this PR also handles the legacy format. If we can't find client or campaign data using the new transient name, we look for data using the legacy name. Then, if legacy data is found, we save that data with the new name and format and then delete the legacy rows. This is not a replacement for a full migration strategy (for that we'll want to programmatically migrate all legacy data to the new format at once), but it will help the plugin fall back gracefully to legacy data while also cleaning up after itself.

May need some light refactoring after #488 lands.

### How to test the changes in this Pull Request:

1. On `master`, publish several prompts to varying segments.
2. In a new incognito session, visit the homepage without visiting any articles.
3. Inspect the `wp_options` table and observe that a new row is created for the new reader with a name like `_transient_amp-wRGBrPpeCBfl_JSik4xLQw-popups` (note the `-popups` suffix), despite having no reader activity yet.
4. View an article and dismiss a prompt or two.
5. Inspect the `wp_options` table again and observe that new rows are created for each dismissed prompt to log the dismissals. Note the option names with the `-id_####-popup` suffix.
6. Check out this branch. In the same incognito session, refresh the article or view another article. Confirm that the prompts you previously dismissed remain dismissed (so the changes in this PR won't have any noticeable effect to front-end readers).
7. Inspect the `wp_options` table. Confirm the following:
  a. There is a new row with a name like `_transient_amp-wRGBrPpeCBfl_JSik4xLQw` (note no suffix). If you inspect the row value, it should have a `prompts` key containing data for each viewed and suppressed prompt.
  b. The previous rows for the reader (with `-popups` suffix) and each prompt (with `-id_####-popup` suffix) are deleted.
8. Close out the session and open a new incognito session. View the homepage without visiting any articles.
9. Inspect the `wp_options` table and confirm that no new row is created, since the new reader has no activity yet.
10. Read an article and inspect the `wp_options` table again—a new row should be created for the reader with posts read activity.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
