### PR TITLE
feat: use RadioControls for prompt type selection

### DIFF
--- a/src/editor/Sidebar.js
+++ b/src/editor/Sidebar.js
@@ -7,7 +7,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Fragment } from '@wordpress/element';
-import { RangeControl, SelectControl, ToggleControl } from '@wordpress/components';
+import { RadioControl, RangeControl, SelectControl, ToggleControl } from '@wordpress/components';
 
 const Sidebar = ( {
 	display_title,
@@ -30,10 +30,15 @@ const Sidebar = ( {
 
 	return (
 		<Fragment>
-			<ToggleControl
-				label={ __( 'Inline Prompt', 'newspack-popups' ) }
-				checked={ ! isOverlay }
-				onChange={ value => updatePlacement( value ? 'inline' : 'center' ) }
+			<RadioControl
+				className="newspack-popups__prompt-type-control"
+				label={ __( 'Prompt type', 'newspack-popups' ) }
+				selected={ isOverlay ? 'center' : 'inline' }
+				options={ [
+					{ label: __( 'Inline', 'newspack-popups' ), value: 'inline' },
+					{ label: __( 'Overlay', 'newspack-popups' ), value: 'center' },
+				] }
+				onChange={ value => updatePlacement( value ) }
 			/>
 			<SelectControl
 				label={ __( 'Placement' ) }

--- a/src/editor/style.scss
+++ b/src/editor/style.scss
@@ -16,6 +16,22 @@
 		}
 	}
 
+	&__prompt-type-control {
+		margin-bottom: 1rem;
+
+		.components-base-control__label {
+			display: block;
+		}
+
+		.components-radio-control__option {
+			display: inline-block;
+
+			&:first-of-type {
+				margin-right: 1rem;
+			}
+		}
+	}
+
 	&__not-interested-button-preview {
 		cursor: not-allowed;
 		font-size: 0.7em;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Updates the `ToggleControl` to make a prompt inline vs. overlay to a pair of radio buttons. This makes it much clearer that a prompt can be either overlay or inline.

Closes #471 (but I selfishly made the executive decision not to kill the "Display prompt title" option, because I use it a lot for testing).

### How to test the changes in this Pull Request:

1. Check out this branch, run `npm run build`
2. Edit a prompt and expand the "Prompt Settings" sidebar.
3. Confirm that the prompt type is now set using these radio buttons, that you can only select one or the other option, and that when "inline" is selected, only inline placement options appear (and vice versa).

<img width="278" alt="Screen Shot 2021-03-25 at 1 58 07 PM" src="https://user-images.githubusercontent.com/2230142/112536140-b5c05100-8d72-11eb-9bf4-138133516208.png">

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
