### PR TITLE
Add missing key prop in CustomPlacementEditor

### DIFF
--- a/src/blocks/custom-placement/edit.js
+++ b/src/blocks/custom-placement/edit.js
@@ -4,7 +4,7 @@
 import apiFetch from '@wordpress/api-fetch';
 import { __, sprintf } from '@wordpress/i18n';
 import { ExternalLink, Notice, Placeholder, SelectControl, Spinner } from '@wordpress/components';
-import { useEffect, useState } from '@wordpress/element';
+import { Fragment, useEffect, useState } from '@wordpress/element';
 import { addQueryArgs } from '@wordpress/url';
 
 /**
@@ -125,42 +125,45 @@ export const CustomPlacementEditor = ( { attributes, setAttributes } ) => {
 									1 < prompts.length ? 's' : ''
 								) }
 							</p>
-							{ Object.keys( segments ).map( segmentName => (
-								<>
-									<h4>
-										{ segments[ segmentName ].id && (
-											<ExternalLink
-												href={ `/wp-admin/admin.php?page=newspack-popups-wizard#/segments/${
-													segments[ segmentName ].id
-												}` }
-											>
-												{ sprintf( __( 'Segment: %s', 'newspack-popup' ), segmentName ) }
-											</ExternalLink>
-										) }
-										{ ! segments[ segmentName ].id && (
-											<>
-												{ sprintf(
-													__( '%s%s%s', 'newspack-popup' ),
-													'Everyone' !== segmentName ? 'Segment: ' : '',
-													segmentName,
-													'Everyone' === segmentName && 1 < Object.keys( segments ).length
-														? __( ' else', 'newspack-popups' )
-														: ''
-												) }
-											</>
-										) }
-									</h4>
-									<ul>
-										{ segments[ segmentName ].prompts.map( prompt => (
-											<li key={ prompt.id }>
-												<ExternalLink href={ `/wp-admin/post.php?post=${ prompt.id }&action=edit` }>
-													{ prompt.title }
+							{ Object.keys( segments ).map( segmentName => {
+								const segmentId = segments[ segmentName ].id;
+								return (
+									<Fragment key={ segmentId }>
+										<h4>
+											{ segmentId && (
+												<ExternalLink
+													href={ `/wp-admin/admin.php?page=newspack-popups-wizard#/segments/${ segmentId }` }
+												>
+													{ sprintf( __( 'Segment: %s', 'newspack-popup' ), segmentName ) }
 												</ExternalLink>
-											</li>
-										) ) }
-									</ul>
-								</>
-							) ) }
+											) }
+											{ ! segmentId && (
+												<>
+													{ sprintf(
+														__( '%s%s%s', 'newspack-popup' ),
+														'Everyone' !== segmentName ? 'Segment: ' : '',
+														segmentName,
+														'Everyone' === segmentName && 1 < Object.keys( segments ).length
+															? __( ' else', 'newspack-popups' )
+															: ''
+													) }
+												</>
+											) }
+										</h4>
+										<ul>
+											{ segments[ segmentName ].prompts.map( prompt => (
+												<li key={ prompt.id }>
+													<ExternalLink
+														href={ `/wp-admin/post.php?post=${ prompt.id }&action=edit` }
+													>
+														{ prompt.title }
+													</ExternalLink>
+												</li>
+											) ) }
+										</ul>
+									</Fragment>
+								);
+							} ) }
 						</>
 					) }
 				</div>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->



### How to test the changes in this Pull Request:

1. On `master`, insert a Custom Placement block on a post or page
2. Observe a React error in the JS console about missing "key" prop
3. Switch to this brach, rebuild
4. Observe error gone

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->