### PR TITLE
Small shortcode, amp-access fixes

### DIFF
--- a/includes/class-newspack-popups-custom-placements.php
+++ b/includes/class-newspack-popups-custom-placements.php
@@ -205,6 +205,9 @@ final class Newspack_Popups_Custom_Placements {
 	 * @return array Array of prompt posts matching the custom placement.
 	 */
 	public static function get_prompts_for_custom_placement( $custom_placement_ids, $fields = 'all', $categories = false ) {
+		if ( empty( $custom_placement_ids ) ) {
+			return [];
+		}
 		$args = [
 			'posts_per_page' => 100,
 			'post_status'    => 'publish',

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Newspack Popups Inserters
+ * Newspack Popups Inserter
  *
  * @package Newspack
  */
@@ -369,11 +369,8 @@ final class Newspack_Popups_Inserter {
 	 * @return HTML
 	 */
 	public static function popup_shortcode( $atts = array() ) {
-		$previewed_popup_id = Newspack_Popups::previewed_popup_id();
-		if ( $previewed_popup_id ) {
-			$found_popup = Newspack_Popups_Model::retrieve_preview_popup( $previewed_popup_id );
-		} elseif ( isset( $atts['id'] ) ) {
-			$found_popup = Newspack_Popups_Model::retrieve_popup_by_id( $atts['id'], ! empty( Newspack_Popups_View_As::viewing_as_spec() ) );
+		if ( isset( $atts['id'] ) ) {
+			$found_popup = Newspack_Popups_Model::retrieve_popup_by_id( $atts['id'] );
 		}
 		if (
 			! $found_popup ||

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -37,3 +37,4 @@ define( 'IS_TEST_ENV', 1 );
 
 // Start up the WP testing environment.
 require $_tests_dir . '/includes/bootstrap.php';
+require dirname( dirname( __FILE__ ) ) . '/tests/wp-unittestcase-pagewithpopups.php';

--- a/tests/test-insertion.php
+++ b/tests/test-insertion.php
@@ -35,6 +35,32 @@ class InsertionTest extends WP_UnitTestCase_PageWithPopups {
 	}
 
 	/**
+	 * Shortcode handling.
+	 */
+	public function test_shortcode() {
+		$post_with_shortcode = '[newspack-popups id="' . self::$popup_id . '"]';
+		self::renderPost( '', $post_with_shortcode );
+		$popup_text_content = self::$dom_xpath->query( '//amp-layout' )->item( 0 )->textContent;
+
+		self::assertContains(
+			self::$popup_content,
+			$popup_text_content,
+			'Shortcode inserts the popup content.'
+		);
+		$amp_access_query = self::getAMPAccessQuery();
+		self::assertEquals(
+			count( $amp_access_query['popups'] ),
+			1,
+			'AMP access has one popup in the query.'
+		);
+		self::assertEquals(
+			$amp_access_query['popups'][0]->id,
+			'id_' . self::$popup_id,
+			'The popup id in the query matches the shortcoded popup id.'
+		);
+	}
+
+	/**
 	 * Tracking.
 	 */
 	public function test_insertion_analytics() {

--- a/tests/wp-unittestcase-pagewithpopups.php
+++ b/tests/wp-unittestcase-pagewithpopups.php
@@ -9,7 +9,6 @@
  * WP_UnitTestCase which renders a page with popups.
  */
 class WP_UnitTestCase_PageWithPopups extends WP_UnitTestCase {
-	protected static $post_id             = false; // phpcs:ignore Squiz.Commenting.VariableComment.Missing
 	protected static $popup_content       = 'The popup content.'; // phpcs:ignore Squiz.Commenting.VariableComment.Missing
 	protected static $popup_id            = false; // phpcs:ignore Squiz.Commenting.VariableComment.Missing
 	protected static $raw_post_content    = 'The post content.'; // phpcs:ignore Squiz.Commenting.VariableComment.Missing

--- a/tests/wp-unittestcase-pagewithpopups.php
+++ b/tests/wp-unittestcase-pagewithpopups.php
@@ -80,4 +80,18 @@ class WP_UnitTestCase_PageWithPopups extends WP_UnitTestCase {
 		@$post_head_dom->loadHTML( self::$post_head ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
 		self::$post_head_dom_xpath = new DOMXpath( $post_head_dom );
 	}
+
+	/**
+	 * Get the amp-access query.
+	 *
+	 * @return object amp-access query.
+	 */
+	protected function getAMPAccessQuery() {
+		$amp_access_content = json_decode( self::$post_head_dom_xpath->query( '//*[@id="amp-access"]' )->item( 0 )->textContent );
+		parse_str( wp_parse_url( $amp_access_content->authorization )['query'], $amp_access_query );
+		$amp_access_query['popups']   = json_decode( $amp_access_query['popups'] );
+		$amp_access_query['settings'] = json_decode( $amp_access_query['settings'] );
+		$amp_access_query['visit']    = json_decode( $amp_access_query['visit'] );
+		return $amp_access_query;
+	}
 }

--- a/tests/wp-unittestcase-pagewithpopups.php
+++ b/tests/wp-unittestcase-pagewithpopups.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Class for test
+ *
+ * @package Newspack_Popups
+ */
+
+/**
+ * WP_UnitTestCase which renders a page with popups.
+ */
+class WP_UnitTestCase_PageWithPopups extends WP_UnitTestCase {
+	protected static $post_id             = false; // phpcs:ignore Squiz.Commenting.VariableComment.Missing
+	protected static $popup_content       = 'The popup content.'; // phpcs:ignore Squiz.Commenting.VariableComment.Missing
+	protected static $popup_id            = false; // phpcs:ignore Squiz.Commenting.VariableComment.Missing
+	protected static $raw_post_content    = 'The post content.'; // phpcs:ignore Squiz.Commenting.VariableComment.Missing
+	protected static $post_content        = false; // phpcs:ignore Squiz.Commenting.VariableComment.Missing
+	protected static $post_head           = false; // phpcs:ignore Squiz.Commenting.VariableComment.Missing
+	protected static $dom_xpath           = false; // phpcs:ignore Squiz.Commenting.VariableComment.Missing
+	protected static $post_head_dom_xpath = false; // phpcs:ignore Squiz.Commenting.VariableComment.Missing
+
+	public function setUp() { // phpcs:ignore Squiz.Commenting.FunctionComment.Missing
+		// Remove any popups (from previous tests).
+		foreach ( Newspack_Popups_Model::retrieve_popups() as $popup ) {
+			wp_delete_post( $popup['id'] );
+		}
+
+		self::$post_id  = self::factory()->post->create(
+			[
+				'post_content' => self::$raw_post_content,
+			]
+		);
+		self::$popup_id = self::factory()->post->create(
+			[
+				'post_type'    => Newspack_Popups::NEWSPACK_POPUPS_CPT,
+				'post_title'   => 'Popup title',
+				'post_content' => self::$popup_content,
+			]
+		);
+
+		Newspack_Popups_Model::set_popup_options(
+			self::$popup_id,
+			[
+				'frequency'    => 'daily',
+				'dismiss_text' => Newspack_Popups::get_default_dismiss_text(),
+			]
+		);
+	}
+
+	/**
+	 * Trigger post rendering with popups in it.
+	 *
+	 * @param string      $url_query Query to append to URL.
+	 * @param null|string $content Raw string to render as post content.
+	 */
+	protected function renderPost( $url_query = '', $content = null ) {
+		// Navigate to post.
+		self::go_to( get_permalink( self::$post_id ) . '&' . $url_query );
+		global $wp_query, $post;
+		$wp_query->in_the_loop = true;
+		setup_postdata( $post );
+
+		// Reset internal duplicate-prevention.
+		Newspack_Popups_Inserter::$the_content_has_rendered = false;
+
+		if ( ! $content ) {
+			$content = get_post( self::$post_id )->post_content;
+		}
+
+		// Save post content.
+		self::$post_content = apply_filters( 'the_content', $content );
+		$dom                = new DomDocument();
+		@$dom->loadHTML( self::$post_content ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+		self::$dom_xpath = new DOMXpath( $dom );
+
+		// Save page head.
+		ob_start();
+		wp_head();
+		self::$post_head = ob_get_clean();
+		$post_head_dom   = new DomDocument();
+		@$post_head_dom->loadHTML( self::$post_head ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+		self::$post_head_dom_xpath = new DOMXpath( $post_head_dom );
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes two small bugs, refactors and adds tests.

### How to test the changes in this Pull Request:

1. On `master`,
2. Create two inline prompts at 0% scroll, "everyone" segment, then insert one of them using a shortcode in a post, right at the top.
3. Open Campaigns Wizard, preview the non-shortcoded prompt 
4. Issue 1. - Observe that the previewed prompt is rendered twice - in the shortcode spot and according to the inline placement rules
5. Load a page as non-admin, where some inline prompts, but none custom-placement prompts are rendered 
6. Issue 2. - Observe the payload in `GET /newspack-popups/api/campaigns/index.php` contains duplicated items in `popups` query var
7. Switch to this branch, observe both issues gone

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->