### PR TITLE
fix: when previewing "everyone" segment, show only prompts with no segments

### DIFF
--- a/api/campaigns/class-maybe-show-campaign.php
+++ b/api/campaigns/class-maybe-show-campaign.php
@@ -277,7 +277,7 @@ class Maybe_Show_Campaign extends Lightweight_API {
 				}
 
 				// Show prompts if the view_as segment doesn't exist.
-				if ( ! property_exists( $settings->all_segments, $view_as_spec['segment'] ) ) {
+				if ( 'everyone' !== $view_as_spec['segment'] && ! property_exists( $settings->all_segments, $view_as_spec['segment'] ) ) {
 					$should_display = true;
 				}
 			}

--- a/tests/test-api.php
+++ b/tests/test-api.php
@@ -1483,7 +1483,7 @@ class APITest extends WP_UnitTestCase {
 			[
 				'placement'           => 'inline',
 				'frequency'           => 'always',
-				'selected_segment_id' => '',
+				'selected_segment_id' => 'garbagio',
 			]
 		);
 
@@ -1494,6 +1494,35 @@ class APITest extends WP_UnitTestCase {
 		self::assertTrue(
 			self::$maybe_show_campaign->should_campaign_be_shown( self::$client_id, $test_popup['payload'], self::$settings, '', '', [ 'segment' => 'not-a-segment' ] ),
 			'Assert visible, a non-existent segment is disregarded.'
+		);
+	}
+
+	/**
+	 * View as a segment - "everyone" segment.
+	 */
+	public function test_view_as_segment_everyone() {
+		$test_popup_with_segment = self::create_test_popup(
+			[
+				'placement'           => 'inline',
+				'frequency'           => 'always',
+				'selected_segment_id' => self::$segment_ids['segmentFavCategory42'], // any segment.
+			]
+		);
+		$test_popup_everyone     = self::create_test_popup(
+			[
+				'placement'           => 'inline',
+				'frequency'           => 'always',
+				'selected_segment_id' => '',
+			]
+		);
+
+		self::assertFalse(
+			self::$maybe_show_campaign->should_campaign_be_shown( self::$client_id, $test_popup_with_segment['payload'], self::$settings, '', '', [ 'segment' => 'everyone' ] ),
+			'Assert prompt with a segment is not visible when previewing "everyone" segment.'
+		);
+		self::assertTrue(
+			self::$maybe_show_campaign->should_campaign_be_shown( self::$client_id, $test_popup_everyone['payload'], self::$settings, '', '', [ 'segment' => 'everyone' ] ),
+			'Assert prompt with no segment is visible when previewing "everyone" segment.'
 		);
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes previewing the "everyone" segment. When previewing "everyone", only prompts that are not assigned to any segments should be shown.

### How to test the changes in this Pull Request:

1. On `master`, create a few prompts that have no segment (thus appearing under "Everyone" in the Campaigns wizard), plus several prompts assigned to one or more segments.
2. Preview the "Everyone" segment. Observe that all prompts are shown in the preview.
3. Check out this branch and preview again.
4. This time, confirm that only prompts with no segment are displayed.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
