### PR TITLE
API: ignore crawler traffic

### DIFF
--- a/api/classes/class-lightweight-api.php
+++ b/api/classes/class-lightweight-api.php
@@ -45,6 +45,9 @@ class Lightweight_API {
 	 * @codeCoverageIgnore
 	 */
 	public function __construct() {
+		if ( $this->is_a_web_crawler() ) {
+			$this->error( 'invalid_referer' );
+		}
 		if ( ! $this->verify_referer() ) {
 			$this->error( 'invalid_referer' );
 		}
@@ -59,6 +62,33 @@ class Lightweight_API {
 			'end_time'               => null,
 			'duration'               => null,
 		];
+	}
+
+	/**
+	 * Is the request coming from a common web crawler?
+	 */
+	public function is_a_web_crawler() {
+		if ( ! isset( $_SERVER['HTTP_USER_AGENT'] ) ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__HTTP_USER_AGENT__
+			return false;
+		}
+		$user_agent = $_SERVER['HTTP_USER_AGENT']; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__HTTP_USER_AGENT__
+		// https://www.keycdn.com/blog/web-crawlers.
+		$common_web_crawlers_user_agents = [
+			'Googlebot',
+			'Bingbot',
+			'Slurp',
+			'DuckDuckBot',
+			'Baiduspider',
+			'YandexBot',
+			'facebot',
+			'ia_archiver',
+		];
+		foreach ( $common_web_crawlers_user_agents as $crawler_agent ) {
+			if ( stristr( $user_agent, $crawler_agent ) ) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	/**

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -547,7 +547,7 @@ final class Newspack_Popups {
 			<div class="notice notice-error">
 				<p>
 					<?php _e( 'Newspack Campaigns requires a custom configuration file, which is missing. Please create this file following instructions found ', 'newspack-popups' ); ?>
-					<a href="https://github.com/Automattic/newspack-popups/blob/master/api/README.md">
+					<a href="https://github.com/Automattic/newspack-popups/blob/master/README.md#config-file">
 						<?php _e( 'here.', 'newspack-popups' ); ?>
 					</a>
 				</p>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -24,6 +24,7 @@ require_once $_tests_dir . '/includes/functions.php';
  */
 function _manually_load_plugin() {
 	$_SERVER['HTTP_REFERER'] = 'https://' . $_SERVER['HTTP_HOST']; // phpcs:ignore
+	$_SERVER['HTTP_USER_AGENT'] = 'Mozilla\/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/89.0.4389.90 Safari\/537.36'; // phpcs:ignore
 
 	require dirname( dirname( __FILE__ ) ) . '/newspack-popups.php';
 	require dirname( dirname( __FILE__ ) ) . '/src/blocks/custom-placement/view.php';

--- a/tests/test-api.php
+++ b/tests/test-api.php
@@ -1557,4 +1557,21 @@ class APITest extends WP_UnitTestCase {
 			'Returns null if segment is missing.'
 		);
 	}
+
+	/**
+	 * Discarding bot traffic.
+	 */
+	public function test_discard_bot_traffic() {
+		$api = new Lightweight_API();
+
+		self::assertFalse(
+			$api->is_a_web_crawler(),
+			'Returns false if the user agent is not of a web crawler.'
+		);
+		$_SERVER['HTTP_USER_AGENT'] = 'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)'; // phpcs:ignore
+		self::assertTrue(
+			$api->is_a_web_crawler(),
+			'Return true if the user agent is of a web crawler.'
+		);
+	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Ignores requests made by commonly known web crawlers in the API.

### How to test the changes in this Pull Request:

1. Verify the API works for regular requests made from a web browser
2. Set up Google Search Console w/ the site (e.g. by setting up Site Kit plugin)
2. Take note of the row count in the transients and events table*
3. Submit a URL of a post (on which prompts are displayed) to the URL inspection in Search Console UI
4. Wait for it to be crawled by Google** 
5. Verify that the row counts in the tables did not increase

\* `$ wp db query "select count(*) from wp_newspack_campaigns_transients"`, `$ wp db query "select count(*) from wp_newspack_campaigns_events"`
\** In my testing I've seen that Google hit my site after a few minutes (by means of an `error_log`ing the user agent in API), but it did not show up in the Search Console UI 🤷‍♀️

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->