### PR TITLE
Fixes: drafts previews, segmentation orderiing

### DIFF
--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -459,6 +459,19 @@ final class Newspack_Popups_Inserter {
 			$shortcoded_popups,
 			$custom_placement_popups
 		);
+		// Sort the array, so the segmented popups come first. This is necessary for proper
+		// prioritisation of single-popup placements (e.g. above header).
+		uasort(
+			$popups,
+			function( $popup_a, $popup_b ) {
+				$a_has_segments = ! empty( $popup_a['options']['selected_segment_id'] );
+				$b_has_segments = ! empty( $popup_b['options']['selected_segment_id'] );
+				if ( $a_has_segments && $b_has_segments ) {
+					return 0;
+				}
+				return $a_has_segments && false === $b_has_segments ? -1 : 1;
+			}
+		);
 
 		// "Escape hatch" if there's a need to block adding amp-access for pages that have no prompts.
 		if ( apply_filters( 'newspack_popups_suppress_insert_amp_access', false, $popups ) ) {

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -344,7 +344,8 @@ final class Newspack_Popups_Inserter {
 	 */
 	public static function popup_shortcode( $atts = array() ) {
 		if ( isset( $atts['id'] ) ) {
-			$found_popup = Newspack_Popups_Model::retrieve_popup_by_id( $atts['id'] );
+			$include_unpublished = Newspack_Popups::is_preview_request();
+			$found_popup         = Newspack_Popups_Model::retrieve_popup_by_id( $atts['id'], $include_unpublished );
 		}
 		if (
 			! $found_popup ||

--- a/tests/test-insertion.php
+++ b/tests/test-insertion.php
@@ -229,4 +229,39 @@ class InsertionTest extends WP_UnitTestCase_PageWithPopups {
 			'Includes the popup content when the tags match.'
 		);
 	}
+
+	/**
+	 * Shortcode handling.
+	 */
+	public function test_amp_access_ordering() {
+		$segments           = Newspack_Popups_Segmentation::create_segment(
+			[
+				'name'          => 'Some Segment',
+				'configuration' => [],
+			]
+		);
+		$segmented_popup_id = self::createPopup();
+		Newspack_Popups_Model::set_popup_options(
+			$segmented_popup_id,
+			[
+				'selected_segment_id' => $segments[0]['id'],
+			]
+		);
+		sleep( 1 ); // Ensure the another popup has the most newest date.
+		$another_popup_id = self::createPopup();
+
+		self::renderPost();
+		$amp_access_query  = self::getAMPAccessQuery();
+		$popup_ids_ordered = array_map(
+			function( $item ) {
+				return $item->id;
+			}, 
+			$amp_access_query['popups']
+		);
+		self::assertEquals(
+			$popup_ids_ordered,
+			[ 'id_' . $segmented_popup_id, 'id_' . self::$popup_id, 'id_' . $another_popup_id ],
+			'The popup with the segment comes first in the array.'
+		);
+	}
 }

--- a/tests/wp-unittestcase-pagewithpopups.php
+++ b/tests/wp-unittestcase-pagewithpopups.php
@@ -23,19 +23,28 @@ class WP_UnitTestCase_PageWithPopups extends WP_UnitTestCase {
 			wp_delete_post( $popup['id'] );
 		}
 
-		self::$popup_id = self::factory()->post->create(
-			[
-				'post_type'    => Newspack_Popups::NEWSPACK_POPUPS_CPT,
-				'post_title'   => 'Popup title',
-				'post_content' => self::$popup_content,
-			]
-		);
+		self::$popup_id = self::createPopup();
 
 		Newspack_Popups_Model::set_popup_options(
 			self::$popup_id,
 			[
 				'frequency'    => 'daily',
 				'dismiss_text' => Newspack_Popups::get_default_dismiss_text(),
+			]
+		);
+	}
+
+	/**
+	 * Create a popup in the database.
+	 *
+	 * @return int Popup ID.
+	 */
+	protected function createPopup() {
+		return self::factory()->post->create(
+			[
+				'post_type'    => Newspack_Popups::NEWSPACK_POPUPS_CPT,
+				'post_title'   => 'Popup title',
+				'post_content' => self::$popup_content,
 			]
 		);
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes two unrelated bugs.

### How to test the changes in this Pull Request:

1. On `master`,
2. Preview a draft inline prompt, observe that it's not shown neither in segment, nor single prompt previews
3. Create two above-header prompts: firstly (it has to be published earlier) one with segment assigned, then one without
4. Visit the site in incognito as the segment member - observe the non-segmented prompt displayed instead of the segmented one
5. Switch to this branch, observe the issues are gone

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->