### PR TITLE
Fix tag criterion

### DIFF
--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -660,21 +660,15 @@ final class Newspack_Popups_Inserter {
 	 * @return bool Should popup be shown based on tags it has.
 	 */
 	public static function assess_tags_filter( $popup ) {
-		$post_tags = get_the_tags();
-		if ( false === $post_tags ) {
-			$post_tags = [];
-		}
 		$popup_tags = get_the_tags( $popup['id'] );
 		if ( false === $popup_tags ) {
-			$popup_tags = [];
+			return true; // No tags on the popup, no need to compare.
 		}
-		if ( count( $post_tags ) || count( $popup_tags ) ) {
-			return array_intersect(
-				array_column( $post_tags, 'term_id' ),
-				array_column( $popup_tags, 'term_id' )
-			);
-		}
-		return true;
+		$post_tags = get_the_tags();
+		return array_intersect(
+			array_column( $post_tags ? $post_tags : [], 'term_id' ),
+			array_column( $popup_tags, 'term_id' )
+		);
 	}
 
 	/**

--- a/tests/test-insertion.php
+++ b/tests/test-insertion.php
@@ -178,6 +178,13 @@ class InsertionTest extends WP_UnitTestCase_PageWithPopups {
 	 * Category criterion.
 	 */
 	public function test_category_criterion() {
+		self::renderPost();
+		self::assertContains(
+			self::$popup_content,
+			self::$post_content,
+			'Does include the popup content if neither post nor popup have a category.'
+		);
+
 		$category_id = $this->factory->term->create(
 			[
 				'name'     => 'Events',
@@ -206,23 +213,52 @@ class InsertionTest extends WP_UnitTestCase_PageWithPopups {
 	 * Tag criterion.
 	 */
 	public function test_tag_criterion() {
-		$tag_id = $this->factory->term->create(
+		self::renderPost();
+		self::assertContains(
+			self::$popup_content,
+			self::$post_content,
+			'Does include the popup content if neither post nor popup have tags.'
+		);
+
+		$tag_1_id = $this->factory->term->create(
 			[
 				'name'     => 'Featured',
 				'taxonomy' => 'post_tag',
 				'slug'     => 'featured',
 			]
 		);
-		wp_set_post_terms( self::$popup_id, [ $tag_id ], 'post_tag' );
+		self::renderPost( '', null, [], [ $tag_1_id ] );
+		self::assertContains(
+			self::$popup_content,
+			self::$post_content,
+			'Includes the popup content when popup does not have tags, but post has.'
+		);
+
+		// Set tag on the popup.
+		wp_set_post_terms( self::$popup_id, [ $tag_1_id ], 'post_tag' );
 
 		self::renderPost();
 		self::assertNotContains(
 			self::$popup_content,
 			self::$post_content,
-			'Does not include the popup content, since the post tag does not match.'
+			'Does not include the popup content when the post has no tags, but popup has.'
 		);
 
-		self::renderPost( '', null, [], [ $tag_id ] );
+		$tag_2_id = $this->factory->term->create(
+			[
+				'name'     => 'Events',
+				'taxonomy' => 'post_tag',
+				'slug'     => 'events',
+			]
+		);
+		self::renderPost( '', null, [], [ $tag_2_id ] );
+		self::assertNotContains(
+			self::$popup_content,
+			self::$post_content,
+			'Does not include the popup content when the post tag has a different tag than the popup.'
+		);
+
+		self::renderPost( '', null, [], [ $tag_1_id ] );
 		self::assertContains(
 			self::$popup_content,
 			self::$post_content,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a regression introduced in #506 

### How to test the changes in this Pull Request:

1. On `master`,
2. Create a post with a tag and an inline prompt with no tags assigned
3. Observe the prompt is not displayed on the post
4. Switch to this branch, observe the prompt is displayed
5. Assign a different tag to the prompt, observe it's now not displayed (since tags don't match)
6. Assign the post's tag to the prompt, observe the prompt is displayed

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->