### PR TITLE
refactor: combine tags/category filtering methods into one

### DIFF
--- a/api/classes/class-lightweight-api.php
+++ b/api/classes/class-lightweight-api.php
@@ -150,6 +150,11 @@ class Lightweight_API {
 	 * @param string $code The error code.
 	 */
 	public function error( $code ) {
+		// Exiting in test env would report the test as passed.
+		if ( defined( 'IS_TEST_ENV' ) && IS_TEST_ENV ) {
+			return;
+		}
+
 		http_response_code( 400 );
 		print json_encode( [ 'error' => $code ] ); // phpcs:ignore
 		exit;

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -653,8 +653,6 @@ final class Newspack_Popups_Inserter {
 			array_column( $post_terms ? $post_terms : [], 'term_id' ),
 			array_column( $popup_terms, 'term_id' )
 		);
-
-		return true;
 	}
 
 	/**

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -644,7 +644,7 @@ final class Newspack_Popups_Inserter {
 	 * @return bool Whether the prompt should be shown based on matching terms.
 	 */
 	public static function assess_taxonomy_filter( $popup, $taxonomy = 'category' ) {
-		$post_terms  = get_the_terms( $post_id, $taxonomy );
+		$post_terms  = get_the_terms( get_the_ID(), $taxonomy );
 		$popup_terms = get_the_terms( $popup['id'], $taxonomy );
 
 		if ( $post_terms && count( $post_terms ) && $popup_terms && count( $popup_terms ) ) {

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -635,7 +635,7 @@ final class Newspack_Popups_Inserter {
 	}
 
 	/**
-	 * If a prompt is assigned the given term, it should only be shown on posts/pages with at least one matching term.
+	 * If a prompt is assigned the given taxonomy, it should only be shown on posts/pages with at least one matching term.
 	 * If the prompt has no terms, it should be shown regardless of the post's terms.
 	 *
 	 * @param object $popup The prompt to assess.

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -635,40 +635,26 @@ final class Newspack_Popups_Inserter {
 	}
 
 	/**
-	 * If Pop-up has categories, it should only be shown on posts/pages with those.
+	 * If a prompt is assigned the given term, it should only be shown on posts/pages with at least one matching term.
+	 * If the prompt has no terms, it should be shown regardless of the post's terms.
 	 *
-	 * @param object $popup The popup to assess.
-	 * @return bool Should popup be shown based on categories it has.
+	 * @param object $popup The prompt to assess.
+	 * @param string $taxonomy The type of taxonomy to match.
+	 *
+	 * @return bool Whether the prompt should be shown based on matching terms.
 	 */
-	public static function assess_categories_filter( $popup ) {
-		$post_categories  = get_the_category();
-		$popup_categories = get_the_category( $popup['id'] );
+	public static function assess_taxonomy_filter( $popup, $taxonomy = 'category' ) {
+		$post_terms  = get_the_terms( $post_id, $taxonomy );
+		$popup_terms = get_the_terms( $popup['id'], $taxonomy );
 
-		if ( $post_categories && count( $post_categories ) && $popup_categories && count( $popup_categories ) ) {
+		if ( $post_terms && count( $post_terms ) && $popup_terms && count( $popup_terms ) ) {
 			return array_intersect(
-				array_column( $post_categories, 'term_id' ),
-				array_column( $popup_categories, 'term_id' )
+				array_column( $post_terms, 'term_id' ),
+				array_column( $popup_terms, 'term_id' )
 			);
 		}
-		return true;
-	}
 
-	/**
-	 * If Pop-up has tags, it should only be shown on posts/pages with those.
-	 *
-	 * @param object $popup The popup to assess.
-	 * @return bool Should popup be shown based on tags it has.
-	 */
-	public static function assess_tags_filter( $popup ) {
-		$popup_tags = get_the_tags( $popup['id'] );
-		if ( false === $popup_tags ) {
-			return true; // No tags on the popup, no need to compare.
-		}
-		$post_tags = get_the_tags();
-		return array_intersect(
-			array_column( $post_tags ? $post_tags : [], 'term_id' ),
-			array_column( $popup_tags, 'term_id' )
-		);
+		return true;
 	}
 
 	/**
@@ -700,8 +686,8 @@ final class Newspack_Popups_Inserter {
 			return true;
 		}
 		return self::assess_is_post( $popup ) &&
-			self::assess_categories_filter( $popup ) &&
-			self::assess_tags_filter( $popup );
+			self::assess_taxonomy_filter( $popup, 'category' ) &&
+			self::assess_taxonomy_filter( $popup, 'post_tag' );
 	}
 
 	/**

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -644,15 +644,15 @@ final class Newspack_Popups_Inserter {
 	 * @return bool Whether the prompt should be shown based on matching terms.
 	 */
 	public static function assess_taxonomy_filter( $popup, $taxonomy = 'category' ) {
-		$post_terms  = get_the_terms( get_the_ID(), $taxonomy );
 		$popup_terms = get_the_terms( $popup['id'], $taxonomy );
-
-		if ( $post_terms && count( $post_terms ) && $popup_terms && count( $popup_terms ) ) {
-			return array_intersect(
-				array_column( $post_terms, 'term_id' ),
-				array_column( $popup_terms, 'term_id' )
-			);
+		if ( false === $popup_terms ) {
+			return true; // No terms on the popup, no need to compare.
 		}
+		$post_terms = get_the_terms( get_the_ID(), $taxonomy );
+		return array_intersect(
+			array_column( $post_terms ? $post_terms : [], 'term_id' ),
+			array_column( $popup_terms, 'term_id' )
+		);
 
 		return true;
 	}

--- a/tests/test-insertion.php
+++ b/tests/test-insertion.php
@@ -177,7 +177,7 @@ class InsertionTest extends WP_UnitTestCase_PageWithPopups {
 	/**
 	 * Category criterion.
 	 */
-	public function test_category_criterion() {
+	public function test_criterion_category() {
 		self::renderPost();
 		self::assertContains(
 			self::$popup_content,
@@ -185,34 +185,56 @@ class InsertionTest extends WP_UnitTestCase_PageWithPopups {
 			'Does include the popup content if neither post nor popup have a category.'
 		);
 
-		$category_id = $this->factory->term->create(
+		$category_1_id = $this->factory->term->create(
 			[
 				'name'     => 'Events',
 				'taxonomy' => 'category',
 				'slug'     => 'events',
 			]
 		);
-		wp_set_post_terms( self::$popup_id, [ $category_id ], 'category' );
+
+		self::renderPost( '', null, [ $category_1_id ] );
+		self::assertContains(
+			self::$popup_content,
+			self::$post_content,
+			'Includes the popup content when the popup does not have a category, but post has.'
+		);
+
+		wp_set_post_terms( self::$popup_id, [ $category_1_id ], 'category' );
 
 		self::renderPost();
 		self::assertNotContains(
 			self::$popup_content,
 			self::$post_content,
-			'Does not include the popup content, since the post category does not match.'
+			'Does not include the popup content when popup does have a category, but post does not.'
 		);
 
-		self::renderPost( '', null, [ $category_id ] );
+		self::renderPost( '', null, [ $category_1_id ] );
 		self::assertContains(
 			self::$popup_content,
 			self::$post_content,
 			'Includes the popup content when the categories match.'
+		);
+
+		$category_2_id = $this->factory->term->create(
+			[
+				'name'     => 'Health',
+				'taxonomy' => 'category',
+				'slug'     => 'health',
+			]
+		);
+		self::renderPost( '', null, [ $category_2_id ] );
+		self::assertNotContains(
+			self::$popup_content,
+			self::$post_content,
+			'Does not include the popup content when popup and post have different categories.'
 		);
 	}
 
 	/**
 	 * Tag criterion.
 	 */
-	public function test_tag_criterion() {
+	public function test_criterion_tag() {
 		self::renderPost();
 		self::assertContains(
 			self::$popup_content,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Inspired by https://github.com/Automattic/newspack-popups/pull/515#discussion_r609913318. I felt that because the category and tag filtering should behave the same way, they should share the same logic and method. This PR combines the methods that compare post and prompt categories and tags into a single method that takes a second `$taxonomy` arg (defaulting to category). Just seemed like one tiny thing we could do to reduce the mental load when troubleshooting prompt display logic.

### How to test the changes in this Pull Request:

This is a pure refactor, so the behavior shouldn't differ at all from `master`. Test that prompts with and without categories and tags display as expected on posts with and without matching categories and tags.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
