### PR TITLE
feat: handle classic content for inline prompt insertion

### DIFF
--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -300,6 +300,7 @@ final class Newspack_Popups_Inserter {
 					$last_position = $position;
 				}
 
+				$pos += strlen( $classic_content );
 				continue;
 			}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds special handling for "Classic Content" blocks when it comes to inline prompt insertion. Instead of treating the entire block as a single block, like other blocks, we now break up the Classic Content string by block-level HTML elements (`</p>`, `</ul>`, `</ol>`, etc.—not [every single one](https://developer.mozilla.org/en-US/docs/Web/HTML/Block-level_elements), but the main ones I think make sense to insert prompts before or after) and insert prompts between those elements. Should work whether the Classic Content block is the only block in a post, or if it's mixed with other blocks.

The insertion approach is inspired by the logic in the Super Cool Ad Inserter plugin, but simplified since we already have handling for short content, lots of prompts, etc. It also looks for various block-level elements, not just paragraphs.

This change should ensure that prompts get inserted in a more logical fashion on imported or legacy content that hasn't been (or can't be) converted to Gutenberg blocks.

Closes #520.

### How to test the changes in this Pull Request:

1. Create at least two posts containing Classic Content blocks, each containing a mix of different HTML content. In one post, ensure that the Classic Content block is the only block in the post; in the other, make sure it's interspersed with blocks of other types containing content as well.
2. Also publish several inline prompts at different insertion points—try 25%, 50%, and 75%.
3. On `master`, in an incognito session, observe that the prompts are inserted around the Classic Content blocks as if they're single blocks, regardless of the classic content length—so in posts that only contain Classic Content, all prompts will appear at the top of the post.
4. Check out this branch, refresh the posts. Confirm that the prompts are now inserted within the Classic Content blocks' content at more or less the expected positions, and that the Classic Content rendered on the front-end matches what's in the editor.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
