### PR TITLE
Fix: empty blocks handling

### DIFF
--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -213,7 +213,7 @@ final class Newspack_Popups_Inserter {
 
 		foreach ( $parsed_blocks as $block ) {
 			if ( ! in_array( $block['blockName'], $blacklisted_blocks ) ) {
-				$is_classic_block = null === $block['blockName']; // Classic block doesn't have a block name.
+				$is_classic_block = null === $block['blockName'] || 'core/freeform' === $block['blockName']; // Classic block doesn't have a block name.
 				$block_content    = $is_classic_block ? force_balance_tags( wpautop( $block['innerHTML'] ) ) : $block['innerHTML'];
 				$total_length    += strlen( wp_strip_all_tags( $block_content ) );
 			} else {

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -251,9 +251,12 @@ final class Newspack_Popups_Inserter {
 			// Classic block content: insert prompts between block-level HTML elements.
 			if ( $is_classic_block ) {
 				$classic_content = force_balance_tags( wpautop( $block['innerHTML'] ) ); // Ensure we have paragraph tags and valid HTML.
-				$positions       = [];
-				$last_position   = -1;
-				$block_endings   = [ // Block-level elements eligble for prompt insertion.
+				if ( 0 === strlen( wp_strip_all_tags( $classic_content ) ) ) {
+					continue;
+				}
+				$positions     = [];
+				$last_position = -1;
+				$block_endings = [ // Block-level elements eligble for prompt insertion.
 					'</p>',
 					'</ol>',
 					'</ul>',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a small issue.

It looks like the Group or Columns blocks are inserting an empty block somewhere, which gets picked up as the classic block in the insertion logic.

### How to test the changes in this Pull Request:

0. On `master`
1. Create a post with the following content: a Group, with Columns, a single Column inside, and a Heading in the Column
2. Ensure some inline prompts are inserted in the post
3. Observe and error (when in WP debug mode) shown on the front-end about `Offset not contained in string`
4. Switch to this branch, observe no error shown

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->