### PR TITLE
Fix: interaction of above-header prompts in non-AMP mode

### DIFF
--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -792,7 +792,7 @@ final class Newspack_Popups_Model {
 		$dismiss_text           = $popup['options']['dismiss_text'];
 		$dismiss_text_alignment = $popup['options']['dismiss_text_alignment'];
 		$is_newsletter_prompt   = self::has_newsletter_prompt( $popup );
-		$classes                = [];
+		$classes                = [ 'newspack-popup' ];
 		$classes[]              = 'above_header' === $popup['options']['placement'] ? 'newspack-above-header-popup' : null;
 		$classes[]              = ! self::is_above_header( $popup ) ? 'newspack-inline-popup' : null;
 		$classes[]              = 'publish' !== $popup['status'] ? 'newspack-inactive-popup-status' : null;
@@ -868,7 +868,7 @@ final class Newspack_Popups_Model {
 		$overlay_color          = $popup['options']['overlay_color'];
 		$hidden_fields          = self::get_hidden_fields( $popup );
 		$is_newsletter_prompt   = self::has_newsletter_prompt( $popup );
-		$classes                = array( 'newspack-lightbox', 'newspack-lightbox-placement-' . $popup['options']['placement'] );
+		$classes                = array( 'newspack-lightbox', 'newspack-popup', 'newspack-lightbox-placement-' . $popup['options']['placement'] );
 		$classes[]              = ( ! empty( $popup['title'] ) && $display_title ) ? 'newspack-lightbox-has-title' : null;
 		$classes[]              = $hide_border ? 'newspack-lightbox-no-border' : null;
 		$classes[]              = $is_newsletter_prompt ? 'newspack-newsletter-prompt-overlay' : null;

--- a/src/view/index.js
+++ b/src/view/index.js
@@ -181,11 +181,8 @@ if ( typeof window !== 'undefined' ) {
 		// But don't manage analytics events until the client ID is available.
 		waitUntil( getClientIDValue, manageAnalyticsEvents );
 
-		const campaignArray = [
-			...document.querySelectorAll( '.newspack-lightbox' ),
-			...document.querySelectorAll( '.newspack-inline-popup' ),
-		];
-		campaignArray.forEach( campaign => {
+		const popupsElements = [ ...document.querySelectorAll( '.newspack-popup' ) ];
+		popupsElements.forEach( campaign => {
 			manageForms( campaign );
 		} );
 	} );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a bug.
Ensures all prompt elements have a `newspack-popup` CSS class for unified targeting.

### How to test the changes in this Pull Request:

1. On `master`, create an above-header prompt
2. View site in non-AMP mode, dismiss the prompt
3. Observe the page reloads, with the prompt still there
4. Switch to this branch, dismiss the prompt - observe the page does not reload and the prompt does not show up again

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->