### PR TITLE
Analytics: revert event encoding

### DIFF
--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -583,17 +583,6 @@ final class Newspack_Popups_Model {
 	}
 
 	/**
-	 * Encode event name to be sent to GA.
-	 *
-	 * @param string $popup_id The popup ID.
-	 * @param int    $event_code The event code.
-	 * @return string Encoded event name.
-	 */
-	private static function encode_event_name( $popup_id, $event_code ) {
-		return $popup_id . $event_code;
-	}
-
-	/**
 	 * Get a shortest possible CSS class name for a form element.
 	 *
 	 * @param string $type Type of the form.
@@ -621,7 +610,8 @@ final class Newspack_Popups_Model {
 		}
 
 		$popup_id       = $popup['id'];
-		$event_category = 'NC';
+		$event_category = 'Newspack Announcement';
+		$event_label    = $popup['title'] . ' [' . $popup['options']['placement'] . '] (' . $popup_id . ')';
 
 		$has_link                = preg_match( '/<a\s/', $body ) !== 0;
 		$has_form                = preg_match( '/<form\s/', $body ) !== 0;
@@ -630,19 +620,15 @@ final class Newspack_Popups_Model {
 
 		$analytics_events = [
 			[
-				'id'              => self::get_uniqid(),
 				'on'              => 'ini-load',
 				'element'         => '#' . esc_attr( $element_id ),
-				'event_name'      => self::encode_event_name( $popup_id, 0 ), // Load.
-				'event_category'  => esc_attr( $event_category ),
+				'event_name'      => __( 'Load', 'newspack-popups' ),
 				'non_interaction' => true,
 			],
 			[
-				'id'              => self::get_uniqid(),
 				'on'              => 'visible',
 				'element'         => '#' . esc_attr( $element_id ),
-				'event_name'      => self::encode_event_name( $popup_id, 1 ), // Seen.
-				'event_category'  => esc_attr( $event_category ),
+				'event_name'      => __( 'Seen', 'newspack-popups' ),
 				'non_interaction' => true,
 				'visibilitySpec'  => [
 					'totalTimeMin' => 500,
@@ -652,46 +638,44 @@ final class Newspack_Popups_Model {
 
 		if ( $has_link ) {
 			$analytics_events[] = [
-				'id'             => self::get_uniqid(),
-				'on'             => 'click',
-				'element'        => '#' . esc_attr( $element_id ) . ' a',
-				'amp_element'    => '#' . esc_attr( $element_id ) . ' a',
-				'event_name'     => self::encode_event_name( $popup_id, 2 ), // Link Click.
-				'event_category' => esc_attr( $event_category ),
+				'on'          => 'click',
+				'element'     => '#' . esc_attr( $element_id ) . ' a',
+				'amp_element' => '#' . esc_attr( $element_id ) . ' a',
+				'event_name'  => __( 'Link Click', 'newspack-popups' ),
 			];
 		}
 
 		if ( $has_form ) {
 			$analytics_events[] = [
-				'id'             => self::get_uniqid(),
-				'amp_on'         => 'amp-form-submit-success',
-				'on'             => 'submit',
-				'element'        => 'form:not(.' . self::get_form_class( 'action', $element_id ) . ')',
-				'event_name'     => self::encode_event_name( $popup_id, 3 ), // Form Submission.
-				'event_category' => esc_attr( $event_category ),
+				'amp_on'     => 'amp-form-submit-success',
+				'on'         => 'submit',
+				'element'    => 'form:not(.' . self::get_form_class( 'action', $element_id ) . ')',
+				'event_name' => __( 'Form Submission', 'newspack-popups' ),
 			];
 		}
 		if ( $has_dismiss_form ) {
 			$analytics_events[] = [
-				'id'              => self::get_uniqid(),
 				'amp_on'          => 'amp-form-submit-success',
 				'on'              => 'submit',
 				'element'         => '.' . self::get_form_class( 'dismiss', $element_id ),
-				'event_name'      => self::encode_event_name( $popup_id, 4 ), // Dismissal.
-				'event_category'  => esc_attr( $event_category ),
+				'event_name'      => __( 'Dismissal', 'newspack-popups' ),
 				'non_interaction' => true,
 			];
 		}
 		if ( $has_not_interested_form ) {
 			$analytics_events[] = [
-				'id'              => self::get_uniqid(),
 				'amp_on'          => 'amp-form-submit-success',
 				'on'              => 'submit',
 				'element'         => '.' . self::get_form_class( 'not-interested', $element_id ),
-				'event_name'      => self::encode_event_name( $popup_id, 5 ), // Permanent Dismissal.
-				'event_category'  => esc_attr( $event_category ),
+				'event_name'      => __( 'Permanent Dismissal', 'newspack-popups' ),
 				'non_interaction' => true,
 			];
+		}
+
+		foreach ( $analytics_events as &$event ) {
+			$event['id']             = self::get_uniqid();
+			$event['event_category'] = esc_attr( $event_category );
+			$event['event_label']    = esc_attr( $event_label );
 		}
 
 		return $analytics_events;

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -609,9 +609,10 @@ final class Newspack_Popups_Model {
 			return [];
 		}
 
-		$popup_id       = $popup['id'];
-		$event_category = 'Newspack Announcement';
-		$event_label    = $popup['title'] . ' [' . $popup['options']['placement'] . '] (' . $popup_id . ')';
+		$popup_id            = $popup['id'];
+		$event_category      = 'Newspack Announcement';
+		$formatted_placement = ucwords( str_replace( '_', ' ', $popup['options']['placement'] ) );
+		$event_label         = $formatted_placement . ': ' . $popup['title'] . ' (' . $popup_id . ')';
 
 		$has_link                = preg_match( '/<a\s/', $body ) !== 0;
 		$has_form                = preg_match( '/<form\s/', $body ) !== 0;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

#497 introduced event encoding to make the GA config size smaller. With changes in https://github.com/Automattic/newspack-plugin/pull/944, this is no longer necessary. On top of that, prompt placement is added to the event label.

### How to test the changes in this Pull Request:

1. Use `feat/ga-amp-config-batching` (https://github.com/Automattic/newspack-plugin/pull/944) branch of Newspack Plugin
2. Load a page with some prompts, observe* GA custom events being sent with `Newspack Announcements` category, `<prompt-position>: <prompt-title> (<prompt-post-id>)` label (e.g. `Inline: Newletters CTA (42)`), and a human-readable name
3. After a day, observe these events showing up properly in Newspack plugin's Campaigns Analytics screen

\* to view GA reporting calls, filter the requests in the Network devtools tab by `collect`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->