### PR TITLE
fix: bump query limit up to 100 for eligible prompts

### DIFF
--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -152,11 +152,11 @@ final class Newspack_Popups_Model {
 	}
 
 	/**
-	 * Retrieve all overlay popups.
+	 * Retrieve all popups eligible to be programmatically inserted (not shortcoded or custom placement).
 	 *
 	 * @param  boolean     $include_unpublished Whether to include unpublished prompts.
 	 * @param  int|boolean $campaign_id Campaign term ID, or false to ignore campaign.
-	 * @return array Overlay popup objects.
+	 * @return array Eligible popup objects.
 	 */
 	public static function retrieve_eligible_popups( $include_unpublished = false, $campaign_id = false ) {
 		$valid_placements = array_merge(

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -164,12 +164,13 @@ final class Newspack_Popups_Model {
 			self::$inline_placements
 		);
 		$args             = [
-			'post_type'    => Newspack_Popups::NEWSPACK_POPUPS_CPT,
-			'post_status'  => $include_unpublished ? [ 'draft', 'pending', 'future', 'publish' ] : 'publish',
-			'meta_key'     => 'placement',
+			'post_type'      => Newspack_Popups::NEWSPACK_POPUPS_CPT,
+			'post_status'    => $include_unpublished ? [ 'draft', 'pending', 'future', 'publish' ] : 'publish',
+			'posts_per_page' => 100,
+			'meta_key'       => 'placement',
 			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
-			'meta_value'   => $valid_placements,
-			'meta_compare' => 'IN',
+			'meta_value'     => $valid_placements,
+			'meta_compare'   => 'IN',
 		];
 
 		// If previewing specific campaign.

--- a/tests/test-api.php
+++ b/tests/test-api.php
@@ -1619,4 +1619,29 @@ class APITest extends WP_UnitTestCase {
 			'Return true if the user agent is of a web crawler.'
 		);
 	}
+
+	/**
+	 * Test prompt retrieval with a lot of prompts.
+	 */
+	public function test_many_prompts() {
+		$number_of_prompts_to_display = 100;
+		$current_index                = 0;
+		$test_popups                  = [];
+
+		while ( $current_index < $number_of_prompts_to_display ) {
+			$test_popups[] = self::create_test_popup(
+				[
+					'placement' => 'inline',
+					'frequency' => 'always',
+				]
+			);
+
+			$current_index ++;
+		}
+
+		self::assertTrue(
+			count( Newspack_Popups_Model::retrieve_eligible_popups() ) === $number_of_prompts_to_display,
+			'Can retrieve up to 100 prompts at once.'
+		);
+	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a bug discovered while testing https://github.com/Automattic/newspack-plugin/pull/944, which limits the number of non-shortcoded and non-custom-placement posts checked against `amp-access` to 10. This fix bumps that limit up to 100, which should give sites a lot more headroom.

### How to test the changes in this Pull Request:

1. On `master`, publish a lot of prompts to "Everyone" or an easily matched segment—at least ~15 of all types (inline, overlay, above-header) which will be programmatically inserted and should be displayed together. Additionally, publish a couple of shortcoded and custom placement prompts and insert into a post.
2. View the post in a new incognito session. Observe that only 10 of the programmatically inserted prompts are displayed, plus the shortcoded and custom placement prompts.
  - If you inspect the DOM and search for `<amp-layout`, you'll see that all prompts are inserted as expected.
  - If you inspect the Network Requests tab and filter by `api/campaigns`, you'll see that the AMP Access request only contains 10 programmatically inserted prompts + shortcoded prompts + custom placement prompts, meaning only those will be potentially displayed.
3. Check out this branch, view the page again in a new session.
4. This time, observe that all prompts are displayed as expected.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
