### PR TITLE
fix: use filter to decide which post types to insert ads into content

### DIFF
--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -170,11 +170,9 @@ final class Newspack_Popups_Inserter {
 			return $content;
 		}
 
-		$post_type = get_post_type();
-
 		// If the current post isn't an allowed post type, ignore.
 		if ( ! in_array(
-			$post_type,
+			get_post_type(),
 			apply_filters(
 				'newspack_campaigns_post_types_for_campaigns',
 				[ 'post', 'page' ]

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -170,8 +170,16 @@ final class Newspack_Popups_Inserter {
 			return $content;
 		}
 
-		// If the current post is a popup, ignore.
-		if ( Newspack_Popups::NEWSPACK_POPUPS_CPT == get_post_type() ) {
+		$post_type = get_post_type();
+
+		// If the current post isn't an allowed post type, ignore.
+		if ( ! in_array(
+			$post_type,
+			apply_filters(
+				'newspack_campaigns_post_types_for_campaigns',
+				[ 'post', 'page' ]
+			)
+		) ) {
 			return $content;
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a bug where the Inserter class tries to inject prompt markup into attachment descriptions and other content that fires the `the_content` hook, instead of the main article content. Does so by using the existing `newspack_campaigns_post_types_for_campaigns` filter to only insert prompts into content for posts and pages, by default, plus any post types added via that filter hook.

### How to test the changes in this Pull Request:

1. On `master`, publish a post and set a featured image. In the featured image details, enter some content into the Description field (not the Caption field). Make sure you have some inline and/or overlay prompts active that will be rendered on the post.
2. View the post in a new incognito session. Observe that the prompts are not displayed, and that their markup might even be partially injected into the featured image description (which the theme shows as the caption if it exists but the Caption field is empty).
3. Check out this branch, refresh the post. Confirm that the prompts are inserted into the main post content, as expected.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
