### PR TITLE
API debugging

### DIFF
--- a/api/classes/class-lightweight-api.php
+++ b/api/classes/class-lightweight-api.php
@@ -61,6 +61,7 @@ class Lightweight_API {
 			'start_time'             => microtime( true ),
 			'end_time'               => null,
 			'duration'               => null,
+			'suppression'            => [],
 		];
 	}
 
@@ -133,7 +134,7 @@ class Lightweight_API {
 		}
 		$this->debug['end_time'] = microtime( true );
 		$this->debug['duration'] = $this->debug['end_time'] - $this->debug['start_time'];
-		if ( defined( 'NEWSPACK_POPUPS_DEBUG' ) && NEWSPACK_POPUPS_DEBUG ) {
+		if ( isset( $_REQUEST['debug'] ) || ( defined( 'NEWSPACK_POPUPS_DEBUG' ) && NEWSPACK_POPUPS_DEBUG ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			$this->response['debug'] = $this->debug;
 		}
 		header( 'Access-Control-Allow-Origin: https://' . parse_url( $_SERVER['HTTP_REFERER'] )['host'], false ); // phpcs:ignore

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -602,6 +602,10 @@ final class Newspack_Popups_Inserter {
 		if ( $view_as_spec ) {
 			$popups_access_provider['authorization'] .= '&view_as=' . wp_json_encode( $view_as_spec );
 		}
+		if ( isset( $_GET['newspack-campaigns-debug'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+			$popups_access_provider['authorization'] .= '&debug';
+		}
+
 		?>
 		<script id="amp-access" type="application/json">
 			<?php echo wp_json_encode( $popups_access_provider ); ?>

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -410,8 +410,16 @@ final class Newspack_Popups_Inserter {
 			$include_unpublished = Newspack_Popups::is_preview_request();
 			$found_popup         = Newspack_Popups_Model::retrieve_popup_by_id( $atts['id'], $include_unpublished );
 		}
+		if ( ! $found_popup ) {
+			return;
+		}
+		$is_overlay = Newspack_Popups_Model::is_overlay( $found_popup );
+		if ( $is_overlay ) {
+			// Only inline popups may be placed using shortcodes.
+			return;
+		}
+
 		if (
-			! $found_popup ||
 			// Bail if it's a non-preview popup which should not be displayed.
 			( ! self::should_display( $found_popup, true ) && ! Newspack_Popups::previewed_popup_id() ) ||
 			// Only inline popups can be inserted via the shortcode.
@@ -491,7 +499,10 @@ final class Newspack_Popups_Inserter {
 				$popup_post = get_post( $id );
 				if ( $popup_post ) {
 					$popup_object = Newspack_Popups_Model::create_popup_object( $popup_post );
-					if ( $popup_object && 'publish' === $popup_object['status'] ) {
+					// Shortcoded overlay popups will not be rendered on the page, but still the shortcode might be present.
+					// This condition is just to remove the unnecessary part of the payload in such a case.
+					$is_overlay = Newspack_Popups_Model::is_overlay( $popup_object );
+					if ( $popup_object && ! $is_overlay && 'publish' === $popup_object['status'] ) {
 						$acc[] = $popup_object;
 					}
 				}

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -458,7 +458,7 @@ final class Newspack_Popups_Model {
 	 * @return boolean True if it is an overlay popup.
 	 */
 	public static function is_overlay( $popup ) {
-		if ( ! isset( $popup['options'], $popup['options']['placement'] ) ) {
+		if ( ! $popup || ! isset( $popup['options'], $popup['options']['placement'] ) ) {
 			return false;
 		}
 		return in_array( $popup['options']['placement'], self::$overlay_placements, true );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

On top of a config variable, exposes the API debugging info via a request param. I don't this this is a security concern, as the debugging information does not contain anything sensitive.
Enables debugging the prompt suppression reasons.
Also, makes a small tweak to `amp-access` payload creation.

### How to test the changes in this Pull Request:

1. Visit a page with some prompts, observe that (only) after appending a `newspack-campaigns-debug` parameter to the URL, `debug` key is returned along with the response from `GET /api/campaigns/index.php`
2. Observe that the response contains a `suppression` key, with data about why a particular prompt was suppressed
3. Try out different suppression scenarios, observe them reflected in the response.
4. Insert an overlay prompt via a shortcode _EDIT: and assign it to a category, visit a post of different category to ensure it will not be inserted programatically_ - observe that on `master` its ID is in the payload sent to the aforementioned endpoint, while on this branch it is not. Only inline prompts will be rendered in shortcodes - this just cleans _EDIT: cleans the output_

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->