### PR TITLE
Fix form selector for analytics

### DIFF
--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -651,7 +651,7 @@ final class Newspack_Popups_Model {
 			$analytics_events[] = [
 				'amp_on'     => 'amp-form-submit-success',
 				'on'         => 'submit',
-				'element'    => 'form:not(.' . self::get_form_class( 'action', $element_id ) . ')',
+				'element'    => '#' . esc_attr( $element_id ) . ' form:not(.' . self::get_form_class( 'action', $element_id ) . ')', // Not an 'action' (dismissal) form.
 				'event_name' => __( 'Form Submission', 'newspack-popups' ),
 			];
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a bug introduced in https://github.com/Automattic/newspack-popups/pull/497. Besides the reproduction scenario below, the fixed bug probably caused inflated counts of `Form Submission` custom GA events. This is because the bug makes other forms' dismissals being reported as a newsletter-bearing form submissions - however I've been able to reproduce that only on non-AMP pages.

### How to test the changes in this Pull Request:

1. On `master`, set up an inline prompt containing the Mailchimp newsletter subscription block 
2. Set the site to AMP transitional mode
2. Visit a page with the prompt
3. Observe that the `Form Submission` GA custom event* is not fired upon form submission on AMP version
4. Switch to this branch
5. Observe the `Form Submission GA custom event fired on both AMP and non-AMP versions

\* filter the requests in the Network tab by `collect` to see GA data sent

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->