### PR TITLE
feat: single prompt block and manual-only placement option

### DIFF
--- a/includes/class-newspack-popups-api.php
+++ b/includes/class-newspack-popups-api.php
@@ -41,6 +41,32 @@ final class Newspack_Popups_API {
 				],
 			]
 		);
+
+		\register_rest_route(
+			'newspack-popups/v1',
+			'prompts',
+			[
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => [ $this, 'get_inline_prompts' ],
+				'permission_callback' => [ $this, 'permission_callback' ],
+				'args'                => [
+					'search'   => [
+						'sanitize_callback' => 'sanitize_text_field',
+					],
+					'_fields'  => [
+						'sanitize_callback' => 'sanitize_text_field',
+					],
+					'include'  => [
+						'sanitize_callback' => 'sanitize_text_field',
+					],
+					'per_page' => [
+						'type'              => 'integer',
+						'default'           => 10,
+						'sanitize_callback' => 'absint',
+					],
+				],
+			]
+		);
 	}
 
 	/**
@@ -90,6 +116,62 @@ final class Newspack_Popups_API {
 				'option_value' => $request['option_value'],
 			]
 		);
+	}
+
+	/**
+	 * Get inline prompts with the given params.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 */
+	public static function get_inline_prompts( $request ) {
+		$params   = $request->get_params();
+		$search   = ! empty( $params['search'] ) ? $params['search'] : null;
+		$include  = ! empty( $params['include'] ) ? explode( ',', $params['include'] ) : null;
+		$per_page = ! empty( $params['per_page'] ) ? $params['per_page'] : 10;
+
+		// Query args.
+		$args = [
+			'post_type'      => Newspack_Popups::NEWSPACK_POPUPS_CPT,
+			'post_status'    => 'publish',
+			'posts_per_page' => $per_page,
+			'meta_key'       => 'placement',
+			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+			'meta_value'     => 'inline',
+		];
+
+		// Look up by title only if provided with a search term and not post IDs.
+		if ( ! empty( $search ) && empty( $include ) ) {
+			$args['s'] = esc_sql( $search );
+		}
+
+		// If given post IDs to include, just get those.
+		if ( ! empty( $include ) && count( $include ) && empty( $search ) ) {
+			$args['post__in'] = $include;
+			$args['orderby']  = 'post__in';
+			$args['order']    = 'ASC';
+		}
+
+		$query = new \WP_Query( $args );
+
+		if ( $query->have_posts() ) {
+			return new \WP_REST_Response(
+				array_map(
+					function( $post ) {
+						$item = [
+							'id'      => $post->ID,
+							'title'   => $post->post_title,
+							'content' => apply_filters( 'the_content', $post->post_content ),
+						];
+
+						return $item;
+					},
+					$query->posts
+				),
+				200
+			);
+		}
+
+		return new \WP_REST_Response( [] );
 	}
 }
 $newspack_popups_api = new Newspack_Popups_API();

--- a/includes/class-newspack-popups-api.php
+++ b/includes/class-newspack-popups-api.php
@@ -47,7 +47,7 @@ final class Newspack_Popups_API {
 			'prompts',
 			[
 				'methods'             => \WP_REST_Server::READABLE,
-				'callback'            => [ $this, 'get_inline_prompts' ],
+				'callback'            => [ $this, 'get_inline_and_manual_prompts' ],
 				'permission_callback' => [ $this, 'permission_callback' ],
 				'args'                => [
 					'search'   => [
@@ -123,7 +123,7 @@ final class Newspack_Popups_API {
 	 *
 	 * @param WP_REST_Request $request Request object.
 	 */
-	public static function get_inline_prompts( $request ) {
+	public static function get_inline_and_manual_prompts( $request ) {
 		$params   = $request->get_params();
 		$search   = ! empty( $params['search'] ) ? $params['search'] : null;
 		$include  = ! empty( $params['include'] ) ? explode( ',', $params['include'] ) : null;
@@ -135,8 +135,9 @@ final class Newspack_Popups_API {
 			'post_status'    => 'publish',
 			'posts_per_page' => $per_page,
 			'meta_key'       => 'placement',
+			'meta_compare'   => 'IN',
 			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
-			'meta_value'     => 'inline',
+			'meta_value'     => [ 'inline', 'manual' ],
 		];
 
 		// Look up by title only if provided with a search term and not post IDs.

--- a/includes/class-newspack-popups-custom-placements.php
+++ b/includes/class-newspack-popups-custom-placements.php
@@ -62,6 +62,7 @@ final class Newspack_Popups_Custom_Placements {
 			'newspack_popups_blocks_data',
 			[
 				'custom_placements' => self::get_custom_placements(),
+				'endpoint'          => Newspack_Popups::NEWSPACK_POPUPS_CPT,
 			]
 		);
 

--- a/includes/class-newspack-popups-custom-placements.php
+++ b/includes/class-newspack-popups-custom-placements.php
@@ -40,40 +40,8 @@ final class Newspack_Popups_Custom_Placements {
 	 * Constructor.
 	 */
 	public function __construct() {
-		add_action( 'enqueue_block_editor_assets', [ __CLASS__, 'manage_editor_assets' ] );
 		add_action( 'init', [ __CLASS__, 'manage_view_assets' ] );
 		add_action( 'rest_api_init', [ __CLASS__, 'rest_api_init' ] );
-	}
-
-	/**
-	 * Enqueue editor assets.
-	 */
-	public static function manage_editor_assets() {
-		\wp_enqueue_script(
-			'newspack-popups-blocks',
-			plugins_url( '../dist/blocks.js', __FILE__ ),
-			[],
-			filemtime( dirname( NEWSPACK_POPUPS_PLUGIN_FILE ) . '/dist/blocks.js' ),
-			true
-		);
-
-		\wp_localize_script(
-			'newspack-popups-blocks',
-			'newspack_popups_blocks_data',
-			[
-				'custom_placements' => self::get_custom_placements(),
-				'endpoint'          => Newspack_Popups::NEWSPACK_POPUPS_CPT,
-			]
-		);
-
-		\wp_register_style(
-			'newspack-popups-blocks',
-			plugins_url( '../dist/blocks.css', __FILE__ ),
-			[],
-			filemtime( dirname( NEWSPACK_POPUPS_PLUGIN_FILE ) . '/dist/blocks.css' )
-		);
-		wp_style_add_data( 'newspack-popups-blocks', 'rtl', 'replace' );
-		wp_enqueue_style( 'newspack-popups-blocks' );
 	}
 
 	/**

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -213,7 +213,7 @@ final class Newspack_Popups_Inserter {
 		// For certain types of blocks, their innerHTML is not a good representation of the length of their content.
 		// For example, slideshows may have an arbitrary amount of slide content, but only show one slide at a time.
 		// For these blocks, let's ignore their length for purposes of inserting prompts.
-		$blacklisted_blocks = [ 'jetpack/slideshow', 'newspack-blocks/carousel' ];
+		$blacklisted_blocks = [ 'jetpack/slideshow', 'newspack-blocks/carousel', 'newspack-popups/single-prompt' ];
 		$parsed_blocks      = parse_blocks( $content );
 		$total_length       = 0;
 
@@ -680,21 +680,44 @@ final class Newspack_Popups_Inserter {
 	 * @return array Found shortcoded popups IDs.
 	 */
 	public static function get_shortcoded_popups_ids( $string ) {
+		$parsed_blocks = parse_blocks( $string );
+
+		$single_prompt_blocks    = array_filter(
+			$parsed_blocks,
+			function( $block ) {
+				return 'newspack-popups/single-prompt' === $block['blockName'];
+			}
+		);
+		$single_prompt_block_ids = array_reduce(
+			$single_prompt_blocks,
+			function( $acc, $popup ) {
+				if ( ! empty( $popup['attrs']['promptId'] ) ) {
+					$acc[] = intval( $popup['attrs']['promptId'] );
+				}
+				return $acc;
+			},
+			[]
+		);
+
 		preg_match_all( '/\[newspack-popup .*\]/', $string, $popup_shortcodes_in_content );
+
 		if ( empty( $popup_shortcodes_in_content ) ) {
 			return [];
 		} else {
 			return array_unique(
-				array_map(
-					function ( $item ) {
-						preg_match( '/id=["|\'](\d*)/', $item, $matches );
-						if ( empty( $matches ) ) {
-							return null;
-						} else {
-							return $matches[1];
-						}
-					},
-					$popup_shortcodes_in_content[0]
+				array_merge(
+					$single_prompt_block_ids,
+					array_map(
+						function ( $item ) {
+							preg_match( '/id=["|\'](\d*)/', $item, $matches );
+							if ( empty( $matches ) ) {
+								return null;
+							} else {
+								return $matches[1];
+							}
+						},
+						$popup_shortcodes_in_content[0]
+					)
 				)
 			);
 		}

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -428,8 +428,8 @@ final class Newspack_Popups_Inserter {
 		if (
 			// Bail if it's a non-preview popup which should not be displayed.
 			( ! self::should_display( $found_popup, true ) && ! Newspack_Popups::previewed_popup_id() ) ||
-			// Only inline popups can be inserted via the shortcode.
-			! Newspack_Popups_Model::is_inline( $found_popup )
+			// Only inline or manual-only popups can be inserted via the shortcode.
+			( ! Newspack_Popups_Model::is_inline( $found_popup ) && ! Newspack_Popups_Model::is_manual_only( $found_popup ) )
 		) {
 			return;
 		}

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -117,7 +117,8 @@ final class Newspack_Popups_Model {
 					$valid_placements = array_merge(
 						self::$overlay_placements,
 						self::$inline_placements,
-						Newspack_Popups_Custom_Placements::get_custom_placement_values()
+						Newspack_Popups_Custom_Placements::get_custom_placement_values(),
+						[ 'manual' ]
 					);
 					if ( ! in_array( $value, $valid_placements ) ) {
 						return new \WP_Error(
@@ -423,6 +424,20 @@ final class Newspack_Popups_Model {
 			$popup['options']['placement'],
 			array_merge( self::$inline_placements, Newspack_Popups_Custom_Placements::get_custom_placement_values() )
 		);
+	}
+
+	/**
+	 * Is it a manual-only popup or not.
+	 *
+	 * @param object $popup The popup object.
+	 * @return boolean True if it is a manual-only popup.
+	 */
+	public static function is_manual_only( $popup ) {
+		if ( ! isset( $popup['options'], $popup['options']['placement'] ) ) {
+			return false;
+		}
+
+		return 'manual' === $popup['options']['placement'];
 	}
 
 	/**

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -359,6 +359,7 @@ final class Newspack_Popups {
 				'custom_placements' => Newspack_Popups_Custom_Placements::get_custom_placements(),
 				'endpoint'          => '/newspack-popups/v1/prompts',
 				'post_type'         => self::NEWSPACK_POPUPS_CPT,
+				'is_prompt'         => self::NEWSPACK_POPUPS_CPT == get_post_type(),
 			]
 		);
 

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -343,6 +343,34 @@ final class Newspack_Popups {
 	public static function enqueue_block_editor_assets() {
 		$screen = get_current_screen();
 
+		// Block assets for Custom Placement and Prompt blocks.
+		\wp_enqueue_script(
+			'newspack-popups-blocks',
+			plugins_url( '../dist/blocks.js', __FILE__ ),
+			[],
+			filemtime( dirname( NEWSPACK_POPUPS_PLUGIN_FILE ) . '/dist/blocks.js' ),
+			true
+		);
+
+		\wp_localize_script(
+			'newspack-popups-blocks',
+			'newspack_popups_blocks_data',
+			[
+				'custom_placements' => Newspack_Popups_Custom_Placements::get_custom_placements(),
+				'endpoint'          => '/newspack-popups/v1/prompts',
+				'post_type'         => self::NEWSPACK_POPUPS_CPT,
+			]
+		);
+
+		\wp_register_style(
+			'newspack-popups-blocks',
+			plugins_url( '../dist/blocks.css', __FILE__ ),
+			[],
+			filemtime( dirname( NEWSPACK_POPUPS_PLUGIN_FILE ) . '/dist/blocks.css' )
+		);
+		wp_style_add_data( 'newspack-popups-blocks', 'rtl', 'replace' );
+		wp_enqueue_style( 'newspack-popups-blocks' );
+
 		if ( self::NEWSPACK_POPUPS_CPT !== $screen->post_type ) {
 			if ( 'page' !== $screen->post_type || 'post' !== $screen->post_type ) {
 				// Script for global settings.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9384,9 +9384,9 @@
       "dev": true
     },
     "@wordpress/base-styles": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-1.2.0.tgz",
-      "integrity": "sha512-jiU7naQ5ARrPhnCOvSXHudDX2zFTW4XfqmqKqnMzZC4A4fjywwfC00P98bcKXvSEhev5IH8BSxS+UxNzbUpPxQ=="
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-1.11.0.tgz",
+      "integrity": "sha512-CV7NsA0SzLGKFmhhTIhi6pWeijeSaBl16hwp+x7OcyQKy/MMbVx2gXsHf3KjGNY18FT1Uf2MlhcdIeBM22RpWQ=="
     },
     "@wordpress/blob": {
       "version": "2.5.1",
@@ -11475,12 +11475,26 @@
       }
     },
     "@wordpress/html-entities": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-2.5.0.tgz",
-      "integrity": "sha512-7TKaJKkOX2Tas0OyXNPz1kA2my1Z804weBf2RsPLiNXm593JDsf6Em8z1TA4mXtn7FO2ZAKTj/3yRemKK4PhnA==",
-      "dev": true,
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-2.11.2.tgz",
+      "integrity": "sha512-WIdEGO9/o7tuTV3jpLHhFC/NBBnNdJeG9nRZbEyb37CL1fvqJA85hTugyDOhGzOVIAtpFTc6kr/gMJK1oTdopw==",
       "requires": {
-        "@babel/runtime": "^7.4.4"
+        "@babel/runtime": "^7.13.10"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.14.0",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.0.tgz",
+          "integrity": "sha512-JELkvo/DlpNdJ7dlyw/eY7E0suy5i5GQH+Vlxaq1nsNJ+H7f4Vtv3jMeCEgRhZZQFXTjldYfQgv2qmM6M1v5wA==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.7",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+          "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
+        }
       }
     },
     "@wordpress/i18n": {
@@ -19783,7 +19797,8 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "grunt": {
       "version": "0.4.5",
@@ -19918,11 +19933,6 @@
       "resolved": "https://registry.npmjs.org/grunt-wp-readme-to-markdown/-/grunt-wp-readme-to-markdown-1.0.0.tgz",
       "integrity": "sha1-dJ/9gDtYTVC9ZOc6ehqRhz6djPs=",
       "dev": true
-    },
-    "gud": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/gud/-/gud-1.0.0.tgz",
-      "integrity": "sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw=="
     },
     "handlebars": {
       "version": "4.7.6",
@@ -20763,7 +20773,8 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.1.1.tgz",
       "integrity": "sha512-ZOoqiXfEwtGknTiuDEy8pN2CfE3TxMHprvNer1mXiqwkOT77Rw3YVrUQ52EqAOU3QAWDQ+bQdx7HJzrv7LS2Hw==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "is-extendable": {
       "version": "0.1.1",
@@ -25791,13 +25802,27 @@
       "dev": true
     },
     "mini-create-react-context": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/mini-create-react-context/-/mini-create-react-context-0.3.2.tgz",
-      "integrity": "sha512-2v+OeetEyliMt5VHMXsBhABoJ0/M4RCe7fatd/fBy6SMiKazUSEt3gxxypfnk2SHMkdBYvorHRoQxuGoiwbzAw==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/mini-create-react-context/-/mini-create-react-context-0.4.1.tgz",
+      "integrity": "sha512-YWCYEmd5CQeHGSAKrYvXgmzzkrvssZcuuQDDeqkT+PziKGMgE+0MCCtcKbROzocGBG1meBLl2FotlRwf4gAzbQ==",
       "requires": {
-        "@babel/runtime": "^7.4.0",
-        "gud": "^1.0.0",
-        "tiny-warning": "^1.0.2"
+        "@babel/runtime": "^7.12.1",
+        "tiny-warning": "^1.0.3"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.14.0",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.0.tgz",
+          "integrity": "sha512-JELkvo/DlpNdJ7dlyw/eY7E0suy5i5GQH+Vlxaq1nsNJ+H7f4Vtv3jMeCEgRhZZQFXTjldYfQgv2qmM6M1v5wA==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.7",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+          "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
+        }
       }
     },
     "mini-css-extract-plugin-with-rtl": {
@@ -26097,18 +26122,48 @@
       "dev": true
     },
     "newspack-components": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/newspack-components/-/newspack-components-1.0.5.tgz",
-      "integrity": "sha512-40n2u3nwIof/vsBpwyyMUDBUC9Drz+pGbWVm8ICBL9I/USAxGgjuE8OGdP7w0TiKGltZKBFo+LDjGvIZM9t9Kg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/newspack-components/-/newspack-components-1.4.0.tgz",
+      "integrity": "sha512-zDbPICE3PdqJFyeW9JfmrNx7rXYVra2V6n/X5uYW/ZVF9JQ7GpG8LxgS6J8HgSeMAhBfCOVbDgOEaGoCjJBXow==",
       "requires": {
         "@material-ui/core": "^4.8.2",
         "@material-ui/icons": "^4.5.1",
         "@wordpress/base-styles": "^1.0.0",
         "@wordpress/components": "^7.3.1",
         "@wordpress/element": "^2.3.0",
+        "@wordpress/i18n": "^3.11.0",
+        "classnames": "^2.2.6",
+        "lodash": "^4.17.20",
         "react-router-dom": "^5.0.1"
       },
       "dependencies": {
+        "@tannin/compile": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@tannin/compile/-/compile-1.1.0.tgz",
+          "integrity": "sha512-n8m9eNDfoNZoxdvWiTfW/hSPhehzLJ3zW7f8E7oT6mCROoMNWCB4TYtv041+2FMAxweiE0j7i1jubQU4MEC/Gg==",
+          "requires": {
+            "@tannin/evaluate": "^1.2.0",
+            "@tannin/postfix": "^1.1.0"
+          }
+        },
+        "@tannin/evaluate": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/@tannin/evaluate/-/evaluate-1.2.0.tgz",
+          "integrity": "sha512-3ioXvNowbO/wSrxsDG5DKIMxC81P0QrQTYai8zFNY+umuoHWRPbQ/TuuDEOju9E+jQDXmj6yI5GyejNuh8I+eg=="
+        },
+        "@tannin/plural-forms": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@tannin/plural-forms/-/plural-forms-1.1.0.tgz",
+          "integrity": "sha512-xl9R2mDZO/qiHam1AgMnAES6IKIg7OBhcXqy6eDsRCdXuxAFPcjrej9HMjyCLE0DJ/8cHf0i5OQTstuBRhpbHw==",
+          "requires": {
+            "@tannin/compile": "^1.1.0"
+          }
+        },
+        "@tannin/postfix": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@tannin/postfix/-/postfix-1.1.0.tgz",
+          "integrity": "sha512-oocsqY7g0cR+Gur5jRQLSrX2OtpMLMse1I10JQBm8CdGMrDkh1Mg2gjsiquMHRtBs4Qwu5wgEp5GgIYHk4SNPw=="
+        },
         "@wordpress/components": {
           "version": "7.4.0",
           "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-7.4.0.tgz",
@@ -26142,15 +26197,79 @@
             "uuid": "^3.3.2"
           }
         },
+        "@wordpress/i18n": {
+          "version": "3.20.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.20.0.tgz",
+          "integrity": "sha512-SIoOJFB4UrrYAScS4H91CYCLW9dX3Ghv8pBKc/yHGculb1AdGr6gRMlmJxZV62Cn3CZ4Ga86c+FfR+GiBu0JPg==",
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@wordpress/hooks": "^2.12.3",
+            "gettext-parser": "^1.3.1",
+            "lodash": "^4.17.19",
+            "memize": "^1.1.0",
+            "sprintf-js": "^1.1.1",
+            "tannin": "^1.2.0"
+          },
+          "dependencies": {
+            "@babel/runtime": {
+              "version": "7.14.0",
+              "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.0.tgz",
+              "integrity": "sha512-JELkvo/DlpNdJ7dlyw/eY7E0suy5i5GQH+Vlxaq1nsNJ+H7f4Vtv3jMeCEgRhZZQFXTjldYfQgv2qmM6M1v5wA==",
+              "requires": {
+                "regenerator-runtime": "^0.13.4"
+              }
+            },
+            "@wordpress/hooks": {
+              "version": "2.12.3",
+              "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-2.12.3.tgz",
+              "integrity": "sha512-LmKiwKldZt6UYqOxV/a6+eUFXdvALFnB/pQx3RmrMvO64sgFhfR6dhrlv+uVbuuezSuv8dce1jx8lUWAT0krMA==",
+              "requires": {
+                "@babel/runtime": "^7.13.10"
+              }
+            },
+            "memize": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/memize/-/memize-1.1.0.tgz",
+              "integrity": "sha512-K4FcPETOMTwe7KL2LK0orMhpOmWD2wRGwWWpbZy0fyArwsyIKR8YJVz8+efBAh3BO4zPqlSICu4vsLTRRqtFAg=="
+            }
+          }
+        },
+        "gettext-parser": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-1.4.0.tgz",
+          "integrity": "sha512-sedZYLHlHeBop/gZ1jdg59hlUEcpcZJofLq2JFwJT1zTqAU3l2wFv6IsuwFHGqbiT9DWzMUW4/em2+hspnmMMA==",
+          "requires": {
+            "encoding": "^0.1.12",
+            "safe-buffer": "^5.1.1"
+          }
+        },
         "lodash": {
-          "version": "4.17.15",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
         },
         "re-resizable": {
           "version": "4.11.0",
           "resolved": "https://registry.npmjs.org/re-resizable/-/re-resizable-4.11.0.tgz",
           "integrity": "sha512-dye+7rERqNf/6mDT1iwps+4Gf42420xuZgygF33uX178DxffqcyeuHbBuJ382FIcB5iP6mMZOhfW7kI0uXwb/Q=="
+        },
+        "regenerator-runtime": {
+          "version": "0.13.7",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+          "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
+        },
+        "sprintf-js": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+          "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
+        },
+        "tannin": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/tannin/-/tannin-1.2.0.tgz",
+          "integrity": "sha512-U7GgX/RcSeUETbV7gYgoz8PD7Ni4y95pgIP/Z6ayI3CfhSujwKEBlGFTCRN+Aqnuyf4AN2yHL+L8x+TCGjb9uA==",
+          "requires": {
+            "@tannin/plural-forms": "^1.1.0"
+          }
         }
       }
     },
@@ -26300,6 +26419,7 @@
       "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-8.0.1.tgz",
       "integrity": "sha512-BvEXF+UmsnAfYfoapKM9nGxnP+Wn7P91YfXmrKnfcYCx6VBeoN5Ez5Ogck6I8Bi5k4RlpqRYaw75pAwzX9OphA==",
       "dev": true,
+      "optional": true,
       "requires": {
         "growly": "^1.3.0",
         "is-wsl": "^2.2.0",
@@ -26314,6 +26434,7 @@
           "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
           "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-docker": "^2.0.0"
           }
@@ -26323,6 +26444,7 @@
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
           "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "yallist": "^4.0.0"
           }
@@ -26332,6 +26454,7 @@
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
           "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
           "dev": true,
+          "optional": true,
           "requires": {
             "lru-cache": "^6.0.0"
           }
@@ -26340,13 +26463,15 @@
           "version": "8.3.2",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
           "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "which": {
           "version": "2.0.2",
           "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
           "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "isexe": "^2.0.0"
           }
@@ -26355,7 +26480,8 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
           "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -32068,15 +32194,15 @@
       "integrity": "sha512-UyLk1KNbFHDye9AFLyr7HBGmzkRDGz2mYp6LDS+LCxM6DXGpviwS5Q4JRzXWdw0tk+n46UE/Kotku/cb8HCh0Q=="
     },
     "react-router": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.1.2.tgz",
-      "integrity": "sha512-yjEuMFy1ONK246B+rsa0cUam5OeAQ8pyclRDgpxuSCrAlJ1qN9uZ5IgyKC7gQg0w8OM50NXHEegPh/ks9YuR2A==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.2.0.tgz",
+      "integrity": "sha512-smz1DUuFHRKdcJC0jobGo8cVbhO3x50tCL4icacOlcwDOEQPq4TMqwx3sY1TP+DvtTgz4nm3thuo7A+BK2U0Dw==",
       "requires": {
         "@babel/runtime": "^7.1.2",
         "history": "^4.9.0",
         "hoist-non-react-statics": "^3.1.0",
         "loose-envify": "^1.3.1",
-        "mini-create-react-context": "^0.3.0",
+        "mini-create-react-context": "^0.4.0",
         "path-to-regexp": "^1.7.0",
         "prop-types": "^15.6.2",
         "react-is": "^16.6.0",
@@ -32085,15 +32211,15 @@
       }
     },
     "react-router-dom": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.1.2.tgz",
-      "integrity": "sha512-7BPHAaIwWpZS074UKaw1FjVdZBSVWEk8IuDXdB+OkLb8vd/WRQIpA4ag9WQk61aEfQs47wHyjWUoUGGZxpQXew==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.2.0.tgz",
+      "integrity": "sha512-gxAmfylo2QUjcwxI63RhQ5G85Qqt4voZpUXSEqCwykV0baaOTQDR1f0PmY8AELqIyVc0NEZUj0Gov5lNGcXgsA==",
       "requires": {
         "@babel/runtime": "^7.1.2",
         "history": "^4.9.0",
         "loose-envify": "^1.3.1",
         "prop-types": "^15.6.2",
-        "react-router": "5.1.2",
+        "react-router": "5.2.0",
         "tiny-invariant": "^1.0.2",
         "tiny-warning": "^1.0.0"
       }
@@ -33982,7 +34108,8 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "showdown": {
       "version": "1.9.1",
@@ -36075,9 +36202,9 @@
       "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q=="
     },
     "tiny-invariant": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.0.6.tgz",
-      "integrity": "sha512-FOyLWWVjG+aC0UqG76V53yAWdXfH8bO6FNmyZOuUrzDzK8DI3/JRY25UD7+g49JWM1LXwymsKERB+DzI0dTEQA=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.1.0.tgz",
+      "integrity": "sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw=="
     },
     "tiny-warning": {
       "version": "1.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3889,11 +3889,18 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.3.tgz",
-      "integrity": "sha512-kq6anf9JGjW8Nt5rYfEuGRaEAaH1mkv3Bbu6rYvLOpPh/RusSJXuKPEAoZ7L7gybZkchE8+NV5g9vKF4AGAtsA==",
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.0.tgz",
+      "integrity": "sha512-JELkvo/DlpNdJ7dlyw/eY7E0suy5i5GQH+Vlxaq1nsNJ+H7f4Vtv3jMeCEgRhZZQFXTjldYfQgv2qmM6M1v5wA==",
       "requires": {
-        "regenerator-runtime": "^0.13.2"
+        "regenerator-runtime": "^0.13.4"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.13.7",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+          "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
+        }
       }
     },
     "@babel/runtime-corejs3": {
@@ -3974,6 +3981,14 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
+    },
+    "@choojs/findup": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@choojs/findup/-/findup-0.2.1.tgz",
+      "integrity": "sha512-YstAqNb0MCN8PjdLCDfRsBcGVRN41f3vgLvaI0IrIcBp4AqILRSS0DeWNGkicC+f/zRIPJLc+9RURVSepwvfBw==",
+      "requires": {
+        "commander": "^2.15.1"
+      }
     },
     "@cnakazawa/watch": {
       "version": "1.0.3",
@@ -4649,6 +4664,11 @@
       "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.2.tgz",
       "integrity": "sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==",
       "dev": true
+    },
+    "@itsjonq/is": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@itsjonq/is/-/is-0.0.2.tgz",
+      "integrity": "sha512-P0Ug+chfjCV1JV8MUxAGPz0BM76yDlR76AIfPwRZ6mAJW56k6b9j0s2cIcEsEAu0gNj/RJD1STw777AQyBN3CQ=="
     },
     "@jest/console": {
       "version": "24.9.0",
@@ -8004,6 +8024,11 @@
         "@types/node": ">= 8"
       }
     },
+    "@popperjs/core": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.9.2.tgz",
+      "integrity": "sha512-VZMYa7+fXHdwIq1TDhSXoVmSPEGM/aa+6Aiq3nVVJ9bXr24zScr+NlKFKC3iPljA7ho/GAZr+d2jOf5GIRC30Q=="
+    },
     "@romainberger/css-diff": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@romainberger/css-diff/-/css-diff-1.0.3.tgz",
@@ -9053,6 +9078,14 @@
         "csstype": "^2.2.0"
       }
     },
+    "@types/react-dom": {
+      "version": "16.9.13",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.9.13.tgz",
+      "integrity": "sha512-34Hr3XnmUSJbUVDxIw/e7dhQn2BJZhJmlAaPyPwfTQyuVS9mV/CeyghFcXyvkJXxI7notQJz8mF8FeCVvloJrA==",
+      "requires": {
+        "@types/react": "^16"
+      }
+    },
     "@types/react-transition-group": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.0.tgz",
@@ -9323,6 +9356,7 @@
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-2.5.1.tgz",
       "integrity": "sha512-aZidVNquAYrGopHLUr96vhX47kteAw41EC3zAsP2wxMkmTd2q2olCAaBo12a4rbj0JwNyw4Pq2uqis5hZVuMXw==",
+      "dev": true,
       "requires": {
         "@babel/runtime": "^7.4.4",
         "@wordpress/dom-ready": "^2.5.1"
@@ -10708,6 +10742,7 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-2.6.1.tgz",
       "integrity": "sha512-nwCZ5pfFCZRwpEOMOVJcPZ6dmcaUfINehfZwPZA/6wK6Ol5sfc5MP22zmz30LFGsP4yqfgSugYDLA2LLAnuWqg==",
+      "dev": true,
       "requires": {
         "@babel/runtime": "^7.4.4",
         "@wordpress/hooks": "^2.6.0"
@@ -10717,6 +10752,7 @@
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-2.5.2.tgz",
       "integrity": "sha512-b/5MAKN24yKuXMUPP7A6Ha898bm0cSsOdrq5w9kjGZpO/ceP4DxeV/GNoE22uXX+KbV4px9KRXO5H9OcFJyroA==",
+      "dev": true,
       "requires": {
         "@babel/runtime": "^7.4.4",
         "lodash": "^4.17.15"
@@ -10725,7 +10761,8 @@
         "lodash": {
           "version": "4.17.15",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
         }
       }
     },
@@ -11388,6 +11425,7 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-1.5.1.tgz",
       "integrity": "sha512-C4chmaS4US5+SDQKcYuqU+MZJa41o7Wq7IwDsqIQfnrqTEhjk5JBFQm2M0slWOti9hry9CAGlmorp5XvE/eiyg==",
+      "dev": true,
       "requires": {
         "@babel/runtime": "^7.4.4"
       }
@@ -11470,6 +11508,7 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-2.6.0.tgz",
       "integrity": "sha512-93THIW9EklVkJLN3wr8PUdWqttRu/wGZgXUrM6fqqOGwm4uCL4S+jQe800kwZioRHvgW5moNLrvSdfanQ4QyEQ==",
+      "dev": true,
       "requires": {
         "@babel/runtime": "^7.4.4"
       }
@@ -11573,6 +11612,7 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-1.6.1.tgz",
       "integrity": "sha512-0vrTVuE6S/lmW4QKklTNqwSUyvxeCPRq02gKk6ViTw3I/QhE65g7dLRwwEDZ+42obSNA7XousutZ3YoN/NpPbA==",
+      "dev": true,
       "requires": {
         "@babel/runtime": "^7.4.4"
       }
@@ -11719,6 +11759,7 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-2.6.2.tgz",
       "integrity": "sha512-xWwyTYdyesZFc6V3RDn2Gjkx5bfa5fGDGrX0WcxT+vA2oEMFqLA2JzUqEzylR7aX3uFfsdDEp0GbPl8ipcLChw==",
+      "dev": true,
       "requires": {
         "@babel/runtime": "^7.4.4",
         "@wordpress/i18n": "^3.6.1",
@@ -11728,7 +11769,8 @@
         "lodash": {
           "version": "4.17.15",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
         }
       }
     },
@@ -12065,6 +12107,7 @@
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-3.7.2.tgz",
       "integrity": "sha512-Mmq+qGBJiLwoEnFN/MqM+o7M2LF1EUYO7FgYwWhlM3m9G+HVBIX3nQeEFADsk3agVYojNbXXowO7Lv8qlZVFDg==",
+      "dev": true,
       "requires": {
         "@babel/runtime": "^7.4.4",
         "@wordpress/compose": "^3.7.2",
@@ -12084,7 +12127,8 @@
         "lodash": {
           "version": "4.17.15",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
         }
       }
     },
@@ -12507,6 +12551,268 @@
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
           "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
           "dev": true
+        }
+      }
+    },
+    "@wp-g2/components": {
+      "version": "0.0.140",
+      "resolved": "https://registry.npmjs.org/@wp-g2/components/-/components-0.0.140.tgz",
+      "integrity": "sha512-bychuhZ3wPSB457CHYcogoPQPlP/eUA9GoTo0Fv0rj7f44Gr9XlPoqVT+GQa3CmPnvSCAl1sjoe75Vkaoo/O1w==",
+      "requires": {
+        "@popperjs/core": "^2.5.4",
+        "@wp-g2/context": "^0.0.140",
+        "@wp-g2/styles": "^0.0.140",
+        "@wp-g2/utils": "^0.0.140",
+        "csstype": "^3.0.3",
+        "downshift": "^6.0.15",
+        "framer-motion": "^2.1.0",
+        "highlight-words-core": "^1.2.2",
+        "history": "^4.9.0",
+        "lodash": "^4.17.19",
+        "path-to-regexp": "^1.7.0",
+        "react-colorful": "4.4.4",
+        "react-textarea-autosize": "^8.2.0",
+        "react-use-gesture": "^9.0.0",
+        "reakit": "1.1.0"
+      },
+      "dependencies": {
+        "body-scroll-lock": {
+          "version": "3.1.5",
+          "resolved": "https://registry.npmjs.org/body-scroll-lock/-/body-scroll-lock-3.1.5.tgz",
+          "integrity": "sha512-Yi1Xaml0EvNA0OYWxXiYNqY24AfWkbA6w5vxE7GWxtKfzIbZM+Qw+aSmkgsbWzbHiy/RCSkUZBplVxTA+E4jJg=="
+        },
+        "compute-scroll-into-view": {
+          "version": "1.0.17",
+          "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-1.0.17.tgz",
+          "integrity": "sha512-j4dx+Fb0URmzbwwMUrhqWM2BEWHdFGx+qZ9qqASHRPqvTYdqvWnHg0H1hIbcyLnvgnoNAVMlwkepyqM3DaIFUg=="
+        },
+        "csstype": {
+          "version": "3.0.8",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.8.tgz",
+          "integrity": "sha512-jXKhWqXPmlUeoQnF/EhTtTl4C9SnrxSH/jZUih3jmO6lBKr99rP3/+FmrMj4EFpOXzMtXHAZkd3x0E6h6Fgflw=="
+        },
+        "downshift": {
+          "version": "6.1.3",
+          "resolved": "https://registry.npmjs.org/downshift/-/downshift-6.1.3.tgz",
+          "integrity": "sha512-RA1MuaNcTbt0j+sVLhSs8R2oZbBXYAtdQP/V+uHhT3DoDteZzJPjlC+LQVm9T07Wpvo84QXaZtUCePLDTDwGXg==",
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "compute-scroll-into-view": "^1.0.17",
+            "prop-types": "^15.7.2",
+            "react-is": "^17.0.2"
+          }
+        },
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+        },
+        "react-is": {
+          "version": "17.0.2",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+          "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
+        },
+        "reakit": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/reakit/-/reakit-1.1.0.tgz",
+          "integrity": "sha512-d/ERtwgBndBPsyPBPUl5jueyfFgsglIfQCnLMKuxM0PaWiIZ6Ys3XsYaNy/AaG8k46Ee5cQPMdRrR30nVcSToQ==",
+          "requires": {
+            "@popperjs/core": "^2.4.2",
+            "body-scroll-lock": "^3.0.2",
+            "reakit-system": "^0.13.0",
+            "reakit-utils": "^0.13.0",
+            "reakit-warning": "^0.4.0"
+          }
+        },
+        "reakit-system": {
+          "version": "0.13.1",
+          "resolved": "https://registry.npmjs.org/reakit-system/-/reakit-system-0.13.1.tgz",
+          "integrity": "sha512-qglfQ53FsJh5+VSkjMtBg7eZiowj9zXOyfJJxfaXh/XYTVe/5ibzWg6rvGHyvSm6C3D7Q2sg/NPCLmCtYGGvQA==",
+          "requires": {
+            "reakit-utils": "^0.13.1"
+          }
+        },
+        "reakit-utils": {
+          "version": "0.13.1",
+          "resolved": "https://registry.npmjs.org/reakit-utils/-/reakit-utils-0.13.1.tgz",
+          "integrity": "sha512-NBKgsot3tU91gZgK5MTInI/PR0T3kIsTmbU5MbGggSOcwU2dG/kbE8IrM2lC6ayCSL2W2QWkijT6kewdrIX7Gw=="
+        },
+        "reakit-warning": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/reakit-warning/-/reakit-warning-0.4.1.tgz",
+          "integrity": "sha512-AgnRN6cf8DYBF/mK2JEMFVL67Sbon8fDbFy1kfm0EDibtGsMOQtsFYfozZL7TwmJ4yg68VMhg8tmPHchVQRrlg==",
+          "requires": {
+            "reakit-utils": "^0.13.1"
+          }
+        }
+      }
+    },
+    "@wp-g2/context": {
+      "version": "0.0.140",
+      "resolved": "https://registry.npmjs.org/@wp-g2/context/-/context-0.0.140.tgz",
+      "integrity": "sha512-z32fxZ2tCVmYQC+wyyziyrhEvWBPFBQfUhUHF85JmTUPzQQeEPiLC3rgDAT0fUTFlJHinPJQq6871RDqFSwCUA==",
+      "requires": {
+        "@wp-g2/styles": "^0.0.140",
+        "@wp-g2/utils": "^0.0.140",
+        "lodash": "^4.17.19"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+        }
+      }
+    },
+    "@wp-g2/create-styles": {
+      "version": "0.0.140",
+      "resolved": "https://registry.npmjs.org/@wp-g2/create-styles/-/create-styles-0.0.140.tgz",
+      "integrity": "sha512-/60DxWjCAhsoYOqY7aiHVbkTAF+L6qZIyHyH50oNs9FTVkcRLHQFSC0kHgAam+Z9K3eImQ7hM52wfBDqae0q2Q==",
+      "requires": {
+        "@emotion/core": "^10.1.1",
+        "@emotion/is-prop-valid": "^0.8.8",
+        "@wp-g2/utils": "^0.0.140",
+        "create-emotion": "^10.0.27",
+        "emotion": "^10.0.27",
+        "emotion-theming": "^10.0.27",
+        "lodash": "^4.17.19",
+        "mitt": "^2.1.0",
+        "rtlcss": "^2.6.2",
+        "styled-griddie": "^0.1.3"
+      },
+      "dependencies": {
+        "@emotion/core": {
+          "version": "10.1.1",
+          "resolved": "https://registry.npmjs.org/@emotion/core/-/core-10.1.1.tgz",
+          "integrity": "sha512-ZMLG6qpXR8x031NXD8HJqugy/AZSkAuMxxqB46pmAR7ze47MhNJ56cdoX243QPZdGctrdfo+s08yZTiwaUcRKA==",
+          "requires": {
+            "@babel/runtime": "^7.5.5",
+            "@emotion/cache": "^10.0.27",
+            "@emotion/css": "^10.0.27",
+            "@emotion/serialize": "^0.11.15",
+            "@emotion/sheet": "0.9.4",
+            "@emotion/utils": "0.11.3"
+          }
+        },
+        "@emotion/is-prop-valid": {
+          "version": "0.8.8",
+          "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
+          "integrity": "sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==",
+          "requires": {
+            "@emotion/memoize": "0.7.4"
+          }
+        },
+        "@emotion/sheet": {
+          "version": "0.9.4",
+          "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-0.9.4.tgz",
+          "integrity": "sha512-zM9PFmgVSqBw4zL101Q0HrBVTGmpAxFZH/pYx/cjJT5advXguvcgjHFTCaIO3enL/xr89vK2bh0Mfyj9aa0ANA=="
+        },
+        "@emotion/utils": {
+          "version": "0.11.3",
+          "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-0.11.3.tgz",
+          "integrity": "sha512-0o4l6pZC+hI88+bzuaX/6BgOvQVhbt2PfmxauVaYOGgbsAw14wdKyvMCZXnsnsHys94iadcF+RG/wZyx6+ZZBw=="
+        },
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+        },
+        "postcss": {
+          "version": "6.0.23",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+          "requires": {
+            "chalk": "^2.4.1",
+            "source-map": "^0.6.1",
+            "supports-color": "^5.4.0"
+          }
+        },
+        "rtlcss": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/rtlcss/-/rtlcss-2.6.2.tgz",
+          "integrity": "sha512-06LFAr+GAPo+BvaynsXRfoYTJvSaWRyOhURCQ7aeI1MKph9meM222F+Zkt3bDamyHHJuGi3VPtiRkpyswmQbGA==",
+          "requires": {
+            "@choojs/findup": "^0.2.1",
+            "chalk": "^2.4.2",
+            "mkdirp": "^0.5.1",
+            "postcss": "^6.0.23",
+            "strip-json-comments": "^2.0.0"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        }
+      }
+    },
+    "@wp-g2/styles": {
+      "version": "0.0.140",
+      "resolved": "https://registry.npmjs.org/@wp-g2/styles/-/styles-0.0.140.tgz",
+      "integrity": "sha512-wAvtqQOqX2zYpfEdVK4l4abH/hUUgw/+8+E5PvPgrsvqFg8IehNSksnjNF5/IloLRGAH70d8ytjMuMnUK8PVYA==",
+      "requires": {
+        "@wp-g2/create-styles": "^0.0.140",
+        "@wp-g2/utils": "^0.0.140"
+      }
+    },
+    "@wp-g2/utils": {
+      "version": "0.0.140",
+      "resolved": "https://registry.npmjs.org/@wp-g2/utils/-/utils-0.0.140.tgz",
+      "integrity": "sha512-a4uYi/XQEDrOAIO3JUQ+L/oeSkgp+08pSy41xxQ1nIRHs7X+Du84X2EFQrvZfGBRuXuVlVuUIlN2e0IE8yUZKw==",
+      "requires": {
+        "copy-to-clipboard": "^3.3.1",
+        "create-emotion": "^10.0.27",
+        "deepmerge": "^4.2.2",
+        "fast-deep-equal": "^3.1.3",
+        "hoist-non-react-statics": "^3.3.2",
+        "json2mq": "^0.2.0",
+        "lodash": "^4.17.19",
+        "memize": "^1.1.0",
+        "react-merge-refs": "^1.1.0",
+        "react-resize-aware": "^3.1.0",
+        "reakit-warning": "^0.5.5",
+        "tinycolor2": "^1.4.2",
+        "use-enhanced-state": "^0.0.13",
+        "use-isomorphic-layout-effect": "^1.0.0"
+      },
+      "dependencies": {
+        "deepmerge": {
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
+          "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg=="
+        },
+        "fast-deep-equal": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+          "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+        },
+        "hoist-non-react-statics": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+          "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+          "requires": {
+            "react-is": "^16.7.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+        },
+        "memize": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/memize/-/memize-1.1.0.tgz",
+          "integrity": "sha512-K4FcPETOMTwe7KL2LK0orMhpOmWD2wRGwWWpbZy0fyArwsyIKR8YJVz8+efBAh3BO4zPqlSICu4vsLTRRqtFAg=="
+        },
+        "react-resize-aware": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/react-resize-aware/-/react-resize-aware-3.1.0.tgz",
+          "integrity": "sha512-bIhHlxVTX7xKUz14ksXMEHjzCZPTpQZKZISY3nbTD273pDKPABGFNFBP6Tr42KECxzC5YQiKpMchjTVJCqaxpA=="
+        },
+        "tinycolor2": {
+          "version": "1.4.2",
+          "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.4.2.tgz",
+          "integrity": "sha512-vJhccZPs965sV/L2sU4oRQVAos0pQXwsvTLkWYdqJ+a8Q5kPFzJTuOFwy7UniPli44NKQGAglksjvOcpo95aZA=="
         }
       }
     },
@@ -14213,6 +14519,15 @@
       "integrity": "sha512-VvxA0xhNqIIfg0V9AmJkDg91DaJwryutH5rVEZAhcNi4iJFj9f+QxmAjgK1LT9I8OgToX27fypX6/MeCXVbBjQ==",
       "dev": true
     },
+    "call-bind": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "requires": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.2"
+      }
+    },
     "caller-callsite": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/caller-callsite/-/caller-callsite-2.0.0.tgz",
@@ -14726,8 +15041,7 @@
     "commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
     },
     "comment-parser": {
       "version": "0.7.2",
@@ -15532,6 +15846,14 @@
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
       "dev": true
     },
+    "copy-to-clipboard": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.1.tgz",
+      "integrity": "sha512-i13qo6kIHTTpCm8/Wup+0b1mVWETvu2kIMzKoK8FpkLkFxlt0znUAHcMzox+T8sPlqtZXq3CulEjQHsYiGFJUw==",
+      "requires": {
+        "toggle-selection": "^1.0.6"
+      }
+    },
     "core-js": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
@@ -15644,6 +15966,29 @@
       "requires": {
         "bn.js": "^4.1.0",
         "elliptic": "^6.0.0"
+      }
+    },
+    "create-emotion": {
+      "version": "10.0.27",
+      "resolved": "https://registry.npmjs.org/create-emotion/-/create-emotion-10.0.27.tgz",
+      "integrity": "sha512-fIK73w82HPPn/RsAij7+Zt8eCE8SptcJ3WoRMfxMtjteYxud8GDTKKld7MYwAX2TVhrw29uR1N/bVGxeStHILg==",
+      "requires": {
+        "@emotion/cache": "^10.0.27",
+        "@emotion/serialize": "^0.11.15",
+        "@emotion/sheet": "0.9.4",
+        "@emotion/utils": "0.11.3"
+      },
+      "dependencies": {
+        "@emotion/sheet": {
+          "version": "0.9.4",
+          "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-0.9.4.tgz",
+          "integrity": "sha512-zM9PFmgVSqBw4zL101Q0HrBVTGmpAxFZH/pYx/cjJT5advXguvcgjHFTCaIO3enL/xr89vK2bh0Mfyj9aa0ANA=="
+        },
+        "@emotion/utils": {
+          "version": "0.11.3",
+          "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-0.11.3.tgz",
+          "integrity": "sha512-0o4l6pZC+hI88+bzuaX/6BgOvQVhbt2PfmxauVaYOGgbsAw14wdKyvMCZXnsnsHys94iadcF+RG/wZyx6+ZZBw=="
+        }
       }
     },
     "create-hash": {
@@ -16538,6 +16883,25 @@
       "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
       "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
       "dev": true
+    },
+    "emotion": {
+      "version": "10.0.27",
+      "resolved": "https://registry.npmjs.org/emotion/-/emotion-10.0.27.tgz",
+      "integrity": "sha512-2xdDzdWWzue8R8lu4G76uWX5WhyQuzATon9LmNeCy/2BHVC6dsEpfhN1a0qhELgtDVdjyEA6J8Y/VlI5ZnaH0g==",
+      "requires": {
+        "babel-plugin-emotion": "^10.0.27",
+        "create-emotion": "^10.0.27"
+      }
+    },
+    "emotion-theming": {
+      "version": "10.0.27",
+      "resolved": "https://registry.npmjs.org/emotion-theming/-/emotion-theming-10.0.27.tgz",
+      "integrity": "sha512-MlF1yu/gYh8u+sLUqA0YuA9JX0P4Hb69WlKc/9OLo+WCXuX6sy/KoIa+qJimgmr2dWqnypYKYPX37esjDBbhdw==",
+      "requires": {
+        "@babel/runtime": "^7.5.5",
+        "@emotion/weak-memoize": "0.2.5",
+        "hoist-non-react-statics": "^3.3.0"
+      }
     },
     "encoding": {
       "version": "0.1.12",
@@ -18583,6 +18947,27 @@
         "map-cache": "^0.2.2"
       }
     },
+    "framer-motion": {
+      "version": "2.9.5",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-2.9.5.tgz",
+      "integrity": "sha512-epSX4Co1YbDv0mjfHouuY0q361TpHE7WQzCp/xMTilxy4kXd+Z23uJzPVorfzbm1a/9q1Yu8T5bndaw65NI4Tg==",
+      "requires": {
+        "@emotion/is-prop-valid": "^0.8.2",
+        "framesync": "^4.1.0",
+        "hey-listen": "^1.0.8",
+        "popmotion": "9.0.0-rc.20",
+        "style-value-types": "^3.1.9",
+        "tslib": "^1.10.0"
+      }
+    },
+    "framesync": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/framesync/-/framesync-4.1.0.tgz",
+      "integrity": "sha512-MmgZ4wCoeVxNbx2xp5hN/zPDCbLSKiDt4BbbslK7j/pM2lg5S0vhTNv1v8BCVb99JPIo6hXBFdwzU7Q4qcAaoQ==",
+      "requires": {
+        "hey-listen": "^1.0.5"
+      }
+    },
     "from2": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
@@ -19308,6 +19693,23 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
+    },
+    "get-intrinsic": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+      "requires": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1"
+      },
+      "dependencies": {
+        "has-symbols": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+          "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw=="
+        }
+      }
     },
     "get-own-enumerable-property-symbols": {
       "version": "3.0.2",
@@ -20082,6 +20484,16 @@
       "integrity": "sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==",
       "dev": true
     },
+    "hey-listen": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/hey-listen/-/hey-listen-1.0.8.tgz",
+      "integrity": "sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q=="
+    },
+    "highlight-words-core": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/highlight-words-core/-/highlight-words-core-1.2.2.tgz",
+      "integrity": "sha512-BXUKIkUuh6cmmxzi5OIbUJxrG8OAk2MqoL1DtO3Wo9D2faJg2ph5ntyuQeLqaHJmzER6H5tllCDA9ZnNe9BVGg=="
+    },
     "history": {
       "version": "4.10.1",
       "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
@@ -20363,6 +20775,14 @@
       "resolved": "https://registry.npmjs.org/in-publish/-/in-publish-2.0.0.tgz",
       "integrity": "sha1-4g/146KvwmkDILbcVSaCqcf631E=",
       "dev": true
+    },
+    "indefinite-observable": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/indefinite-observable/-/indefinite-observable-2.0.1.tgz",
+      "integrity": "sha512-G8vgmork+6H9S8lUAg1gtXEj2JxIQTo0g2PbFiYOdjkziSI0F7UYBiVwhZRuixhBCNGczAls34+5HJPyZysvxQ==",
+      "requires": {
+        "symbol-observable": "1.2.0"
+      }
     },
     "indent-string": {
       "version": "2.1.0",
@@ -24430,6 +24850,14 @@
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
     },
+    "json2mq": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/json2mq/-/json2mq-0.2.0.tgz",
+      "integrity": "sha1-tje9O6nqvhIsg+lyBIOusQ0skEo=",
+      "requires": {
+        "string-convert": "^0.2.0"
+      }
+    },
     "json2php": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/json2php/-/json2php-0.0.4.tgz",
@@ -25808,21 +26236,6 @@
       "requires": {
         "@babel/runtime": "^7.12.1",
         "tiny-warning": "^1.0.3"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.14.0",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.0.tgz",
-          "integrity": "sha512-JELkvo/DlpNdJ7dlyw/eY7E0suy5i5GQH+Vlxaq1nsNJ+H7f4Vtv3jMeCEgRhZZQFXTjldYfQgv2qmM6M1v5wA==",
-          "requires": {
-            "regenerator-runtime": "^0.13.4"
-          }
-        },
-        "regenerator-runtime": {
-          "version": "0.13.7",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-          "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
-        }
       }
     },
     "mini-css-extract-plugin-with-rtl": {
@@ -25936,6 +26349,11 @@
         "through2": "^2.0.0"
       }
     },
+    "mitt": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-2.1.0.tgz",
+      "integrity": "sha512-ILj2TpLiysu2wkBbWjAmww7TkZb65aiQO+DkVdUTBpBXq+MHYiETENkKFMtsJZX1Lf4pe4QOrTSjIfUwN5lRdg=="
+    },
     "mixin-deep": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
@@ -25961,7 +26379,6 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       },
@@ -25969,8 +26386,7 @@
         "minimist": {
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         }
       }
     },
@@ -26122,21 +26538,121 @@
       "dev": true
     },
     "newspack-components": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/newspack-components/-/newspack-components-1.4.0.tgz",
-      "integrity": "sha512-zDbPICE3PdqJFyeW9JfmrNx7rXYVra2V6n/X5uYW/ZVF9JQ7GpG8LxgS6J8HgSeMAhBfCOVbDgOEaGoCjJBXow==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/newspack-components/-/newspack-components-1.5.1.tgz",
+      "integrity": "sha512-sl8Bwp8TWmQO+olAkzpwa+wQra6iMjYUQRotLQ2Yd+qp7jl8PEZYw8AjKnTXMZR8NsXWLWw+2F8pFV9OihLmoA==",
       "requires": {
-        "@material-ui/core": "^4.8.2",
-        "@material-ui/icons": "^4.5.1",
-        "@wordpress/base-styles": "^1.0.0",
-        "@wordpress/components": "^7.3.1",
-        "@wordpress/element": "^2.3.0",
-        "@wordpress/i18n": "^3.11.0",
+        "@material-ui/core": "^4.11.2",
+        "@material-ui/icons": "^4.11.2",
+        "@wordpress/base-styles": "^1.6.0",
+        "@wordpress/components": "^12.0.6",
+        "@wordpress/element": "^2.19.0",
+        "@wordpress/i18n": "^3.17.0",
         "classnames": "^2.2.6",
         "lodash": "^4.17.20",
-        "react-router-dom": "^5.0.1"
+        "qs": "^6.9.6",
+        "react-router-dom": "^5.2.0"
       },
       "dependencies": {
+        "@emotion/core": {
+          "version": "10.1.1",
+          "resolved": "https://registry.npmjs.org/@emotion/core/-/core-10.1.1.tgz",
+          "integrity": "sha512-ZMLG6qpXR8x031NXD8HJqugy/AZSkAuMxxqB46pmAR7ze47MhNJ56cdoX243QPZdGctrdfo+s08yZTiwaUcRKA==",
+          "requires": {
+            "@babel/runtime": "^7.5.5",
+            "@emotion/cache": "^10.0.27",
+            "@emotion/css": "^10.0.27",
+            "@emotion/serialize": "^0.11.15",
+            "@emotion/sheet": "0.9.4",
+            "@emotion/utils": "0.11.3"
+          }
+        },
+        "@emotion/hash": {
+          "version": "0.8.0",
+          "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
+          "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
+        },
+        "@emotion/sheet": {
+          "version": "0.9.4",
+          "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-0.9.4.tgz",
+          "integrity": "sha512-zM9PFmgVSqBw4zL101Q0HrBVTGmpAxFZH/pYx/cjJT5advXguvcgjHFTCaIO3enL/xr89vK2bh0Mfyj9aa0ANA=="
+        },
+        "@emotion/utils": {
+          "version": "0.11.3",
+          "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-0.11.3.tgz",
+          "integrity": "sha512-0o4l6pZC+hI88+bzuaX/6BgOvQVhbt2PfmxauVaYOGgbsAw14wdKyvMCZXnsnsHys94iadcF+RG/wZyx6+ZZBw=="
+        },
+        "@material-ui/core": {
+          "version": "4.11.4",
+          "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-4.11.4.tgz",
+          "integrity": "sha512-oqb+lJ2Dl9HXI9orc6/aN8ZIAMkeThufA5iZELf2LQeBn2NtjVilF5D2w7e9RpntAzDb4jK5DsVhkfOvFY/8fg==",
+          "requires": {
+            "@babel/runtime": "^7.4.4",
+            "@material-ui/styles": "^4.11.4",
+            "@material-ui/system": "^4.11.3",
+            "@material-ui/types": "5.1.0",
+            "@material-ui/utils": "^4.11.2",
+            "@types/react-transition-group": "^4.2.0",
+            "clsx": "^1.0.4",
+            "hoist-non-react-statics": "^3.3.2",
+            "popper.js": "1.16.1-lts",
+            "prop-types": "^15.7.2",
+            "react-is": "^16.8.0 || ^17.0.0",
+            "react-transition-group": "^4.4.0"
+          }
+        },
+        "@material-ui/icons": {
+          "version": "4.11.2",
+          "resolved": "https://registry.npmjs.org/@material-ui/icons/-/icons-4.11.2.tgz",
+          "integrity": "sha512-fQNsKX2TxBmqIGJCSi3tGTO/gZ+eJgWmMJkgDiOfyNaunNaxcklJQFaFogYcFl0qFuaEz1qaXYXboa/bUXVSOQ==",
+          "requires": {
+            "@babel/runtime": "^7.4.4"
+          }
+        },
+        "@material-ui/styles": {
+          "version": "4.11.4",
+          "resolved": "https://registry.npmjs.org/@material-ui/styles/-/styles-4.11.4.tgz",
+          "integrity": "sha512-KNTIZcnj/zprG5LW0Sao7zw+yG3O35pviHzejMdcSGCdWbiO8qzRgOYL8JAxAsWBKOKYwVZxXtHWaB5T2Kvxew==",
+          "requires": {
+            "@babel/runtime": "^7.4.4",
+            "@emotion/hash": "^0.8.0",
+            "@material-ui/types": "5.1.0",
+            "@material-ui/utils": "^4.11.2",
+            "clsx": "^1.0.4",
+            "csstype": "^2.5.2",
+            "hoist-non-react-statics": "^3.3.2",
+            "jss": "^10.5.1",
+            "jss-plugin-camel-case": "^10.5.1",
+            "jss-plugin-default-unit": "^10.5.1",
+            "jss-plugin-global": "^10.5.1",
+            "jss-plugin-nested": "^10.5.1",
+            "jss-plugin-props-sort": "^10.5.1",
+            "jss-plugin-rule-value-function": "^10.5.1",
+            "jss-plugin-vendor-prefixer": "^10.5.1",
+            "prop-types": "^15.7.2"
+          }
+        },
+        "@material-ui/system": {
+          "version": "4.11.3",
+          "resolved": "https://registry.npmjs.org/@material-ui/system/-/system-4.11.3.tgz",
+          "integrity": "sha512-SY7otguNGol41Mu2Sg6KbBP1ZRFIbFLHGK81y4KYbsV2yIcaEPOmsCK6zwWlp+2yTV3J/VwT6oSBARtGIVdXPw==",
+          "requires": {
+            "@babel/runtime": "^7.4.4",
+            "@material-ui/utils": "^4.11.2",
+            "csstype": "^2.5.2",
+            "prop-types": "^15.7.2"
+          }
+        },
+        "@material-ui/utils": {
+          "version": "4.11.2",
+          "resolved": "https://registry.npmjs.org/@material-ui/utils/-/utils-4.11.2.tgz",
+          "integrity": "sha512-Uul8w38u+PICe2Fg2pDKCaIG7kOyhowZ9vjiC1FsVwPABTW8vPPKfF6OvxRq3IiBaI1faOJmgdvMG7rMJARBhA==",
+          "requires": {
+            "@babel/runtime": "^7.4.4",
+            "prop-types": "^15.7.2",
+            "react-is": "^16.8.0 || ^17.0.0"
+          }
+        },
         "@tannin/compile": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/@tannin/compile/-/compile-1.1.0.tgz",
@@ -26164,37 +26680,169 @@
           "resolved": "https://registry.npmjs.org/@tannin/postfix/-/postfix-1.1.0.tgz",
           "integrity": "sha512-oocsqY7g0cR+Gur5jRQLSrX2OtpMLMse1I10JQBm8CdGMrDkh1Mg2gjsiquMHRtBs4Qwu5wgEp5GgIYHk4SNPw=="
         },
-        "@wordpress/components": {
-          "version": "7.4.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-7.4.0.tgz",
-          "integrity": "sha512-riVey0Z5835YdPZLWFSAs/4Hzo0nr7WA/393mRXwGuUtkqdk7ia++5emKfhyaCLYbinVBd6366xFFfiFxxcsCA==",
+        "@wordpress/a11y": {
+          "version": "2.15.3",
+          "resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-2.15.3.tgz",
+          "integrity": "sha512-uoCznHY3/TaNWeXutLI6juC198ykaBwZ34P51PNHHQqi3WzVoBhFx6AnAR/9Uupl3tZcekefpkVHy7AJHMAPIA==",
           "requires": {
-            "@babel/runtime": "^7.4.4",
-            "@wordpress/a11y": "^2.3.0",
-            "@wordpress/api-fetch": "^3.2.0",
-            "@wordpress/compose": "^3.3.0",
-            "@wordpress/dom": "^2.3.0",
-            "@wordpress/element": "^2.4.0",
-            "@wordpress/hooks": "^2.3.0",
-            "@wordpress/i18n": "^3.4.0",
-            "@wordpress/is-shallow-equal": "^1.3.0",
-            "@wordpress/keycodes": "^2.3.0",
-            "@wordpress/rich-text": "^3.3.0",
-            "@wordpress/url": "^2.6.0",
+            "@babel/runtime": "^7.13.10",
+            "@wordpress/dom-ready": "^2.13.2",
+            "@wordpress/i18n": "^3.20.0"
+          }
+        },
+        "@wordpress/components": {
+          "version": "12.0.8",
+          "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-12.0.8.tgz",
+          "integrity": "sha512-sq0vs7Bm9yoF0Li3XpXUN6z7ggf72pPmqJd0u+DrAg0ZaPxYfCNCdazOHRXrc/0psyHF+xSTb5J8XpsE1DiWLQ==",
+          "requires": {
+            "@babel/runtime": "^7.12.5",
+            "@emotion/core": "^10.1.1",
+            "@emotion/css": "^10.0.22",
+            "@emotion/native": "^10.0.22",
+            "@emotion/styled": "^10.0.23",
+            "@wordpress/a11y": "^2.14.3",
+            "@wordpress/compose": "^3.24.5",
+            "@wordpress/date": "^3.13.1",
+            "@wordpress/deprecated": "^2.11.1",
+            "@wordpress/dom": "^2.16.2",
+            "@wordpress/element": "^2.19.1",
+            "@wordpress/hooks": "^2.11.1",
+            "@wordpress/i18n": "^3.18.0",
+            "@wordpress/icons": "^2.9.1",
+            "@wordpress/is-shallow-equal": "^3.0.1",
+            "@wordpress/keycodes": "^2.18.3",
+            "@wordpress/primitives": "^1.11.1",
+            "@wordpress/rich-text": "^3.24.8",
+            "@wordpress/warning": "^1.3.1",
+            "@wp-g2/components": "^0.0.140",
+            "@wp-g2/context": "^0.0.140",
+            "@wp-g2/styles": "^0.0.140",
+            "@wp-g2/utils": "^0.0.140",
             "classnames": "^2.2.5",
-            "clipboard": "^2.0.1",
-            "diff": "^3.5.0",
             "dom-scroll-into-view": "^1.2.1",
-            "lodash": "^4.17.11",
-            "memize": "^1.0.5",
+            "downshift": "^6.0.15",
+            "gradient-parser": "^0.1.5",
+            "highlight-words-core": "^1.2.2",
+            "lodash": "^4.17.19",
+            "memize": "^1.1.0",
             "moment": "^2.22.1",
-            "mousetrap": "^1.6.2",
-            "re-resizable": "^4.7.1",
-            "react-click-outside": "^3.0.0",
+            "re-resizable": "^6.4.0",
             "react-dates": "^17.1.1",
+            "react-merge-refs": "^1.0.0",
+            "react-resize-aware": "^3.1.0",
+            "react-spring": "^8.0.20",
+            "react-use-gesture": "^9.0.0",
+            "reakit": "^1.3.5",
             "rememo": "^3.0.0",
-            "tinycolor2": "^1.4.1",
-            "uuid": "^3.3.2"
+            "tinycolor2": "^1.4.2",
+            "uuid": "^8.3.0"
+          }
+        },
+        "@wordpress/compose": {
+          "version": "3.25.3",
+          "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.25.3.tgz",
+          "integrity": "sha512-tCO2EnJCkCH548OqA0uU8V1k/1skz2QwBlHs8ZQSpimqUS4OWWsAlndCEFe4U4vDTqFt2ow7tzAir+05Cw8MAg==",
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@wordpress/deprecated": "^2.12.3",
+            "@wordpress/dom": "^2.18.0",
+            "@wordpress/element": "^2.20.3",
+            "@wordpress/is-shallow-equal": "^3.1.3",
+            "@wordpress/keycodes": "^2.19.3",
+            "@wordpress/priority-queue": "^1.11.2",
+            "clipboard": "^2.0.1",
+            "lodash": "^4.17.19",
+            "memize": "^1.1.0",
+            "mousetrap": "^1.6.5",
+            "react-resize-aware": "^3.1.0",
+            "use-memo-one": "^1.1.1"
+          }
+        },
+        "@wordpress/data": {
+          "version": "4.27.3",
+          "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-4.27.3.tgz",
+          "integrity": "sha512-5763NgNV9IIa1CC3Q80dAvrH6108tJtj3IrHfUCZmUk1atSNsOMBCkLdQ7tGTTi2JFejeGEMg1LJI22JD5zM6Q==",
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@wordpress/compose": "^3.25.3",
+            "@wordpress/deprecated": "^2.12.3",
+            "@wordpress/element": "^2.20.3",
+            "@wordpress/is-shallow-equal": "^3.1.3",
+            "@wordpress/priority-queue": "^1.11.2",
+            "@wordpress/redux-routine": "^3.14.2",
+            "equivalent-key-map": "^0.2.2",
+            "is-promise": "^4.0.0",
+            "lodash": "^4.17.19",
+            "memize": "^1.1.0",
+            "redux": "^4.0.0",
+            "turbo-combine-reducers": "^1.0.2",
+            "use-memo-one": "^1.1.1"
+          }
+        },
+        "@wordpress/date": {
+          "version": "3.15.1",
+          "resolved": "https://registry.npmjs.org/@wordpress/date/-/date-3.15.1.tgz",
+          "integrity": "sha512-SuHiObvjbegL8RpaSQ6JqFnG+QyGP+oUhx1FZDMdt1nOQA9HE7D5ssVlZFlMEAdo6iS8xMuW+4SgJN3Eo1fb4w==",
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "moment": "^2.22.1",
+            "moment-timezone": "^0.5.31"
+          }
+        },
+        "@wordpress/deprecated": {
+          "version": "2.12.3",
+          "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-2.12.3.tgz",
+          "integrity": "sha512-qr+yDfTQfI3M4h6oY6IeHWwoHr4jxbILjSlV+Ht6Jjto9Owap6OuzSqR13Ev4xqIoG4C7b5B3gZXVfwVDae1zg==",
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@wordpress/hooks": "^2.12.3"
+          }
+        },
+        "@wordpress/dom": {
+          "version": "2.18.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-2.18.0.tgz",
+          "integrity": "sha512-tM2WeQuSObl3nzWjUTF0/dyLnA7sdl/MXaSe32D64OF89bjSyJvjUipI7gjKzI3kJ7ddGhwcTggGvSB06MOoCQ==",
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "lodash": "^4.17.19"
+          }
+        },
+        "@wordpress/dom-ready": {
+          "version": "2.13.2",
+          "resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-2.13.2.tgz",
+          "integrity": "sha512-COH7n2uZfBq4FtluSbl37N3nCEcdMXzV42ETCWKUcumiP1Zd3qnkfQKcsxTaHWY8aVt/358RvJ7ghWe3xAd+fg==",
+          "requires": {
+            "@babel/runtime": "^7.13.10"
+          }
+        },
+        "@wordpress/element": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.20.3.tgz",
+          "integrity": "sha512-f4ZPTDf9CxiiOXiMxc4v1K7jcBMT4dsiehVOpkKzCDKboNXp4qVf8oe5PE23VGZNEjcOj5Mkg9hB57R0nqvMTw==",
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@types/react": "^16.9.0",
+            "@types/react-dom": "^16.9.0",
+            "@wordpress/escape-html": "^1.12.2",
+            "lodash": "^4.17.19",
+            "react": "^16.13.1",
+            "react-dom": "^16.13.1"
+          }
+        },
+        "@wordpress/escape-html": {
+          "version": "1.12.2",
+          "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-1.12.2.tgz",
+          "integrity": "sha512-FabgSwznhdaUwe6hr1CsGpgxQbzqEoGevv73WIL1B9GvlZ6csRWodgHfWh4P6fYqpzxFL4WYB8wPJ1PdO32XFA==",
+          "requires": {
+            "@babel/runtime": "^7.13.10"
+          }
+        },
+        "@wordpress/hooks": {
+          "version": "2.12.3",
+          "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-2.12.3.tgz",
+          "integrity": "sha512-LmKiwKldZt6UYqOxV/a6+eUFXdvALFnB/pQx3RmrMvO64sgFhfR6dhrlv+uVbuuezSuv8dce1jx8lUWAT0krMA==",
+          "requires": {
+            "@babel/runtime": "^7.13.10"
           }
         },
         "@wordpress/i18n": {
@@ -26209,28 +26857,114 @@
             "memize": "^1.1.0",
             "sprintf-js": "^1.1.1",
             "tannin": "^1.2.0"
+          }
+        },
+        "@wordpress/icons": {
+          "version": "2.10.3",
+          "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-2.10.3.tgz",
+          "integrity": "sha512-hVXArGOHLE5pL1G3rHNzsUEuTR4/G6lB+enKYwhYSSIqWuSbyXbZq3nvibxpepPrLy9B3d5t6aR6QUmjMVzIcQ==",
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@wordpress/element": "^2.20.3",
+            "@wordpress/primitives": "^1.12.3"
+          }
+        },
+        "@wordpress/is-shallow-equal": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-3.1.3.tgz",
+          "integrity": "sha512-eDLhfC4aaSgklzqwc6F/F4zmJVpTVTAvhqX+q0SP/8LPcP2HuKErPHVrEc75PMWqIutja2wJg98YSNPdewrj1w==",
+          "requires": {
+            "@babel/runtime": "^7.13.10"
+          }
+        },
+        "@wordpress/keycodes": {
+          "version": "2.19.3",
+          "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-2.19.3.tgz",
+          "integrity": "sha512-8rNdmP5M1ifTgLIL0dt/N1uTGsq/Rx1ydCXy+gg24WdxBRhyu5sudNVCtascVXo26aIfOH9OJRdqRZZTEORhog==",
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@wordpress/i18n": "^3.20.0",
+            "lodash": "^4.17.19"
+          }
+        },
+        "@wordpress/primitives": {
+          "version": "1.12.3",
+          "resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-1.12.3.tgz",
+          "integrity": "sha512-LIF44bVlJS7CJEVmk6TLuV6HZMdj5iwkyM8do4ukGY6qnZIzrXpBablgJeDBcyjzWrWRLn+w+tiZ/8l+2egoVA==",
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@wordpress/element": "^2.20.3",
+            "classnames": "^2.2.5"
+          }
+        },
+        "@wordpress/priority-queue": {
+          "version": "1.11.2",
+          "resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-1.11.2.tgz",
+          "integrity": "sha512-ulwmUOklY3orn1xXpcPnTyGWV5B/oycxI+cHZ6EevBVgM5sq+BW3xo0PKLR/MMm6UNBtFTu/71QAJrNZcD6V1g==",
+          "requires": {
+            "@babel/runtime": "^7.13.10"
+          }
+        },
+        "@wordpress/redux-routine": {
+          "version": "3.14.2",
+          "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-3.14.2.tgz",
+          "integrity": "sha512-aqi4UtvMP/+NhULxyCR8ktG0v4BJVTRcMpByAqDg7Oabq2sz2LPuShxd5UY8vxQYQY9t1uUJbslhom4ytcohWg==",
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "is-promise": "^4.0.0",
+            "lodash": "^4.17.19",
+            "rungen": "^0.3.2"
+          }
+        },
+        "@wordpress/rich-text": {
+          "version": "3.25.3",
+          "resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-3.25.3.tgz",
+          "integrity": "sha512-FdqL1/rHTsRxZ1gW1UEWuy0URmUEqMzj5hcAbOhHFPO5m0ENrkzC9bBa195KqZBSNSmBmXnDZdHu4UJUolzcZg==",
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@wordpress/compose": "^3.25.3",
+            "@wordpress/data": "^4.27.3",
+            "@wordpress/dom": "^2.18.0",
+            "@wordpress/element": "^2.20.3",
+            "@wordpress/escape-html": "^1.12.2",
+            "@wordpress/is-shallow-equal": "^3.1.3",
+            "@wordpress/keycodes": "^2.19.3",
+            "classnames": "^2.2.5",
+            "lodash": "^4.17.19",
+            "memize": "^1.1.0",
+            "rememo": "^3.0.0"
+          }
+        },
+        "@wordpress/warning": {
+          "version": "1.4.2",
+          "resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-1.4.2.tgz",
+          "integrity": "sha512-MjrkSp6Jyfx+92AE32A83P503noUtGb6//BYUH4GiWzzzSNhDHgbQ0UcOJwJaEYK166DxSNpMk/JXc4YENi1Cw=="
+        },
+        "body-scroll-lock": {
+          "version": "3.1.5",
+          "resolved": "https://registry.npmjs.org/body-scroll-lock/-/body-scroll-lock-3.1.5.tgz",
+          "integrity": "sha512-Yi1Xaml0EvNA0OYWxXiYNqY24AfWkbA6w5vxE7GWxtKfzIbZM+Qw+aSmkgsbWzbHiy/RCSkUZBplVxTA+E4jJg=="
+        },
+        "compute-scroll-into-view": {
+          "version": "1.0.17",
+          "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-1.0.17.tgz",
+          "integrity": "sha512-j4dx+Fb0URmzbwwMUrhqWM2BEWHdFGx+qZ9qqASHRPqvTYdqvWnHg0H1hIbcyLnvgnoNAVMlwkepyqM3DaIFUg=="
+        },
+        "downshift": {
+          "version": "6.1.3",
+          "resolved": "https://registry.npmjs.org/downshift/-/downshift-6.1.3.tgz",
+          "integrity": "sha512-RA1MuaNcTbt0j+sVLhSs8R2oZbBXYAtdQP/V+uHhT3DoDteZzJPjlC+LQVm9T07Wpvo84QXaZtUCePLDTDwGXg==",
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "compute-scroll-into-view": "^1.0.17",
+            "prop-types": "^15.7.2",
+            "react-is": "^17.0.2"
           },
           "dependencies": {
-            "@babel/runtime": {
-              "version": "7.14.0",
-              "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.0.tgz",
-              "integrity": "sha512-JELkvo/DlpNdJ7dlyw/eY7E0suy5i5GQH+Vlxaq1nsNJ+H7f4Vtv3jMeCEgRhZZQFXTjldYfQgv2qmM6M1v5wA==",
-              "requires": {
-                "regenerator-runtime": "^0.13.4"
-              }
-            },
-            "@wordpress/hooks": {
-              "version": "2.12.3",
-              "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-2.12.3.tgz",
-              "integrity": "sha512-LmKiwKldZt6UYqOxV/a6+eUFXdvALFnB/pQx3RmrMvO64sgFhfR6dhrlv+uVbuuezSuv8dce1jx8lUWAT0krMA==",
-              "requires": {
-                "@babel/runtime": "^7.13.10"
-              }
-            },
-            "memize": {
-              "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/memize/-/memize-1.1.0.tgz",
-              "integrity": "sha512-K4FcPETOMTwe7KL2LK0orMhpOmWD2wRGwWWpbZy0fyArwsyIKR8YJVz8+efBAh3BO4zPqlSICu4vsLTRRqtFAg=="
+            "react-is": {
+              "version": "17.0.2",
+              "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+              "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
             }
           }
         },
@@ -26243,20 +26977,231 @@
             "safe-buffer": "^5.1.1"
           }
         },
+        "hoist-non-react-statics": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+          "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+          "requires": {
+            "react-is": "^16.7.0"
+          }
+        },
+        "is-promise": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+          "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="
+        },
+        "jss": {
+          "version": "10.6.0",
+          "resolved": "https://registry.npmjs.org/jss/-/jss-10.6.0.tgz",
+          "integrity": "sha512-n7SHdCozmxnzYGXBHe0NsO0eUf9TvsHVq2MXvi4JmTn3x5raynodDVE/9VQmBdWFyyj9HpHZ2B4xNZ7MMy7lkw==",
+          "requires": {
+            "@babel/runtime": "^7.3.1",
+            "csstype": "^3.0.2",
+            "indefinite-observable": "^2.0.1",
+            "is-in-browser": "^1.1.3",
+            "tiny-warning": "^1.0.2"
+          },
+          "dependencies": {
+            "csstype": {
+              "version": "3.0.8",
+              "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.8.tgz",
+              "integrity": "sha512-jXKhWqXPmlUeoQnF/EhTtTl4C9SnrxSH/jZUih3jmO6lBKr99rP3/+FmrMj4EFpOXzMtXHAZkd3x0E6h6Fgflw=="
+            }
+          }
+        },
+        "jss-plugin-camel-case": {
+          "version": "10.6.0",
+          "resolved": "https://registry.npmjs.org/jss-plugin-camel-case/-/jss-plugin-camel-case-10.6.0.tgz",
+          "integrity": "sha512-JdLpA3aI/npwj3nDMKk308pvnhoSzkW3PXlbgHAzfx0yHWnPPVUjPhXFtLJzgKZge8lsfkUxvYSQ3X2OYIFU6A==",
+          "requires": {
+            "@babel/runtime": "^7.3.1",
+            "hyphenate-style-name": "^1.0.3",
+            "jss": "10.6.0"
+          }
+        },
+        "jss-plugin-default-unit": {
+          "version": "10.6.0",
+          "resolved": "https://registry.npmjs.org/jss-plugin-default-unit/-/jss-plugin-default-unit-10.6.0.tgz",
+          "integrity": "sha512-7y4cAScMHAxvslBK2JRK37ES9UT0YfTIXWgzUWD5euvR+JR3q+o8sQKzBw7GmkQRfZijrRJKNTiSt1PBsLI9/w==",
+          "requires": {
+            "@babel/runtime": "^7.3.1",
+            "jss": "10.6.0"
+          }
+        },
+        "jss-plugin-global": {
+          "version": "10.6.0",
+          "resolved": "https://registry.npmjs.org/jss-plugin-global/-/jss-plugin-global-10.6.0.tgz",
+          "integrity": "sha512-I3w7ji/UXPi3VuWrTCbHG9rVCgB4yoBQLehGDTmsnDfXQb3r1l3WIdcO8JFp9m0YMmyy2CU7UOV6oPI7/Tmu+w==",
+          "requires": {
+            "@babel/runtime": "^7.3.1",
+            "jss": "10.6.0"
+          }
+        },
+        "jss-plugin-nested": {
+          "version": "10.6.0",
+          "resolved": "https://registry.npmjs.org/jss-plugin-nested/-/jss-plugin-nested-10.6.0.tgz",
+          "integrity": "sha512-fOFQWgd98H89E6aJSNkEh2fAXquC9aZcAVjSw4q4RoQ9gU++emg18encR4AT4OOIFl4lQwt5nEyBBRn9V1Rk8g==",
+          "requires": {
+            "@babel/runtime": "^7.3.1",
+            "jss": "10.6.0",
+            "tiny-warning": "^1.0.2"
+          }
+        },
+        "jss-plugin-props-sort": {
+          "version": "10.6.0",
+          "resolved": "https://registry.npmjs.org/jss-plugin-props-sort/-/jss-plugin-props-sort-10.6.0.tgz",
+          "integrity": "sha512-oMCe7hgho2FllNc60d9VAfdtMrZPo9n1Iu6RNa+3p9n0Bkvnv/XX5San8fTPujrTBScPqv9mOE0nWVvIaohNuw==",
+          "requires": {
+            "@babel/runtime": "^7.3.1",
+            "jss": "10.6.0"
+          }
+        },
+        "jss-plugin-rule-value-function": {
+          "version": "10.6.0",
+          "resolved": "https://registry.npmjs.org/jss-plugin-rule-value-function/-/jss-plugin-rule-value-function-10.6.0.tgz",
+          "integrity": "sha512-TKFqhRTDHN1QrPTMYRlIQUOC2FFQb271+AbnetURKlGvRl/eWLswcgHQajwuxI464uZk91sPiTtdGi7r7XaWfA==",
+          "requires": {
+            "@babel/runtime": "^7.3.1",
+            "jss": "10.6.0",
+            "tiny-warning": "^1.0.2"
+          }
+        },
+        "jss-plugin-vendor-prefixer": {
+          "version": "10.6.0",
+          "resolved": "https://registry.npmjs.org/jss-plugin-vendor-prefixer/-/jss-plugin-vendor-prefixer-10.6.0.tgz",
+          "integrity": "sha512-doJ7MouBXT1lypLLctCwb4nJ6lDYqrTfVS3LtXgox42Xz0gXusXIIDboeh6UwnSmox90QpVnub7au8ybrb0krQ==",
+          "requires": {
+            "@babel/runtime": "^7.3.1",
+            "css-vendor": "^2.0.8",
+            "jss": "10.6.0"
+          }
+        },
         "lodash": {
           "version": "4.17.21",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
           "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
         },
-        "re-resizable": {
-          "version": "4.11.0",
-          "resolved": "https://registry.npmjs.org/re-resizable/-/re-resizable-4.11.0.tgz",
-          "integrity": "sha512-dye+7rERqNf/6mDT1iwps+4Gf42420xuZgygF33uX178DxffqcyeuHbBuJ382FIcB5iP6mMZOhfW7kI0uXwb/Q=="
+        "memize": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/memize/-/memize-1.1.0.tgz",
+          "integrity": "sha512-K4FcPETOMTwe7KL2LK0orMhpOmWD2wRGwWWpbZy0fyArwsyIKR8YJVz8+efBAh3BO4zPqlSICu4vsLTRRqtFAg=="
         },
-        "regenerator-runtime": {
-          "version": "0.13.7",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-          "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
+        "moment-timezone": {
+          "version": "0.5.33",
+          "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.33.tgz",
+          "integrity": "sha512-PTc2vcT8K9J5/9rDEPe5czSIKgLoGsH8UNpA4qZTVw0Vd/Uz19geE9abbIOQKaAQFcnQ3v5YEXrbSc5BpshH+w==",
+          "requires": {
+            "moment": ">= 2.9.0"
+          }
+        },
+        "mousetrap": {
+          "version": "1.6.5",
+          "resolved": "https://registry.npmjs.org/mousetrap/-/mousetrap-1.6.5.tgz",
+          "integrity": "sha512-QNo4kEepaIBwiT8CDhP98umTetp+JNfQYBWvC1pc6/OAibuXtRcxZ58Qz8skvEHYvURne/7R8T5VoOI7rDsEUA=="
+        },
+        "object-inspect": {
+          "version": "1.10.3",
+          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.3.tgz",
+          "integrity": "sha512-e5mCJlSH7poANfC8z8S9s9S2IN5/4Zb3aZ33f5s8YqoazCFzNLloLU8r5VCG+G7WoqLvAAZoVMcy3tp/3X0Plw=="
+        },
+        "popper.js": {
+          "version": "1.16.1-lts",
+          "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1-lts.tgz",
+          "integrity": "sha512-Kjw8nKRl1m+VrSFCoVGPph93W/qrSO7ZkqPpTf7F4bk/sqcfWK019dWBUpE/fBOsOQY1dks/Bmcbfn1heM/IsA=="
+        },
+        "qs": {
+          "version": "6.10.1",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.1.tgz",
+          "integrity": "sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==",
+          "requires": {
+            "side-channel": "^1.0.4"
+          }
+        },
+        "re-resizable": {
+          "version": "6.9.0",
+          "resolved": "https://registry.npmjs.org/re-resizable/-/re-resizable-6.9.0.tgz",
+          "integrity": "sha512-3cUDG81ylyqI0Pdgle/RHwwRYq0ORZzsUaySOCO8IbEtNyaRtrIHYm/jMQ5pjcNiKCxR3vsSymIQZHwJq4gg2Q==",
+          "requires": {
+            "fast-memoize": "^2.5.1"
+          }
+        },
+        "react": {
+          "version": "16.14.0",
+          "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
+          "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "react-dom": {
+          "version": "16.14.0",
+          "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
+          "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "scheduler": "^0.19.1"
+          }
+        },
+        "react-resize-aware": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/react-resize-aware/-/react-resize-aware-3.1.0.tgz",
+          "integrity": "sha512-bIhHlxVTX7xKUz14ksXMEHjzCZPTpQZKZISY3nbTD273pDKPABGFNFBP6Tr42KECxzC5YQiKpMchjTVJCqaxpA=="
+        },
+        "reakit": {
+          "version": "1.3.8",
+          "resolved": "https://registry.npmjs.org/reakit/-/reakit-1.3.8.tgz",
+          "integrity": "sha512-8SVejx6FUaFi2+Q9eXoDAd4wWi/xAn6v8JgXH8x2xnzye8pb6v5bYvegACVpYVZnrS5w/JUgMTGh1Xy8MkkPww==",
+          "requires": {
+            "@popperjs/core": "^2.5.4",
+            "body-scroll-lock": "^3.1.5",
+            "reakit-system": "^0.15.1",
+            "reakit-utils": "^0.15.1",
+            "reakit-warning": "^0.6.1"
+          }
+        },
+        "reakit-system": {
+          "version": "0.15.1",
+          "resolved": "https://registry.npmjs.org/reakit-system/-/reakit-system-0.15.1.tgz",
+          "integrity": "sha512-PkqfAyEohtcEu/gUvKriCv42NywDtUgvocEN3147BI45dOFAB89nrT7wRIbIcKJiUT598F+JlPXAZZVLWhc1Kg==",
+          "requires": {
+            "reakit-utils": "^0.15.1"
+          }
+        },
+        "reakit-utils": {
+          "version": "0.15.1",
+          "resolved": "https://registry.npmjs.org/reakit-utils/-/reakit-utils-0.15.1.tgz",
+          "integrity": "sha512-6cZgKGvOkAMQgkwU9jdYbHfkuIN1Pr+vwcB19plLvcTfVN0Or10JhIuj9X+JaPZyI7ydqTDFaKNdUcDP69o/+Q=="
+        },
+        "reakit-warning": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/reakit-warning/-/reakit-warning-0.6.1.tgz",
+          "integrity": "sha512-poFUV0EyxB+CcV9uTNBAFmcgsnR2DzAbOTkld4Ul+QOKSeEHZB3b3+MoZQgcYHmbvG19Na1uWaM7ES+/Eyr8tQ==",
+          "requires": {
+            "reakit-utils": "^0.15.1"
+          }
+        },
+        "scheduler": {
+          "version": "0.19.1",
+          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
+          "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1"
+          }
+        },
+        "side-channel": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+          "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+          "requires": {
+            "call-bind": "^1.0.0",
+            "get-intrinsic": "^1.0.2",
+            "object-inspect": "^1.9.0"
+          }
         },
         "sprintf-js": {
           "version": "1.1.2",
@@ -26270,6 +27215,16 @@
           "requires": {
             "@tannin/plural-forms": "^1.1.0"
           }
+        },
+        "tinycolor2": {
+          "version": "1.4.2",
+          "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.4.2.tgz",
+          "integrity": "sha512-vJhccZPs965sV/L2sU4oRQVAos0pQXwsvTLkWYdqJ+a8Q5kPFzJTuOFwy7UniPli44NKQGAglksjvOcpo95aZA=="
+        },
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
         }
       }
     },
@@ -31038,6 +31993,17 @@
       "integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
       "dev": true
     },
+    "popmotion": {
+      "version": "9.0.0-rc.20",
+      "resolved": "https://registry.npmjs.org/popmotion/-/popmotion-9.0.0-rc.20.tgz",
+      "integrity": "sha512-f98sny03WuA+c8ckBjNNXotJD4G2utG/I3Q23NU69OEafrXtxxSukAaJBxzbtxwDvz3vtZK69pu9ojdkMoBNTg==",
+      "requires": {
+        "framesync": "^4.1.0",
+        "hey-listen": "^1.0.8",
+        "style-value-types": "^3.1.9",
+        "tslib": "^1.10.0"
+      }
+    },
     "popper.js": {
       "version": "1.16.1",
       "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
@@ -32094,20 +33060,10 @@
         "prop-types": "^15.5.6"
       }
     },
-    "react-click-outside": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/react-click-outside/-/react-click-outside-3.0.1.tgz",
-      "integrity": "sha512-d0KWFvBt+esoZUF15rL2UBB7jkeAqLU8L/Ny35oLK6fW6mIbOv/ChD+ExF4sR9PD26kVx+9hNfD0FTIqRZEyRQ==",
-      "requires": {
-        "hoist-non-react-statics": "^2.1.1"
-      },
-      "dependencies": {
-        "hoist-non-react-statics": {
-          "version": "2.5.5",
-          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
-          "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
-        }
-      }
+    "react-colorful": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/react-colorful/-/react-colorful-4.4.4.tgz",
+      "integrity": "sha512-01V2/6rr6sa1vaZntWZJXZxnU7ew02NG2rqq0eoVp4d3gFU5Ug9lDzNMbr+8ns0byXsJbBR8LbwQTlAjz6x7Kg=="
     },
     "react-dates": {
       "version": "17.2.0",
@@ -32151,6 +33107,11 @@
       "version": "16.11.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.11.0.tgz",
       "integrity": "sha512-gbBVYR2p8mnriqAwWx9LbuUrShnAuSCNnuPGyc7GJrMVQtPDAh8iLpv7FRuMPFb56KkaVZIYSz1PrjI9q0QPCw=="
+    },
+    "react-merge-refs": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/react-merge-refs/-/react-merge-refs-1.1.0.tgz",
+      "integrity": "sha512-alTKsjEL0dKH/ru1Iyn7vliS2QRcBp9zZPGoWxUOvRGWPUYgjo+V01is7p04It6KhgrzhJGnIj9GgX8W4bZoCQ=="
     },
     "react-moment-proptypes": {
       "version": "1.7.0",
@@ -32257,6 +33218,16 @@
         }
       }
     },
+    "react-textarea-autosize": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.3.2.tgz",
+      "integrity": "sha512-JrMWVgQSaExQByP3ggI1eA8zF4mF0+ddVuX7acUeK2V7bmrpjVOY72vmLz2IXFJSAXoY3D80nEzrn0GWajWK3Q==",
+      "requires": {
+        "@babel/runtime": "^7.10.2",
+        "use-composed-ref": "^1.0.0",
+        "use-latest": "^1.0.0"
+      }
+    },
     "react-transition-group": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.1.tgz",
@@ -32267,6 +33238,11 @@
         "loose-envify": "^1.4.0",
         "prop-types": "^15.6.2"
       }
+    },
+    "react-use-gesture": {
+      "version": "9.1.3",
+      "resolved": "https://registry.npmjs.org/react-use-gesture/-/react-use-gesture-9.1.3.tgz",
+      "integrity": "sha512-CdqA2SmS/fj3kkS2W8ZU8wjTbVBAIwDWaRprX7OKaj7HlGwBasGEFggmk5qNklknqk9zK/h8D355bEJFTpqEMg=="
     },
     "react-with-direction": {
       "version": "1.3.1",
@@ -32378,6 +33354,21 @@
       "version": "0.7.3",
       "resolved": "https://registry.npmjs.org/reakit-utils/-/reakit-utils-0.7.3.tgz",
       "integrity": "sha512-sQsgKYcn+OthBkvKz+TeHlYZq2SF5ZP9RutHg7O67GI+sdYqf0BVy6VeTe28TG4Vui6hoMheiMnZqhidOtN7EA=="
+    },
+    "reakit-warning": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/reakit-warning/-/reakit-warning-0.5.5.tgz",
+      "integrity": "sha512-OuP1r7rlSSJZsoLuc0CPA2ACPKnWO8HDbFktiiidbT67UjuX6udYV1AUsIgMJ8ado9K5gZGjPj7IB/GDYo9Yjg==",
+      "requires": {
+        "reakit-utils": "^0.14.4"
+      },
+      "dependencies": {
+        "reakit-utils": {
+          "version": "0.14.4",
+          "resolved": "https://registry.npmjs.org/reakit-utils/-/reakit-utils-0.14.4.tgz",
+          "integrity": "sha512-jDEf/NmZVJ6fs10G16ifD+RFhQikSLN7VfjRHu0CPoUj4g6lFXd5PPcRXCY81qiqc9FVHjr2d2fmsw1hs6xUxA=="
+        }
+      }
     },
     "realpath-native": {
       "version": "1.1.0",
@@ -34702,6 +35693,11 @@
       "integrity": "sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==",
       "dev": true
     },
+    "string-convert": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/string-convert/-/string-convert-0.2.1.tgz",
+      "integrity": "sha1-aYLMMEn7tM2F+LJFaLnZvznu/5c="
+    },
     "string-length": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.1.tgz",
@@ -35021,14 +36017,27 @@
     "strip-json-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-      "dev": true
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
     },
     "style-search": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/style-search/-/style-search-0.1.0.tgz",
       "integrity": "sha1-eVjHk+R+MuB9K1yv5cC/jhLneQI=",
       "dev": true
+    },
+    "style-value-types": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/style-value-types/-/style-value-types-3.2.0.tgz",
+      "integrity": "sha512-ih0mGsrYYmVvdDi++/66O6BaQPRPRMQHoZevNNdMMcPlP/cH28Rnfsqf1UEba/Bwfuw9T8BmIMwbGdzsPwQKrQ==",
+      "requires": {
+        "hey-listen": "^1.0.8",
+        "tslib": "^1.10.0"
+      }
+    },
+    "styled-griddie": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/styled-griddie/-/styled-griddie-0.1.3.tgz",
+      "integrity": "sha512-RjsiiADJrRpdPTF8NR26nlZutnvkrX78tiM5/za/E+ftVdpjD8ZBb2iOzrIzfix80uDcHYQbg3iIR0lOGaYmEQ=="
     },
     "stylehacks": {
       "version": "4.0.3",
@@ -36284,6 +37293,11 @@
         "repeat-string": "^1.6.1"
       }
     },
+    "toggle-selection": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
+      "integrity": "sha1-bkWxJj8gF/oKzH2J14sVuL932jI="
+    },
     "tough-cookie": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
@@ -36372,11 +37386,15 @@
         }
       }
     },
+    "ts-essentials": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-2.0.12.tgz",
+      "integrity": "sha512-3IVX4nI6B5cc31/GFFE+i8ey/N2eA0CZDbo6n0yrz0zDX8ZJ8djmU1p+XRz7G3is0F3bB3pu2pAroFdAWQKU3w=="
+    },
     "tslib": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
-      "dev": true
+      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
     },
     "tty-browserify": {
       "version": "0.0.0",
@@ -36734,6 +37752,36 @@
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
       "dev": true
+    },
+    "use-composed-ref": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.1.0.tgz",
+      "integrity": "sha512-my1lNHGWsSDAhhVAT4MKs6IjBUtG6ZG11uUqexPH9PptiIZDQOzaF4f5tEbJ2+7qvNbtXNBbU3SfmN+fXlWDhg==",
+      "requires": {
+        "ts-essentials": "^2.0.3"
+      }
+    },
+    "use-enhanced-state": {
+      "version": "0.0.13",
+      "resolved": "https://registry.npmjs.org/use-enhanced-state/-/use-enhanced-state-0.0.13.tgz",
+      "integrity": "sha512-RCtUQdhfUXu/0GAQqLnKPetUt3BheYFpOTogppHe9x1XGwluiu6DQLKVNnc3yMfj0HM3IOVBgw5nVJJuZS5TWQ==",
+      "requires": {
+        "@itsjonq/is": "0.0.2",
+        "tiny-warning": "^1.0.3"
+      }
+    },
+    "use-isomorphic-layout-effect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.1.tgz",
+      "integrity": "sha512-L7Evj8FGcwo/wpbv/qvSfrkHFtOpCzvM5yl2KVyDJoylVuSvzphiiasmjgQPttIGBAy2WKiBNR98q8w7PiNgKQ=="
+    },
+    "use-latest": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-latest/-/use-latest-1.2.0.tgz",
+      "integrity": "sha512-d2TEuG6nSLKQLAfW3By8mKr8HurOlTkul0sOpxbClIv4SQ4iOd7BYr7VIzdbktUCnv7dua/60xzd8igMU6jmyw==",
+      "requires": {
+        "use-isomorphic-layout-effect": "^1.0.0"
+      }
     },
     "use-memo-one": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -118,6 +118,7 @@
     }
   },
   "dependencies": {
+    "@babel/runtime": "^7.14.0",
     "@material-ui/core": "^4.11.0",
     "@material-ui/icons": "^4.9.1",
     "@wordpress/api-fetch": "^3.11.0",
@@ -130,7 +131,7 @@
     "@wordpress/i18n": "^3.9.0",
     "@wordpress/url": "^2.19.0",
     "intersection-observer": "^0.11.0",
-    "newspack-components": "^1.4.0",
+    "newspack-components": "^1.5.1",
     "qs": "^6.9.4",
     "whatwg-fetch": "^3.5.0"
   }

--- a/package.json
+++ b/package.json
@@ -126,10 +126,11 @@
     "@wordpress/data": "^4.14.1",
     "@wordpress/dom-ready": "^2.9.0",
     "@wordpress/element": "^2.11.0",
+    "@wordpress/html-entities": "^2.11.2",
     "@wordpress/i18n": "^3.9.0",
     "@wordpress/url": "^2.19.0",
     "intersection-observer": "^0.11.0",
-    "newspack-components": "^1.0.5",
+    "newspack-components": "^1.4.0",
     "qs": "^6.9.4",
     "whatwg-fetch": "^3.5.0"
   }

--- a/src/blocks/custom-placement/index.js
+++ b/src/blocks/custom-placement/index.js
@@ -18,7 +18,7 @@ const { attributes, category, name } = metadata;
 import { CustomPlacementEditor } from './edit';
 
 export const registerCustomPlacementBlock = () => {
-	const isPrompt = Boolean( window.newspack_popups_data?.is_prompt );
+	const isPrompt = Boolean( window.newspack_popups_blocks_data?.is_prompt );
 
 	// No prompts inside prompts.
 	if ( isPrompt ) {

--- a/src/blocks/index.js
+++ b/src/blocks/index.js
@@ -2,6 +2,8 @@
  * Internal dependencies.
  */
 import { registerCustomPlacementBlock } from './custom-placement';
+import { registerSinglePromptBlock } from './single-prompt';
 
 // Register the Custom Placement block.
 registerCustomPlacementBlock();
+registerSinglePromptBlock();

--- a/src/blocks/single-prompt/block.json
+++ b/src/blocks/single-prompt/block.json
@@ -1,0 +1,10 @@
+{
+	"name": "newspack-popups/single-prompt",
+	"category": "newspack",
+	"attributes": {
+		"promptId": {
+			"type": "number",
+			"default": 0
+		}
+	}
+}

--- a/src/blocks/single-prompt/edit.js
+++ b/src/blocks/single-prompt/edit.js
@@ -100,7 +100,7 @@ export const SinglePromptEditor = ( { attributes, setAttributes } ) => {
 
 			{ ! error && ! loading && ! promptId && (
 				<AutocompleteWithSuggestions
-					label={ __( 'Search for an inline prompt:', 'newspack' ) }
+					label={ __( 'Search for an inline or manual-only prompt:', 'newspack' ) }
 					help={ __(
 						'Begin typing prompt title, click autocomplete result to select.',
 						'newspack'

--- a/src/blocks/single-prompt/edit.js
+++ b/src/blocks/single-prompt/edit.js
@@ -1,0 +1,149 @@
+/**
+ * WordPress dependencies.
+ */
+import apiFetch from '@wordpress/api-fetch';
+import { __, sprintf } from '@wordpress/i18n';
+import { Button, ExternalLink, Notice, Placeholder, Spinner } from '@wordpress/components';
+import { useEffect, useState } from '@wordpress/element';
+import { decodeEntities } from '@wordpress/html-entities';
+import { addQueryArgs } from '@wordpress/url';
+
+/**
+ * External dependencies.
+ */
+import CallToActionIcon from '@material-ui/icons/CallToAction';
+import { AutocompleteWithSuggestions } from 'newspack-components';
+
+export const SinglePromptEditor = ( { attributes, setAttributes } ) => {
+	const [ loading, setLoading ] = useState( false );
+	const [ prompt, setPrompt ] = useState( null );
+	const [ error, setError ] = useState( null );
+	const { promptId } = attributes;
+	const { endpoint } = window?.newspack_popups_blocks_data;
+
+	const getPrompt = async () => {
+		setError( null );
+		setLoading( true );
+
+		try {
+			const response = await apiFetch( {
+				path: addQueryArgs( '/wp/v2/' + endpoint, {
+					per_page: 1,
+					include: promptId,
+					_fields: 'meta,title,content',
+				} ),
+			} );
+
+			setPrompt( response.shift() );
+			setLoading( false );
+		} catch ( e ) {
+			setError(
+				e.message ||
+					sprintf(
+						__( 'There was an error fetching prompt with ID %s.', 'newspack-popups' ),
+						promptId
+					)
+			);
+			setLoading( false );
+		}
+	};
+
+	useEffect(() => {
+		if ( promptId ) {
+			getPrompt();
+		}
+	}, [ promptId ]);
+
+	if ( ! loading && promptId && prompt ) {
+		return (
+			<div className="newspack-popups__single-prompt">
+				<h4 className="newspack-popups__single-prompt-title">
+					{ prompt.title?.rendered || __( '(no title)', 'newspack-popups' ) }{' '}
+					<ExternalLink href={ `/wp-admin/post.php?post=${ promptId }&action=edit` }>
+						{ __( 'edit', 'newspack-popups' ) }
+					</ExternalLink>
+				</h4>
+				<div
+					className="newspack-popup newspack-inline-popup"
+					dangerouslySetInnerHTML={ { __html: prompt.content?.rendered } }
+				/>
+				<Button
+					isSecondary
+					onClick={ () => {
+						setAttributes( { promptId: 0 } );
+						setPrompt( null );
+					} }
+				>
+					{ __( 'Clear prompt' ) }
+				</Button>
+			</div>
+		);
+	}
+
+	return (
+		<Placeholder
+			className="newspack-popups__single-prompt-placeholder"
+			label={ __( 'Prompt', 'newspack-popups' ) }
+			icon={ <CallToActionIcon style={ { color: '#36f' } } /> }
+		>
+			{ loading && <Spinner /> }
+
+			{ error && (
+				<div className="newspack-popups__single-prompt">
+					<Notice status="error" isDismissible={ false }>
+						{ error }
+					</Notice>
+				</div>
+			) }
+
+			{ ! error && ! loading && ! promptId && (
+				<AutocompleteWithSuggestions
+					label={ __( 'Search for a prompt', 'newspack' ) }
+					help={ __(
+						'Begin typing prompt title, click autocomplete result to select.',
+						'newspack'
+					) }
+					fetchSavedPosts={ async postIDs => {
+						const posts = await apiFetch( {
+							path: addQueryArgs( '/wp/v2/' + endpoint, {
+								per_page: 100,
+								include: postIDs.join( ',' ),
+								_fields: 'id,title',
+							} ),
+						} );
+
+						return posts.map( post => ( {
+							value: post.id,
+							label: decodeEntities( post.title ) || __( '(no title)', 'newspack' ),
+						} ) );
+					} }
+					fetchSuggestions={ async search => {
+						const posts = await apiFetch( {
+							path: addQueryArgs( '/wp/v2/' + endpoint, {
+								search,
+								per_page: 10,
+								_fields: 'id,title',
+							} ),
+						} );
+
+						// Format suggestions for FormTokenField display.
+						const result = posts.reduce( ( acc, post ) => {
+							acc.push( {
+								value: post.id,
+								label: decodeEntities( post.title.rendered ) || __( '(no title)', 'newspack' ),
+							} );
+
+							return acc;
+						}, [] );
+						return result;
+					} }
+					postType={ endpoint }
+					postTypeLabel={ 'prompt' }
+					maxLength={ 1 }
+					onChange={ _value => setAttributes( { promptId: parseInt( _value ) } ) }
+					selectedPost={ null }
+				/>
+			) }
+		</Placeholder>
+	);
+};

--- a/src/blocks/single-prompt/edit.js
+++ b/src/blocks/single-prompt/edit.js
@@ -153,7 +153,7 @@ export const SinglePromptEditor = ( { attributes, setAttributes } ) => {
 					postType={ postType }
 					postTypeLabel={ 'prompt' }
 					maxLength={ 1 }
-					onChange={ _value => setAttributes( { promptId: parseInt( _value ) } ) }
+					onChange={ items => setAttributes( { promptId: parseInt( items.pop().value ) } ) }
 					selectedPost={ null }
 				/>
 			) }

--- a/src/blocks/single-prompt/edit.js
+++ b/src/blocks/single-prompt/edit.js
@@ -12,7 +12,7 @@ import { addQueryArgs } from '@wordpress/url';
  * External dependencies.
  */
 import CallToActionIcon from '@material-ui/icons/CallToAction';
-import { AutocompleteWithSuggestions } from 'newspack-components';
+import { AutocompleteWithSuggestions } from 'newspack-components'; // TODO: update newspack-components package once this component lands
 
 export const SinglePromptEditor = ( { attributes, setAttributes } ) => {
 	const [ loading, setLoading ] = useState( false );

--- a/src/blocks/single-prompt/edit.js
+++ b/src/blocks/single-prompt/edit.js
@@ -33,8 +33,21 @@ export const SinglePromptEditor = ( { attributes, setAttributes } ) => {
 				} ),
 			} );
 
-			setPrompt( response.shift() );
-			setLoading( false );
+			if ( 0 === response.length ) {
+				setError(
+					sprintf(
+						__(
+							'No active prompts found with ID %s. Try choosing another prompt.',
+							'newspack-popups'
+						),
+						promptId
+					)
+				);
+				setLoading( false );
+			} else {
+				setPrompt( response.shift() );
+				setLoading( false );
+			}
 		} catch ( e ) {
 			setError(
 				e.message ||
@@ -98,7 +111,7 @@ export const SinglePromptEditor = ( { attributes, setAttributes } ) => {
 				</Notice>
 			) }
 
-			{ ! error && ! loading && ! promptId && (
+			{ ! prompt && ! loading && (
 				<AutocompleteWithSuggestions
 					label={ __( 'Search for an inline or manual-only prompt:', 'newspack' ) }
 					help={ __(

--- a/src/blocks/single-prompt/editor.scss
+++ b/src/blocks/single-prompt/editor.scss
@@ -10,18 +10,11 @@
 	}
 
 	&__single-prompt-title {
+		margin-top: 0.5rem !important;
+
 		a {
-			color: #0073aa;
 			font-size: 13px;
 			font-weight: normal;
-		}
-
-		&:active,
-		&:focus,
-		&:hover {
-			a {
-				color: #0096dd;
-			}
 		}
 	}
 }

--- a/src/blocks/single-prompt/editor.scss
+++ b/src/blocks/single-prompt/editor.scss
@@ -9,6 +9,15 @@
 		}
 	}
 
+	&__single-prompt-placeholder {
+		.components-notice {
+			margin-bottom: 2rem;
+			margin-left: 0;
+			margin-right: 0;
+			width: 100%;
+		}
+	}
+
 	&__single-prompt-title {
 		margin-top: 0.5rem !important;
 

--- a/src/blocks/single-prompt/editor.scss
+++ b/src/blocks/single-prompt/editor.scss
@@ -8,9 +8,7 @@
 			pointer-events: none;
 		}
 
-		[submit-success],
-		[submit-error],
-		[submitting] {
+		.wp-block-jetpack-mailchimp_notification {
 			display: none;
 		}
 	}

--- a/src/blocks/single-prompt/editor.scss
+++ b/src/blocks/single-prompt/editor.scss
@@ -1,0 +1,27 @@
+.newspack-popups {
+	&__single-prompt {
+		border: 1px solid rgba( 0, 0, 0, 0.2 );
+		padding: 0.75em;
+
+		.newspack-inline-popup {
+			margin-bottom: 1rem;
+			pointer-events: none;
+		}
+	}
+
+	&__single-prompt-title {
+		a {
+			color: #0073aa;
+			font-size: 13px;
+			font-weight: normal;
+		}
+
+		&:active,
+		&:focus,
+		&:hover {
+			a {
+				color: #0096dd;
+			}
+		}
+	}
+}

--- a/src/blocks/single-prompt/editor.scss
+++ b/src/blocks/single-prompt/editor.scss
@@ -7,6 +7,12 @@
 			margin-bottom: 1rem;
 			pointer-events: none;
 		}
+
+		[submit-success],
+		[submit-error],
+		[submitting] {
+			display: none;
+		}
 	}
 
 	&__single-prompt-placeholder {

--- a/src/blocks/single-prompt/index.js
+++ b/src/blocks/single-prompt/index.js
@@ -1,0 +1,45 @@
+/**
+ * WordPress dependencies.
+ */
+import { __ } from '@wordpress/i18n';
+import { registerBlockType } from '@wordpress/blocks';
+
+/**
+ * External dependencies.
+ */
+import CallToActionIcon from '@material-ui/icons/CallToAction';
+
+/**
+ * Internal dependencies.
+ */
+import './editor.scss';
+import metadata from './block.json';
+const { attributes, category, name } = metadata;
+import { SinglePromptEditor } from './edit';
+
+export const registerSinglePromptBlock = () => {
+	const isPrompt = Boolean( window.newspack_popups_data?.is_prompt );
+
+	// No prompts inside prompts.
+	if ( isPrompt ) {
+		return null;
+	}
+
+	registerBlockType( name, {
+		title: __( 'Newspack Campaigns: Prompt', 'newspack-listing' ),
+		icon: <CallToActionIcon style={ { color: '#36f' } } />,
+		category,
+		keywords: [
+			__( 'newspack', 'newspack-popups' ),
+			__( 'campaigns', 'newspack-popups' ),
+			__( 'campaign', 'newspack-popups' ),
+			__( 'single', 'newspack-popups' ),
+			__( 'prompt', 'newspack-popups' ),
+		],
+
+		attributes,
+
+		edit: SinglePromptEditor,
+		save: () => null, // uses view.php
+	} );
+};

--- a/src/blocks/single-prompt/index.js
+++ b/src/blocks/single-prompt/index.js
@@ -18,7 +18,7 @@ const { attributes, category, name } = metadata;
 import { SinglePromptEditor } from './edit';
 
 export const registerSinglePromptBlock = () => {
-	const isPrompt = Boolean( window.newspack_popups_data?.is_prompt );
+	const isPrompt = Boolean( window.newspack_popups_blocks_data?.is_prompt );
 
 	// No prompts inside prompts.
 	if ( isPrompt ) {

--- a/src/blocks/single-prompt/index.js
+++ b/src/blocks/single-prompt/index.js
@@ -26,7 +26,7 @@ export const registerSinglePromptBlock = () => {
 	}
 
 	registerBlockType( name, {
-		title: __( 'Newspack Campaigns: Prompt', 'newspack-listing' ),
+		title: __( 'Newspack Campaigns: Single Prompt', 'newspack-listing' ),
 		icon: <CallToActionIcon style={ { color: '#36f' } } />,
 		category,
 		keywords: [

--- a/src/blocks/single-prompt/view.php
+++ b/src/blocks/single-prompt/view.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Front-end render functions for the Prompt block.
+ *
+ * @package Newspack_Popups
+ */
+
+namespace Newspack_Popups\Prompt_Block;
+
+/**
+ * Dynamic block registration.
+ */
+function register_block() {
+	// Prompt block attributes.
+	$block_json = json_decode(
+		file_get_contents( __DIR__ . '/block.json' ), // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+		true
+	);
+
+	register_block_type(
+		$block_json['name'],
+		[
+			'attributes'      => $block_json['attributes'],
+			'render_callback' => __NAMESPACE__ . '\render_block',
+		]
+	);
+}
+
+/**
+ * Block render callback.
+ *
+ * @param array $attributes Block attributes.
+ */
+function render_block( $attributes ) {
+	$content   = '';
+	$prompt_id = $attributes['promptId'];
+
+	if ( empty( $prompt_id ) ) {
+		return $content;
+	}
+
+	// Get the prompt by id.
+	$prompt = \Newspack_Popups_Model::retrieve_popup_by_id( intval( $prompt_id ) );
+
+	if ( ! empty( $prompt ) ) {
+		if ( defined( 'WP_NEWSPACK_DEBUG' ) && WP_NEWSPACK_DEBUG ) {
+			$content .= '<!-- Newspack Campaigns: Start Prompt ' . $prompt_id . '-->';
+		}
+
+		$content .= '<!-- wp:shortcode -->[newspack-popup id="' . $prompt_id . '"]<!-- /wp:shortcode -->';
+
+		if ( defined( 'WP_NEWSPACK_DEBUG' ) && WP_NEWSPACK_DEBUG ) {
+			$content .= '<!-- Newspack Campaigns: End Prompt ' . $prompt_id . '-->';
+		}
+	}
+
+	return $content;
+}
+
+register_block();

--- a/src/blocks/single-prompt/view.php
+++ b/src/blocks/single-prompt/view.php
@@ -42,7 +42,8 @@ function render_block( $attributes ) {
 	// Get the prompt by id.
 	$prompt = \Newspack_Popups_Model::retrieve_popup_by_id( intval( $prompt_id ) );
 
-	if ( ! empty( $prompt ) ) {
+	// Only show inline prompts (should only be selectable in editor, but verify just in case).
+	if ( ! empty( $prompt ) && \Newspack_Popups_Model::is_inline( $prompt ) ) {
 		if ( defined( 'WP_NEWSPACK_DEBUG' ) && WP_NEWSPACK_DEBUG ) {
 			$content .= '<!-- Newspack Campaigns: Start Prompt ' . $prompt_id . '-->';
 		}

--- a/src/blocks/single-prompt/view.php
+++ b/src/blocks/single-prompt/view.php
@@ -42,8 +42,8 @@ function render_block( $attributes ) {
 	// Get the prompt by id.
 	$prompt = \Newspack_Popups_Model::retrieve_popup_by_id( intval( $prompt_id ) );
 
-	// Only show inline prompts (should only be selectable in editor, but verify just in case).
-	if ( ! empty( $prompt ) && \Newspack_Popups_Model::is_inline( $prompt ) ) {
+	// Only show inline or manual-only prompts (should only be selectable in editor, but verify just in case).
+	if ( ! empty( $prompt ) && ( \Newspack_Popups_Model::is_inline( $prompt ) || \Newspack_Popups_Model::is_manual_only( $prompt ) ) ) {
 		if ( defined( 'WP_NEWSPACK_DEBUG' ) && WP_NEWSPACK_DEBUG ) {
 			$content .= '<!-- Newspack Campaigns: Start Prompt ' . $prompt_id . '-->';
 		}

--- a/src/editor/Sidebar.js
+++ b/src/editor/Sidebar.js
@@ -12,7 +12,7 @@ import { RadioControl, RangeControl, SelectControl, ToggleControl } from '@wordp
 /**
  * Internal dependencies
  */
-import { isCustomPlacement } from '../editor/utils';
+import { isCustomPlacement, getPlacementHelpMessage } from '../editor/utils';
 
 const Sidebar = ( {
 	display_title,
@@ -47,12 +47,8 @@ const Sidebar = ( {
 				onChange={ value => updatePlacement( value ) }
 			/>
 			<SelectControl
-				label={ __( 'Placement' ) }
-				help={
-					isOverlay
-						? __( 'The location to display the overlay prompt.', 'newspack-popups' )
-						: __( 'The location to insert the prompt.', 'newspack-popups' )
-				}
+				label={ isOverlay ? __( 'Position' ) : __( 'Placement' ) }
+				help={ getPlacementHelpMessage( placement, trigger_scroll_progress ) }
 				value={ placement }
 				onChange={ updatePlacement }
 				options={
@@ -65,6 +61,7 @@ const Sidebar = ( {
 						: [
 								{ value: 'inline', label: __( 'In article content' ) },
 								{ value: 'above_header', label: __( 'Above site header' ) },
+								{ value: 'manual', label: __( 'Manual only', 'newspack-popups' ) },
 						  ].concat(
 								Object.keys( customPlacements ).map( key => ( {
 									value: key,

--- a/src/editor/utils.js
+++ b/src/editor/utils.js
@@ -1,3 +1,5 @@
+import { __, sprintf } from '@wordpress/i18n';
+
 /**
  * Data selector for popup options (stored in post meta)
  *
@@ -116,4 +118,62 @@ export const updateEditorColors = backgroundColor => {
 export const isCustomPlacement = placementValue => {
 	const customPlacements = window.newspack_popups_data?.custom_placements || {};
 	return -1 < Object.keys( customPlacements ).indexOf( placementValue );
+};
+
+/**
+ * Given a placement value, construct a context-sensitive help message to display in the editor sidebar.
+ *
+ * @param {string} placementValue Placement of the prompt.
+ * @param {int|string} triggerPercentage Insertion percentage, for inline prompts.
+ * @returns
+ */
+export const getPlacementHelpMessage = ( placementValue, triggerPercentage = 0 ) => {
+	if ( isCustomPlacement( placementValue ) ) {
+		const customPlacements = window.newspack_popups_data?.custom_placements || {};
+		return sprintf(
+			__(
+				'The prompt will appear where %s is inserted using the Custom Placement block.',
+				'newspack-popups'
+			),
+			customPlacements[ placementValue ] || __( 'this custom placement', 'newspack-popups' )
+		);
+	}
+
+	switch ( placementValue ) {
+		case 'center':
+			return __(
+				'The prompt will be displayed as an overlay at the center of the viewport.',
+				'newspack-popups'
+			);
+		case 'top':
+			return __(
+				'The prompt will be displayed as an overlay at the top of the viewport.',
+				'newspack-popups'
+			);
+		case 'bottom':
+			return __(
+				'The prompt will be displayed as an overlay at the bottom of the viewport.',
+				'newspack-popups'
+			);
+		case 'above_header':
+			return __(
+				'The prompt will be automatically inserted at the very top of the page, above the header.',
+				'newspack-popups'
+			);
+		case 'inline':
+			return sprintf(
+				__(
+					'The prompt will be automatically inserted about %s into article content.',
+					'newspack-popups'
+				),
+				triggerPercentage + '%'
+			);
+		case 'manual':
+			return __(
+				'The prompt will appear only where inserted using the Single Prompt block or a shortcode.',
+				'newspack-popups'
+			);
+		default:
+			return __( 'The placement where the prompt can appear.', 'newspack-popups' );
+	}
 };

--- a/tests/test-blocks.php
+++ b/tests/test-blocks.php
@@ -34,9 +34,31 @@ class BlocksTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Basic Block rendering.
+	 * Basic Block rendering - Single Prompt block.
 	 */
-	public function test_block_rendering() {
+	public function test_prompt_block_rendering() {
+		$inline_popup_id       = self::create_popup( [ 'placement' => 'inline' ] );
+		$overlay_popup_id      = self::create_popup( [ 'placement' => 'center' ] );
+		$inline_block_content  = Newspack_Popups\Prompt_Block\render_block( [ 'promptId' => $inline_popup_id ] );
+		$overlay_block_content = Newspack_Popups\Prompt_Block\render_block( [ 'promptId' => $overlay_popup_id ] );
+
+		self::assertEquals(
+			$inline_block_content,
+			'<!-- wp:shortcode -->[newspack-popup id="' . $inline_popup_id . '"]<!-- /wp:shortcode -->',
+			'Includes inline popup shortcode.'
+		);
+
+		self::assertEquals(
+			$overlay_block_content,
+			'',
+			'Overlay prompt not rendered by the Single Prompt block.'
+		);
+	}
+
+	/**
+	 * Basic Block rendering - Custom Placement block.
+	 */
+	public function test_custom_placement_block_rendering() {
 		$custom_placement_id = 'custom1';
 		$popup_id            = self::create_popup( [ 'placement' => $custom_placement_id ] );
 		$block_content       = Newspack_Popups\Custom_Placement_Block\render_block( [ 'customPlacement' => $custom_placement_id ] );

--- a/tests/test-insertion.php
+++ b/tests/test-insertion.php
@@ -175,6 +175,33 @@ class InsertionTest extends WP_UnitTestCase_PageWithPopups {
 	}
 
 	/**
+	 * Test manual placement popups and single prompt block.
+	 */
+	public function test_prompt_block() {
+		Newspack_Popups_Model::set_popup_options(
+			self::$popup_id,
+			[
+				'placement' => 'manual',
+				'frequency' => 'always',
+			]
+		);
+
+		self::renderPost();
+		self::assertNotContains(
+			self::$popup_content,
+			self::$post_content,
+			'Does not include the popup content, since it is a manual-only placement popup.'
+		);
+
+		self::renderPost( '', '<!-- wp:newspack-popups/single-prompt {"promptId":' . self::$popup_id . '} /-->' );
+		self::assertContains(
+			self::$popup_content,
+			self::$post_content,
+			'Includes the popup content when the prompt is placed in post content via the Single Prompt block.'
+		);
+	}
+
+	/**
 	 * Category criterion.
 	 */
 	public function test_criterion_category() {
@@ -313,7 +340,7 @@ class InsertionTest extends WP_UnitTestCase_PageWithPopups {
 		$popup_ids_ordered = array_map(
 			function( $item ) {
 				return $item->id;
-			}, 
+			},
 			$amp_access_query['popups']
 		);
 		self::assertEquals(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Does a few things:

1. Reinstates "manual-only" as a placement option (not a frequency option as it was previously). Prompts with this placement option will never get programmatically inserted anywhere, so they won't be displayed unless used in a shortcode or the new Single Prompt block (see below).
2. Creates a Single Prompt block which allows you to select a single inline or manual-only prompt to be displayed where placed in a post or page. This is basically a controlled wrapper UI that renders the prompt as a `[newspack-popup]` shortcode, and will hopefully be a more user-friendly alternative to using shortcodes for this purpose.
3. Makes the help text shown alongside the Placement options in the editor sidebar more helpful, by describing the currently selected option's behavior. Also changes the label to "Position" if the prompt is an overlay. See [this comment](https://github.com/Automattic/newspack-popups/issues/538#issuecomment-833859880) for details.

Closes #538.

Note that this PR uses the `AutocompleteWithSuggestions` component [implemented here](https://github.com/Automattic/newspack-plugin/pull/952), so this PR is blocked until that PR gets deployed and the new component gets published to the NPM library. Adding an "On Hold" label to reflect this, but it can still be reviewed and tested at this point.

### How to test the changes in this Pull Request:

#### Setup and prereqs

Prior to testing, make sure you have [this branch](https://github.com/Automattic/newspack-plugin/pull/952) checked out for Newspack Plugin. Then:

1. `cd` into the `newspack-plugin/assets/components` folder.
2. Run `npm run prereleaseOnly` to build the components.
3. In the `newspack-popups` plugin folder, check out this branch and run `npm ci`.
4. Copy the entire contents of the `newspack-plugin/assets/components` folder into `newspack-popups/node_modules/newspack-components`, overwriting when prompted. This will simulate the new `AutocompleteWithSuggestions` component being available via the `newspack-components` package.
5. After the above, in the Newspack Plugin repo, check out the branch from https://github.com/Automattic/newspack-plugin/pull/960 as this is required to see the new "manual only" placement option in the Campaigns wizard.

#### Testing the manual-only placement option

1. In Newspack > Campaigns, create a new inline prompt, or edit an existing inline prompt.
2. In the Campaigns dashboard, open the popover with the Placement dropdown.
3. Confirm that there's now a "Manual Only" option in the dropdown, and if selected, that the flag next to the prompt title changes to say "Manual Only."
4. Confirm that for Overlay prompts, the "Manual Only" option doesn't appear (only available for inline prompts).
5. View the prompt in the block editor. In the Prompt Settings sidebar, confirm that "Manual Only" is an available Placement option only if the Prompt Type is set to "Inline".

#### Testing the contextual Placement help

1. View the prompt in the block editor. In the Prompt Settings sidebar, confirm that when "Prompt Type" is set to "Overlay", the Placement label changes to "Position" instead, and vice versa.
2. Change the Position/Placement option to various values, and confirm that the help text updates itself according to the selected option. [More details on what they should say here](https://github.com/Automattic/newspack-popups/issues/538#issuecomment-833859880).

#### Testing the new Single Prompt block

1. Edit a post or page.
2. In the block inserter, under the Newspack category, confirm that there's a new "Newspack Campaigns: Single Prompt" block.
3. Insert the block. The placeholder should look something like this:

<img width="817" alt="Screen Shot 2021-05-12 at 2 26 43 PM" src="https://user-images.githubusercontent.com/2230142/118192278-21ce4580-b403-11eb-8694-21fca9bfbb93.png">

4. Save or publish the post without selecting any prompt (leaving the block in placeholder mode). In a new incognito window, confirm that the block doesn't render any markup when no prompt is selected.
5. Confirm that the suggestions that load are up to 10 of the most recent **inline** or **manual-only** prompts. Prompts with overlay, above-header, or custom placement options are not selectable with this block.
6. Type a prompt name using the autocomplete field, and confirm that it shows matching inline or manual-only prompts.
7. Select a prompt using either the autocomplete or the suggestions list. Confirm that the block preview changes to show the prompt content:

<img width="818" alt="Screen Shot 2021-05-12 at 2 26 52 PM" src="https://user-images.githubusercontent.com/2230142/118192450-64901d80-b403-11eb-9c6a-09366d0e7b1f.png">

8. Confirm that the "edit" link next to the prompt title opens that prompt in the editor, in a new tab.
9. Confirm that the prompt content shown matches the selected prompt.
10. Confirm that clicking "Clear Prompt" clears your selection and returns the block back to placeholder mode.
11. Re-select a prompt in the "Everyone" segment (or an easily matched segment) with the "Manual only" placement option and save the post.
12. View the post in a new incognito session. Confirm that the prompt is displayed exactly where you placed the block.
13. Change the prompt's placement to "inline." Refresh the post in the incognito session and confirm that the prompt is now shown twice—once where you placed the block, and again where it's programmatically inserted as an inline prompt.
14. Add another Single Prompt block to the same post, and select the same prompt. Refresh the post in the incognito session and confirm that the prompt is now shown three times—once for each instance of the block, and again for the programmatic inline placement.
15. Change the prompt's segment to something you don't match. Refresh the post and confirm that the prompt is no longer shown in any instance, because it's not in your best-priority segment.
16. Deactivate or delete the prompt. Refresh the post editor where you placed the prompt in a Single Prompt block and confirm that the block now shows a warning:

<img width="815" alt="Screen Shot 2021-05-13 at 4 59 17 PM" src="https://user-images.githubusercontent.com/2230142/118197671-a2457400-b40c-11eb-8315-93797f263707.png">

17. Confirm on the front-end that the block with a non-existent prompt assigned doesn't render any markup.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
