### PR TITLE
feat: duplicate a prompt

### DIFF
--- a/includes/class-newspack-popups-api.php
+++ b/includes/class-newspack-popups-api.php
@@ -192,7 +192,7 @@ final class Newspack_Popups_API {
 
 
 	/**
-	 * Duplicate a Pop-up.
+	 * Duplicate a prompt.
 	 *
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return WP_REST_Response with complete info to render the Engagement Wizard.

--- a/includes/class-newspack-popups-api.php
+++ b/includes/class-newspack-popups-api.php
@@ -67,6 +67,21 @@ final class Newspack_Popups_API {
 				],
 			]
 		);
+
+		\register_rest_route(
+			'newspack-popups/v1',
+			'/(?P<id>\d+)/duplicate',
+			[
+				'methods'             => \WP_REST_Server::EDITABLE,
+				'callback'            => [ $this, 'api_duplicate_popup' ],
+				'permission_callback' => [ $this, 'permission_callback' ],
+				'args'                => [
+					'id' => [
+						'sanitize_callback' => 'absint',
+					],
+				],
+			]
+		);
 	}
 
 	/**
@@ -173,6 +188,18 @@ final class Newspack_Popups_API {
 		}
 
 		return new \WP_REST_Response( [] );
+	}
+
+
+	/**
+	 * Duplicate a Pop-up.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response with complete info to render the Engagement Wizard.
+	 */
+	public function api_duplicate_popup( $request ) {
+		$response = Newspack_Popups::duplicate_popup( $request['id'] );
+		return rest_ensure_response( $response );
 	}
 }
 $newspack_popups_api = new Newspack_Popups_API();

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -315,16 +315,13 @@ final class Newspack_Popups_Model {
 	}
 
 	/**
-	 * Create the popup object.
+	 * Get options for the given prompt, with defaults.
 	 *
-	 * @param WP_Post $campaign_post The prompt post object.
-	 * @param boolean $include_taxonomies If true, returned objects will include assigned categories and tags.
-	 * @param object  $options Popup options to use instead of the options retrieved from the post. Used for popup previews.
-	 * @return object Popup object
+	 * @param int         $id ID of the prompt.
+	 * @param object|null $options Popup options to use instead of the options retrieved from the post. Used for popup previews.
+	 * @return object Array of prompt options.
 	 */
-	public static function create_popup_object( $campaign_post, $include_taxonomies = false, $options = null ) {
-		$id = $campaign_post->ID;
-
+	public static function get_popup_options( $id, $options = null ) {
 		$post_options = isset( $options ) ? $options : [
 			'background_color'        => get_post_meta( $id, 'background_color', true ),
 			'dismiss_text'            => get_post_meta( $id, 'dismiss_text', true ),
@@ -342,30 +339,44 @@ final class Newspack_Popups_Model {
 			'selected_segment_id'     => get_post_meta( $id, 'selected_segment_id', true ),
 		];
 
-		$popup = [
+		return wp_parse_args(
+			array_filter( $post_options ),
+			[
+				'background_color'        => '#FFFFFF',
+				'display_title'           => false,
+				'hide_border'             => false,
+				'dismiss_text'            => '',
+				'dismiss_text_alignment'  => 'center',
+				'frequency'               => 'always',
+				'overlay_color'           => '#000000',
+				'overlay_opacity'         => 30,
+				'placement'               => 'inline',
+				'trigger_type'            => 'time',
+				'trigger_delay'           => 0,
+				'trigger_scroll_progress' => 0,
+				'utm_suppression'         => null,
+				'selected_segment_id'     => '',
+			]
+		);
+	}
+
+	/**
+	 * Create the popup object.
+	 *
+	 * @param WP_Post $campaign_post The prompt post object.
+	 * @param boolean $include_taxonomies If true, returned objects will include assigned categories and tags.
+	 * @param object  $options Popup options to use instead of the options retrieved from the post. Used for popup previews.
+	 * @return object Popup object
+	 */
+	public static function create_popup_object( $campaign_post, $include_taxonomies = false, $options = null ) {
+		$id                    = $campaign_post->ID;
+		$campaign_post_options = self::get_popup_options( $id, $options );
+		$popup                 = [
 			'id'      => $id,
 			'status'  => $campaign_post->post_status,
 			'title'   => $campaign_post->post_title,
 			'content' => $campaign_post->post_content,
-			'options' => wp_parse_args(
-				array_filter( $post_options ),
-				[
-					'background_color'        => '#FFFFFF',
-					'display_title'           => false,
-					'hide_border'             => false,
-					'dismiss_text'            => '',
-					'dismiss_text_alignment'  => 'center',
-					'frequency'               => 'always',
-					'overlay_color'           => '#000000',
-					'overlay_opacity'         => 30,
-					'placement'               => 'inline',
-					'trigger_type'            => 'time',
-					'trigger_delay'           => 0,
-					'trigger_scroll_progress' => 0,
-					'utm_suppression'         => null,
-					'selected_segment_id'     => '',
-				]
-			),
+			'options' => $campaign_post_options,
 		];
 
 		$assigned_segments = explode( ',', $popup['options']['selected_segment_id'] );

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -763,9 +763,7 @@ final class Newspack_Popups {
 			// Set prompt options to match old prompt.
 			$old_popup_options = Newspack_Popups_Model::get_popup_options( $id );
 			foreach ( $old_popup_options as $key => $value ) {
-				if ( ! empty( $value ) ) {
-					update_post_meta( $new_popup_id, $key, $value );
-				}
+				update_post_meta( $new_popup_id, $key, $value );
 			}
 		}
 

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -749,16 +749,16 @@ final class Newspack_Popups {
 				'post_category' => wp_get_post_categories( $id, [ 'fields' => 'ids' ] ),
 				'tags_input'    => wp_get_post_tags( $id, [ 'fields' => 'ids' ] ),
 			];
+			// Create the copy.
+			$new_popup_id = wp_insert_post( $new_popup );
 
 			// Apply campaign taxonomy.
-			$new_popup['tax_input'][ self::NEWSPACK_POPUPS_TAXONOMY ] = wp_get_post_terms(
+			$old_campaigns = wp_get_post_terms(
 				$id,
 				self::NEWSPACK_POPUPS_TAXONOMY,
 				[ 'fields' => 'ids' ]
 			);
-
-			// Create the copy.
-			$new_popup_id = wp_insert_post( $new_popup );
+			wp_set_post_terms( $new_popup_id, $old_campaigns, self::NEWSPACK_POPUPS_TAXONOMY );
 
 			// Set prompt options to match old prompt.
 			$old_popup_options = Newspack_Popups_Model::get_popup_options( $id );

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -271,6 +271,19 @@ final class Newspack_Popups {
 			]
 		);
 
+		\register_meta(
+			'post',
+			'duplicate_of',
+			[
+				'object_subtype' => self::NEWSPACK_POPUPS_CPT,
+				'show_in_rest'   => true,
+				'type'           => 'integer',
+				'default'        => 0,
+				'single'         => true,
+				'auth_callback'  => '__return_true',
+			]
+		);
+
 		// Meta field for all post types.
 		\register_meta(
 			'post',
@@ -727,6 +740,35 @@ final class Newspack_Popups {
 	}
 
 	/**
+	 * Get a default title for duplicated prompts.
+	 *
+	 * @param int $old_id The ID of the prompt being duplicated.
+	 * @return string The title for the duplicated prompt.
+	 */
+	public static function get_duplicate_title( $old_id ) {
+		/* translators: %s: Duplicate prompt title */
+		$duplicate_title  = sprintf( __( '%s copy', 'newspack-popups' ), get_the_title( $old_id ) );
+		$duplicated_posts = new \WP_Query(
+			[
+				'fields'      => 'ids',
+				'post_status' => [ 'publish', 'draft', 'pending', 'future' ],
+				'post_type'   => self::NEWSPACK_POPUPS_CPT,
+				'meta_key'    => 'duplicate_of', // phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+				'meta_value'  => $old_id,
+			]
+		);
+
+		$duplicate_count = $duplicated_posts->found_posts;
+
+		// Append iterator to title if there are already copies.
+		if ( 0 < $duplicate_count ) {
+			$duplicate_title .= ' ' . strval( $duplicate_count + 1 );
+		}
+
+		return $duplicate_title;
+	}
+
+	/**
 	 * Duplicate a prompt. Duplicates are created with all the same content and options
 	 * as the source prompt, but are always set to draft status at first.
 	 *
@@ -738,17 +780,22 @@ final class Newspack_Popups {
 		$new_popup_id = false;
 
 		if ( is_a( $old_popup, 'WP_Post' ) && self::NEWSPACK_POPUPS_CPT === $old_popup->post_type ) {
-			$new_popup = [
+			$duplicate_of = get_post_meta( $id, 'duplicate_of', true );
+			$original_id  = 0 < $duplicate_of ? $duplicate_of : $id; // If the post we're duplicating is itself a copy, inherit the 'duplicate_of' value. Otherwise, set the value to the post we're duplicating.
+			$new_popup    = [
 				'post_type'     => self::NEWSPACK_POPUPS_CPT,
 				'post_status'   => 'draft',
-				/* translators: %s: Duplicate prompt title */
-				'post_title'    => sprintf( __( 'Copy of %s', 'newspack-popups' ), $old_popup->post_title ),
+				'post_title'    => self::get_duplicate_title( $original_id ),
 				'post_author'   => $old_popup->post_author,
 				'post_content'  => $old_popup->post_content,
 				'post_excerpt'  => $old_popup->post_excerpt,
 				'post_category' => wp_get_post_categories( $id, [ 'fields' => 'ids' ] ),
 				'tags_input'    => wp_get_post_tags( $id, [ 'fields' => 'ids' ] ),
+				'meta_input'    => [
+					'duplicate_of' => $original_id,
+				],
 			];
+
 			// Create the copy.
 			$new_popup_id = wp_insert_post( $new_popup );
 

--- a/src/editor/Duplicate.js
+++ b/src/editor/Duplicate.js
@@ -1,0 +1,59 @@
+/**
+ * WordPress dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+import { Button } from '@wordpress/components';
+import { withSelect, withDispatch } from '@wordpress/data';
+import { compose } from '@wordpress/compose';
+import { __ } from '@wordpress/i18n';
+
+const DuplicateButton = ( { autosavePost, createNotice, isSavingPost, postId } ) => {
+	const duplicatePrompt = async id => {
+		try {
+			const newId = await apiFetch( {
+				path: `/newspack-popups/v1/${ id }/duplicate`,
+				method: 'POST',
+			} );
+
+			if ( isNaN( newId ) ) {
+				throw new Error( __( 'Error duplicating prompt.', 'newspack-popups' ) );
+			}
+
+			window.location = `/wp-admin/post.php?post=${ newId }&action=edit`;
+		} catch ( e ) {
+			createNotice( 'error', e?.message || __( 'Error duplicating prompt.', 'newspack-popups' ), {
+				id: 'newspack-popups__duplicate-prompt-error',
+				isDismissible: true,
+				type: 'default',
+			} );
+		}
+	};
+	return (
+		<Button
+			isSecondary
+			isBusy={ isSavingPost }
+			disabled={ isSavingPost }
+			onClick={ () => autosavePost().then( () => duplicatePrompt( postId ) ) }
+		>
+			{ __( 'Duplicate', 'newspack-popups' ) }
+		</Button>
+	);
+};
+
+export default compose( [
+	withSelect( select => {
+		const { isSavingPost, getCurrentPostId } = select( 'core/editor' );
+		return {
+			postId: getCurrentPostId(),
+			isSavingPost: isSavingPost(),
+		};
+	} ),
+	withDispatch( dispatch => {
+		const { autosave } = dispatch( 'core/editor' );
+		const { createNotice } = dispatch( 'core/notices' );
+		return {
+			autosavePost: autosave,
+			createNotice,
+		};
+	} ),
+] )( DuplicateButton );

--- a/src/editor/Duplicate.js
+++ b/src/editor/Duplicate.js
@@ -3,15 +3,15 @@
  */
 import apiFetch from '@wordpress/api-fetch';
 import { Button } from '@wordpress/components';
-import { withSelect, withDispatch } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
+import { withSelect, withDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 
-const DuplicateButton = ( { autosavePost, createNotice, isSavingPost, postId } ) => {
-	const duplicatePrompt = async id => {
+const DuplicateButton = ( { autosave, createNotice, isSavingPost, postId } ) => {
+	const duplicatePrompt = async () => {
 		try {
 			const newId = await apiFetch( {
-				path: `/newspack-popups/v1/${ id }/duplicate`,
+				path: `/newspack-popups/v1/${ postId }/duplicate`,
 				method: 'POST',
 			} );
 
@@ -19,6 +19,13 @@ const DuplicateButton = ( { autosavePost, createNotice, isSavingPost, postId } )
 				throw new Error( __( 'Error duplicating prompt.', 'newspack-popups' ) );
 			}
 
+			createNotice( 'success', __( 'Prompt duplicated! Redirecting...', 'newspack-popups' ), {
+				id: 'newspack-popups__duplicate-prompt-success',
+				isDismissible: false,
+				type: 'default',
+			} );
+
+			// Redirect to edit page for the copy.
 			window.location = `/wp-admin/post.php?post=${ newId }&action=edit`;
 		} catch ( e ) {
 			createNotice( 'error', e?.message || __( 'Error duplicating prompt.', 'newspack-popups' ), {
@@ -28,12 +35,13 @@ const DuplicateButton = ( { autosavePost, createNotice, isSavingPost, postId } )
 			} );
 		}
 	};
+
 	return (
 		<Button
 			isSecondary
 			isBusy={ isSavingPost }
 			disabled={ isSavingPost }
-			onClick={ () => autosavePost().then( () => duplicatePrompt( postId ) ) }
+			onClick={ () => autosave().then( () => duplicatePrompt() ) }
 		>
 			{ __( 'Duplicate', 'newspack-popups' ) }
 		</Button>
@@ -52,7 +60,7 @@ export default compose( [
 		const { autosave } = dispatch( 'core/editor' );
 		const { createNotice } = dispatch( 'core/notices' );
 		return {
-			autosavePost: autosave,
+			autosave,
 			createNotice,
 		};
 	} ),

--- a/src/editor/Preview.js
+++ b/src/editor/Preview.js
@@ -31,7 +31,7 @@ const PreviewSetting = ( { autosavePost, isSavingPost, postId, metaFields } ) =>
 					disabled={ isSavingPost }
 					onClick={ () => autosavePost().then( showPreview ) }
 				>
-					{ __( 'Preview' ) }
+					{ __( 'Preview', 'newspack-popups' ) }
 				</Button>
 			) }
 		/>

--- a/src/editor/index.js
+++ b/src/editor/index.js
@@ -117,7 +117,7 @@ registerPlugin( 'newspack-popups-editor', {
 
 // Add a button in post status section
 const PluginPostStatusInfoTest = () => (
-	<PluginPostStatusInfo>
+	<PluginPostStatusInfo className="newspack-popups__status-options">
 		<Preview />
 		<Duplicate />
 	</PluginPostStatusInfo>

--- a/src/editor/index.js
+++ b/src/editor/index.js
@@ -21,6 +21,7 @@ import SegmentationSidebar from './SegmentationSidebar';
 import DismissSidebar from './DismissSidebar';
 import ColorsSidebar from './ColorsSidebar';
 import Preview from './Preview';
+import Duplicate from './Duplicate';
 import EditorAdditions from './EditorAdditions';
 import './style.scss';
 
@@ -118,6 +119,7 @@ registerPlugin( 'newspack-popups-editor', {
 const PluginPostStatusInfoTest = () => (
 	<PluginPostStatusInfo>
 		<Preview />
+		<Duplicate />
 	</PluginPostStatusInfo>
 );
 registerPlugin( 'newspack-popups-preview', { render: PluginPostStatusInfoTest } );

--- a/src/editor/style.scss
+++ b/src/editor/style.scss
@@ -9,10 +9,10 @@
 
 .newspack-popups {
 	&__status-options {
-		margin: 1rem 0;
+		justify-content: flex-start;
 
-		.components-base-control .components-base-control__help {
-			margin-top: 4px;
+		.components-button + .components-button {
+			margin-left: 8px;
 		}
 	}
 

--- a/tests/test-e2e.php
+++ b/tests/test-e2e.php
@@ -98,6 +98,32 @@ class E2ETest extends WP_UnitTestCase_PageWithPopups {
 			]
 		);
 
+		// Set up some taxonomy terms to apply to the prompt.
+		$category_id = $this->factory->term->create(
+			[
+				'name'     => 'Featured',
+				'taxonomy' => 'category',
+				'slug'     => 'featured',
+			]
+		);
+		$tag_id      = $this->factory->term->create(
+			[
+				'name'     => 'Best of',
+				'taxonomy' => 'post_tag',
+				'slug'     => 'best-of',
+			]
+		);
+		$campaign_id = $this->factory->term->create(
+			[
+				'name'     => 'Everyday',
+				'taxonomy' => Newspack_Popups::NEWSPACK_POPUPS_TAXONOMY,
+				'slug'     => 'everyday',
+			]
+		);
+		wp_set_post_terms( $original_popup_id, [ $category_id ], 'category' );
+		wp_set_post_terms( $original_popup_id, [ $tag_id ], 'post_tag' );
+		wp_set_post_terms( $original_popup_id, [ $campaign_id ], Newspack_Popups::NEWSPACK_POPUPS_TAXONOMY );
+
 		$duplicate_popup_id = Newspack_Popups::duplicate_popup( $original_popup_id );
 		$original_popup     = get_post( $original_popup_id );
 		$duplicate_popup    = get_post( $duplicate_popup_id );
@@ -116,8 +142,8 @@ class E2ETest extends WP_UnitTestCase_PageWithPopups {
 
 		self::assertEmpty(
 			array_diff(
-				wp_get_post_terms( $original_popup_id, [ 'category', 'post_tag', Newspack_Popups::NEWSPACK_POPUPS_TAXONOMY ] ),
-				wp_get_post_terms( $duplicate_popup_id, [ 'category', 'post_tag', Newspack_Popups::NEWSPACK_POPUPS_TAXONOMY ] )
+				wp_get_post_terms( $original_popup_id, [ 'category', 'post_tag', Newspack_Popups::NEWSPACK_POPUPS_TAXONOMY ], [ 'fields' => 'ids' ] ),
+				wp_get_post_terms( $duplicate_popup_id, [ 'category', 'post_tag', Newspack_Popups::NEWSPACK_POPUPS_TAXONOMY ], [ 'fields' => 'ids' ] )
 			),
 			'Duplicated prompt has the same categories, tags, and campaign terms as original prompt.'
 		);

--- a/tests/test-e2e.php
+++ b/tests/test-e2e.php
@@ -87,7 +87,7 @@ class E2ETest extends WP_UnitTestCase_PageWithPopups {
 	/**
 	 * Test duplication feature.
 	 * Duplicated prompts should have the same content, taxonomy terms, and prompt options as the original.
-	 * Duplicated prompt title should have "Copy of" appended to the original prompt's title.
+	 * Duplicated prompt title should have "copy" appended to the original prompt's title.
 	 */
 	public function test_e2e_duplicate_prompt() {
 		$original_popup_id = self::createPopup(
@@ -124,14 +124,22 @@ class E2ETest extends WP_UnitTestCase_PageWithPopups {
 		wp_set_post_terms( $original_popup_id, [ $tag_id ], 'post_tag' );
 		wp_set_post_terms( $original_popup_id, [ $campaign_id ], Newspack_Popups::NEWSPACK_POPUPS_TAXONOMY );
 
-		$duplicate_popup_id = Newspack_Popups::duplicate_popup( $original_popup_id );
-		$original_popup     = get_post( $original_popup_id );
-		$duplicate_popup    = get_post( $duplicate_popup_id );
+		$duplicate_popup_id  = Newspack_Popups::duplicate_popup( $original_popup_id );
+		$second_duplicate_id = Newspack_Popups::duplicate_popup( $duplicate_popup_id );
+		$original_popup      = get_post( $original_popup_id );
+		$duplicate_popup     = get_post( $duplicate_popup_id );
+		$second_duplicate    = get_post( $second_duplicate_id );
 
 		self::assertEquals(
 			$duplicate_popup->post_title,
-			'Copy of Popup title',
-			'Duplicated prompt appends "Copy of" to original post title.'
+			'Popup title copy',
+			'Duplicated prompt appends "copy" to original post title.'
+		);
+
+		self::assertEquals(
+			$second_duplicate->post_title,
+			'Popup title copy 2',
+			'Subsequent duplicates are iterated based on the original’s title.'
 		);
 
 		self::assertEquals(

--- a/tests/test-e2e.php
+++ b/tests/test-e2e.php
@@ -153,7 +153,7 @@ class E2ETest extends WP_UnitTestCase_PageWithPopups {
 				Newspack_Popups_Model::get_popup_options( $original_popup_id ),
 				Newspack_Popups_Model::get_popup_options( $duplicate_popup_id )
 			),
-			'Duplicated prompt has the prompt options as the original prompt.'
+			'Duplicated prompt has the same prompt options as the original prompt.'
 		);
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds functionality to duplicate a prompt. Copies are created as new draft prompts with the same title/content, taxonomy terms, and prompt-related meta values as the source prompt.

Prompts can be duplicated from either the Campaigns dashboard or from a single prompt editor screen.

Closes #554.

### How to test the changes in this Pull Request:

1. Ensure Campaigns is on this branch and Newspack Plugin is on https://github.com/Automattic/newspack-plugin/pull/1001.
2. In WP admin, visit **Newspack > Campaigns**. Confirm that in the primary popover menu for any prompt, there's a new menu item to "Duplicate" the prompt:

<img width="242" alt="Screen Shot 2021-06-11 at 11 47 40 AM" src="https://user-images.githubusercontent.com/2230142/121728692-d747f380-caaa-11eb-9b63-755838fe16ea.png">

3. Click "Duplicate". Confirm that a new draft prompt is created with the title "Copy of <original prompt title". It should have the same segment assignments, categories, tags, and meta values (so if copying an overlay, it should be created as an overlay, etc.). 
  - **Note** that if you're duplicating from the "Active Prompts" filter, the copy won't be visible until you filter by its campaigns (or "Unassigned" if it has none), because it's not active. Should we therefore not show the "Duplicate" option when viewing "Active Prompts"? What do you think, @thomasguillot?
4. View both the original prompt and its copy in the editor and confirm that all content, category and tag terms, selected campaign(s), and prompt-related settings match across both prompts.
5. In the editor for a prompt, confirm there's a new "Duplicate" button next to the "Preview" button:

<img width="277" alt="Screen Shot 2021-06-11 at 11 40 26 AM" src="https://user-images.githubusercontent.com/2230142/121729891-33f7de00-caac-11eb-9143-51cbba3f24b4.png">

6. Click the button and observe that after the request completes, you're automatically redirected to the editor screen for a new draft prompt with all the same content, terms, prompt options, etc. as the original.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
