### PR TITLE
fix: prevent prompts in account related posts

### DIFF
--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -813,6 +813,10 @@ final class Newspack_Popups_Inserter {
 		if ( ! Newspack_Popups::is_user_admin() && Newspack_Popups_Settings::is_non_interactive() && ! Newspack_Popups_Model::is_inline( $popup ) ) {
 			return false;
 		}
+		// Hide prompts in account related posts.
+		if ( Newspack_Popups::is_account_related_post( get_post() ) ) {
+			return false;
+		}
 
 		if ( $skip_context_checks ) {
 			return true;

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -605,6 +605,15 @@ final class Newspack_Popups {
 	}
 
 	/**
+	 * Is the post related to the user account.
+	 * 
+	 * @param WP_Post $post The prompt post object.
+	 */
+	public static function is_account_related_post( $post ) {
+		return has_shortcode( $post->post_content, 'woocommerce_my_account' );
+	}
+
+	/**
 	 * Create campaign.
 	 *
 	 * @param string $name New campaign name.

--- a/tests/test-insertion.php
+++ b/tests/test-insertion.php
@@ -398,4 +398,27 @@ class InsertionTest extends WP_UnitTestCase_PageWithPopups {
 			'The popup with the segment comes first in the array.'
 		);
 	}
+
+	/**
+	 * Account related page handling.
+	 */
+	public function test_account_related_posts() {
+		$woo_commerce_account_shortcode = 'woocommerce_my_account';
+		$post_with_account_details      = "<!-- wp:shortcode -->[$woo_commerce_account_shortcode]<!-- /wp:shortcode -->";
+
+		// Register WooCommerce shortcode.
+		add_shortcode(
+			$woo_commerce_account_shortcode,
+			function() use ( $post_with_account_details ) {
+				return $post_with_account_details;
+			} 
+		);
+		self::renderPost( '', $post_with_account_details );
+
+		self::assertStringNotContainsString(
+			self::$popup_content,
+			self::$post_content,
+			'Popup content not rendered in account related posts.'
+		);
+	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #430.

### How to test the changes in this Pull Request:

1. In `master` branch, set up a new prompt above the header.
2. Visit an account-related page like `/my-account/lost-password/`, and observe the prompt on the page.
3. Check out this branch, refresh the post. Confirm that the prompt is not displayed on the page.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
