### PR TITLE
feat: improved duplication UI via modal

### DIFF
--- a/includes/class-newspack-popups-api.php
+++ b/includes/class-newspack-popups-api.php
@@ -72,12 +72,30 @@ final class Newspack_Popups_API {
 			'newspack-popups/v1',
 			'/(?P<id>\d+)/duplicate',
 			[
-				'methods'             => \WP_REST_Server::EDITABLE,
-				'callback'            => [ $this, 'api_duplicate_popup' ],
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => [ $this, 'api_get_duplicate_title' ],
 				'permission_callback' => [ $this, 'permission_callback' ],
 				'args'                => [
 					'id' => [
 						'sanitize_callback' => 'absint',
+					],
+				],
+			]
+		);
+
+		\register_rest_route(
+			'newspack-popups/v1',
+			'/(?P<id>\d+)/duplicate',
+			[
+				'methods'             => \WP_REST_Server::EDITABLE,
+				'callback'            => [ $this, 'api_duplicate_popup' ],
+				'permission_callback' => [ $this, 'permission_callback' ],
+				'args'                => [
+					'id'    => [
+						'sanitize_callback' => 'absint',
+					],
+					'title' => [
+						'sanitize_callback' => 'sanitize_text_field',
 					],
 				],
 			]
@@ -190,6 +208,16 @@ final class Newspack_Popups_API {
 		return new \WP_REST_Response( [] );
 	}
 
+	/**
+	 * Get default title for a duplicated prompt.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response with complete info to render the Engagement Wizard.
+	 */
+	public function api_get_duplicate_title( $request ) {
+		$response = Newspack_Popups::get_duplicate_title( $request['id'] );
+		return rest_ensure_response( $response );
+	}
 
 	/**
 	 * Duplicate a prompt.
@@ -198,7 +226,7 @@ final class Newspack_Popups_API {
 	 * @return WP_REST_Response with complete info to render the Engagement Wizard.
 	 */
 	public function api_duplicate_popup( $request ) {
-		$response = Newspack_Popups::duplicate_popup( $request['id'] );
+		$response = Newspack_Popups::duplicate_popup( $request['id'], $request['title'] );
 		return rest_ensure_response( $response );
 	}
 }

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -389,6 +389,12 @@ final class Newspack_Popups_Model {
 			$popup['campaign_groups'] = get_the_terms( $id, Newspack_Popups::NEWSPACK_POPUPS_TAXONOMY );
 		}
 
+		$duplicate_of = get_post_meta( $id, 'duplicate_of', true );
+
+		if ( $duplicate_of ) {
+			$popup['duplicate_of'] = $duplicate_of;
+		}
+
 		if ( self::is_inline( $popup ) ) {
 			return $popup;
 		}

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -619,7 +619,7 @@ final class Newspack_Popups {
 
 	/**
 	 * Is the post related to the user account.
-	 * 
+	 *
 	 * @param WP_Post $post The prompt post object.
 	 */
 	public static function is_account_related_post( $post ) {
@@ -781,10 +781,11 @@ final class Newspack_Popups {
 	 * Duplicate a prompt. Duplicates are created with all the same content and options
 	 * as the source prompt, but are always set to draft status at first.
 	 *
-	 * @param int $id Prompt ID.
+	 * @param int    $id Prompt ID to duplicate.
+	 * @param string $title Title to give to the duplicate.
 	 * @return int|boolean|WP_Error The copy's post ID, false if the ID to copy isn't a valid prompt, or WP_Error if the operation failed.
 	 */
-	public static function duplicate_popup( $id ) {
+	public static function duplicate_popup( $id, $title = '' ) {
 		$old_popup    = get_post( $id );
 		$new_popup_id = false;
 
@@ -794,7 +795,7 @@ final class Newspack_Popups {
 			$new_popup    = [
 				'post_type'     => self::NEWSPACK_POPUPS_CPT,
 				'post_status'   => 'draft',
-				'post_title'    => self::get_duplicate_title( $original_id ),
+				'post_title'    => ! empty( $title ) ? $title : self::get_duplicate_title( $original_id ),
 				'post_author'   => $old_popup->post_author,
 				'post_content'  => $old_popup->post_content,
 				'post_excerpt'  => $old_popup->post_excerpt,

--- a/package-lock.json
+++ b/package-lock.json
@@ -9410,9 +9410,9 @@
       "dev": true
     },
     "@wordpress/base-styles": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-3.5.0.tgz",
-      "integrity": "sha512-LjN+425dIt+JWTJq/ke9sQxKj4brNutlBhb1+zlOy3nQWNUhCPRKRD2szkvmrA6I0rmlnYlVWZZ+tA4/NrQYHQ=="
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-3.5.2.tgz",
+      "integrity": "sha512-29M9yiZte+1gInnHmAvfRr8HaPrkm8c+kDX2PkO1IJ5trWOUFcM8sCG/Cxm0N+c+6EpE5ToxME0Ex8CgZ52IKA=="
     },
     "@wordpress/blob": {
       "version": "2.5.1",
@@ -9899,6 +9899,63 @@
             "@babel/runtime": "^7.8.3"
           }
         },
+        "@wordpress/icons": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-1.4.0.tgz",
+          "integrity": "sha512-YNW1ocZddZ6c40QHiR/Q3yIPYzh4Fdcq/J4sJIkegwqEXltVknYa90RNaDG9xr+qMvXN5/wotYaLA+AP6pUfHA==",
+          "requires": {
+            "@babel/runtime": "^7.9.2",
+            "@wordpress/element": "^2.13.1",
+            "@wordpress/primitives": "^1.4.0"
+          },
+          "dependencies": {
+            "@babel/runtime": {
+              "version": "7.14.6",
+              "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.6.tgz",
+              "integrity": "sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==",
+              "requires": {
+                "regenerator-runtime": "^0.13.4"
+              }
+            },
+            "@wordpress/element": {
+              "version": "2.20.3",
+              "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.20.3.tgz",
+              "integrity": "sha512-f4ZPTDf9CxiiOXiMxc4v1K7jcBMT4dsiehVOpkKzCDKboNXp4qVf8oe5PE23VGZNEjcOj5Mkg9hB57R0nqvMTw==",
+              "requires": {
+                "@babel/runtime": "^7.13.10",
+                "@types/react": "^16.9.0",
+                "@types/react-dom": "^16.9.0",
+                "@wordpress/escape-html": "^1.12.2",
+                "lodash": "^4.17.19",
+                "react": "^16.13.1",
+                "react-dom": "^16.13.1"
+              }
+            },
+            "@wordpress/escape-html": {
+              "version": "1.12.2",
+              "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-1.12.2.tgz",
+              "integrity": "sha512-FabgSwznhdaUwe6hr1CsGpgxQbzqEoGevv73WIL1B9GvlZ6csRWodgHfWh4P6fYqpzxFL4WYB8wPJ1PdO32XFA==",
+              "requires": {
+                "@babel/runtime": "^7.13.10"
+              }
+            },
+            "@wordpress/primitives": {
+              "version": "1.12.3",
+              "resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-1.12.3.tgz",
+              "integrity": "sha512-LIF44bVlJS7CJEVmk6TLuV6HZMdj5iwkyM8do4ukGY6qnZIzrXpBablgJeDBcyjzWrWRLn+w+tiZ/8l+2egoVA==",
+              "requires": {
+                "@babel/runtime": "^7.13.10",
+                "@wordpress/element": "^2.20.3",
+                "classnames": "^2.2.5"
+              }
+            },
+            "lodash": {
+              "version": "4.17.21",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+              "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+            }
+          }
+        },
         "@wordpress/is-shallow-equal": {
           "version": "1.8.0",
           "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-1.8.0.tgz",
@@ -10006,10 +10063,40 @@
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
           "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
         },
+        "react": {
+          "version": "16.14.0",
+          "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
+          "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "react-dom": {
+          "version": "16.14.0",
+          "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
+          "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "scheduler": "^0.19.1"
+          }
+        },
         "regenerator-runtime": {
           "version": "0.13.5",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
           "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
+        },
+        "scheduler": {
+          "version": "0.19.1",
+          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
+          "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1"
+          }
         }
       }
     },
@@ -11572,31 +11659,6 @@
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
           "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
-        }
-      }
-    },
-    "@wordpress/icons": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-1.1.0.tgz",
-      "integrity": "sha512-JPSWz1qOj7pWhAd3pQaHIRrgVDaePv7w6nPX5Uy3LFny+RfBXMNDh+tBGEQvC5iAAhBhDvJyekiDc63tbdnO4g==",
-      "requires": {
-        "@babel/runtime": "^7.8.3",
-        "@wordpress/element": "^2.11.0",
-        "@wordpress/primitives": "^1.1.0"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.8.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.7.tgz",
-          "integrity": "sha512-+AATMUFppJDw6aiR5NVPHqIQBlV/Pj8wY/EZH+lmvRdUo9xBaz/rF3alAwFJQavvKfeOlPE7oaaDHVbcySbCsg==",
-          "requires": {
-            "regenerator-runtime": "^0.13.4"
-          }
-        },
-        "regenerator-runtime": {
-          "version": "0.13.5",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
-          "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
         }
       }
     },
@@ -20776,14 +20838,6 @@
       "integrity": "sha1-4g/146KvwmkDILbcVSaCqcf631E=",
       "dev": true
     },
-    "indefinite-observable": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/indefinite-observable/-/indefinite-observable-2.0.1.tgz",
-      "integrity": "sha512-G8vgmork+6H9S8lUAg1gtXEj2JxIQTo0g2PbFiYOdjkziSI0F7UYBiVwhZRuixhBCNGczAls34+5HJPyZysvxQ==",
-      "requires": {
-        "symbol-observable": "1.2.0"
-      }
-    },
     "indent-string": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
@@ -26538,16 +26592,15 @@
       "dev": true
     },
     "newspack-components": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/newspack-components/-/newspack-components-1.6.0.tgz",
-      "integrity": "sha512-Pl1P5ZT/md7aTdARfzOS4Cj5PEXS9Y4erazBfOtoEAWEOa8Ydm1VcGoZQz+iFK7QENYy7zUs2pyDuiL3pUylqQ==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/newspack-components/-/newspack-components-1.6.1.tgz",
+      "integrity": "sha512-ZdlCzAFxIfKt08A9jfTCYSiFL77Kx3yyB5fTiBmIOxFQvF00ZAioFEbOSEnyiMMY4JKepNq1JuCQB/e3i/d+9w==",
       "requires": {
-        "@material-ui/core": "^4.11.2",
-        "@material-ui/icons": "^4.11.2",
-        "@wordpress/base-styles": "^3.4.4",
+        "@wordpress/base-styles": "^3.5.1",
         "@wordpress/components": "^12.0.6",
         "@wordpress/element": "^2.19.0",
         "@wordpress/i18n": "^3.17.0",
+        "@wordpress/icons": "^4.0.1",
         "classnames": "^2.2.6",
         "lodash": "^4.17.20",
         "qs": "^6.9.6",
@@ -26567,11 +26620,6 @@
             "@emotion/utils": "0.11.3"
           }
         },
-        "@emotion/hash": {
-          "version": "0.8.0",
-          "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
-          "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
-        },
         "@emotion/sheet": {
           "version": "0.9.4",
           "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-0.9.4.tgz",
@@ -26581,77 +26629,6 @@
           "version": "0.11.3",
           "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-0.11.3.tgz",
           "integrity": "sha512-0o4l6pZC+hI88+bzuaX/6BgOvQVhbt2PfmxauVaYOGgbsAw14wdKyvMCZXnsnsHys94iadcF+RG/wZyx6+ZZBw=="
-        },
-        "@material-ui/core": {
-          "version": "4.11.4",
-          "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-4.11.4.tgz",
-          "integrity": "sha512-oqb+lJ2Dl9HXI9orc6/aN8ZIAMkeThufA5iZELf2LQeBn2NtjVilF5D2w7e9RpntAzDb4jK5DsVhkfOvFY/8fg==",
-          "requires": {
-            "@babel/runtime": "^7.4.4",
-            "@material-ui/styles": "^4.11.4",
-            "@material-ui/system": "^4.11.3",
-            "@material-ui/types": "5.1.0",
-            "@material-ui/utils": "^4.11.2",
-            "@types/react-transition-group": "^4.2.0",
-            "clsx": "^1.0.4",
-            "hoist-non-react-statics": "^3.3.2",
-            "popper.js": "1.16.1-lts",
-            "prop-types": "^15.7.2",
-            "react-is": "^16.8.0 || ^17.0.0",
-            "react-transition-group": "^4.4.0"
-          }
-        },
-        "@material-ui/icons": {
-          "version": "4.11.2",
-          "resolved": "https://registry.npmjs.org/@material-ui/icons/-/icons-4.11.2.tgz",
-          "integrity": "sha512-fQNsKX2TxBmqIGJCSi3tGTO/gZ+eJgWmMJkgDiOfyNaunNaxcklJQFaFogYcFl0qFuaEz1qaXYXboa/bUXVSOQ==",
-          "requires": {
-            "@babel/runtime": "^7.4.4"
-          }
-        },
-        "@material-ui/styles": {
-          "version": "4.11.4",
-          "resolved": "https://registry.npmjs.org/@material-ui/styles/-/styles-4.11.4.tgz",
-          "integrity": "sha512-KNTIZcnj/zprG5LW0Sao7zw+yG3O35pviHzejMdcSGCdWbiO8qzRgOYL8JAxAsWBKOKYwVZxXtHWaB5T2Kvxew==",
-          "requires": {
-            "@babel/runtime": "^7.4.4",
-            "@emotion/hash": "^0.8.0",
-            "@material-ui/types": "5.1.0",
-            "@material-ui/utils": "^4.11.2",
-            "clsx": "^1.0.4",
-            "csstype": "^2.5.2",
-            "hoist-non-react-statics": "^3.3.2",
-            "jss": "^10.5.1",
-            "jss-plugin-camel-case": "^10.5.1",
-            "jss-plugin-default-unit": "^10.5.1",
-            "jss-plugin-global": "^10.5.1",
-            "jss-plugin-nested": "^10.5.1",
-            "jss-plugin-props-sort": "^10.5.1",
-            "jss-plugin-rule-value-function": "^10.5.1",
-            "jss-plugin-vendor-prefixer": "^10.5.1",
-            "prop-types": "^15.7.2"
-          }
-        },
-        "@material-ui/system": {
-          "version": "4.11.3",
-          "resolved": "https://registry.npmjs.org/@material-ui/system/-/system-4.11.3.tgz",
-          "integrity": "sha512-SY7otguNGol41Mu2Sg6KbBP1ZRFIbFLHGK81y4KYbsV2yIcaEPOmsCK6zwWlp+2yTV3J/VwT6oSBARtGIVdXPw==",
-          "requires": {
-            "@babel/runtime": "^7.4.4",
-            "@material-ui/utils": "^4.11.2",
-            "csstype": "^2.5.2",
-            "prop-types": "^15.7.2"
-          }
-        },
-        "@material-ui/utils": {
-          "version": "4.11.2",
-          "resolved": "https://registry.npmjs.org/@material-ui/utils/-/utils-4.11.2.tgz",
-          "integrity": "sha512-Uul8w38u+PICe2Fg2pDKCaIG7kOyhowZ9vjiC1FsVwPABTW8vPPKfF6OvxRq3IiBaI1faOJmgdvMG7rMJARBhA==",
-          "requires": {
-            "@babel/runtime": "^7.4.4",
-            "prop-types": "^15.7.2",
-            "react-is": "^16.8.0 || ^17.0.0"
-          }
         },
         "@tannin/compile": {
           "version": "1.1.0",
@@ -26736,6 +26713,18 @@
             "rememo": "^3.0.0",
             "tinycolor2": "^1.4.2",
             "uuid": "^8.3.0"
+          },
+          "dependencies": {
+            "@wordpress/icons": {
+              "version": "2.10.3",
+              "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-2.10.3.tgz",
+              "integrity": "sha512-hVXArGOHLE5pL1G3rHNzsUEuTR4/G6lB+enKYwhYSSIqWuSbyXbZq3nvibxpepPrLy9B3d5t6aR6QUmjMVzIcQ==",
+              "requires": {
+                "@babel/runtime": "^7.13.10",
+                "@wordpress/element": "^2.20.3",
+                "@wordpress/primitives": "^1.12.3"
+              }
+            }
           }
         },
         "@wordpress/compose": {
@@ -26860,13 +26849,47 @@
           }
         },
         "@wordpress/icons": {
-          "version": "2.10.3",
-          "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-2.10.3.tgz",
-          "integrity": "sha512-hVXArGOHLE5pL1G3rHNzsUEuTR4/G6lB+enKYwhYSSIqWuSbyXbZq3nvibxpepPrLy9B3d5t6aR6QUmjMVzIcQ==",
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-4.0.1.tgz",
+          "integrity": "sha512-dYv2GsQ1o2a775mS7gVWNfZOK8S9PCZ/kdc8nz9lApebFFfUu1M0+eTWPvhs109P9yKQ2s1ZZGWGomP/WUwWOQ==",
           "requires": {
             "@babel/runtime": "^7.13.10",
-            "@wordpress/element": "^2.20.3",
-            "@wordpress/primitives": "^1.12.3"
+            "@wordpress/element": "^3.1.1",
+            "@wordpress/primitives": "^2.1.1"
+          },
+          "dependencies": {
+            "@wordpress/element": {
+              "version": "3.1.1",
+              "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-3.1.1.tgz",
+              "integrity": "sha512-OaqKQVEV3CCTdrx/G7fMbmxhrxjApobHUAGAVYCCR1MIqScfluYJRLWFLx8tlkl/Qm/UbF9IfdXS1lphufvYog==",
+              "requires": {
+                "@babel/runtime": "^7.13.10",
+                "@types/react": "^16.9.0",
+                "@types/react-dom": "^16.9.0",
+                "@wordpress/escape-html": "^2.1.1",
+                "lodash": "^4.17.21",
+                "react": "^16.13.1",
+                "react-dom": "^16.13.1"
+              }
+            },
+            "@wordpress/escape-html": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-2.1.1.tgz",
+              "integrity": "sha512-ZIkLxGLBhXkZu3t0yF82/brPV5aCOGCXGiH0EMV8GCohhXCNIfQwwFrZ5gd5NyNX5Q8alTLsiA84azJd+n0XiQ==",
+              "requires": {
+                "@babel/runtime": "^7.13.10"
+              }
+            },
+            "@wordpress/primitives": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-2.1.1.tgz",
+              "integrity": "sha512-iX31v/302zOrxEVwFUbbwr4BKZcxR+XQ53wuShc8CzcydAYj5JUFdEuwG6Z9jRGJAX2AgizSP6Fex4ercgFLXA==",
+              "requires": {
+                "@babel/runtime": "^7.13.10",
+                "@wordpress/element": "^3.1.1",
+                "classnames": "^2.2.5"
+              }
+            }
           }
         },
         "@wordpress/is-shallow-equal": {
@@ -26959,13 +26982,6 @@
             "compute-scroll-into-view": "^1.0.17",
             "prop-types": "^15.7.2",
             "react-is": "^17.0.2"
-          },
-          "dependencies": {
-            "react-is": {
-              "version": "17.0.2",
-              "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-              "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
-            }
           }
         },
         "gettext-parser": {
@@ -26977,104 +26993,10 @@
             "safe-buffer": "^5.1.1"
           }
         },
-        "hoist-non-react-statics": {
-          "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
-          "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
-          "requires": {
-            "react-is": "^16.7.0"
-          }
-        },
         "is-promise": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
           "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="
-        },
-        "jss": {
-          "version": "10.6.0",
-          "resolved": "https://registry.npmjs.org/jss/-/jss-10.6.0.tgz",
-          "integrity": "sha512-n7SHdCozmxnzYGXBHe0NsO0eUf9TvsHVq2MXvi4JmTn3x5raynodDVE/9VQmBdWFyyj9HpHZ2B4xNZ7MMy7lkw==",
-          "requires": {
-            "@babel/runtime": "^7.3.1",
-            "csstype": "^3.0.2",
-            "indefinite-observable": "^2.0.1",
-            "is-in-browser": "^1.1.3",
-            "tiny-warning": "^1.0.2"
-          },
-          "dependencies": {
-            "csstype": {
-              "version": "3.0.8",
-              "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.8.tgz",
-              "integrity": "sha512-jXKhWqXPmlUeoQnF/EhTtTl4C9SnrxSH/jZUih3jmO6lBKr99rP3/+FmrMj4EFpOXzMtXHAZkd3x0E6h6Fgflw=="
-            }
-          }
-        },
-        "jss-plugin-camel-case": {
-          "version": "10.6.0",
-          "resolved": "https://registry.npmjs.org/jss-plugin-camel-case/-/jss-plugin-camel-case-10.6.0.tgz",
-          "integrity": "sha512-JdLpA3aI/npwj3nDMKk308pvnhoSzkW3PXlbgHAzfx0yHWnPPVUjPhXFtLJzgKZge8lsfkUxvYSQ3X2OYIFU6A==",
-          "requires": {
-            "@babel/runtime": "^7.3.1",
-            "hyphenate-style-name": "^1.0.3",
-            "jss": "10.6.0"
-          }
-        },
-        "jss-plugin-default-unit": {
-          "version": "10.6.0",
-          "resolved": "https://registry.npmjs.org/jss-plugin-default-unit/-/jss-plugin-default-unit-10.6.0.tgz",
-          "integrity": "sha512-7y4cAScMHAxvslBK2JRK37ES9UT0YfTIXWgzUWD5euvR+JR3q+o8sQKzBw7GmkQRfZijrRJKNTiSt1PBsLI9/w==",
-          "requires": {
-            "@babel/runtime": "^7.3.1",
-            "jss": "10.6.0"
-          }
-        },
-        "jss-plugin-global": {
-          "version": "10.6.0",
-          "resolved": "https://registry.npmjs.org/jss-plugin-global/-/jss-plugin-global-10.6.0.tgz",
-          "integrity": "sha512-I3w7ji/UXPi3VuWrTCbHG9rVCgB4yoBQLehGDTmsnDfXQb3r1l3WIdcO8JFp9m0YMmyy2CU7UOV6oPI7/Tmu+w==",
-          "requires": {
-            "@babel/runtime": "^7.3.1",
-            "jss": "10.6.0"
-          }
-        },
-        "jss-plugin-nested": {
-          "version": "10.6.0",
-          "resolved": "https://registry.npmjs.org/jss-plugin-nested/-/jss-plugin-nested-10.6.0.tgz",
-          "integrity": "sha512-fOFQWgd98H89E6aJSNkEh2fAXquC9aZcAVjSw4q4RoQ9gU++emg18encR4AT4OOIFl4lQwt5nEyBBRn9V1Rk8g==",
-          "requires": {
-            "@babel/runtime": "^7.3.1",
-            "jss": "10.6.0",
-            "tiny-warning": "^1.0.2"
-          }
-        },
-        "jss-plugin-props-sort": {
-          "version": "10.6.0",
-          "resolved": "https://registry.npmjs.org/jss-plugin-props-sort/-/jss-plugin-props-sort-10.6.0.tgz",
-          "integrity": "sha512-oMCe7hgho2FllNc60d9VAfdtMrZPo9n1Iu6RNa+3p9n0Bkvnv/XX5San8fTPujrTBScPqv9mOE0nWVvIaohNuw==",
-          "requires": {
-            "@babel/runtime": "^7.3.1",
-            "jss": "10.6.0"
-          }
-        },
-        "jss-plugin-rule-value-function": {
-          "version": "10.6.0",
-          "resolved": "https://registry.npmjs.org/jss-plugin-rule-value-function/-/jss-plugin-rule-value-function-10.6.0.tgz",
-          "integrity": "sha512-TKFqhRTDHN1QrPTMYRlIQUOC2FFQb271+AbnetURKlGvRl/eWLswcgHQajwuxI464uZk91sPiTtdGi7r7XaWfA==",
-          "requires": {
-            "@babel/runtime": "^7.3.1",
-            "jss": "10.6.0",
-            "tiny-warning": "^1.0.2"
-          }
-        },
-        "jss-plugin-vendor-prefixer": {
-          "version": "10.6.0",
-          "resolved": "https://registry.npmjs.org/jss-plugin-vendor-prefixer/-/jss-plugin-vendor-prefixer-10.6.0.tgz",
-          "integrity": "sha512-doJ7MouBXT1lypLLctCwb4nJ6lDYqrTfVS3LtXgox42Xz0gXusXIIDboeh6UwnSmox90QpVnub7au8ybrb0krQ==",
-          "requires": {
-            "@babel/runtime": "^7.3.1",
-            "css-vendor": "^2.0.8",
-            "jss": "10.6.0"
-          }
         },
         "lodash": {
           "version": "4.17.21",
@@ -27103,11 +27025,6 @@
           "version": "1.10.3",
           "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.3.tgz",
           "integrity": "sha512-e5mCJlSH7poANfC8z8S9s9S2IN5/4Zb3aZ33f5s8YqoazCFzNLloLU8r5VCG+G7WoqLvAAZoVMcy3tp/3X0Plw=="
-        },
-        "popper.js": {
-          "version": "1.16.1-lts",
-          "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1-lts.tgz",
-          "integrity": "sha512-Kjw8nKRl1m+VrSFCoVGPph93W/qrSO7ZkqPpTf7F4bk/sqcfWK019dWBUpE/fBOsOQY1dks/Bmcbfn1heM/IsA=="
         },
         "qs": {
           "version": "6.10.1",
@@ -27145,6 +27062,11 @@
             "prop-types": "^15.6.2",
             "scheduler": "^0.19.1"
           }
+        },
+        "react-is": {
+          "version": "17.0.2",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+          "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
         },
         "react-resize-aware": {
           "version": "3.1.0",
@@ -33219,9 +33141,9 @@
       }
     },
     "react-textarea-autosize": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.3.2.tgz",
-      "integrity": "sha512-JrMWVgQSaExQByP3ggI1eA8zF4mF0+ddVuX7acUeK2V7bmrpjVOY72vmLz2IXFJSAXoY3D80nEzrn0GWajWK3Q==",
+      "version": "8.3.3",
+      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.3.3.tgz",
+      "integrity": "sha512-2XlHXK2TDxS6vbQaoPbMOfQ8GK7+irc2fVK6QFIcC8GOnH3zI/v481n+j1L0WaPVvKxwesnY93fEfH++sus2rQ==",
       "requires": {
         "@babel/runtime": "^7.10.2",
         "use-composed-ref": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "@wordpress/i18n": "^3.9.0",
     "@wordpress/url": "^2.19.0",
     "intersection-observer": "^0.11.0",
-    "newspack-components": "^1.6.0",
+    "newspack-components": "^1.6.1",
     "qs": "^6.9.4",
     "whatwg-fetch": "^3.5.0"
   }

--- a/src/editor/Duplicate.js
+++ b/src/editor/Duplicate.js
@@ -2,16 +2,57 @@
  * WordPress dependencies
  */
 import apiFetch from '@wordpress/api-fetch';
-import { Button } from '@wordpress/components';
+import { Button, Modal, Notice, TextControl } from '@wordpress/components';
 import { compose } from '@wordpress/compose';
 import { withSelect, withDispatch } from '@wordpress/data';
-import { __ } from '@wordpress/i18n';
+import { useEffect, useState } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+import { addQueryArgs } from '@wordpress/url';
 
-const DuplicateButton = ( { autosave, createNotice, isSavingPost, postId } ) => {
-	const duplicatePrompt = async () => {
+const DuplicateButton = ( {
+	autosave,
+	campaignGroups,
+	duplicateOf,
+	isSavingPost,
+	postId,
+	title,
+} ) => {
+	const [ error, setError ] = useState( null );
+	const [ modalVisible, setModalVisible ] = useState( false );
+	const [ duplicateTitle, setDuplicateTitle ] = useState( null );
+	const [ duplicated, setDuplicated ] = useState( null );
+
+	useEffect(() => {
+		setError( null );
+		if ( modalVisible && ! duplicateTitle ) {
+			getDefaultDupicateTitle();
+		}
+		if ( ! modalVisible ) {
+			setDuplicated( null );
+			setDuplicateTitle( null );
+		}
+	}, [ modalVisible ]);
+
+	const getDefaultDupicateTitle = async () => {
+		const promptToDuplicate = parseInt( duplicateOf || postId );
+		try {
+			const defaultTitle = await apiFetch( {
+				path: `/newspack-popups/v1/${ promptToDuplicate }/duplicate`,
+			} );
+
+			setDuplicateTitle( defaultTitle );
+		} catch ( e ) {
+			setDuplicateTitle( title + __( ' copy', 'newspack-popups' ) );
+		}
+	};
+
+	const duplicatePrompt = async ( popupId, titleForDuplicate ) => {
+		setError( null );
 		try {
 			const newId = await apiFetch( {
-				path: `/newspack-popups/v1/${ postId }/duplicate`,
+				path: addQueryArgs( `/newspack-popups/v1/${ popupId }/duplicate`, {
+					title: titleForDuplicate,
+				} ),
 				method: 'POST',
 			} );
 
@@ -19,41 +60,110 @@ const DuplicateButton = ( { autosave, createNotice, isSavingPost, postId } ) => 
 				throw new Error( __( 'Error duplicating prompt.', 'newspack-popups' ) );
 			}
 
-			createNotice( 'success', __( 'Prompt duplicated! Redirecting...', 'newspack-popups' ), {
-				id: 'newspack-popups__duplicate-prompt-success',
-				isDismissible: false,
-				type: 'default',
-			} );
-
 			// Redirect to edit page for the copy.
-			window.location = `/wp-admin/post.php?post=${ newId }&action=edit`;
+			setDuplicated( newId );
 		} catch ( e ) {
-			createNotice( 'error', e?.message || __( 'Error duplicating prompt.', 'newspack-popups' ), {
-				id: 'newspack-popups__duplicate-prompt-error',
-				isDismissible: true,
-				type: 'default',
-			} );
+			setError( e?.message || __( 'Error duplicating prompt.', 'newspack-popups' ) );
 		}
 	};
 
 	return (
-		<Button
-			isSecondary
-			isBusy={ isSavingPost }
-			disabled={ isSavingPost }
-			onClick={ () => autosave().then( () => duplicatePrompt() ) }
-		>
-			{ __( 'Duplicate', 'newspack-popups' ) }
-		</Button>
+		<>
+			<Button
+				isSecondary
+				isBusy={ isSavingPost }
+				disabled={ isSavingPost }
+				onClick={ () => setModalVisible( true ) }
+			>
+				{ __( 'Duplicate', 'newspack-popups' ) }
+			</Button>
+			{ modalVisible && (
+				<Modal
+					className="newspack-popups__duplicate-modal"
+					title={ sprintf( __( 'Duplicate “%s”', 'newspack-popups' ), title ) }
+					onRequestClose={ () => setModalVisible( false ) }
+				>
+					{ error && (
+						<Notice isDismissible={ false } status="error">
+							{ error }
+						</Notice>
+					) }
+					{ duplicated ? (
+						<>
+							{ ( ! campaignGroups || 0 === campaignGroups.length ) && (
+								<Notice status="warning" isDismissible={ false }>
+									{ __( 'The prompt is currently unassigned.', 'newspack-popups' ) }
+								</Notice>
+							) }
+							<p>
+								{ sprintf(
+									__( 'Duplicate of “%s” created as a draft.', 'newspack-popups' ),
+									title
+								) }
+							</p>
+							<div className="newspack-buttons-card">
+								<Button isSecondary onClick={ () => setModalVisible( false ) }>
+									{ __( 'Close', 'newspack-popups' ) }
+								</Button>
+								<Button isPrimary href={ `/wp-admin/post.php?post=${ duplicated }&action=edit` }>
+									{ __( 'Edit', 'newspack-popups' ) }
+								</Button>
+							</div>
+						</>
+					) : (
+						<>
+							{ ( ! campaignGroups || 0 === campaignGroups.length ) && (
+								<Notice status="warning" isDismissible={ false }>
+									{ __( 'This prompt will be unassigned.', 'newspack-popups' ) }
+								</Notice>
+							) }
+							<TextControl
+								disabled={ isSavingPost || null === duplicateTitle }
+								label={ __( 'New Title', 'newspack-popups' ) }
+								value={ duplicateTitle }
+								onChange={ value => setDuplicateTitle( value ) }
+							/>
+							<div className="newspack-buttons-card">
+								<Button
+									isBusy={ isSavingPost }
+									isSecondary
+									onClick={ () => {
+										setModalVisible( false );
+									} }
+								>
+									{ __( 'Cancel', 'newspack-popups' ) }
+								</Button>
+								<Button
+									isBusy={ isSavingPost }
+									disabled={ null === duplicateTitle }
+									isPrimary
+									onClick={ () => {
+										const titleForDuplicate =
+											duplicateTitle.trim() || title + __( ' copy', 'newspack-popups' );
+										autosave().then( duplicatePrompt( postId, titleForDuplicate ) );
+									} }
+								>
+									{ __( 'Duplicate', 'newspack-popups' ) }
+								</Button>
+							</div>
+						</>
+					) }
+				</Modal>
+			) }
+		</>
 	);
 };
 
 export default compose( [
 	withSelect( select => {
-		const { isSavingPost, getCurrentPostId } = select( 'core/editor' );
+		const { isSavingPost, getCurrentPostId, getEditedPostAttribute } = select( 'core/editor' );
+		const { duplicate_of: duplicateOf } = getEditedPostAttribute( 'meta' );
 		return {
 			postId: getCurrentPostId(),
 			isSavingPost: isSavingPost(),
+			title: getEditedPostAttribute( 'title' ),
+			campaignGroups: getEditedPostAttribute( 'newspack_popups_taxonomy' ),
+			duplicateOf,
 		};
 	} ),
 	withDispatch( dispatch => {

--- a/src/editor/Duplicate.js
+++ b/src/editor/Duplicate.js
@@ -98,7 +98,10 @@ const DuplicateButton = ( {
 							</Notice>
 							{ ( ! campaignGroups || 0 === campaignGroups.length ) && (
 								<Notice status="warning" isDismissible={ false }>
-									{ __( 'This prompt is currently not assigned to any campaign.', 'newspack-popups' ) }
+									{ __(
+										'This prompt is currently not assigned to any campaign.',
+										'newspack-popups'
+									) }
 								</Notice>
 							) }
 							<Flex justify="flex-end">

--- a/src/editor/Duplicate.js
+++ b/src/editor/Duplicate.js
@@ -114,7 +114,7 @@ const DuplicateButton = ( {
 						<>
 							{ ( ! campaignGroups || 0 === campaignGroups.length ) && (
 								<Notice status="warning" isDismissible={ false }>
-									{ __( 'This prompt will be unassigned.', 'newspack-popups' ) }
+									{ __( 'This prompt will not be assigned to any campaign.', 'newspack-popups' ) }
 								</Notice>
 							) }
 							<TextControl

--- a/src/editor/Duplicate.js
+++ b/src/editor/Duplicate.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import apiFetch from '@wordpress/api-fetch';
-import { Button, Modal, Notice, TextControl } from '@wordpress/components';
+import { Button, Flex, Modal, Notice, TextControl } from '@wordpress/components';
 import { compose } from '@wordpress/compose';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { useEffect, useState } from '@wordpress/element';
@@ -90,25 +90,25 @@ const DuplicateButton = ( {
 					) }
 					{ duplicated ? (
 						<>
+							<Notice status="success" isDismissible={ false }>
+								{ sprintf(
+									__( 'Duplicate of “%s” created as a draft.', 'newspack-popups' ),
+									title
+								) }
+							</Notice>
 							{ ( ! campaignGroups || 0 === campaignGroups.length ) && (
 								<Notice status="warning" isDismissible={ false }>
 									{ __( 'The prompt is currently unassigned.', 'newspack-popups' ) }
 								</Notice>
 							) }
-							<p>
-								{ sprintf(
-									__( 'Duplicate of “%s” created as a draft.', 'newspack-popups' ),
-									title
-								) }
-							</p>
-							<div className="newspack-buttons-card">
+							<Flex justify="flex-end">
 								<Button isSecondary onClick={ () => setModalVisible( false ) }>
 									{ __( 'Close', 'newspack-popups' ) }
 								</Button>
 								<Button isPrimary href={ `/wp-admin/post.php?post=${ duplicated }&action=edit` }>
 									{ __( 'Edit', 'newspack-popups' ) }
 								</Button>
-							</div>
+							</Flex>
 						</>
 					) : (
 						<>
@@ -119,11 +119,11 @@ const DuplicateButton = ( {
 							) }
 							<TextControl
 								disabled={ isSavingPost || null === duplicateTitle }
-								label={ __( 'New Title', 'newspack-popups' ) }
+								label={ __( 'Title', 'newspack-popups' ) }
 								value={ duplicateTitle }
 								onChange={ value => setDuplicateTitle( value ) }
 							/>
-							<div className="newspack-buttons-card">
+							<Flex justify="flex-end">
 								<Button
 									isBusy={ isSavingPost }
 									isSecondary
@@ -145,7 +145,7 @@ const DuplicateButton = ( {
 								>
 									{ __( 'Duplicate', 'newspack-popups' ) }
 								</Button>
-							</div>
+							</Flex>
 						</>
 					) }
 				</Modal>

--- a/src/editor/Duplicate.js
+++ b/src/editor/Duplicate.js
@@ -98,7 +98,7 @@ const DuplicateButton = ( {
 							</Notice>
 							{ ( ! campaignGroups || 0 === campaignGroups.length ) && (
 								<Notice status="warning" isDismissible={ false }>
-									{ __( 'The prompt is currently unassigned.', 'newspack-popups' ) }
+									{ __( 'This prompt is currently not assigned to any campaign.', 'newspack-popups' ) }
 								</Notice>
 							) }
 							<Flex justify="flex-end">

--- a/src/editor/style.scss
+++ b/src/editor/style.scss
@@ -45,20 +45,20 @@
 	}
 
 	&__duplicate-modal {
-		min-width: 500px;
+		@media only screen and ( min-width: 600px ) {
+			min-width: 560px;
+		}
 
 		.components-notice {
-			margin: 0 0 1rem 0;
+			margin: 0 0 24px 0;
 		}
 
 		.components-text-control__input[disabled] {
 			background-color: #f0f0f0;
 		}
 
-		.newspack-buttons-card {
-			.components-button.is-secondary {
-				margin-left: 0.5rem;
-			}
+		.components-flex {
+			margin-top: 24px;
 		}
 	}
 }

--- a/src/editor/style.scss
+++ b/src/editor/style.scss
@@ -43,4 +43,22 @@
 			display: none;
 		}
 	}
+
+	&__duplicate-modal {
+		min-width: 500px;
+
+		.components-notice {
+			margin: 0 0 1rem 0;
+		}
+
+		.components-text-control__input[disabled] {
+			background-color: #f0f0f0;
+		}
+
+		.newspack-buttons-card {
+			.components-button.is-secondary {
+				margin-left: 0.5rem;
+			}
+		}
+	}
 }

--- a/src/editor/utils.js
+++ b/src/editor/utils.js
@@ -106,10 +106,6 @@ export const updateEditorColors = backgroundColor => {
 			'--newspack-popups-editor-placeholder-color',
 			`${ foregroundColor }80`
 		);
-		editorPostTitleEl.style.setProperty(
-			'--newspack-popups-editor-background-color',
-			`${ foregroundColor }20`
-		);
 	}
 };
 

--- a/src/editor/utils.js
+++ b/src/editor/utils.js
@@ -106,6 +106,10 @@ export const updateEditorColors = backgroundColor => {
 			'--newspack-popups-editor-placeholder-color',
 			`${ foregroundColor }80`
 		);
+		editorPostTitleEl.style.setProperty(
+			'--newspack-popups-editor-background-color',
+			`${ foregroundColor }20`
+		);
 	}
 };
 

--- a/src/editor/utils.js
+++ b/src/editor/utils.js
@@ -124,8 +124,8 @@ export const isCustomPlacement = placementValue => {
  * Given a placement value, construct a context-sensitive help message to display in the editor sidebar.
  *
  * @param {string} placementValue Placement of the prompt.
- * @param {int|string} triggerPercentage Insertion percentage, for inline prompts.
- * @returns
+ * @param {number|string} triggerPercentage Insertion percentage, for inline prompts.
+ * @return {string} An appropriate help message.
  */
 export const getPlacementHelpMessage = ( placementValue, triggerPercentage = 0 ) => {
 	if ( isCustomPlacement( placementValue ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Improves the UI for duplicating prompts. When duplicating a prompt from the single-prompt edit screen, you are now presented with a modal with the opportunity to rename the duplicate before creating it, an option to close the modal or edit the duplicate after it's created, and a notice if the duplicate is created without a campaign (which would cause it to be visible in the Campaigns dashboard only under the "unassigned" filter).

Closes #560.

### How to test the changes in this Pull Request:

#### Campaigns dashboard UI

1. Go to **Newspack > Campaigns**. Open the primary popover menu and select "Duplicate". Confirm that you now see a modal with a text input to rename the duplicate, which loads the default name ("Prompt title copy", "Prompt title copy 2", etc.) at first.

<img width="1122" alt="Screen Shot 2021-06-17 at 4 18 30 PM" src="https://user-images.githubusercontent.com/2230142/122612452-61123680-d040-11eb-95f8-a02dfa26d370.png">

2. Edit the name, but click "Cancel", click "Duplicate" again on the same prompt, confirm that the changes you had entered are discarded.
3. Click "Cancel" again and click "Duplicate" for another prompt. Confirm that the modal now shows info for whatever prompt you clicked "Duplicate" for.
4. Duplicate the prompt. Confirm that after successful duplication, you are presented with a success message and the option to close the modal (remaining on the Campaigns dashboard page) or edit the duplicate (which redirects you to the edit page for the newly created prompt). You can also test the failure state by blocking the request in the Dev Tools > Network tab. Note that when blocking a request you must attempt to duplicate the same prompt and with the same title as when blocked. A failed duplication request should result in the standard "fatal error" modal for all Newspack dashboard pages.

<img width="1066" alt="Screen Shot 2021-06-17 at 4 24 07 PM" src="https://user-images.githubusercontent.com/2230142/122613575-4fca2980-d042-11eb-9ac3-6666eb7d438d.png">

5. Edit the duplicate and confirm that the title of the duplicate matches whatever you entered in the input field before, and that the content, taxonomy terms, and prompt settings all match those of the prompts you duplicated.
6. Create another duplicate, but make sure you duplicate a prompt that's not assigned. Confirm that both before and after you create the duplicate, the modal shows a warning that the prompt is unassigned.

<img width="715" alt="Screen Shot 2021-06-18 at 2 37 55 PM" src="https://user-images.githubusercontent.com/2230142/122613872-cd8e3500-d042-11eb-844d-bb37272ae99a.png">

7. Also test that if you create multiple duplicates of the same prompt (or duplicates of the duplicates of a prompt), the default title increments as expected.

<img width="1063" alt="Screen Shot 2021-06-17 at 4 24 18 PM" src="https://user-images.githubusercontent.com/2230142/122613938-e5fe4f80-d042-11eb-88bd-41e7632e660c.png">

#### Single prompt edit UI

1. Edit any prompt. Click the "Duplicate" button next to the "Preview" button.
2. The modal UI should be pretty much exactly the same as from the Campaigns dashboard. However, we're using core WP components here instead of Newspack components because when I tried using Newspack components, I kept running into [this same issue](https://github.com/Automattic/newspack-popups/issues/556) that happens when trying to preview. @thomasguillot or @adekbadek, do you have any ideas about why the `@wordpress/icons` package seems to not be importable when Newspack Components are imported as an NPM package? If we can solve this bug, we can switch the components here to Newspack Components instead of core.

<img width="514" alt="Screen Shot 2021-06-18 at 2 42 21 PM" src="https://user-images.githubusercontent.com/2230142/122614206-6e7cf000-d043-11eb-816f-4a90776df9c8.png">


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
