### PR TITLE
fix(wp-5.8): avoid an editor crash due to missing data in widgets block editor

### DIFF
--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -385,6 +385,11 @@ final class Newspack_Popups {
 		wp_style_add_data( 'newspack-popups-blocks', 'rtl', 'replace' );
 		wp_enqueue_style( 'newspack-popups-blocks' );
 
+		// Don't enqueue Prompt editor files if we don't have a valid post type or ID (e.g. on the Widget Blocks screen).
+		if ( empty( $screen->post_type ) || empty( get_post_ID() ) ) {
+			return;
+		}
+
 		if ( self::NEWSPACK_POPUPS_CPT !== $screen->post_type ) {
 			if ( 'page' !== $screen->post_type || 'post' !== $screen->post_type ) {
 				// Script for global settings.

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -386,7 +386,7 @@ final class Newspack_Popups {
 		wp_enqueue_style( 'newspack-popups-blocks' );
 
 		// Don't enqueue Prompt editor files if we don't have a valid post type or ID (e.g. on the Widget Blocks screen).
-		if ( empty( $screen->post_type ) || empty( get_post_ID() ) ) {
+		if ( empty( $screen->post_type ) || empty( get_the_ID() ) ) {
 			return;
 		}
 

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -391,8 +391,9 @@ final class Newspack_Popups {
 		}
 
 		if ( self::NEWSPACK_POPUPS_CPT !== $screen->post_type ) {
-			if ( 'page' !== $screen->post_type || 'post' !== $screen->post_type ) {
-				// Script for global settings.
+			// It's not a popup CPT.
+			if ( 'page' === $screen->post_type || 'post' === $screen->post_type ) {
+				// But it's a page or post.
 				\wp_enqueue_script(
 					'newspack-popups',
 					plugins_url( '../dist/documentSettings.js', __FILE__ ),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Avoids a hard editor crash in the new WP 5.8 widgets block editor by not enqueuing editor assets that assume we're editing a single post.

Closes #570.

### How to test the changes in this Pull Request:

This one is a bit hard to test because the crash doesn't always occur on every site. To truly confirm the fix, you'll need to have access to a site such as [this one](https://wp58test-localprofile.newspackstaging.com/wp-admin/widgets.php) where the bug is confirmed to be happening with the latest plugin release (ping me for credentials to this site).

1. On `master` or the latest release package, visit **Appearance > Widgets** and observe a hard editor crash with a JS console error such as:

```
TypeError: _wordpress_edit_post__WEBPACK_IMPORTED_MODULE_4__ is undefined
    PopupsSettingsPanel webpack:///./src/document-settings/index.js?:31
    ...
```

2. Check out and build this branch as a package, e.g. `npm run build && npm run release:archive`
3. Install/activate the built package and refresh the Widgets page. Confirm that the crash no longer occurs, that you're able to place the Campaigns blocks (Custom Placement, Single Campaign) in a widget area, and that the blocks render their prompts according to segmentation logic as expected on the front-end.
4. If you're not able to replicate the crash in the first place, you can confirm in the JS console on the Widgets page by looking for `window.newspack_popups_data`. This object should be `undefined` on this branch.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
