### PR TITLE
fix(wp-5.8): allow manual-only prompts to appear in widget blocks

### DIFF
--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -534,11 +534,16 @@ final class Newspack_Popups_Inserter {
 			[]
 		);
 
+		// Get manual-only prompts, which might be placed as a Single Prompt block in a widget area (post-WP 5.8).
+		$manual_only_popups = Newspack_Popups_Model::retrieve_eligible_popups( false, false, [ 'manual' ] );
+
 		$popups = array_merge(
 			self::popups_for_post(),
 			$shortcoded_popups,
-			$custom_placement_popups
+			$custom_placement_popups,
+			$manual_only_popups
 		);
+
 		// Prevent duplicates - a popup might be duplicated in a shortcode.
 		$unique_ids = [];
 		$popups     = array_filter(
@@ -827,7 +832,8 @@ final class Newspack_Popups_Inserter {
 	}
 
 	/**
-	 * Get all widget shortcoded popups IDs.
+	 * Get all widget shortcoded popups IDs. This will get prompts placed via legacy widgets (pre-WP 5.8).
+	 * Post-WP 5.8, widget blocks must be retrieved separately.
 	 *
 	 * @return array IDs of popups shortcoded in widgets.
 	 */

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -153,14 +153,16 @@ final class Newspack_Popups_Model {
 	}
 
 	/**
-	 * Retrieve all popups eligible to be programmatically inserted (not shortcoded or custom placement).
+	 * Retrieve prompts by placement. If $placement is not given, get only prompts eligible to be
+	 * programmatically inserted (not shortcoded, custom placement, or manual-only).
 	 *
 	 * @param  boolean     $include_unpublished Whether to include unpublished prompts.
 	 * @param  int|boolean $campaign_id Campaign term ID, or false to ignore campaign.
+	 * @param  array|null  $placements If given, find prompts matching these exact placements.
 	 * @return array Eligible popup objects.
 	 */
-	public static function retrieve_eligible_popups( $include_unpublished = false, $campaign_id = false ) {
-		$valid_placements = array_merge(
+	public static function retrieve_eligible_popups( $include_unpublished = false, $campaign_id = false, $placements = null ) {
+		$valid_placements = is_array( $placements ) ? $placements : array_merge(
 			self::$overlay_placements,
 			self::$inline_placements
 		);

--- a/src/editor/Sidebar.js
+++ b/src/editor/Sidebar.js
@@ -116,7 +116,7 @@ const Sidebar = ( {
 				checked={ display_title }
 				onChange={ value => onMetaFieldChange( 'display_title', value ) }
 			/>
-			{ ( placement === 'inline' || isCustomPlacement( placement ) ) && (
+			{ ( placement === 'inline' || placement === 'manual' || isCustomPlacement( placement ) ) && (
 				<ToggleControl
 					label={ __( 'Hide Prompt Border', 'newspack-popups' ) }
 					checked={ hide_border }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

In WP 5.8, blocks-based widget content is no longer saved in the `widget_text` option. Therefore, the method we use to get prompts placed in widget areas no longer works—which means that any prompts with the "manual only" placement that won't appear in the post content that are placed in a widget area via a Single Prompt block won't be included in the AMP access request and thus will never be shown. This PR fixes this by ensuring that any active "manual only" prompts are always checked against AMP access. This hopefully won't result in much performance impact since "manual only" prompts are meant to be used sparingly.

Closes #573.

### How to test the changes in this Pull Request:

1. On a site running WP 5.8, go to **Appearance > Widgets**. Insert a Single Prompt block and select an active block that has the "manual only" placement.
2. View the widget on the front-end and ensure that you meet the prompt's segmentation requirements. Observe that the prompt isn't shown under any circumstances. If you [debug the campaigns API](https://fieldguide.automattic.com/newspack/newspack-campaigns/troubleshooting-newspack-campaigns/#a-why-not-displayed), you should see that the request does not include the widget prompt's ID in its payload.
3. Check out this branch, refresh, confirm that the prompt is now shown as expected according to segmentation logic.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
