### PR TITLE
fix: load document settings panel only on posts and pages

### DIFF
--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -386,8 +386,9 @@ final class Newspack_Popups {
 		wp_enqueue_style( 'newspack-popups-blocks' );
 
 		if ( self::NEWSPACK_POPUPS_CPT !== $screen->post_type ) {
-			if ( 'page' !== $screen->post_type || 'post' !== $screen->post_type ) {
-				// Script for global settings.
+			// It's not a popup CPT.
+			if ( 'page' === $screen->post_type || 'post' === $screen->post_type ) {
+				// But it's a page or post.
 				\wp_enqueue_script(
 					'newspack-popups',
 					plugins_url( '../dist/documentSettings.js', __FILE__ ),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #570 

### How to test the changes in this Pull Request:

1. On WP 5.8 and on `master`branch, visit the Widgets screen
2. Observe the page crashing
3. Switch to this branch, observe the page loading fine
4. Confirm a "Newspack Campaigns Settings" panel is visible in the sidebar when editing a post or a page

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->