### PR TITLE
fix: allow custom placement prompts to be displayed if in widget blocks

### DIFF
--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -518,7 +518,7 @@ final class Newspack_Popups_Inserter {
 		);
 
 		// Get prompts for custom placements.
-		$custom_placement_ids    = self::get_custom_placement_ids( get_the_content() );
+		$custom_placement_ids    = Newspack_Popups_Custom_Placements::get_custom_placement_values();
 		$custom_placement_popups = array_reduce(
 			Newspack_Popups_Custom_Placements::get_prompts_for_custom_placement( $custom_placement_ids ),
 			function ( $acc, $custom_placement_popup ) {
@@ -726,35 +726,6 @@ final class Newspack_Popups_Inserter {
 				)
 			);
 		}
-	}
-
-	/**
-	 * Get custom placement IDs from a string.
-	 *
-	 * @param string $string String to assess.
-	 * @return array Found custom placement IDs.
-	 */
-	public static function get_custom_placement_ids( $string ) {
-		preg_match_all( '/<!-- wp:newspack-popups\/custom-placement {"customPlacement":".*"} \/-->/', $string, $custom_placement_ids );
-		if ( empty( $custom_placement_ids ) ) {
-			return [];
-		} else {
-			return array_unique(
-				array_map(
-					function ( $item ) {
-						preg_match( '/"customPlacement":"(.*)"/', $item, $matches );
-						if ( empty( $matches ) ) {
-							return null;
-						} else {
-							return $matches[1];
-						}
-					},
-					$custom_placement_ids[0]
-				)
-			);
-		}
-
-		return [];
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Allows prompts in Custom Placements to be rendered when placed via widgets.

Closes #576.

### How to test the changes in this Pull Request:

Confirm that this solves #576—prompts placed in widgets with the Custom Placement block should be shown to readers according to segmentation logic.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
