### PR TITLE
fix: assume DB prefix; ensure https

### DIFF
--- a/api/setup.php
+++ b/api/setup.php
@@ -60,11 +60,12 @@ if ( file_exists( WP_CONTENT_DIR . '/object-cache.php' ) ) {
 }
 
 global $wpdb;
+$db_prefix = defined('DB_PREFIX') ? DB_PREFIX : 'wp_';
 $wpdb = new wpdb( DB_USER, DB_PASSWORD, DB_NAME, DB_HOST );
-$wpdb->set_prefix( DB_PREFIX );
+$wpdb->set_prefix( $db_prefix );
 
 global $table_prefix;
-$table_prefix = DB_PREFIX;
+$table_prefix = $db_prefix;
 
 wp_cache_init();
 

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -1054,7 +1054,7 @@ final class Newspack_Popups_Model {
 	 * @return string Endpoint URL.
 	 */
 	public static function get_reader_endpoint() {
-		return plugins_url( '../api/campaigns/index.php', __FILE__ );
+		return str_replace( 'http:', 'https:', plugins_url( '../api/campaigns/index.php', __FILE__ ) );
 	}
 
 	/**

--- a/includes/class-newspack-popups-segmentation.php
+++ b/includes/class-newspack-popups-segmentation.php
@@ -372,9 +372,9 @@ final class Newspack_Popups_Segmentation {
 		// Filter out non-existing categories.
 		$existing_categories_ids = get_categories(
 			[
-				'hide_empty' => false, 
+				'hide_empty' => false,
 				'fields'     => 'ids',
-			] 
+			]
 		);
 		foreach ( $segments as &$segment ) {
 			if ( ! isset( $segment['configuration']['favorite_categories'] ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Small tweaks:
1. Assume the DB prefix is `wp_` if it's not defined. 
2. Ensure API URL has uses HTTPS - it happened on my local instance that the `plugins_url` returned HTTP URL despite the site URL set to HTTPS. Don't know why, but this won't hurt - if site is not HTTPS, `amp-access` won't work anyway.

### How to test the changes in this Pull Request:

1. Remove `DB_PREFIX` definition from your Campaigns config file
2. Ensure the Campaigns API works correctly

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->