### PR TITLE
feat: enable retrieving prompts from trash

### DIFF
--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -29,14 +29,18 @@ final class Newspack_Popups_Model {
 	 * Retrieve all Popups (first 100).
 	 *
 	 * @param  boolean $include_unpublished Whether to include unpublished posts.
+	 * @param  boolean $include_trash Whether to include trashed posts.
 	 * @return array Array of Popup objects.
 	 */
-	public static function retrieve_popups( $include_unpublished = false ) {
+	public static function retrieve_popups( $include_unpublished = false, $include_trash = false ) {
 		$args = [
 			'post_type'      => Newspack_Popups::NEWSPACK_POPUPS_CPT,
-			'post_status'    => $include_unpublished ? [ 'draft', 'pending', 'future', 'publish' ] : 'publish',
+			'post_status'    => $include_unpublished ? [ 'draft', 'pending', 'future', 'publish' ] : [ 'publish' ],
 			'posts_per_page' => 100,
 		];
+		if ( $include_trash ) {
+			$args['post_status'][] = 'trash';
+		}
 
 		$popups = self::retrieve_popups_with_query( new WP_Query( $args ), true );
 		return $popups;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Enables trash retrieval.

### How to test the changes in this Pull Request:

_Instructions in https://github.com/Automattic/newspack-plugin/pull/1052_

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->