### PR TITLE
feat(api): remove reader data if no updates in 30 days

### DIFF
--- a/includes/class-newspack-popups-segmentation.php
+++ b/includes/class-newspack-popups-segmentation.php
@@ -633,15 +633,20 @@ final class Newspack_Popups_Segmentation {
 
 		// Remove reader data if not containing donations nor subscriptions, and not updated in 30 days.
 		$removed_rows_count_transients = $wpdb->query( "DELETE FROM $transients_table_name WHERE `option_value` LIKE '%\"donations\";a:0%' AND `option_value` LIKE '%\"email_subscriptions\";a:0%' AND date < now() - interval 30 DAY" ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.DirectQuery
-		error_log( 'Newspack Campaigns: Data pruning – removed ' . $removed_rows_count_transients . ' rows from ' . $transients_table_name . ' table.' ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 
 		// Remove all preview sessions data.
 		$removed_rows_count_previews_transients = $wpdb->query( "DELETE FROM $transients_table_name WHERE option_name LIKE '%preview%'" ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.DirectQuery
-		error_log( 'Newspack Campaigns: Data pruning – removed ' . $removed_rows_count_previews_transients . ' preview session rows from ' . $transients_table_name . ' table.' ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 
 		// Events, like post read, don't need to stick around for more than 30 days.
 		$events_table_name         = Segmentation::get_events_table_name();
 		$removed_rows_count_events = $wpdb->query( $wpdb->prepare( "DELETE FROM $events_table_name WHERE type = %s AND created_at < now() - interval 30 DAY", 'post_read' ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.DirectQuery
+
+		if ( defined( 'IS_TEST_ENV' ) && IS_TEST_ENV ) {
+			return;
+		}
+
+		error_log( 'Newspack Campaigns: Data pruning – removed ' . $removed_rows_count_transients . ' rows from ' . $transients_table_name . ' table.' ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+		error_log( 'Newspack Campaigns: Data pruning – removed ' . $removed_rows_count_previews_transients . ' preview session rows from ' . $transients_table_name . ' table.' ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 		error_log( 'Newspack Campaigns: Data pruning – removed ' . $removed_rows_count_events . ' rows from ' . $events_table_name . ' table.' ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 	}
 }

--- a/includes/class-newspack-popups-segmentation.php
+++ b/includes/class-newspack-popups-segmentation.php
@@ -629,16 +629,20 @@ final class Newspack_Popups_Segmentation {
 	 */
 	public static function prune_data() {
 		global $wpdb;
+		$transients_table_name = Segmentation::get_transients_table_name();
+
+		// Remove reader data if not containing donations nor subscriptions, and not updated in 30 days.
+		$removed_rows_count_transients = $wpdb->query( "DELETE FROM $transients_table_name WHERE `option_value` LIKE '%\"donations\";a:0%' AND `option_value` LIKE '%\"email_subscriptions\";a:0%' AND date < now() - interval 30 DAY" ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.DirectQuery
+		error_log( 'Newspack Campaigns: Data pruning – removed ' . $removed_rows_count_transients . ' rows from ' . $transients_table_name . ' table.' ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+
+		// Remove all preview sessions data.
+		$removed_rows_count_previews_transients = $wpdb->query( "DELETE FROM $transients_table_name WHERE option_name LIKE '%preview%'" ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.DirectQuery
+		error_log( 'Newspack Campaigns: Data pruning – removed ' . $removed_rows_count_previews_transients . ' preview session rows from ' . $transients_table_name . ' table.' ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 
 		// Events, like post read, don't need to stick around for more than 30 days.
 		$events_table_name         = Segmentation::get_events_table_name();
 		$removed_rows_count_events = $wpdb->query( $wpdb->prepare( "DELETE FROM $events_table_name WHERE type = %s AND created_at < now() - interval 30 DAY", 'post_read' ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.DirectQuery
 		error_log( 'Newspack Campaigns: Data pruning – removed ' . $removed_rows_count_events . ' rows from ' . $events_table_name . ' table.' ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
-
-		// Remove all preview sessions data.
-		$transients_table_name         = Segmentation::get_transients_table_name();
-		$removed_rows_count_transients = $wpdb->query( "DELETE FROM $transients_table_name WHERE option_name LIKE '%preview%'" ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.DirectQuery
-		error_log( 'Newspack Campaigns: Data pruning – removed ' . $removed_rows_count_transients . ' preview sessions  rows from ' . $transients_table_name . ' table.' ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 	}
 }
 Newspack_Popups_Segmentation::instance();

--- a/tests/test-segmentation.php
+++ b/tests/test-segmentation.php
@@ -15,8 +15,10 @@ class SegmentationTest extends WP_UnitTestCase {
 
 	public function setUp() { // phpcs:ignore Squiz.Commenting.FunctionComment.Missing
 		global $wpdb;
-		$events_table_name = Segmentation::get_events_table_name();
+		$events_table_name     = Segmentation::get_events_table_name();
+		$transients_table_name = Segmentation::get_transients_table_name();
 		$wpdb->query( "DELETE FROM $events_table_name;" ); // phpcs:ignore
+		$wpdb->query( "DELETE FROM $transients_table_name;" ); // phpcs:ignore
 		if ( file_exists( Segmentation::get_log_file_path() ) ) {
 			unlink( Segmentation::get_log_file_path() ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_unlink
 		}
@@ -201,6 +203,90 @@ class SegmentationTest extends WP_UnitTestCase {
 			Segmentation::parse_view_as( '' ),
 			[],
 			'Empty array is returned if there is no spec.'
+		);
+	}
+
+	/**
+	 * Prune the data.
+	 */
+	public function test_data_pruning() {
+		global $wpdb;
+		$transients_table_name = Segmentation::get_transients_table_name();
+
+		$api_campaign_handler = new Maybe_Show_Campaign();
+
+		// Add the donor client data.
+		$api_campaign_handler->save_client_data(
+			'test-donor',
+			[
+				'donation' => [ 'amount' => 100 ],
+			]
+		);
+
+		// Add and backdate the subscriber client data.
+		$api_campaign_handler->save_client_data(
+			'test-subscriber',
+			[
+				'email_subscriptions' => [ 'address' => 'test@testing.com' ],
+			]
+		);
+		$wpdb->query( "UPDATE $transients_table_name SET `date` = '2020-04-29 15:39:13' WHERE `option_name` = '_transient_test-subcriber';" ); // phpcs:ignore
+
+		// Add and backdate the one time reader client data.
+		$api_campaign_handler->save_client_data(
+			'test-one-time-reader',
+			[
+				'posts_read' => [
+					[
+						'post_id'      => '142',
+						'category_ids' => '',
+					],
+				],
+			]
+		);
+
+		// Add and backdate the one time reader client data.
+		$api_campaign_handler->save_client_data(
+			'test-one-time-reader-backdated',
+			[
+				'posts_read' => [
+					[
+						'post_id'      => '142',
+						'category_ids' => '',
+					],
+				],
+			]
+		);
+		$wpdb->query( "UPDATE $transients_table_name SET `date` = '2020-04-29 15:39:13' WHERE `option_name` = '_transient_test-one-time-reader-backdated';" ); // phpcs:ignore
+
+		$all_readers_rows = $wpdb->get_results( "SELECT option_name FROM $transients_table_name" ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		self::assertEquals(
+			4,
+			count( $all_readers_rows ),
+			'All reader data is present before pruning.'
+		);
+
+		// Prune the data.
+		Newspack_Popups_Segmentation::prune_data();
+
+		$all_readers_rows = $wpdb->get_results( "SELECT option_name FROM $transients_table_name" ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		self::assertEquals(
+			[
+				// Donor was not removed.
+				(object) [
+					'option_name' => '_transient_test-donor',
+				],
+				// One time reader was not removed, since they visited in the last 30 days.
+				(object) [
+					'option_name' => '_transient_test-one-time-reader',
+				],
+				// Subscriber was not removed, despite not visiting since >30 days.
+				(object) [
+					'option_name' => '_transient_test-subscriber',
+				],
+			],
+			$all_readers_rows,
+			'After pruning, expected rows are still there.'
 		);
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Remove reader data not updated in 30 days and not containing any donations or subscriptions.

Closes #583.

### How to test the changes in this Pull Request:

There is a test added, but double-checking won't hurt.

1. Manipulate the reader data* so that you can test the following premises:
    1. A reader who did subscribe or donate, and was not updated since more than 30 days should **not** be removed
    2. A reader who did not subscribe nor donate, and was **not updated** since more than 30 days should be removed
    3. A reader who did not subscribe nor donate, and **was updated** less than 30 days ago should **not** be removed
2. Force pruning by running `wp cron event delete newspack_popups_segmentation_data_prune` and loading any admin page
3. Observe pruning results in the DB 

\* In the `wp_newspack_campaigns_transients` table. The `date` (the last update date) can be changed directly, for the encoded data (donations, subscriptions) you can change the value of `$value` saved to the table [here](https://github.com/Automattic/newspack-popups/blob/b4e4e6d1ef3ba18fb2a45e8df38fa06ca32e34fc/api/classes/class-lightweight-api.php#L193-L208).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->