### PR TITLE
feat: show prompts inside widget blocks in customizer preview

### DIFF
--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -733,9 +733,15 @@ final class Newspack_Popups_Model {
 	/**
 	 * Get amp-access attributes for a popup-enclosing amp-layout tag.
 	 *
-	 * @param object $popup Popup.
+	 * @param object  $popup Popup.
+	 * @param boolean $always_show If true, bypass AMP Access check and always show the prompt.
+	 *
+	 * @return string AMP access attribute string.
 	 */
-	public static function get_access_attrs( $popup ) {
+	public static function get_access_attrs( $popup, $always_show = false ) {
+		if ( $always_show ) {
+			return '';
+		}
 		if ( Newspack_Popups_Settings::is_non_interactive() ) {
 			return '';
 		}
@@ -794,10 +800,12 @@ final class Newspack_Popups_Model {
 	/**
 	 * Generate markup for an inline popup.
 	 *
-	 * @param string $popup The popup object.
+	 * @param string  $popup The popup object.
+	 * @param boolean $always_show If true, bypass AMP Access check and always show the prompt.
+	 *
 	 * @return string The generated markup.
 	 */
-	public static function generate_inline_popup( $popup ) {
+	public static function generate_inline_popup( $popup, $always_show = false ) {
 		global $wp;
 
 		do_action( 'newspack_campaigns_before_campaign_render', $popup );
@@ -838,7 +846,7 @@ final class Newspack_Popups_Model {
 		?>
 			<?php self::insert_event_tracking( $popup, $body, $element_id ); ?>
 			<amp-layout
-				<?php echo self::get_access_attrs( $popup ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+				<?php echo self::get_access_attrs( $popup, $always_show ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 				<?php echo self::get_data_status_preview_attrs( $popup ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 				class="<?php echo esc_attr( implode( ' ', $classes ) ); ?>"
 				role="button"
@@ -861,17 +869,19 @@ final class Newspack_Popups_Model {
 	/**
 	 * Generate markup and styles for an overlay popup.
 	 *
-	 * @param string $popup The popup object.
+	 * @param string  $popup The popup object.
+	 * @param boolean $always_show If true, bypass AMP Access check and always show the prompt.
+	 *
 	 * @return string The generated markup.
 	 */
-	public static function generate_popup( $popup ) {
+	public static function generate_popup( $popup, $always_show = false ) {
 		// If previewing a single prompt, override saved settings with preview settings.
 		if ( Newspack_Popups::previewed_popup_id() ) {
 			$popup = self::retrieve_preview_popup( Newspack_Popups::previewed_popup_id() );
 		}
 
 		if ( ! self::is_overlay( $popup ) ) {
-			return self::generate_inline_popup( $popup );
+			return self::generate_inline_popup( $popup, $always_show );
 		}
 
 		do_action( 'newspack_campaigns_before_campaign_render', $popup );

--- a/src/blocks/custom-placement/view.php
+++ b/src/blocks/custom-placement/view.php
@@ -54,12 +54,27 @@ function render_block( $attributes ) {
 		$prompts = \Newspack_Popups_Custom_Placements::get_prompts_for_custom_placement( [ $custom_placement_id ], 'ids', [] );
 	}
 
+	$index = 0;
+
 	if ( ! empty( $prompts ) ) {
+		$is_customizer = is_customize_preview();
+
 		if ( defined( 'WP_NEWSPACK_DEBUG' ) && WP_NEWSPACK_DEBUG ) {
 			$content .= '<!-- Newspack Campaigns: Start custom placement ' . $custom_placement_id . '-->';
 		}
+
 		foreach ( $prompts as $prompt_id ) {
-			$content .= '<!-- wp:shortcode -->[newspack-popup id="' . $prompt_id . '"]<!-- /wp:shortcode -->';
+			// If viewing the block in the Customizer preview, only show one prompt.
+			if ( $is_customizer && $index > 0 ) {
+				continue;
+			}
+
+			$content .= sprintf(
+				'<!-- wp:shortcode -->[newspack-popup id="%s"]<!-- /wp:shortcode -->',
+				$prompt_id
+			);
+
+			$index ++;
 		}
 		if ( defined( 'WP_NEWSPACK_DEBUG' ) && WP_NEWSPACK_DEBUG ) {
 			$content .= '<!-- Newspack Campaigns: End custom placement ' . $custom_placement_id . '-->';

--- a/src/blocks/single-prompt/editor.scss
+++ b/src/blocks/single-prompt/editor.scss
@@ -11,6 +11,10 @@
 		.wp-block-jetpack-mailchimp_notification {
 			display: none;
 		}
+
+		img {
+			height: auto;
+		}
 	}
 
 	&__single-prompt-placeholder {

--- a/src/blocks/single-prompt/view.php
+++ b/src/blocks/single-prompt/view.php
@@ -48,7 +48,10 @@ function render_block( $attributes ) {
 			$content .= '<!-- Newspack Campaigns: Start Prompt ' . $prompt_id . '-->';
 		}
 
-		$content .= '<!-- wp:shortcode -->[newspack-popup id="' . $prompt_id . '"]<!-- /wp:shortcode -->';
+		$content .= sprintf(
+			'<!-- wp:shortcode -->[newspack-popup id="%s"]<!-- /wp:shortcode -->',
+			$prompt_id
+		);
 
 		if ( defined( 'WP_NEWSPACK_DEBUG' ) && WP_NEWSPACK_DEBUG ) {
 			$content .= '<!-- Newspack Campaigns: End Prompt ' . $prompt_id . '-->';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

In WP 5.8, it's possible to add blocks to widget areas in the Customizer. These blocks currently don't show anything when logged in, so this PR ensures that if a widget block can show a prompt, it displays at least something in the widget area in the Customizer preview.

It does this by using the new [`widget_block_content`](https://github.com/WordPress/WordPress/blob/master/wp-includes/widgets/class-wp-widget-block.php#L68-L82) filter to add a shortcode attribute when a prompt is displayed inside a widget block, then if the block is being rendered in the Customizer preview, it bypasses the AMP access check to ensure that the block displays the first prompt that can be shown by the block.

Question: is it now weird that only prompts inside widgets are shown in the preview? At first I tried making all prompts be displayed in the Customizer, but it got annoying because every prompt is displayed every time you change a Customizer setting (so every overlay pops up again even if dismissed, for example). I think showing only prompts that are inside widget blocks is a good compromise even if it's not logically consistent.

Closes #577.

### How to test the changes in this Pull Request:

1. Publish three inline prompts. Make sure two are assigned to a custom placement.
2. Go to **Appearance > Customize > Widgets**. In any widget area, add a Single Prompt block and a Custom Placement block and select a prompt and custom placement containing prompts, respectively. In the Customizer preview, navigate to a page that displays the widget area with your blocks and observe that nothing is shown in the preview widget area.
3. Check out this branch, refresh the Customizer, and repeat step 2. This time confirm that one prompt is shown for each block, ignoring segmentation rules for previewing purposes.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
