### PR TITLE
fix: above-header popups on pages

### DIFF
--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -712,8 +712,12 @@ final class Newspack_Popups_Inserter {
 	 * @return bool Should popup be shown.
 	 */
 	public static function should_display( $popup, $check_if_is_post = false ) {
-		// Inline prompts may only be rendered on posts.
-		if ( $check_if_is_post && Newspack_Popups_Model::is_inline( $popup ) && 'post' !== get_post_type() ) {
+		// Inline prompts may only be rendered on posts, unless they are above-header.
+		if (
+			$check_if_is_post &&
+			'post' !== get_post_type() &&
+			( Newspack_Popups_Model::is_inline( $popup ) && ! Newspack_Popups_Model::is_above_header( $popup ) )
+		) {
 			return false;
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a regression introduced in #587 

### How to test the changes in this Pull Request:

1. Create a prompt and set it to above header placement
2. Observe that it's not displayed on pages when on `master`
3. Switch to this branch, observe the prompt is displayed

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

