### PR TITLE
fix: email substitution in newsletter forms

### DIFF
--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -600,7 +600,7 @@ final class Newspack_Popups_Model {
 					'popup_id'            => esc_attr( self::canonize_popup_id( $popup['id'] ) ),
 					'cid'                 => 'CLIENT_ID(' . esc_attr( Newspack_Popups_Segmentation::NEWSPACK_SEGMENTATION_CID_NAME ) . ')',
 					'mailing_list_status' => 'subscribed',
-					'email'               => '$[formFields[' . esc_attr( $email_form_field_name ) . ']}',
+					'email'               => '${formFields[' . esc_attr( $email_form_field_name ) . ']}',
 				],
 			];
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #598.

### How to test the changes in this Pull Request:

1. On `master`, create a prompt with a Jetpack Mailchimp form
2. Visit the frontend, sign up for the newsletter - observe that the payload to `POST /wp-content/plugins/newspack-popups/api/campaigns/index.php` has a wrong value in the `email` param (not substituted for the email address)
3. Switch to this branch, observe the `email` param i sent correctly

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->