### PR TITLE
fix: amp analytics polyfill tweak

### DIFF
--- a/src/view/utils/index.js
+++ b/src/view/utils/index.js
@@ -39,7 +39,7 @@ export const getClientIDValue = () => getCookies()[ 'newspack-cid' ];
  * @return {string} String with the value replaced.
  */
 export const substituteDynamicValue = value => {
-	if ( value && value.replace( /\s/g, '' ) === 'CLIENT_ID(newspack-cid)' ) {
+	if ( value && String( value ).replace( /\s/g, '' ) === 'CLIENT_ID(newspack-cid)' ) {
 		value = getClientIDValue() || '';
 	}
 	return value;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Tiny bugfix.

### How to test the changes in this Pull Request:

Can be taken at face value, but the issue appeared on after making a recurring donation using WC. WC then creates and logs in a user, so a `user_id` param of type `number` [is used in `amp-analytics` config](https://github.com/Automattic/newspack-popups/blob/0f1ae4d1ad16e8378940267af6bd227223f533a3/includes/class-newspack-popups-segmentation.php#L256). Anyway, the value of a URL param can be a number, too.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->