### PR TITLE
feat: targeting campaigns by post type

### DIFF
--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -152,6 +152,9 @@ final class Newspack_Popups_Model {
 					}
 					update_post_meta( $id, $key, $value );
 					break;
+				case 'post_types':
+					update_post_meta( $id, $key, $value );
+					break;
 				default:
 					update_post_meta( $id, $key, esc_attr( $value ) );
 			}
@@ -345,6 +348,7 @@ final class Newspack_Popups_Model {
 			'trigger_scroll_progress' => get_post_meta( $id, 'trigger_scroll_progress', true ),
 			'utm_suppression'         => get_post_meta( $id, 'utm_suppression', true ),
 			'selected_segment_id'     => get_post_meta( $id, 'selected_segment_id', true ),
+			'post_types'              => get_post_meta( $id, 'post_types', true ),
 		];
 
 		return wp_parse_args(
@@ -364,8 +368,26 @@ final class Newspack_Popups_Model {
 				'trigger_scroll_progress' => 0,
 				'utm_suppression'         => null,
 				'selected_segment_id'     => '',
+				'post_types'              => self::get_globally_supported_post_types(),
 			]
 		);
+	}
+
+	/**
+	 * Get the globally supported post types.
+	 */
+	public static function get_globally_supported_post_types() {
+		return apply_filters(
+			'newspack_campaigns_post_types_for_campaigns',
+			self::get_default_popup_post_types()
+		);
+	}
+
+	/**
+	 * Get the default supported post types.
+	 */
+	public static function get_default_popup_post_types() {
+		return [ 'post', 'page' ];
 	}
 
 	/**

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -288,6 +288,25 @@ final class Newspack_Popups {
 			]
 		);
 
+		\register_meta(
+			'post',
+			'post_types',
+			[
+				'object_subtype' => self::NEWSPACK_POPUPS_CPT,
+				'show_in_rest'   => [
+					'schema' => [
+						'items' => [
+							'type' => 'string',
+						],
+					],
+				],
+				'type'           => 'array',
+				'default'        => Newspack_Popups_Model::get_default_popup_post_types(),
+				'single'         => true,
+				'auth_callback'  => '__return_true',
+			]
+		);
+
 		// Meta field for all post types.
 		\register_meta(
 			'post',
@@ -422,11 +441,22 @@ final class Newspack_Popups {
 			'newspack-popups',
 			'newspack_popups_data',
 			[
-				'preview_post'      => self::preview_post_permalink(),
-				'segments'          => Newspack_Popups_Segmentation::get_segments(),
-				'custom_placements' => Newspack_Popups_Custom_Placements::get_custom_placements(),
-				'taxonomy'          => self::NEWSPACK_POPUPS_TAXONOMY,
-				'is_prompt'         => self::NEWSPACK_POPUPS_CPT == get_post_type(),
+				'preview_post'         => self::preview_post_permalink(),
+				'segments'             => Newspack_Popups_Segmentation::get_segments(),
+				'custom_placements'    => Newspack_Popups_Custom_Placements::get_custom_placements(),
+				'taxonomy'             => self::NEWSPACK_POPUPS_TAXONOMY,
+				'is_prompt'            => self::NEWSPACK_POPUPS_CPT == get_post_type(),
+				'available_post_types' => array_values(
+					get_post_types(
+						[
+							'public'       => true,
+							'show_in_rest' => true,
+							'_builtin'     => false,
+						],
+						'objects'
+					)
+				),
+
 			]
 		);
 		\wp_enqueue_style(

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@wordpress/url": "^2.19.0",
         "intersection-observer": "^0.11.0",
         "js-cookie": "^2.2.1",
+        "lodash": "^0.9.2",
         "newspack-components": "^1.6.1",
         "qs": "^6.9.4",
         "whatwg-fetch": "^3.5.0"
@@ -21445,7 +21446,8 @@
         "util-deprecate",
         "wide-align",
         "wrappy",
-        "yallist"
+        "yallist",
+        "ini"
       ],
       "dev": true,
       "optional": true,
@@ -29462,7 +29464,6 @@
       "version": "0.9.2",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz",
       "integrity": "sha1-jzSZxSRdNG1oLlsNO0B2fgnxqSw=",
-      "dev": true,
       "engines": [
         "node",
         "rhino"
@@ -32085,7 +32086,8 @@
         "y18n",
         "yallist",
         "yargs",
-        "yargs-parser"
+        "yargs-parser",
+        "ini"
       ],
       "dev": true,
       "dependencies": {
@@ -70821,8 +70823,7 @@
     "lodash": {
       "version": "0.9.2",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz",
-      "integrity": "sha1-jzSZxSRdNG1oLlsNO0B2fgnxqSw=",
-      "dev": true
+      "integrity": "sha1-jzSZxSRdNG1oLlsNO0B2fgnxqSw="
     },
     "lodash._baseisequal": {
       "version": "3.0.7",

--- a/package.json
+++ b/package.json
@@ -132,6 +132,7 @@
     "@wordpress/url": "^2.19.0",
     "intersection-observer": "^0.11.0",
     "js-cookie": "^2.2.1",
+    "lodash": "^0.9.2",
     "newspack-components": "^1.6.1",
     "qs": "^6.9.4",
     "whatwg-fetch": "^3.5.0"

--- a/src/editor/PostTypesPanel.js
+++ b/src/editor/PostTypesPanel.js
@@ -1,0 +1,33 @@
+/**
+ * External dependencies
+ */
+import { without } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { PanelRow, CheckboxControl } from '@wordpress/components';
+
+const PostTypesPanel = ( { post_types = [], onMetaFieldChange } ) => {
+	const availablePostTypes = [
+		{ name: 'post', label: 'Posts' },
+		{ name: 'page', label: 'Pages' },
+		...window.newspack_popups_data.available_post_types,
+	];
+	return availablePostTypes.map( ( { name, label } ) => (
+		<PanelRow key={ name }>
+			<CheckboxControl
+				label={ label }
+				checked={ post_types.indexOf( name ) > -1 }
+				onChange={ isIncluded => {
+					onMetaFieldChange(
+						'post_types',
+						isIncluded ? [ ...post_types, name ] : without( post_types, name )
+					);
+				} }
+			/>
+		</PanelRow>
+	) );
+};
+
+export default PostTypesPanel;

--- a/src/editor/index.js
+++ b/src/editor/index.js
@@ -23,6 +23,7 @@ import ColorsSidebar from './ColorsSidebar';
 import Preview from './Preview';
 import Duplicate from './Duplicate';
 import EditorAdditions from './EditorAdditions';
+import PostTypesPanel from './PostTypesPanel';
 import './style.scss';
 
 // Action dispatchers for the sidebar components.
@@ -48,6 +49,7 @@ const FrequencySidebarWithData = connectData( FrequencySidebar );
 const SegmentationSidebarWithData = connectData( SegmentationSidebar );
 const DismissSidebarWithData = connectData( DismissSidebar );
 const ColorsSidebarWithData = connectData( ColorsSidebar );
+const PostTypesPanelWithData = connectData( PostTypesPanel );
 
 // Register components.
 registerPlugin( 'newspack-popups', {
@@ -105,6 +107,18 @@ registerPlugin( 'newspack-popups-colors', {
 			title={ __( 'Color Settings', 'newspack-popups' ) }
 		>
 			<ColorsSidebarWithData />
+		</PluginDocumentSettingPanel>
+	),
+	icon: null,
+} );
+
+registerPlugin( 'newspack-popups-post-types', {
+	render: () => (
+		<PluginDocumentSettingPanel
+			name="post-types-panel"
+			title={ __( 'Post Types', 'newspack-popups' ) }
+		>
+			<PostTypesPanelWithData />
 		</PluginDocumentSettingPanel>
 	),
 	icon: null,

--- a/src/editor/utils.js
+++ b/src/editor/utils.js
@@ -23,6 +23,7 @@ export const optionsFieldsSelector = select => {
 		trigger_type,
 		utm_suppression,
 		selected_segment_id,
+		post_types,
 	} = meta || {};
 
 	const isInlinePlacement = placementValue =>
@@ -46,6 +47,7 @@ export const optionsFieldsSelector = select => {
 		selected_segment_id,
 		isInlinePlacement,
 		isOverlay,
+		post_types,
 	};
 };
 

--- a/tests/test-e2e.php
+++ b/tests/test-e2e.php
@@ -148,19 +148,15 @@ class E2ETest extends WP_UnitTestCase_PageWithPopups {
 			'Duplicated prompt has same content as original prompt.'
 		);
 
-		self::assertEmpty(
-			array_diff(
-				wp_get_post_terms( $original_popup_id, [ 'category', 'post_tag', Newspack_Popups::NEWSPACK_POPUPS_TAXONOMY ], [ 'fields' => 'ids' ] ),
-				wp_get_post_terms( $duplicate_popup_id, [ 'category', 'post_tag', Newspack_Popups::NEWSPACK_POPUPS_TAXONOMY ], [ 'fields' => 'ids' ] )
-			),
+		self::assertEquals(
+			wp_get_post_terms( $original_popup_id, [ 'category', 'post_tag', Newspack_Popups::NEWSPACK_POPUPS_TAXONOMY ], [ 'fields' => 'ids' ] ),
+			wp_get_post_terms( $duplicate_popup_id, [ 'category', 'post_tag', Newspack_Popups::NEWSPACK_POPUPS_TAXONOMY ], [ 'fields' => 'ids' ] ),
 			'Duplicated prompt has the same categories, tags, and campaign terms as original prompt.'
 		);
 
-		self::assertEmpty(
-			array_diff(
-				Newspack_Popups_Model::get_popup_options( $original_popup_id ),
-				Newspack_Popups_Model::get_popup_options( $duplicate_popup_id )
-			),
+		self::assertEquals(
+			Newspack_Popups_Model::get_popup_options( $original_popup_id ),
+			Newspack_Popups_Model::get_popup_options( $duplicate_popup_id ),
 			'Duplicated prompt has the same prompt options as the original prompt.'
 		);
 	}

--- a/tests/test-insertion-cpt.php
+++ b/tests/test-insertion-cpt.php
@@ -1,0 +1,137 @@
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+/**
+ * Class Insertion Test CPT
+ *
+ * @package Newspack_Popups
+ */
+
+/**
+ * Insertion test case.
+ */
+class InsertionTestCPT extends WP_UnitTestCase_PageWithPopups {
+	private static $podcast_cpt_name       = 'podcast'; // phpcs:ignore Squiz.Commenting.VariableComment.Missing
+	private static $press_release_cpt_name = 'press-release'; // phpcs:ignore Squiz.Commenting.VariableComment.Missing
+	public static function filter_use_only_podcast_cpt_name() { // phpcs:ignore Squiz.Commenting.FunctionComment.Missing
+		return [ self::$podcast_cpt_name ];
+	}
+	public static function filter_use_podcast_cpt_name( $post_types ) { // phpcs:ignore Squiz.Commenting.FunctionComment.Missing
+		$post_types[] = self::$podcast_cpt_name;
+		return $post_types;
+	}
+	public static function filter_use_press_release_cpt_name( $post_types ) { // phpcs:ignore Squiz.Commenting.FunctionComment.Missing
+		$post_types[] = self::$press_release_cpt_name;
+		return $post_types;
+	}
+
+	/**
+	 * Test popup insertion into a CPT, with global supported-CPT setting.
+	 */
+	public function test_insertion_in_cpt_global() {
+		\register_post_type( self::$podcast_cpt_name, [ 'public' => true ] );
+
+		self::renderPost( '', null, [], [], self::$podcast_cpt_name );
+		self::assertEquals(
+			0,
+			self::getRenderedPopupsAmount(),
+			'No popups displayed until the CPT is registered as popup-compatible.'
+		);
+
+		// Add the podcast CPT to the globally supported post types.
+		add_filter( 'newspack_campaigns_post_types_for_campaigns', [ __CLASS__, 'filter_use_podcast_cpt_name' ] );
+		self::renderPost( '', null, [], [], self::$podcast_cpt_name );
+		self::assertEquals(
+			1,
+			self::getRenderedPopupsAmount(),
+			'Popup is rendered, since the CPT was added to supported post types list.'
+		);
+		remove_filter( 'newspack_campaigns_post_types_for_campaigns', [ __CLASS__, 'filter_use_podcast_cpt_name' ] );
+
+		// Set the podcast CPT as the *only* globally supported post type.
+		add_filter( 'newspack_campaigns_post_types_for_campaigns', [ __CLASS__, 'filter_use_only_podcast_cpt_name' ] );
+		self::renderPost( '', null, [], [] );
+		self::assertEquals(
+			0,
+			self::getRenderedPopupsAmount(),
+			'No popups displayed - the only popup is set to display on the podcast CPT only.'
+		);
+		self::renderPost( '', null, [], [], self::$podcast_cpt_name );
+		self::assertEquals(
+			1,
+			self::getRenderedPopupsAmount(),
+			'Popup is rendered, since the CPT was added to supported post types list.'
+		);
+		remove_filter( 'newspack_campaigns_post_types_for_campaigns', [ __CLASS__, 'filter_use_only_podcast_cpt_name' ] );
+	}
+
+	/**
+	 * Test popup insertion into a CPT, with popup-specific supported-CPT setting.
+	 */
+	public function test_insertion_in_cpt_popup_specific() {
+		$episode_cpt_name = 'episode';
+		\register_post_type( $episode_cpt_name, [ 'public' => true ] );
+
+		self::renderPost( '', null, [], [], $episode_cpt_name );
+		self::assertEquals(
+			0,
+			self::getRenderedPopupsAmount(),
+			'There are no popups before the CPT is assigned to the popup.'
+		);
+		self::renderPost( '', null, [], [] );
+		self::assertEquals(
+			1,
+			self::getRenderedPopupsAmount(),
+			'Popup is rendered on a regular post.'
+		);
+
+		Newspack_Popups_Model::set_popup_options(
+			self::$popup_id,
+			[
+				'post_types' => [ $episode_cpt_name ],
+			]
+		);
+		self::renderPost( '', null, [], [], $episode_cpt_name );
+		self::assertEquals(
+			1,
+			self::getRenderedPopupsAmount(),
+			'Popup is rendered, since the CPT was added to popup options.'
+		);
+
+		self::renderPost( '', null, [], [] );
+		self::assertEquals(
+			0,
+			self::getRenderedPopupsAmount(),
+			'No popups displayed - the only popup is set to display on the episode CPT only.'
+		);
+	}
+
+	/**
+	 * Test popup insertion into a CPT, with popup-specific supported-CPT setting.
+	 */
+	public function test_insertion_in_cpt_popup_specific_vs_global() {
+		\register_post_type( self::$podcast_cpt_name, [ 'public' => true ] );
+		\register_post_type( self::$press_release_cpt_name, [ 'public' => true ] );
+
+		Newspack_Popups_Model::set_popup_options(
+			self::$popup_id,
+			[
+				'post_types' => [ self::$podcast_cpt_name ],
+			]
+		);
+
+		add_filter( 'newspack_campaigns_post_types_for_campaigns', [ __CLASS__, 'filter_use_press_release_cpt_name' ] );
+		self::renderPost( '', null, [], [], self::$press_release_cpt_name );
+		self::assertEquals(
+			0,
+			self::getRenderedPopupsAmount(),
+			'No popups displayed - the popup is set to display only on podcast post types.'
+		);
+
+		self::renderPost( '', null, [], [], self::$podcast_cpt_name );
+		self::assertEquals(
+			1,
+			self::getRenderedPopupsAmount(),
+			'Popup is rendered, since the CPT was added to popup options.'
+		);
+		remove_filter( 'newspack_campaigns_post_types_for_campaigns', [ __CLASS__, 'filter_use_press_release_cpt_name' ] );
+	}
+}

--- a/tests/test-model.php
+++ b/tests/test-model.php
@@ -43,6 +43,7 @@ class ModelTest extends WP_UnitTestCase {
 				'trigger_scroll_progress' => '30',
 				'utm_suppression'         => null,
 				'selected_segment_id'     => '',
+				'post_types'              => [ 'post', 'page' ],
 			],
 			'Default options are as expected.'
 		);

--- a/tests/wp-unittestcase-pagewithpopups.php
+++ b/tests/wp-unittestcase-pagewithpopups.php
@@ -73,6 +73,13 @@ class WP_UnitTestCase_PageWithPopups extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Get number of popups rendered on the page.
+	 */
+	protected function getRenderedPopupsAmount() {
+		return self::$dom_xpath->query( '//amp-layout' )->length;
+	}
+
+	/**
 	 * Trigger post rendering with popups in it.
 	 *
 	 * @param string $url_query Query to append to URL.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #567 .

### How to test the changes in this Pull Request:

1. Create a prompt, observe a new panel in the sidebar editor - "Post Types"
2. Observe "Posts" and "Pages" selected by default
3. Publish the prompt, observe it behaving as expected
4. Visit a CPT, observe the prompt is not visible there
5. In the editor select the CPT name and re-publish the prompt
6. Observe the prompt visible on the respective CPT
7. Create another prompt, and use a filter to set globally supported CPTs*
8. Publish the prompt, observe it is visible on the globally-enabled CPT

\* e.g.:  
```
add_filter( 'newspack_campaigns_post_types_for_campaigns', function( $post_types ) {
	$post_types[] = 'press_release';
	return $post_types;
} );
```


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->