### PR TITLE
fix: disable until configured

### DIFF
--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -47,26 +47,29 @@ final class Newspack_Popups {
 	public function __construct() {
 		add_action( 'admin_init', [ __CLASS__, 'create_lightweight_api_config' ] );
 		add_action( 'admin_notices', [ __CLASS__, 'api_config_missing_notice' ] );
-		add_action( 'init', [ __CLASS__, 'register_cpt' ] );
-		add_action( 'init', [ __CLASS__, 'register_meta' ] );
-		add_action( 'init', [ __CLASS__, 'register_taxonomy' ] );
-		add_action( 'enqueue_block_editor_assets', [ __CLASS__, 'enqueue_block_editor_assets' ] );
-		add_action( 'customize_controls_enqueue_scripts', [ __CLASS__, 'enqueue_customizer_assets' ] );
-		add_filter( 'display_post_states', [ __CLASS__, 'display_post_states' ], 10, 2 );
-		add_action( 'save_post_' . self::NEWSPACK_POPUPS_CPT, [ __CLASS__, 'popup_default_fields' ], 10, 3 );
-		add_action( 'transition_post_status', [ __CLASS__, 'remove_default_category' ], 10, 3 );
 
-		add_filter( 'show_admin_bar', [ __CLASS__, 'show_admin_bar' ], 10, 2 ); // phpcs:ignore WordPressVIPMinimum.UserExperience.AdminBarRemoval.RemovalDetected
+		if ( self::is_api_configured() ) {
+			add_action( 'init', [ __CLASS__, 'register_cpt' ] );
+			add_action( 'init', [ __CLASS__, 'register_meta' ] );
+			add_action( 'init', [ __CLASS__, 'register_taxonomy' ] );
+			add_action( 'enqueue_block_editor_assets', [ __CLASS__, 'enqueue_block_editor_assets' ] );
+			add_action( 'customize_controls_enqueue_scripts', [ __CLASS__, 'enqueue_customizer_assets' ] );
+			add_filter( 'display_post_states', [ __CLASS__, 'display_post_states' ], 10, 2 );
+			add_action( 'save_post_' . self::NEWSPACK_POPUPS_CPT, [ __CLASS__, 'popup_default_fields' ], 10, 3 );
+			add_action( 'transition_post_status', [ __CLASS__, 'remove_default_category' ], 10, 3 );
 
-		include_once dirname( __FILE__ ) . '/class-newspack-popups-model.php';
-		include_once dirname( __FILE__ ) . '/class-newspack-popups-inserter.php';
-		include_once dirname( __FILE__ ) . '/class-newspack-popups-api.php';
-		include_once dirname( __FILE__ ) . '/class-newspack-popups-settings.php';
-		include_once dirname( __FILE__ ) . '/class-newspack-popups-segmentation.php';
-		include_once dirname( __FILE__ ) . '/class-newspack-popups-custom-placements.php';
-		include_once dirname( __FILE__ ) . '/class-newspack-popups-parse-logs.php';
-		include_once dirname( __FILE__ ) . '/class-newspack-popups-donations.php';
-		include_once dirname( __FILE__ ) . '/class-newspack-popups-view-as.php';
+			add_filter( 'show_admin_bar', [ __CLASS__, 'show_admin_bar' ], 10, 2 ); // phpcs:ignore WordPressVIPMinimum.UserExperience.AdminBarRemoval.RemovalDetected
+
+			include_once dirname( __FILE__ ) . '/class-newspack-popups-model.php';
+			include_once dirname( __FILE__ ) . '/class-newspack-popups-inserter.php';
+			include_once dirname( __FILE__ ) . '/class-newspack-popups-api.php';
+			include_once dirname( __FILE__ ) . '/class-newspack-popups-settings.php';
+			include_once dirname( __FILE__ ) . '/class-newspack-popups-segmentation.php';
+			include_once dirname( __FILE__ ) . '/class-newspack-popups-custom-placements.php';
+			include_once dirname( __FILE__ ) . '/class-newspack-popups-parse-logs.php';
+			include_once dirname( __FILE__ ) . '/class-newspack-popups-donations.php';
+			include_once dirname( __FILE__ ) . '/class-newspack-popups-view-as.php';
+		}
 	}
 
 	/**
@@ -626,13 +629,17 @@ final class Newspack_Popups {
 	}
 
 	/**
+	 * Is the API configured?
+	 */
+	public static function is_api_configured() {
+		return file_exists( self::LIGHTWEIGHT_API_CONFIG_FILE_PATH_LEGACY ) || file_exists( self::LIGHTWEIGHT_API_CONFIG_FILE_PATH );
+	}
+
+	/**
 	 * Add an admin notice if config is missing.
 	 */
 	public static function api_config_missing_notice() {
-		if (
-			file_exists( self::LIGHTWEIGHT_API_CONFIG_FILE_PATH_LEGACY ) ||
-			file_exists( self::LIGHTWEIGHT_API_CONFIG_FILE_PATH )
-		) {
+		if ( self::is_api_configured() ) {
 			return;
 		}
 		?>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -16,6 +16,11 @@ if ( ! file_exists( $_tests_dir . '/includes/functions.php' ) ) {
 	exit( 1 );
 }
 
+// Create the config file.
+$popups_config_file_path = $_tests_dir . '/../wordpress/newspack-popups-config.php';
+$wp_config_file_path     = $_tests_dir . '/wp-tests-config.php';
+copy( $wp_config_file_path, $popups_config_file_path );
+
 // Give access to tests_add_filter() function.
 require_once $_tests_dir . '/includes/functions.php';
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #591.

### How to test the changes in this Pull Request:

1. Ensure Site Kit w/ Analytics module is configured on your site, and that the data is reported to GA*
2. On `master`, remove (or rename) the [configuration file](https://github.com/Automattic/newspack-popups/blob/master/README.md#config-file)
2. Observe that the pageview request is not sent now 
3. Switch to this branch, observe the pageview request is sent
4. Reinstate the configuration file, observe the pageview request is sent still

\* Visit the frontend, verify a `GET google-analytics.com/r/collect` request is sent on page load, with a `t=pageview` parameter

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->