### PR TITLE
fix: include drafts in segment previews

### DIFF
--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -475,7 +475,13 @@ final class Newspack_Popups_Inserter {
 		if ( ! Newspack_Popups_Segmentation::is_tracking() ) {
 			return;
 		}
-		$popups = array_filter( Newspack_Popups_Model::retrieve_active_popups(), [ __CLASS__, 'should_display' ] );
+		$popups = array_filter(
+			Newspack_Popups_Model::retrieve_popups(
+				// Include drafts if it's a preview request.
+				Newspack_Popups::is_preview_request()
+			),
+			[ __CLASS__, 'should_display' ]
+		);
 
 		// Prevent duplicates - a popup might be duplicated in a shortcode.
 		$unique_ids = [];

--- a/tests/test-insertion.php
+++ b/tests/test-insertion.php
@@ -455,7 +455,7 @@ class InsertionTest extends WP_UnitTestCase_PageWithPopups {
 	}
 
 	/**
-	 * Shortcode handling.
+	 * Ordering of amp-access array.
 	 */
 	public function test_amp_access_ordering() {
 		$segments           = Newspack_Popups_Segmentation::create_segment(
@@ -486,6 +486,47 @@ class InsertionTest extends WP_UnitTestCase_PageWithPopups {
 			$popup_ids_ordered,
 			[ 'id_' . $segmented_popup_id, 'id_' . self::$popup_id, 'id_' . $another_popup_id ],
 			'The popup with the segment comes first in the array.'
+		);
+	}
+
+	/**
+	 * Test amp-access when previewing.
+	 */
+	public function test_amp_access_when_previewing() {
+		self::remove_all_popups();
+
+		$published_popup_id = self::createPopup();
+		$draft_popup_id     = self::createPopup( 'rafraf', null, [ 'post_status' => 'draft' ] );
+
+		self::renderPost();
+		$amp_access_config    = self::getAMPAccessConfig();
+		$popups_in_amp_access = $amp_access_config['popups'];
+		self::assertEquals(
+			count( $popups_in_amp_access ),
+			1,
+			'Just one popup in amp-access'
+		);
+		self::assertEquals(
+			$popups_in_amp_access[0]->id,
+			'id_' . $published_popup_id,
+			'And it is the published one.'
+		);
+
+		$user_id = $this->factory->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $user_id );
+
+		self::renderPost( 'view_as=all' );
+		$amp_access_config    = self::getAMPAccessConfig();
+		$popups_in_amp_access = $amp_access_config['popups'];
+		self::assertEquals(
+			count( $popups_in_amp_access ),
+			2,
+			'Two popups are in amp-access'
+		);
+		self::assertEquals(
+			$popups_in_amp_access[1]->id,
+			'id_' . $draft_popup_id,
+			'The second one is the draft popup.'
 		);
 	}
 

--- a/tests/wp-unittestcase-pagewithpopups.php
+++ b/tests/wp-unittestcase-pagewithpopups.php
@@ -29,9 +29,7 @@ class WP_UnitTestCase_PageWithPopups extends WP_UnitTestCase {
 		);
 
 		// Remove any popups (from previous tests).
-		foreach ( Newspack_Popups_Model::retrieve_popups() as $popup ) {
-			wp_delete_post( $popup['id'] );
-		}
+		self::remove_all_popups();
 
 		self::$popup_id = self::createPopup();
 
@@ -42,6 +40,15 @@ class WP_UnitTestCase_PageWithPopups extends WP_UnitTestCase {
 				'dismiss_text' => Newspack_Popups::get_default_dismiss_text(),
 			]
 		);
+	}
+
+	/**
+	 * Remove all popups on the test instance.
+	 */
+	protected static function remove_all_popups() {
+		foreach ( Newspack_Popups_Model::retrieve_popups( true ) as $popup ) {
+			wp_delete_post( $popup['id'] );
+		}
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a previewing bug.

### How to test the changes in this Pull Request:

1. On `master`, visit the Campaigns wizard and preview a segment
2. Notice that draft prompts are not being displayed
3. Switch to this branch, observe the draft prompts are displayed

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->