### PR TITLE
fix: ensure only popup CPTs are handled

### DIFF
--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -269,14 +269,17 @@ final class Newspack_Popups_Model {
 		if ( $query->have_posts() ) {
 			while ( $query->have_posts() ) {
 				$query->the_post();
-				$popup = self::create_popup_object(
-					get_post( get_the_ID() ),
-					$include_taxonomies
-				);
-				$popup = self::deprecate_test_never_manual( $popup, 'publish' === $query->get( 'post_status', null ) );
+				$popup_post = get_post( get_the_ID() );
+				if ( Newspack_Popups::NEWSPACK_POPUPS_CPT === $popup_post->post_type ) {
+					$popup = self::create_popup_object(
+						$popup_post,
+						$include_taxonomies
+					);
+					$popup = self::deprecate_test_never_manual( $popup, 'publish' === $query->get( 'post_status', null ) );
 
-				if ( $popup ) {
-					$popups[] = $popup;
+					if ( $popup ) {
+						$popups[] = $popup;
+					}
 				}
 			}
 			wp_reset_postdata();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

It turns out that another plugin can [modify](https://github.com/INN/link-roundups/blob/be0f2a93a892904bf1d55a9dfd8ccf9311822d87/inc/link-roundups/class-link-roundups.php#L60) the `WP_Query` ran by this plugin!

### How to test the changes in this Pull Request:

1. Install the [Link Roundups plugin](https://github.com/INN/link-roundups/)
2. Create at least one link roundup
3. On `master` visit Newspack->Campaigns wizard and observe the link roundups listed as prompts*
4. Switch to this branch, observe the problem gone 🪄

\* in my testing, I had to also update "Link Roundups" options and set custom name and slug

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->