### PR TITLE
fix: cpt handling

### DIFF
--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -726,8 +726,8 @@ final class Newspack_Popups_Inserter {
 		// - the type of the post supported by this popup, if different than the global setting.
 		$popup_post_types = $popup['options']['post_types'];
 
-		if ( 0 === count( array_diff( $popup_post_types, Newspack_Popups_Model::get_default_popup_post_types() ) ) ) {
-			// Popup post types are same as default post types - no need to check the former.
+		if ( 0 === count( array_diff( $global_post_types, $popup_post_types ) ) ) {
+			// Popup post types are same as globally-set post types - no need to check the former.
 			$is_post_type_matching_global_post_types = in_array( $post_type, $global_post_types );
 			$is_post_context_matching                = $is_taxonomy_matching && $is_post_type_matching_global_post_types;
 		} else {

--- a/tests/test-insertion-cpt.php
+++ b/tests/test-insertion-cpt.php
@@ -134,4 +134,35 @@ class InsertionTestCPT extends WP_UnitTestCase_PageWithPopups {
 		);
 		remove_filter( 'newspack_campaigns_post_types_for_campaigns', [ __CLASS__, 'filter_use_press_release_cpt_name' ] );
 	}
+
+	/**
+	 * Test popup insertion into a CPT, with popup-specific supported-CPT setting,
+	 * when there's overlap between the popup-specific post types and globally
+	 * supported post types.
+	 */
+	public function test_insertion_in_cpt_popup_specific_vs_global_with_overlap() {
+		\register_post_type( self::$podcast_cpt_name, [ 'public' => true ] );
+
+		self::remove_all_popups();
+		$post_only_popup    = self::createPopup( null, [ 'post_types' => [ 'post' ] ] );
+		$podcast_only_popup = self::createPopup( null, [ 'post_types' => [ self::$podcast_cpt_name ] ] );
+
+		add_filter( 'newspack_campaigns_post_types_for_campaigns', [ __CLASS__, 'filter_use_podcast_cpt_name' ] );
+
+		self::renderPost();
+		self::assertEquals(
+			1,
+			self::getRenderedPopupsAmount(),
+			'One popup is rendered on a post.'
+		);
+
+		self::renderPost( '', null, [], [], self::$podcast_cpt_name );
+		self::assertEquals(
+			1,
+			self::getRenderedPopupsAmount(),
+			'One popup is rendered on podcast CPT.'
+		);
+
+		remove_filter( 'newspack_campaigns_post_types_for_campaigns', [ __CLASS__, 'filter_use_podcast_cpt_name' ] );
+	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a bug related to CPT handling.

### How to test the changes in this Pull Request:

1. Ensure you have a publicly-viewable CPT (e.g. from [`newspack-podcasts`](https://github.com/Automattic/newspack-podcasts/)) 
1. On `master`, create two inline prompts - one set to `post` post type only, the other to the CPT
2. Visit a post and a CPT  - observe the post-only prompt is appearing on the CPT
3. Switch to this branch, observe that the post-only prompt is appearing only on posts and the CPT-only prompt only on CPTs

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->