### PR TITLE
feat(segmentation): improve how Mailchimp merge fields are handled

### DIFF
--- a/api/segmentation/class-segmentation-client-data.php
+++ b/api/segmentation/class-segmentation-client-data.php
@@ -94,11 +94,11 @@ class Segmentation_Client_Data extends Lightweight_API {
 							return;
 						}
 						$has_donated_according_to_mailchimp = array_reduce(
-							// Get all merge fields' names that start with `DONA` (e.g. `DONATION`, `DONATED`).
+							// Get all merge fields' names that start with `DONAT` (e.g. `DONATION`, `DONATED`).
 							array_filter(
 								array_keys( $subscriber['merge_fields'] ),
 								function ( $merge_field ) {
-									return substr( $merge_field, 0, 4 ) === 'DONA';
+									return strpos( $merge_field, 'DONAT' ) !== false;
 								}
 							),
 							// If any of these fields is "true", the subscriber has donated.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Turns out that NRH has some legacy merge fields naming schemes. This PR ensures that if a merge field has the string `DONAT` in the name, it will be treated as a merge field denoting a donor. This should cover such cases as `DONATION`, `DONATED`, `HUB-DONATION`.

### How to test the changes in this Pull Request:

Same flow as #305, but with different merge field names. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->