### PR TITLE
enable homepage-posts posts duplication  between a page and an overlay prompt

### DIFF
--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -900,6 +900,10 @@ final class Newspack_Popups_Model {
 			$popup = self::retrieve_preview_popup( Newspack_Popups::previewed_popup_id() );
 		}
 
+		if ( has_block( 'newspack-blocks/homepage-articles', $popup['content'] ) ) {
+			add_filter( 'newspack_blocks_homepage_enable_duplication', '__return_true' );
+		}
+
 		if ( ! self::is_overlay( $popup ) ) {
 			return self::generate_inline_popup( $popup );
 		}
@@ -1024,7 +1028,12 @@ final class Newspack_Popups_Model {
 				}
 			</script>
 		</amp-animation>
-		<?php self::insert_event_tracking( $popup, $body, $element_id ); ?>
+		<?php
+		self::insert_event_tracking( $popup, $body, $element_id );
+		if ( has_block( 'newspack-blocks/homepage-articles', $popup['content'] ) ) {
+			add_filter( 'newspack_blocks_homepage_enable_duplication', '__return_false' );
+		}
+		?>
 		<?php
 		return ob_get_clean();
 	}

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -902,6 +902,7 @@ final class Newspack_Popups_Model {
 
 		if ( self::is_overlay( $popup ) && self::is_overlay( $popup ) && has_block( 'newspack-blocks/homepage-articles', $popup['content'] ) ) {
 			add_filter( 'newspack_blocks_homepage_enable_duplication', '__return_true' );
+			add_filter( 'newspack_blocks_homepage_shown_rendered_posts', '__return_true' );
 		}
 
 		if ( ! self::is_overlay( $popup ) ) {
@@ -1032,6 +1033,7 @@ final class Newspack_Popups_Model {
 		self::insert_event_tracking( $popup, $body, $element_id );
 		if ( self::is_overlay( $popup ) && has_block( 'newspack-blocks/homepage-articles', $popup['content'] ) ) {
 			add_filter( 'newspack_blocks_homepage_enable_duplication', '__return_false' );
+			add_filter( 'newspack_blocks_homepage_shown_rendered_posts', '__return_false' );
 		}
 		?>
 		<?php

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -900,7 +900,7 @@ final class Newspack_Popups_Model {
 			$popup = self::retrieve_preview_popup( Newspack_Popups::previewed_popup_id() );
 		}
 
-		if ( has_block( 'newspack-blocks/homepage-articles', $popup['content'] ) ) {
+		if ( self::is_overlay( $popup ) && self::is_overlay( $popup ) && has_block( 'newspack-blocks/homepage-articles', $popup['content'] ) ) {
 			add_filter( 'newspack_blocks_homepage_enable_duplication', '__return_true' );
 		}
 
@@ -1030,7 +1030,7 @@ final class Newspack_Popups_Model {
 		</amp-animation>
 		<?php
 		self::insert_event_tracking( $popup, $body, $element_id );
-		if ( has_block( 'newspack-blocks/homepage-articles', $popup['content'] ) ) {
+		if ( self::is_overlay( $popup ) && has_block( 'newspack-blocks/homepage-articles', $popup['content'] ) ) {
 			add_filter( 'newspack_blocks_homepage_enable_duplication', '__return_false' );
 		}
 		?>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

enable showing the same post in popups and page if they both contain the homepage-posts block with
the same category filter.

fix #126 

### How to test the changes in this Pull Request:

1. On a new page add the homepage-posts block and filter the posts to be displayed by a category.
2. Add a new overlay prompt with a homepage-posts block as its content.
3. Filter the posts by the same category as 1. on the overlay homepage-posts block.
4. Load the page and observe that the posts on the page don't contain the posts on the popup.
5. Reload the page a second time and observe that the page still doesn't show the posts from the popup, but the popup doesn't show (popups are shown once or once a day).
6. If this https://github.com/Automattic/newspack-blocks/pull/886 is not merged, pull it, or apply the small changes from it.
7. Checkout this branch.
8. Reload the page.
9. Observe now the page loading all the category posts.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
