### PR TITLE
fix(segmentation): change MC API key option name

### DIFF
--- a/api/segmentation/class-segmentation-client-data.php
+++ b/api/segmentation/class-segmentation-client-data.php
@@ -72,10 +72,11 @@ class Segmentation_Client_Data extends Lightweight_API {
 		$mailchimp_campaign_id   = $this->get_request_param( 'mc_cid', $request );
 		$mailchimp_subscriber_id = $this->get_request_param( 'mc_eid', $request );
 		if ( $mailchimp_campaign_id && $mailchimp_subscriber_id ) {
-			$mailchimp_api_key_option_name = 'newspack_newsletters_mailchimp_api_key';
+			$mailchimp_api_key_option_name        = 'newspack_mailchimp_api_key';
+			$mailchimp_api_key_option_name_legacy = 'newspack_newsletters_mailchimp_api_key';
 			global $wpdb;
 			$mailchimp_api_key = $wpdb->get_row( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-				$wpdb->prepare( "SELECT option_value FROM `$wpdb->options` WHERE option_name=%s", $mailchimp_api_key_option_name )
+				$wpdb->prepare( "SELECT option_value FROM `$wpdb->options` WHERE option_name IN (%s,%s) ORDER BY FIELD(%s,%s)", $mailchimp_api_key_option_name, $mailchimp_api_key_option_name_legacy, $mailchimp_api_key_option_name, $mailchimp_api_key_option_name_legacy )
 			);
 			if ( $mailchimp_api_key ) {
 				$mc            = new Mailchimp( $mailchimp_api_key->option_value );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->
https://github.com/Automattic/newspack-plugin/pull/1168 introduced a new name for the MC API key
option, which will be managed from `newspack-plugin` instead of `newspack-newsletters`. We do keep the
old name for backward compatibility.

~~BREAKING CHANGE: Change MC API key option name, we'll use the new one from `newspack-plugin` instead
of the old one from `newspack-newsletters`. Keeping the old name for backward compatibility.~~

### How to test the changes in this Pull Request:

1. Create a donation page if you don't already have one in local, with a one-time payment option.
2. Add an offline payment method in WooCommerce (Check payments).
3. Register a Mailchimp API key from the `newspack-newsletters` plugin `Newsletters > Settings > Mailchimp API Key`
4. I didn't find a way to get `mc_cid` and `mc_eid` on the request, so you can add a thruty condition in [this line](https://github.com/Automattic/newspack-popups/compare/fix/change-mc-api-key-option-name?expand=1#diff-2eea47d2369b82457f6cff4933955101e9c615917d31e01b2d7630e75eb0a989R74) and dump the value of `$mailchimp_api_key` [here](https://github.com/Automattic/newspack-popups/compare/fix/change-mc-api-key-option-name?expand=1#diff-2eea47d2369b82457f6cff4933955101e9c615917d31e01b2d7630e75eb0a989R81)
5. Enable the `Network` tab from your dev tool, and do a donation.
6. In the checkout page, filter the requests in the Network by `api/segmentation/index.php` it should be a `POST` request.
6. Preview the result, and observe that the value from the `newspack-newsletters` is well shown.
7. Checkout this PR, and redo 5. and 6. you should have the same value which means the backward compatibility is 👌 
8. If https://github.com/Automattic/newspack-plugin/pull/1168 is not merged yet, please pull it. From the`connections` screen set a new API key (this will use the new option name).
9. Redo 5. and 6. and observe now, the new API key value.

Sorry, didn't find a better way to test this 😓 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
