### PR TITLE
feat: initialize prompt creation by manual placement

### DIFF
--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -653,6 +653,10 @@ final class Newspack_Popups {
 				$placement = 'custom1';
 				$frequency = 'always';
 				break;
+			case 'manual':
+				$placement = 'manual';
+				$frequency = 'always';
+				break;
 			default:
 				$placement = 'inline';
 				$frequency = 'always';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
https://github.com/Automattic/newspack-plugin/pull/1133 adds a menu to create prompts with manual placement, this PR handles it.
<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

### How to test the changes in this Pull Request:

1. Checkout this.
2. Go to `/wp-admin/post-new.php?post_type=newspack_popups_cpt&placement=manual`
3. Observe that placement is set to `Manual Only`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
