### PR TITLE
feat: relink full screen close button to Campaigns wizard if available

### DIFF
--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -517,7 +517,7 @@ final class Newspack_Popups {
 						'objects'
 					)
 				),
-
+				'newspack_plugin_is_active'    => is_plugin_active( 'newspack-plugin/newspack.php' ),
 			]
 		);
 		\wp_enqueue_style(

--- a/src/editor/index.js
+++ b/src/editor/index.js
@@ -9,7 +9,12 @@ import { __ } from '@wordpress/i18n';
 import { compose } from '@wordpress/compose';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { registerPlugin } from '@wordpress/plugins';
-import { PluginDocumentSettingPanel, PluginPostStatusInfo } from '@wordpress/edit-post';
+import {
+	PluginDocumentSettingPanel,
+	PluginPostStatusInfo,
+	__experimentalMainDashboardButton as MainDashboardButton,
+	__experimentalFullscreenModeClose as FullscreenModeClose,
+} from '@wordpress/edit-post';
 
 /**
  * Internal dependencies
@@ -50,6 +55,8 @@ const SegmentationSidebarWithData = connectData( SegmentationSidebar );
 const DismissSidebarWithData = connectData( DismissSidebar );
 const ColorsSidebarWithData = connectData( ColorsSidebar );
 const PostTypesPanelWithData = connectData( PostTypesPanel );
+
+const { newspack_plugin_is_active: newspackPluginIsActive = false } = window?.newspack_popups_data;
 
 // Register components.
 registerPlugin( 'newspack-popups', {
@@ -137,3 +144,14 @@ const PluginPostStatusInfoTest = () => (
 	</PluginPostStatusInfo>
 );
 registerPlugin( 'newspack-popups-preview', { render: PluginPostStatusInfoTest } );
+
+// If the main Newspack plugin is active, let's link back to the Campaigns wizard instead of the post type dashboard page.
+if ( newspackPluginIsActive ) {
+	registerPlugin( 'main-dashboard-button-replace', {
+		render: () => (
+			<MainDashboardButton>
+				<FullscreenModeClose href="/wp-admin/admin.php?page=newspack-popups-wizard" />
+			</MainDashboardButton>
+		),
+	} );
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This fixes a very minor and inconsequential pet peeve of mine that's existed since we launched the new and improved Campaigns Wizard™️ UI in 2020. Prior to Gutenberg v8.2 (which wasn't merged into WP core until v5.5), there was no API to do this, but [now there is](https://developer.wordpress.org/block-editor/reference-guides/slotfills/main-dashboard-button/)! Although it's apparently been available in core since August 2020, it's still considered "experimental" and hasn't been discussed much. I discovered the new API while working on an unrelated feature in Newspack Listings that needed a similar solution.

When both the Newspack Plugin and Newspack Campaigns plugins are installed together, the Campaigns wizard UI in the Newspack dashboard is used to manage all prompts and settings. The Newspack Plugin actively [suppresses Newspack Campaigns' dashboard menu links](https://github.com/Automattic/newspack-plugin/blob/master/includes/class-newspack.php#L148). However, when editing a prompt, the full-screen close button (the WP icon in the top-left corner of the editor) still links back to the (normally inaccessible) post type list for prompts, which has caused some confusion for publishers who don't expect to see this dashboard UI when using the Campaigns plugin. This PR filters that button to link back to the Campaigns wizard instead, if the Newspack Plugin is active.

<img width="1374" alt="T6X6AN" src="https://user-images.githubusercontent.com/2230142/138364907-c8556fe2-f812-4c45-b5cb-60a6db708501.png">

Note that trashing a prompt from the editor will still redirect to the prompts post type list. We may be able to fix this using a [hook](https://wordpress.org/support/topic/redirect-when-moving-post-to-bin/), but I haven't tested that yet.

### How to test the changes in this Pull Request:

1. On `master`, ensure the Newspack Plugin is installed and active. Edit or create a prompt, enable full-screen mode, and observe that the WP icon in the upper-left corner links to the post type list for prompts (`/wp-admin/edit.php?post_type=newspack_popups_cpt`).
2. Check out this branch, refresh the editor, confirm that the button now links back to the Newspack Campaigns wizard. Also verify that this only happens when editing prompts, not for any other post type.
3. Deactivate Newspack Plugin and Newspack Blocks (the latter will throw fatals if active without the main plugin) and edit a prompt. Confirm that the close button link now links back to the standard post type list, since the Newspack Campaigns wizard isn't available.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
