### PR TITLE
fix: displaying on custom post types

### DIFF
--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -763,7 +763,12 @@ final class Newspack_Popups_Inserter {
 		// - the type of the post supported by this popup, if different than the global setting.
 		$popup_post_types = $popup['options']['post_types'];
 
-		if ( 0 === count( array_diff( $global_post_types, $popup_post_types ) ) ) {
+		if (
+			// PHP's array_diff "returns the values in [first argument] that are not present in any of the other arrays",
+			// to get a diff between arrays, the arrays have to be compared twice, with reversed argument order.
+			0 === count( array_diff( $popup_post_types, $global_post_types ) )
+			&& 0 === count( array_diff( $global_post_types, $popup_post_types ) )
+		) {
 			// Popup post types are same as globally-set post types - no need to check the former.
 			$is_post_type_matching_global_post_types = in_array( $post_type, $global_post_types );
 			$is_post_context_matching                = $is_taxonomy_matching && $is_post_type_matching_global_post_types;

--- a/tests/test-insertion-cpt.php
+++ b/tests/test-insertion-cpt.php
@@ -86,6 +86,19 @@ class InsertionTestCPT extends WP_UnitTestCase_PageWithPopups {
 		Newspack_Popups_Model::set_popup_options(
 			self::$popup_id,
 			[
+				'post_types' => [ 'post', 'page', $episode_cpt_name ],
+			]
+		);
+		self::renderPost( '', null, [], [], $episode_cpt_name );
+		self::assertEquals(
+			1,
+			self::getRenderedPopupsAmount(),
+			'Popup is rendered when the CPT was added to targeted post types.'
+		);
+
+		Newspack_Popups_Model::set_popup_options(
+			self::$popup_id,
+			[
 				'post_types' => [ $episode_cpt_name ],
 			]
 		);
@@ -93,7 +106,7 @@ class InsertionTestCPT extends WP_UnitTestCase_PageWithPopups {
 		self::assertEquals(
 			1,
 			self::getRenderedPopupsAmount(),
-			'Popup is rendered, since the CPT was added to popup options.'
+			'Popup is rendered when the CPT is the only targeted post type.'
 		);
 
 		self::renderPost( '', null, [], [] );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a bug with CPT targeting (#607).

### How to test the changes in this Pull Request:

1. On `master`, set a prompt to target a CPT _in addition_ to the default post & page post types
2. Observe that it does not render on the CPT 
3. Switch, to this branch, observe it does

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->