### PR TITLE
fix: donor landing page

### DIFF
--- a/api/segmentation/class-segmentation-client-data.php
+++ b/api/segmentation/class-segmentation-client-data.php
@@ -45,8 +45,8 @@ class Segmentation_Client_Data extends Lightweight_API {
 		// Add a donation to client.
 		$donation = $this->get_request_param( 'donation', $request );
 		if ( $donation ) {
-			if ( 'string' === $donation ) {
-				$donation = json_decode( $donation );
+			if ( 'string' === gettype( $donation ) ) {
+				$donation = (array) json_decode( $donation );
 			}
 			$client_data_update['donations'][] = $donation;
 		}

--- a/includes/class-newspack-popups-segmentation.php
+++ b/includes/class-newspack-popups-segmentation.php
@@ -256,6 +256,15 @@ final class Newspack_Popups_Segmentation {
 			$initial_client_report_url_params['user_id'] = get_current_user_id();
 		}
 
+		// If visiting the donor landing page, mark the visitor as donor.
+		if ( intval( Newspack_Popups_Settings::donor_landing_page() ) === get_queried_object_id() ) {
+			$initial_client_report_url_params['donation'] = wp_json_encode(
+				[
+					'offsite_has_donated' => true,
+				]
+			);
+		}
+
 		if ( ! empty( $initial_client_report_url_params ) ) {
 			$amp_analytics_config['requests']                            = [
 				'initialClientDataReport' => esc_url( self::get_client_data_endpoint() ),
@@ -269,22 +278,6 @@ final class Newspack_Popups_Segmentation {
 						'client_id' => 'CLIENT_ID(' . esc_attr( self::NEWSPACK_SEGMENTATION_CID_NAME ) . ')',
 					]
 				),
-			];
-		}
-
-		$donor_landing_page = Newspack_Popups_Settings::donor_landing_page();
-		if ( $donor_landing_page && intval( $donor_landing_page ) === get_queried_object_id() ) {
-			$amp_analytics_config['triggers']['reportDonor'] = [
-				'on'             => 'ini-load',
-				'request'        => 'event',
-				'extraUrlParams' => [
-					'donation'  => wp_json_encode(
-						[
-							'offsite_has_donated' => true,
-						]
-					),
-					'client_id' => 'CLIENT_ID(' . esc_attr( self::NEWSPACK_SEGMENTATION_CID_NAME ) . ')',
-				],
 			];
 		}
 

--- a/tests/test-api.php
+++ b/tests/test-api.php
@@ -746,7 +746,7 @@ class APITest extends WP_UnitTestCase {
 		$client_id = 'test_' . uniqid();
 
 		// Report a donation.
-		$donation = [
+		$donation_1 = [
 			'order_id' => '120',
 			'date'     => '2020-10-28',
 			'amount'   => '180.00',
@@ -754,7 +754,25 @@ class APITest extends WP_UnitTestCase {
 		self::$report_client_data->report_client_data(
 			[
 				'client_id' => $client_id,
-				'donation'  => $donation,
+				'donation'  => $donation_1,
+			]
+		);
+		// Add a duplicate to ensure it will not be added.
+		self::$report_client_data->report_client_data(
+			[
+				'client_id' => $client_id,
+				'donation'  => $donation_1,
+			]
+		);
+		// Add another donation, JSON-encoded.
+		$donation_2 = [
+			'date'   => '2020-11-28',
+			'amount' => '180.00',
+		];
+		self::$report_client_data->report_client_data(
+			[
+				'client_id' => $client_id,
+				'donation'  => wp_json_encode( $donation_2 ),
 			]
 		);
 
@@ -764,7 +782,7 @@ class APITest extends WP_UnitTestCase {
 				'suppressed_newsletter_campaign' => false,
 				'posts_read'                     => [],
 				'email_subscriptions'            => [],
-				'donations'                      => [ $donation ],
+				'donations'                      => [ $donation_1, $donation_2 ],
 				'user_id'                        => false,
 				'prompts'                        => [],
 			],


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a bug with donor tagging via donor landing page. The bug resulted from an unfortunate sequence of PRs - https://github.com/Automattic/newspack-popups/pull/397 was submitted before https://github.com/Automattic/newspack-popups/pull/408, but merged after it, and in the process a couple of lines of code were erroneously removed.

### How to test the changes in this Pull Request:

1. Visit the Campaign Wizard, settings tab
4. Set a page to act as a donor landing page (a "Thank you for donation" page) via "Donor landing page" setting
5. Create two prompts, one targeted at donors (A), other at non-donors (B)
6. Visit the site in a new session, observe the prompt B is displayed
7. Visit the donation landing page and navigate to another page or post
8. Observe that prompt A is now displayed

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->