### PR TITLE
fix: check if gtm exists

### DIFF
--- a/src/view/index.js
+++ b/src/view/index.js
@@ -57,7 +57,7 @@ const manageAnalyticsEvents = () => {
 		/**
 		 * Fetch remote GTAG config and trigger GTAG reporting using it.
 		 */
-		if ( type === 'gtag' && config ) {
+		if ( typeof gtag !== 'undefined' && type === 'gtag' && config ) {
 			fetch( parseDynamicURL( config ) )
 				.then( response => response.json() )
 				.then( remoteConfig => {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Same issue as in https://github.com/Automattic/newspack-plugin/pull/1216

### How to test the changes in this Pull Request:

1. On `master`,
1. Set up a site with Site Kit, connecting both Analytics & Google Tag Manager modules
2. Visit a page which has AMP disabled
3. Observe `gtag is not defined` errors in the JS console
4. Switch to this branch, observe no errors shown.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->