### PR TITLE
fix: post type support conditions

### DIFF
--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -379,7 +379,7 @@ final class Newspack_Popups_Model {
 				'archive_insertion_is_repeating' => false,
 				'utm_suppression'                => null,
 				'selected_segment_id'            => '',
-				'post_types'                     => self::get_globally_supported_post_types(),
+				'post_types'                     => self::get_default_popup_post_types(),
 				'archive_page_types'             => self::get_supported_archive_page_types(),
 			]
 		);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Cleans up the insertion logic a bit. Before, the post type conditions used a bit convoluted logic of checking the equality of globally-supported post types and prompt's post types. Also, the default value for the supported post types meta was set to the default post types in [meta registration](https://github.com/Automattic/newspack-popups/blob/89ba2147be4cdb4839eab5a4a59d02887a0a4fcf/includes/class-newspack-popups.php#L333), but to globally-supported post types as fallback in `get_popup_options` method. I've only run into this when running tests in isolation, and was not able to come up with a reproducible scenario.

Logic is refactored so that it's clear and readable:

1. If prompt's supported post types are same as the defaults, use the globally-supported post types
2. Otherwise, use prompt's post types – since this means the defaults were overridden

### How to test the changes in this Pull Request (if you need to!):

1. On `master`, run the `test_insertion_in_cpt_global` test in isolation*
2. Observe it failing
3. Switch to this branch, observe it passing

\* `phpunit --filter=test_insertion_in_cpt_global`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->