### PR TITLE
feat: disable site kit analytics interaction if the module is not used

### DIFF
--- a/includes/class-newspack-popups-segmentation.php
+++ b/includes/class-newspack-popups-segmentation.php
@@ -56,7 +56,11 @@ final class Newspack_Popups_Segmentation {
 		add_action( 'wp_footer', [ __CLASS__, 'insert_amp_analytics' ], 20 );
 
 		add_filter( 'newspack_custom_dimensions', [ __CLASS__, 'register_custom_dimensions' ] );
-		if ( ! Newspack_Popups_Settings::is_non_interactive() && ( ! defined( 'NEWSPACK_POPUPS_DISABLE_REPORTING_CUSTOM_DIMENSIONS' ) || true !== NEWSPACK_POPUPS_DISABLE_REPORTING_CUSTOM_DIMENSIONS ) ) {
+		if (
+			! Newspack_Popups_Settings::is_non_interactive()
+			&& ( ! defined( 'NEWSPACK_POPUPS_DISABLE_REPORTING_CUSTOM_DIMENSIONS' ) || true !== NEWSPACK_POPUPS_DISABLE_REPORTING_CUSTOM_DIMENSIONS )
+			&& method_exists( '\Newspack\Analytics', 'can_use_site_kits_analytics' ) && \Newspack\Analytics::can_use_site_kits_analytics()
+		) {
 			// Sending pageviews with segmentation-related custom dimensions.
 			// 1. Disable pageview sending from Site Kit's GTAG implementation. The custom events sent using Site Kit's
 			// GTAG will not contain the segmentation-related custom dimensions.
@@ -143,7 +147,6 @@ final class Newspack_Popups_Segmentation {
 	 * Inset GTAG amp-analytics with a remote config, which will insert segmentation-related custom dimensions.
 	 */
 	public static function insert_gtag_amp_analytics() {
-
 		$custom_dimensions = [];
 		if ( class_exists( 'Newspack\Analytics_Wizard' ) ) {
 			$custom_dimensions = Newspack\Analytics_Wizard::list_configured_custom_dimensions();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This plugin reports pageviews – after turning off Site Kit Analytics module's pageview reporting – to add segmentation-derived custom dimensions.

Thsi PR disables this feature if Analytics module is not active. If both Analytics & GTM modules are active, Site Kit will _not use_ the Analytics module, so `googlesitekit_gtag_opt` and `googlesitekit_amp_gtag_opt` filters will not run. This might result in doubled pageviews when pageviews are reported via GTM, and then by Newspack Campaigns.

Related to https://github.com/Automattic/newspack-popups/pull/652.

### How to test the changes in this Pull Request:

1. Switch to `add/expose-can-use-sitekit-analytics` branch of `newspack-plugin`
2. Configure Site Kit and turn on both Analytics and GTM modules
3. Observe that no pageview event is fired (unless a pageview tag is added in GTM container)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->