### PR TITLE
Don't use "here" as link text

### DIFF
--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -743,9 +743,9 @@ final class Newspack_Popups {
 		?>
 			<div class="notice notice-error">
 				<p>
-					<?php _e( 'Newspack Campaigns requires a custom configuration file, which is missing. Please create this file following instructions found ', 'newspack-popups' ); ?>
+					<?php _e( 'Newspack Campaigns requires a custom configuration file, which is missing. Please create this file by following ', 'newspack-popups' ); ?>
 					<a href="https://github.com/Automattic/newspack-popups/blob/master/README.md#config-file">
-						<?php _e( 'here.', 'newspack-popups' ); ?>
+						<?php _e( 'these instructions.', 'newspack-popups' ); ?>
 					</a>
 				</p>
 			</div>


### PR DESCRIPTION
Adjust the wording in the config instructions to avoid use of "here" as link text.

### All Submissions:

* [x ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

Closes #454