### PR TITLE
Fix/Use WordPress Constants

### DIFF
--- a/api/setup.php
+++ b/api/setup.php
@@ -18,15 +18,12 @@ define( 'WPINC', 'wp-includes/' );
 if ( ! defined( 'WP_CONTENT_DIR' ) ) {
 	define( 'WP_CONTENT_DIR', ABSPATH . 'wp-content/' );
 }
-if ( ! defined( 'WP_PLUGIN_DIR' ) ) {
-	define( 'WP_PLUGIN_DIR', ABSPATH . 'wp-content/plugins/' );
-}
 if ( ! defined( 'WP_DEBUG' ) ) {
 	define( 'WP_DEBUG', false );
 }
 
 $legacy_config_path = $wp_root_path . 'newspack-popups-config.php';
-$config_path        = WP_PLUGIN_DIR . 'newspack-popups-config.php';
+$config_path        = $wp_root_path . 'wp-content/newspack-popups-config.php';
 if ( file_exists( $legacy_config_path ) ) {
 	require_once $legacy_config_path;
 } elseif ( file_exists( $config_path ) ) {

--- a/api/setup.php
+++ b/api/setup.php
@@ -18,12 +18,15 @@ define( 'WPINC', 'wp-includes/' );
 if ( ! defined( 'WP_CONTENT_DIR' ) ) {
 	define( 'WP_CONTENT_DIR', ABSPATH . 'wp-content/' );
 }
+if ( ! defined( 'WP_PLUGIN_DIR' ) ) {
+	define( 'WP_PLUGIN_DIR', ABSPATH . 'wp-content/plugins/' );
+}
 if ( ! defined( 'WP_DEBUG' ) ) {
 	define( 'WP_DEBUG', false );
 }
 
 $legacy_config_path = $wp_root_path . 'newspack-popups-config.php';
-$config_path        = $wp_root_path . 'wp-content/newspack-popups-config.php';
+$config_path        = WP_PLUGIN_DIR . 'newspack-popups-config.php';
 if ( file_exists( $legacy_config_path ) ) {
 	require_once $legacy_config_path;
 } elseif ( file_exists( $config_path ) ) {

--- a/api/setup.php
+++ b/api/setup.php
@@ -23,7 +23,7 @@ if ( ! defined( 'WP_DEBUG' ) ) {
 }
 
 $legacy_config_path = $wp_root_path . 'newspack-popups-config.php';
-$config_path        = $wp_root_path . 'wp-content/newspack-popups-config.php';
+$config_path        = WP_CONTENT_DIR . 'newspack-popups-config.php';
 if ( file_exists( $legacy_config_path ) ) {
 	require_once $legacy_config_path;
 } elseif ( file_exists( $config_path ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Use WordPress constants to cover scenario where custom wp-content directory name is used

Closes #612

### How to test the changes in this Pull Request:

1. Configure WordPress to use custom WP_CONTENT_DIR
2. Apply changes proposed in this PR
3. Review access.log  for 200 Ok or Response in Developer tools.

### Other information:

- Code to be written to use wp constant for wp-content/plugins/ in  
https://github.com/Automattic/newspack-popups/blob/bb5b1cb871ca8b7f9f4c99f918c6892b49658f3b/api/setup.php#L9

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
