### PR TITLE
fix: path to config file

### DIFF
--- a/api/setup.php
+++ b/api/setup.php
@@ -23,7 +23,7 @@ if ( ! defined( 'WP_DEBUG' ) ) {
 }
 
 $legacy_config_path = $wp_root_path . 'newspack-popups-config.php';
-$config_path        = WP_CONTENT_DIR . 'newspack-popups-config.php';
+$config_path        = rtrim( WP_CONTENT_DIR, '/' ) . '/newspack-popups-config.php';
 if ( file_exists( $legacy_config_path ) ) {
 	require_once $legacy_config_path;
 } elseif ( file_exists( $config_path ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a bug occurring when `WP_CONTENT_DIR` has no trailing slash. 

### How to test the changes in this Pull Request:

1. [Define](https://github.com/Automattic/newspack-popups/blob/b2ae835d045907ad28acd09cb5dce03732deb1ff/api/setup.php#L19) `WP_CONTENT_DIR` without trailing slash
2. Make sure your API config file is in `wp-content` (not WP root) 
3. On `master`, observe the `GET` call to `/wp-content/plugins/newspack-popups/api/segmentation/index.php` failing (returning `missing config file`)
4. Switch to this branch, observe the call returning JSON

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->