### PR TITLE
fix: archive prompt spacing

### DIFF
--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -437,7 +437,8 @@ final class Newspack_Popups_Inserter {
 				|| ( $popup['options']['archive_insertion_is_repeating'] && 0 === $post_count % $archive_insertion_posts_count )
 				|| ( $archive_insertion_posts_count >= $wp_query->post_count && $post_count === $wp_query->post_count )
 			) {
-				echo Newspack_Popups_Model::generate_popup( $popup ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				// Wrapping the popup in an article with `entry` class element to keep the archive page markup.
+				echo '<article class="entry">' . Newspack_Popups_Model::generate_popup( $popup ) . '</article>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			}
 		}
 	}

--- a/src/view/patterns.scss
+++ b/src/view/patterns.scss
@@ -1,8 +1,7 @@
 .newspack-pattern {
 	&.subscribe__style-1 {
-		.newspack-inline-popup &,
 		.newspack-lightbox-placement-center & {
-			margin: -0.75em -0.75em 0;
+			margin: -1.5em -1.5em 0;
 
 			p:empty {
 				display: none;
@@ -14,18 +13,10 @@
 
 			+ .popup-not-interested-form {
 				margin-top: 0.75rem;
-			}
-		}
-
-		.newspack-lightbox-placement-center & {
-			margin: -1.5em -1.5em 0;
-
-			+ .popup-not-interested-form {
 				margin-bottom: -0.75rem;
 			}
 		}
 
-		.newspack-lightbox-has-title.newspack-inline-popup &,
 		.newspack-lightbox-has-title.newspack-lightbox-placement-center & {
 			margin-top: 0;
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #708.

### How to test the changes in this Pull Request:

1. Create a new prompt and set `In archive pages` as its placement, and select `Subscribe Pattern 1` as a pattern for the content `Patterns > Newspack Subscribe > Subscribe Pattern 1`.
2. Load an archive page (e.g. A user or category page).
3. Notice that there is no space between the prompt and the article before it. Notice also the subscribe pattern is not centered inside the block.
4. Load this ☺️ 
5. Reload the archive page, notice the prompt is placed evenly between articles, and its content is now centered.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
