### PR TITLE
feat(api): add HTTP reponse codes to error reponses

### DIFF
--- a/api/campaigns/index.php
+++ b/api/campaigns/index.php
@@ -16,6 +16,8 @@ switch ( $_SERVER['REQUEST_METHOD'] ) { //phpcs:ignore
 		include './class-report-campaign-data.php';
 		break;
 	default:
+		header( 'HTTP/1.0 404 Not Found' );
+		header( 'Content-Type: application/json' );
 		die( "{ error: 'unsupported_method' }" );
 }
 // @codeCoverageIgnoreEnd

--- a/api/segmentation/index.php
+++ b/api/segmentation/index.php
@@ -15,5 +15,7 @@ switch ( $_SERVER['REQUEST_METHOD'] ) { //phpcs:ignore
 		include './class-segmentation-client-data.php';
 		break;
 	default:
+		header( 'HTTP/1.0 404 Not Found' );
+		header( 'Content-Type: application/json' );
 		die( "{ error: 'unsupported_method' }" );
 }

--- a/api/setup.php
+++ b/api/setup.php
@@ -29,7 +29,9 @@ if ( file_exists( $legacy_config_path ) ) {
 } elseif ( file_exists( $config_path ) ) {
 	require_once $config_path;
 } else {
-	die( 'missing config file' );
+	header( 'HTTP/1.0 503 Service Unavailable' );
+	header( 'Content-Type: application/json' );
+	die( "{ error: 'missing_config_file' }" );
 }
 
 // phpcs:disable
@@ -50,6 +52,8 @@ if ( file_exists( ABSPATH . WPINC . '/wp-db.php' ) ) {
 	require_once ABSPATH . WPINC . '/wp-db.php';
 	require_once ABSPATH . WPINC . '/functions.php';
 } else {
+	header( 'HTTP/1.0 503 Service Unavailable' );
+	header( 'Content-Type: application/json' );
 	die( "{ error: 'no_wordpress' }" );
 }
 
@@ -60,8 +64,8 @@ if ( file_exists( WP_CONTENT_DIR . '/object-cache.php' ) ) {
 }
 
 global $wpdb;
-$db_prefix = defined('DB_PREFIX') ? DB_PREFIX : 'wp_';
-$wpdb = new wpdb( DB_USER, DB_PASSWORD, DB_NAME, DB_HOST );
+$db_prefix = defined( 'DB_PREFIX' ) ? DB_PREFIX : 'wp_';
+$wpdb      = new wpdb( DB_USER, DB_PASSWORD, DB_NAME, DB_HOST );
 $wpdb->set_prefix( $db_prefix );
 
 global $table_prefix;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds error response codes to failing API responses. 

### How to test the changes in this Pull Request:

It's hard to procure this errors with regular use of this plugin – easiest way to test would be to comment out fragments of code to verify the response codes are correct. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->