### PR TITLE
fix: stricter empty block check

### DIFF
--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -219,25 +219,6 @@ final class Newspack_Popups_Inserter {
 
 		$parsed_blocks = self::convert_classic_blocks( parse_blocks( $content ) );
 
-		// List of blocks that require innerHTML to render content.
-		$innerhtml_blocks_names = [
-			'core/paragraph',
-			'core/heading',
-			'core/list',
-			'core/quote',
-			'core/html',
-			'core/freeform',
-		];
-		$parsed_blocks          = array_values( // array_values will reindex the array.
-			// Filter out empty blocks.
-			array_filter(
-				$parsed_blocks,
-				function( $block ) use ( $innerhtml_blocks_names ) {
-					return ! ( in_array( $block['blockName'], $innerhtml_blocks_names ) && empty( trim( $block['innerHTML'] ) ) );
-				}
-			)
-		);
-
 		$block_index          = 0;
 		$parsed_blocks_groups = array_reduce(
 			$parsed_blocks,

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -228,7 +228,7 @@ final class Newspack_Popups_Inserter {
 			'core/html',
 			'core/freeform',
 		];
-		$parsed_blocks = array_values( // array_values will reindex the array.
+		$parsed_blocks          = array_values( // array_values will reindex the array.
 			// Filter out empty blocks.
 			array_filter(
 				$parsed_blocks,

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -233,7 +233,7 @@ final class Newspack_Popups_Inserter {
 			array_filter(
 				$parsed_blocks,
 				function( $block ) use ( $innerhtml_blocks_names ) {
-					return ! ( in_array( $block['innerHTML'], $innerhtml_blocks_names ) && empty( trim( $block['innerHTML'] ) ) );
+					return ! ( in_array( $block['blockName'], $innerhtml_blocks_names ) && empty( trim( $block['innerHTML'] ) ) );
 				}
 			)
 		);

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -219,12 +219,21 @@ final class Newspack_Popups_Inserter {
 
 		$parsed_blocks = self::convert_classic_blocks( parse_blocks( $content ) );
 
+		// List of blocks that require innerHTML to render content.
+		$innerhtml_blocks_names = [
+			'core/paragraph',
+			'core/heading',
+			'core/list',
+			'core/quote',
+			'core/html',
+			'core/freeform',
+		];
 		$parsed_blocks = array_values( // array_values will reindex the array.
 			// Filter out empty blocks.
 			array_filter(
 				$parsed_blocks,
-				function( $block ) {
-					return ! ( 'core/paragraph' === $block['blockName'] && empty( trim( $block['innerHTML'] ) ) );
+				function( $block ) use ( $innerhtml_blocks_names ) {
+					return ! ( in_array( $block['innerHTML'], $innerhtml_blocks_names ) && empty( trim( $block['innerHTML'] ) ) );
 				}
 			)
 		);

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -220,7 +220,7 @@ final class Newspack_Popups_Inserter {
 		$parsed_blocks = self::convert_classic_blocks( parse_blocks( $content ) );
 
 		// List of blocks that require innerHTML to render content.
-		$innerhtml_blocks_names = [
+		$blocks_to_skip_empty = [
 			'core/paragraph',
 			'core/heading',
 			'core/list',
@@ -228,15 +228,15 @@ final class Newspack_Popups_Inserter {
 			'core/html',
 			'core/freeform',
 		];
-		$parsed_blocks          = array_values( // array_values will reindex the array.
+		$parsed_blocks        = array_values( // array_values will reindex the array.
 			// Filter out empty blocks.
 			array_filter(
 				$parsed_blocks,
-				function( $block ) use ( $innerhtml_blocks_names ) {
-					$null_block_name    = null === $block['blockName'];
-					$is_innerhtml_block = in_array( $block['blockName'], $innerhtml_blocks_names, true );
-					$is_empty           = empty( trim( $block['innerHTML'] ) );
-					return ! ( $is_empty && ( $null_block_name || $is_innerhtml_block ) );
+				function( $block ) use ( $blocks_to_skip_empty ) {
+					$null_block_name     = null === $block['blockName'];
+					$is_skip_empty_block = in_array( $block['blockName'], $blocks_to_skip_empty, true );
+					$is_empty            = empty( trim( $block['innerHTML'] ) );
+					return ! ( $is_empty && ( $null_block_name || $is_skip_empty_block ) );
 				}
 			)
 		);

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -224,7 +224,7 @@ final class Newspack_Popups_Inserter {
 			array_filter(
 				$parsed_blocks,
 				function( $block ) {
-					return 0 !== strlen( trim( $block['innerHTML'] ) );
+					return ! ( 'core/paragraph' === $block['blockName'] && empty( trim( $block['innerHTML'] ) ) );
 				}
 			)
 		);

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -219,6 +219,28 @@ final class Newspack_Popups_Inserter {
 
 		$parsed_blocks = self::convert_classic_blocks( parse_blocks( $content ) );
 
+		// List of blocks that require innerHTML to render content.
+		$innerhtml_blocks_names = [
+			'core/paragraph',
+			'core/heading',
+			'core/list',
+			'core/quote',
+			'core/html',
+			'core/freeform',
+		];
+		$parsed_blocks          = array_values( // array_values will reindex the array.
+			// Filter out empty blocks.
+			array_filter(
+				$parsed_blocks,
+				function( $block ) use ( $innerhtml_blocks_names ) {
+					$null_block_name    = null === $block['blockName'];
+					$is_innerhtml_block = in_array( $block['blockName'], $innerhtml_blocks_names, true );
+					$is_empty           = empty( trim( $block['innerHTML'] ) );
+					return ! ( $is_empty && ( $null_block_name || $is_innerhtml_block ) );
+				}
+			)
+		);
+
 		$block_index          = 0;
 		$parsed_blocks_groups = array_reduce(
 			$parsed_blocks,

--- a/tests/test-content-intertion.php
+++ b/tests/test-content-intertion.php
@@ -93,8 +93,8 @@ class ContentInsertionTest extends WP_UnitTestCase {
 				'core/paragraph',
 				'core/shortcode', // Popup 2.
 				'core/heading',
-				'core/paragraph', // Popup 3.
-				'core/shortcode',
+				'core/paragraph',
+				'core/shortcode', // Popup 3.
 			],
 			$content_with_popups,
 			'The popups are inserted into the content at expected positions.'

--- a/tests/test-content-intertion.php
+++ b/tests/test-content-intertion.php
@@ -36,6 +36,18 @@ class ContentInsertionTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Assert that that serialized blocks match the block names.
+	 *
+	 * @param string[] $expected List of block names.
+	 * @param array    $actual   Parsed blocks for assertion.
+	 * @param string   $message  Message.
+	 */
+	private static function assertEqualBlockNames( $expected, $actual, $message = '' ) {
+		$actual_names = wp_list_pluck( $actual, 'blockName' );
+		self::assertEquals( $expected, $actual_names, $message );
+	}
+
+	/**
 	 * Insertion into block-based post content.
 	 */
 	public function test_insertion_into_block_content() {
@@ -64,24 +76,26 @@ class ContentInsertionTest extends WP_UnitTestCase {
 			// A popup after all content.
 			self::create_inline_popup( '3', '100' ),
 		];
-		$content_with_popups = serialize_blocks(
-			Newspack_Popups_Inserter::insert_popups_in_post_content(
-				$post_content,
-				$popups
+		$content_with_popups = parse_blocks(
+			str_replace(
+				array( "\n", "\r" ),
+				'',
+				Newspack_Popups_Inserter::insert_popups_in_post_content(
+					$post_content,
+					$popups
+				)
 			)
 		);
-		self::assertEquals(
-			serialize_blocks(
-				self::rendered_popup( '1' ) . '<!-- wp:image {"align":"right"} -->
-<div class="wp-block-image">image</div>
-<!-- /wp:image --><!-- wp:paragraph -->
-<p>Paragraph 1</p>
-<!-- /wp:paragraph -->' . self::rendered_popup( '2' ) . '<!-- wp:heading -->
-<h2>A heading</h2>
-<!-- /wp:heading --><!-- wp:paragraph -->
-<p>Paragraph 2</p>
-<!-- /wp:paragraph -->' . self::rendered_popup( '3' )
-			),
+		self::assertEqualBlockNames(
+			[
+				'core/shortcode', // Popup 1.
+				'core/image',
+				'core/paragraph',
+				'core/shortcode', // Popup 2.
+				'core/heading',
+				'core/paragraph', // Popup 3.
+				'core/shortcode',
+			],
 			$content_with_popups,
 			'The popups are inserted into the content at expected positions.'
 		);
@@ -103,14 +117,22 @@ Paragraph 2
 			// A popup after all content.
 			self::create_inline_popup( '3', '100' ),
 		];
-		$content_with_popups = serialize_blocks(
+		$content_with_popups = parse_blocks(
 			Newspack_Popups_Inserter::insert_popups_in_post_content(
 				$post_content,
 				$popups
 			)
 		);
-		self::assertEquals(
-			serialize_blocks( self::rendered_popup( '1' ) . '<!-- wp:html --><p>Paragraph 1</p><!-- /wp:html -->' . self::rendered_popup( '2' ) . '<!-- wp:heading --><h2>A heading</h2><!-- /wp:heading --><!-- wp:html --><p>Paragraph 2</p><!-- /wp:html --><!-- wp:html --><blockquote><p>A quote</p></blockquote><!-- /wp:html -->' . self::rendered_popup( '3' ) ),
+		self::assertEqualBlockNames(
+			[
+				'core/shortcode', // Popup 1.
+				'core/html',
+				'core/shortcode', // Popup 2.
+				'core/heading',
+				'core/html',
+				'core/html',
+				'core/shortcode', // Popup 3.
+			],
 			$content_with_popups,
 			'The popups are inserted into the content at expected positions.'
 		);

--- a/tests/test-content-intertion.php
+++ b/tests/test-content-intertion.php
@@ -64,12 +64,15 @@ class ContentInsertionTest extends WP_UnitTestCase {
 			// A popup after all content.
 			self::create_inline_popup( '3', '100' ),
 		];
-		$content_with_popups = Newspack_Popups_Inserter::insert_popups_in_post_content(
-			$post_content,
-			$popups
+		$content_with_popups = serialize_blocks(
+			Newspack_Popups_Inserter::insert_popups_in_post_content(
+				$post_content,
+				$popups
+			)
 		);
 		self::assertEquals(
-			self::rendered_popup( '1' ) . '<!-- wp:image {"align":"right"} -->
+			serialize_blocks(
+				self::rendered_popup( '1' ) . '<!-- wp:image {"align":"right"} -->
 <div class="wp-block-image">image</div>
 <!-- /wp:image --><!-- wp:paragraph -->
 <p>Paragraph 1</p>
@@ -77,7 +80,8 @@ class ContentInsertionTest extends WP_UnitTestCase {
 <h2>A heading</h2>
 <!-- /wp:heading --><!-- wp:paragraph -->
 <p>Paragraph 2</p>
-<!-- /wp:paragraph -->' . self::rendered_popup( '3' ),
+<!-- /wp:paragraph -->' . self::rendered_popup( '3' )
+			),
 			$content_with_popups,
 			'The popups are inserted into the content at expected positions.'
 		);
@@ -99,12 +103,14 @@ Paragraph 2
 			// A popup after all content.
 			self::create_inline_popup( '3', '100' ),
 		];
-		$content_with_popups = Newspack_Popups_Inserter::insert_popups_in_post_content(
-			$post_content,
-			$popups
+		$content_with_popups = serialize_blocks(
+			Newspack_Popups_Inserter::insert_popups_in_post_content(
+				$post_content,
+				$popups
+			)
 		);
 		self::assertEquals(
-			self::rendered_popup( '1' ) . '<!-- wp:html --><p>Paragraph 1</p><!-- /wp:html -->' . self::rendered_popup( '2' ) . '<!-- wp:heading --><h2>A heading</h2><!-- /wp:heading --><!-- wp:html --><p>Paragraph 2</p><!-- /wp:html --><!-- wp:html --><blockquote><p>A quote</p></blockquote><!-- /wp:html -->' . self::rendered_popup( '3' ),
+			serialize_blocks( self::rendered_popup( '1' ) . '<!-- wp:html --><p>Paragraph 1</p><!-- /wp:html -->' . self::rendered_popup( '2' ) . '<!-- wp:heading --><h2>A heading</h2><!-- /wp:heading --><!-- wp:html --><p>Paragraph 2</p><!-- /wp:html --><!-- wp:html --><blockquote><p>A quote</p></blockquote><!-- /wp:html -->' . self::rendered_popup( '3' ) ),
 			$content_with_popups,
 			'The popups are inserted into the content at expected positions.'
 		);

--- a/tests/test-content-intertion.php
+++ b/tests/test-content-intertion.php
@@ -36,7 +36,7 @@ class ContentInsertionTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Assert that that serialized blocks match the block names.
+	 * Assert that serialized blocks match the block names.
 	 *
 	 * @param string[] $expected List of block names.
 	 * @param array    $actual   Parsed blocks for assertion.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

#647 introduced a new bug in which some blocks are being stripped out of the page while being parsed by its filters. This is due the filtering out of blocks without `innerHTML`.

Not all blocks require `innerHTML` to display content. Blocks such as the Donation block and the Homepage Posts block uses other attributes to render their content.

This PR implements a stricter check to only filter out empty innerHTML of the following blocks:

- `null`
- core/paragraph
- core/heading
- core/list
- core/quote
- core/html
- core/freeform

It also implements a new assertion for more readable and less sensitive testing of block content insertion.

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->


### How to test the changes in this Pull Request:

1. On the master branch, make sure you have inline campaigns visible
2. Create a page with donation and homepage posts block
3. Visit the page and see the blocks are not visible
4. Check out this branch and confirm they are displayed as expected

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
