### PR TITLE
feat: add a filter for supported post types

### DIFF
--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -811,14 +811,6 @@ final class Newspack_Popups_Inserter {
 	 */
 	public static function should_display( $popup, $check_if_is_post = false ) {
 		$post_type = get_post_type();
-		// Inline prompts may not be rendered on pages, unless they are above-header.
-		if (
-			$check_if_is_post &&
-			'page' === $post_type &&
-			( Newspack_Popups_Model::is_inline( $popup ) && ! Newspack_Popups_Model::is_above_header( $popup ) )
-		) {
-			return false;
-		}
 
 		// Unless it's a preview request, perform some additional checks.
 		if ( ! Newspack_Popups::is_preview_request() ) {

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -507,9 +507,22 @@ final class Newspack_Popups_Model {
 	 * Get the default supported post types.
 	 */
 	public static function get_default_popup_post_types() {
+		// Any custom post type that is both public and has a post type archive.
+		$public_post_types = array_values(
+			get_post_types(
+				[
+					'has_archive' => true,
+					'public'      => true,
+				]
+			)
+		);
+
+		// Default 'post' and 'page' post types actually have 'is_archive' => false, but we still want them.
+		$public_post_types = array_merge( [ 'post', 'page' ], $public_post_types );
+
 		return apply_filters(
 			'newspack_campaigns_default_supported_post_types',
-			[ 'post', 'page' ]
+			$public_post_types
 		);
 	}
 

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -507,7 +507,10 @@ final class Newspack_Popups_Model {
 	 * Get the default supported post types.
 	 */
 	public static function get_default_popup_post_types() {
-		return [ 'post', 'page' ];
+		return apply_filters(
+			'newspack_campaigns_default_supported_post_types',
+			[ 'post', 'page' ]
+		);
 	}
 
 	/**

--- a/tests/test-insertion.php
+++ b/tests/test-insertion.php
@@ -42,9 +42,9 @@ class InsertionTest extends WP_UnitTestCase_PageWithPopups {
 		$amp_layout_elements = self::$dom_xpath->query( '//amp-layout' );
 
 		self::assertEquals(
-			0,
+			1,
 			$amp_layout_elements->length,
-			'There are no popups, since the only one available is an inline one, and this is a page.'
+			'Inserts the inline prompt on a page.'
 		);
 		self::assertContains(
 			self::$raw_post_content,
@@ -61,7 +61,7 @@ class InsertionTest extends WP_UnitTestCase_PageWithPopups {
 		self::assertContains(
 			$overlay_content,
 			$overlay_text_content,
-			'Inserts the popup content on a page, since this is an overlay prompt.'
+			'Inserts the overlay prompt on a page.'
 		);
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Instead of supporting just `[ 'post', 'page' ]` as the default post types for Campaigns, uses `get_post_types` to support posts, pages, and all public CPTs that have archives by default. Also applies a filter to the array of supported post types to allow other plugins to add or remove Campaigns support for specific post types.

Fixes some unexpected behavior that @kariae and I debugged together when trying to display an archive prompt on a category archive page that contained both posts and listings.

As a bonus, also fixes #720, as before we implemented post type support, we had hard-coded an exception to prevent inline prompts from being rendered on pages.

### How to test the changes in this Pull Request:

1. On your test site, make sure you have Newspack Listings and Newsletter plugins active, and some listings/newsletter posts published and assigned to categories or tags. These should have more recent publish dates so that they appear at the top of their respective category or tag archives, before any regular posts with the same terms.
2. In Newspack Campaigns, publish an archive prompt that should display after 1 post in category archives. Don't edit the Post Types options (but do observe that it shows listing post types, but they're not selected by default).
3. On `master`, observe that the prompt is not displayed on the category archive (because the first post shown is a listing, not a post).
4. Check out this branch, confirm that the archive prompt and any new prompt now have listing post types selected by default.
5. Confirm that the category archive now shows the prompt after the first post.

#### Bonus fix

1. Publish an inline prompt and make sure "Page" is selected as one of the supported post types for the prompt (it should be on by default).
2. Confirm that the prompt gets displayed on pages.
3. De-select "Page" from the prompt's supported post types.
4. Confirm that the prompt no longer gets displayed on pages, but continues to get displayed on other supported post types.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
