### PR TITLE
fix: duplicated, grouped blocks

### DIFF
--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -253,9 +253,11 @@ final class Newspack_Popups_Inserter {
 					return $block_groups;
 				}
 
-				// Look up the next block to maybe include it in the group.
-				$should_block_be_grouped_with_next = ! self::can_block_be_followed_by_prompt( $block ) && $total_blocks > $block_index + 1;
-				if ( $should_block_be_grouped_with_next ) {
+				// If this block can be followed by a prompt, and/or it's the last block.
+				if ( self::can_block_be_followed_by_prompt( $block ) || $total_blocks === $block_index + 1 ) {
+					$block_groups[] = [ $block ];
+				} else {
+					// Look up the next block to maybe include it in the group.
 					$next_block   = $block;
 					$next_index   = 0;
 					$group_blocks = [];
@@ -272,8 +274,6 @@ final class Newspack_Popups_Inserter {
 					}
 
 					$block_groups[] = $group_blocks;
-				} else {
-					$block_groups[] = [ $block ];
 				}
 
 				$block_index++;

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -266,7 +266,7 @@ final class Newspack_Popups_Inserter {
 					$next_block               = $parsed_blocks[ $next_index ];
 					$group_blocks[]           = $next_block;
 					$grouped_blocks_indexes[] = $next_index;
-					$next_index       ++;
+					$next_index ++;
 					$index_in_group++;
 				}
 				// Always insert the initial block in the group (if the index in group was not incremented, this is the initial block).

--- a/tests/test-content-insertion.php
+++ b/tests/test-content-insertion.php
@@ -9,15 +9,25 @@
  * ContentInsertion test case.
  */
 class ContentInsertionTest extends WP_UnitTestCase {
+	private static $popups = []; // phpcs:ignore Squiz.Commenting.VariableComment.Missing
+
+	public function setUp() { // phpcs:ignore Squiz.Commenting.FunctionComment.Missing
+		self::$popups = [
+			self::create_inline_popup( '0' ),
+			self::create_inline_popup( '70' ),
+			self::create_inline_popup( '100' ),
+		];
+	}
+
+
 	/**
 	 * Create an inline popup configuration object.
 	 *
-	 * @param string $id ID.
 	 * @param string $placement Placement, as percentage in content.
 	 */
-	private static function create_inline_popup( $id, $placement ) {
+	private static function create_inline_popup( $placement ) {
 		return [
-			'id'      => $id,
+			'id'      => wp_rand(),
 			'content' => 'Some content.',
 			'options' => [
 				'placement'               => 'inline',
@@ -46,7 +56,7 @@ class ContentInsertionTest extends WP_UnitTestCase {
 		$parsed_blocks = parse_blocks(
 			str_replace(
 				array( "\n", "\r" ),
-				'', 
+				'',
 				$actual
 			)
 		);
@@ -75,14 +85,99 @@ class ContentInsertionTest extends WP_UnitTestCase {
 <p>Paragraph 2</p>
 <!-- /wp:paragraph -->
 ';
-		$popups       = [
-			// A popup before any content.
-			self::create_inline_popup( '1', '0' ),
-			// A popup that should not be inserted right after a heading.
-			self::create_inline_popup( '2', '70' ),
-			// A popup after all content.
-			self::create_inline_popup( '3', '100' ),
-		];
+		self::assertEqualBlockNames(
+			[
+				'core/shortcode', // Popup 1.
+				'core/image',
+				'core/paragraph',
+				'core/shortcode', // Popup 2 – inserted before the heading, not after it.
+				'core/heading',
+				'core/paragraph',
+				'core/shortcode', // Popup 3.
+			],
+			Newspack_Popups_Inserter::insert_popups_in_post_content(
+				$post_content,
+				self::$popups
+			),
+			'The popups are inserted into the content at expected positions.'
+		);
+	}
+
+	/**
+	 * Insertion into block-based post content, a longer version.
+	 */
+	public function test_insertion_into_block_content_long() {
+		$post_content = '
+<!-- wp:image {"align":"right"} -->
+<div class="wp-block-image">image</div>
+<!-- /wp:image -->
+
+<!-- wp:paragraph -->
+<p>Paragraph</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Paragraph</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Paragraph</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading -->
+<h2>A heading</h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>Paragraph</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Paragraph</p>
+<!-- /wp:paragraph -->
+';
+		self::assertEqualBlockNames(
+			[
+				'core/image',
+				'core/paragraph',
+				'core/shortcode', // Popup.
+				'core/paragraph',
+				'core/shortcode', // Popup.
+				'core/paragraph',
+				'core/shortcode', // Popup.
+				'core/heading',
+				'core/paragraph',
+				'core/paragraph',
+			],
+			Newspack_Popups_Inserter::insert_popups_in_post_content(
+				$post_content,
+				[
+					self::create_inline_popup( '24' ),
+					self::create_inline_popup( '50' ),
+					self::create_inline_popup( '60' ),
+				]
+			),
+			'The popups are inserted into the content at expected positions.'
+		);
+	}
+
+	/**
+	 * Insertion into block-based post content, when a heading is the last block.
+	 */
+	public function test_insertion_into_block_content_ending_with_heading() {
+		$post_content = '
+<!-- wp:image {"align":"right"} -->
+<div class="wp-block-image">image</div>
+<!-- /wp:image -->
+
+<!-- wp:paragraph -->
+<p>Paragraph</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading -->
+<h2>A heading</h2>
+<!-- /wp:heading -->
+';
 		self::assertEqualBlockNames(
 			[
 				'core/shortcode', // Popup 1.
@@ -90,14 +185,91 @@ class ContentInsertionTest extends WP_UnitTestCase {
 				'core/paragraph',
 				'core/shortcode', // Popup 2.
 				'core/heading',
+				'core/shortcode', // Popup 3.
+			],
+			Newspack_Popups_Inserter::insert_popups_in_post_content(
+				$post_content,
+				self::$popups
+			),
+			'The popups are inserted into the content at expected positions when a heading is the last block.'
+		);
+	}
+
+	/**
+	 * Insertion into block-based post content, when a heading is the first block.
+	 */
+	public function test_insertion_into_block_content_starting_with_heading() {
+		$post_content = '
+<!-- wp:heading -->
+<h2>A heading</h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>Paragraph</p>
+<!-- /wp:paragraph -->
+';
+		self::assertEqualBlockNames(
+			[
+				'core/shortcode', // Popup 1.
+				'core/shortcode', // Popup 2.
+				'core/heading',
 				'core/paragraph',
 				'core/shortcode', // Popup 3.
 			],
 			Newspack_Popups_Inserter::insert_popups_in_post_content(
 				$post_content,
-				$popups
+				self::$popups
 			),
-			'The popups are inserted into the content at expected positions.'
+			'The popups are inserted into the content at expected positions when a heading is the first block.'
+		);
+	}
+
+	/**
+	 * Insertion into block-based post content, when there are consecutive insertion-preventing blocks.
+	 */
+	public function test_insertion_into_block_content_consecutive() {
+		$post_content = '
+<!-- wp:paragraph -->
+<p>Paragraph</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading -->
+<h2>A heading</h2>
+<!-- /wp:heading -->
+
+<!-- wp:image {"align":"right"} -->
+<div class="wp-block-image">image</div>
+<!-- /wp:image -->
+
+<!-- wp:heading -->
+<h2>A heading</h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>Paragraph</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Paragraph</p>
+<!-- /wp:paragraph -->
+';
+		self::assertEqualBlockNames(
+			[
+				'core/shortcode', // Popup 1.
+				'core/paragraph',
+				'core/shortcode', // Popup 2.
+				'core/heading',
+				'core/image',
+				'core/heading',
+				'core/paragraph',
+				'core/paragraph',
+				'core/shortcode', // Popup 3.
+			],
+			Newspack_Popups_Inserter::insert_popups_in_post_content(
+				$post_content,
+				self::$popups
+			),
+			'The popups are inserted into the content at expected positions when there are consecutive insertion-preventing blocks.'
 		);
 	}
 
@@ -111,11 +283,11 @@ Paragraph 2
 <blockquote>A quote</blockquote>';
 		$popups       = [
 			// A popup before any content.
-			self::create_inline_popup( '1', '0' ),
+			self::create_inline_popup( '0' ),
 			// A popup that should not be inserted right after a heading.
-			self::create_inline_popup( '2', '30' ),
+			self::create_inline_popup( '30' ),
 			// A popup after all content.
-			self::create_inline_popup( '3', '100' ),
+			self::create_inline_popup( '100' ),
 		];
 		self::assertEqualBlockNames(
 			[

--- a/tests/test-content-intertion.php
+++ b/tests/test-content-intertion.php
@@ -91,8 +91,8 @@ class ContentInsertionTest extends WP_UnitTestCase {
 				'core/shortcode', // Popup 1.
 				'core/image',
 				'core/paragraph',
-				'core/shortcode', // Popup 2.
 				'core/heading',
+				'core/shortcode', // Popup 2.
 				'core/paragraph',
 				'core/shortcode', // Popup 3.
 			],

--- a/tests/test-content-intertion.php
+++ b/tests/test-content-intertion.php
@@ -91,8 +91,8 @@ class ContentInsertionTest extends WP_UnitTestCase {
 				'core/shortcode', // Popup 1.
 				'core/image',
 				'core/paragraph',
-				'core/heading',
 				'core/shortcode', // Popup 2.
+				'core/heading',
 				'core/paragraph',
 				'core/shortcode', // Popup 3.
 			],


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

#647 introduced grouping of blocks in order to avoid placing prompts after headings and floated image blocks. However, this introduced an edge case where if blocks can be duplicated if multiple headings and/or floated images appear consecutively.

### How to test the changes in this Pull Request:

1. On `master`, publish a post with test content that includes several individual paragraphs (which can be followed by prompts) as well as a series of consecutive headings and/or floated images (left or right). Or use the following test content:

<details>
<summary>Click for test content</summary>

```html
<!-- wp:paragraph -->
<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce turpis leo, euismod egestas mauris non, aliquam ultrices dui. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec fermentum vulputate turpis, non auctor lectus. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Sed sollicitudin nec neque eu tincidunt. Aenean at velit urna. Vivamus sapien leo, luctus sit amet commodo et, sollicitudin sed purus. Donec pulvinar tempor ipsum non molestie. Ut accumsan, magna id interdum consequat, massa elit tincidunt lacus, nec lacinia sapien ex sit amet nunc. Integer semper tortor pellentesque diam efficitur pellentesque. Morbi eget mauris est. Fusce pharetra pretium elit, a varius eros tempus in.</p>
<!-- /wp:paragraph -->

<!-- wp:heading -->
<h2>Heading 1</h2>
<!-- /wp:heading -->

<!-- wp:image {"align":"left","id":2214,"width":300,"height":200,"sizeSlug":"full","linkDestination":"none"} -->
<div class="wp-block-image"><figure class="alignleft size-full is-resized"><img src="https://newspack-dkoo.ngrok.io/wp-content/uploads/2021/02/automated_upload-18.jpg" alt="" class="wp-image-2214" width="300" height="200"/></figure></div>
<!-- /wp:image -->

<!-- wp:heading -->
<h2>Another heading</h2>
<!-- /wp:heading -->

<!-- wp:paragraph -->
<p>Quisque et iaculis lectus, quis malesuada mauris. Sed quis venenatis metus. Sed congue dictum diam. Vivamus eu malesuada ex. Mauris varius mattis mi eget fermentum. Vivamus in justo sit amet enim dapibus volutpat non sit amet diam. Praesent molestie purus mauris, a sagittis mauris pharetra pharetra. Sed diam odio, feugiat sed augue id, tempor volutpat sapien. Duis nisi leo, porttitor non magna nec, venenatis tincidunt mauris. Pellentesque euismod augue id arcu vehicula ornare in ac leo. Suspendisse quis finibus nibh. Donec finibus, quam eget faucibus ultrices, nisi tellus ultrices nulla, a feugiat enim leo eu sapien. Sed non dui sagittis, tincidunt purus sit amet, semper orci. Aenean maximus tortor quis congue sodales. Etiam posuere consectetur sagittis. Phasellus ullamcorper lacus eget erat convallis, sit amet ultricies augue lobortis.</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph -->
<p>Praesent velit leo, pretium ac eros et, maximus facilisis ante. Suspendisse vulputate imperdiet augue quis sodales. Suspendisse pharetra rhoncus justo, in porta arcu euismod et. In semper nisi eu turpis cursus, sit amet tincidunt dolor egestas. Vestibulum sit amet urna tincidunt ligula cursus consequat. Aenean eros leo, convallis ut massa nec, fringilla feugiat diam. Nulla malesuada elit sed blandit efficitur. Pellentesque porta est eget accumsan ultrices. Cras sagittis nisl tellus, non rutrum dolor ultrices in. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Etiam gravida dapibus elit, at gravida velit scelerisque sed. Integer vehicula bibendum est, vel lobortis ex placerat nec.</p>
<!-- /wp:paragraph -->

<!-- wp:heading -->
<h2>Heading 2</h2>
<!-- /wp:heading -->

<!-- wp:image {"align":"left","id":2214,"width":300,"height":200,"sizeSlug":"full","linkDestination":"none"} -->
<div class="wp-block-image"><figure class="alignleft size-full is-resized"><img src="https://newspack-dkoo.ngrok.io/wp-content/uploads/2021/02/automated_upload-18.jpg" alt="" class="wp-image-2214" width="300" height="200"/></figure></div>
<!-- /wp:image -->

<!-- wp:paragraph -->
<p>Vestibulum aliquam metus neque, ut fringilla est sodales vel. Mauris congue imperdiet enim, hendrerit ullamcorper purus convallis in. Quisque ultricies interdum sem ut pharetra. Fusce feugiat egestas enim, quis sodales ipsum luctus at. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Duis placerat malesuada congue. Integer id lectus at sapien rhoncus laoreet id ac justo. Sed vel venenatis justo. Etiam nec orci et diam egestas vulputate nec vel est. Curabitur lacus neque, pulvinar in maximus sit amet, facilisis sit amet purus. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Praesent nibh elit, dignissim quis suscipit non, euismod sit amet lectus. Pellentesque sit amet ante sed orci vehicula luctus. Donec semper, felis at dignissim pellentesque, felis nisl laoreet felis, a convallis tortor orci id purus. Sed lobortis tortor in porttitor dictum.</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph -->
<p>Phasellus et blandit diam. Vivamus molestie risus quis erat aliquet, quis varius nibh aliquet. Ut condimentum a metus nec euismod. Praesent tincidunt imperdiet lacinia. Cras vitae felis id leo posuere rhoncus at non quam. Vivamus ultricies sodales fringilla. Proin et pretium mauris, ut rutrum nisl. Nam massa libero, sagittis non lacus at, aliquam congue purus. Suspendisse potenti.</p>
<!-- /wp:paragraph -->

<!-- wp:heading -->
<h2>Heading 3</h2>
<!-- /wp:heading -->

<!-- wp:image {"align":"left","id":2214,"width":300,"height":200,"sizeSlug":"full","linkDestination":"none"} -->
<div class="wp-block-image"><figure class="alignleft size-full is-resized"><img src="https://newspack-dkoo.ngrok.io/wp-content/uploads/2021/02/automated_upload-18.jpg" alt="" class="wp-image-2214" width="300" height="200"/></figure></div>
<!-- /wp:image -->

<!-- wp:paragraph -->
<p>Etiam tincidunt ultricies rhoncus. Praesent condimentum eget lectus vitae fermentum. Aenean congue, dui placerat feugiat cursus, mi velit pharetra justo, in tristique erat justo non nibh. Proin mollis, risus et scelerisque suscipit, lacus magna ultrices arcu, eu aliquam neque libero nec justo. Nunc mollis tellus augue, a semper sapien viverra non. Pellentesque pretium, urna in vulputate consectetur, tortor velit elementum libero, eget facilisis enim enim eget tellus. Quisque augue metus, egestas nec ex vitae, posuere congue urna. Aliquam eleifend venenatis arcu. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Phasellus malesuada convallis erat. Ut venenatis quam leo, pharetra tempus lacus malesuada eget. Maecenas ultrices dui et nunc fringilla, eget volutpat purus tempor. Sed mi orci, sagittis vitae lectus ut, sollicitudin suscipit risus. Morbi sodales odio mauris, ac viverra tellus aliquam eget.</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph -->
<p>Vestibulum molestie tempus nibh. Aenean congue maximus ipsum, in maximus velit bibendum id. Praesent non mauris volutpat, blandit nibh et, volutpat purus. Maecenas viverra nibh in velit mollis blandit. Mauris eu pharetra neque, eget consequat mi. Curabitur vehicula cursus velit a hendrerit. Cras bibendum, erat ut efficitur vehicula, tellus erat fermentum dui, eget vulputate dolor ante ac odio. Sed consequat placerat nunc.</p>
<!-- /wp:paragraph -->

<!-- wp:heading -->
<h2>Heading 4</h2>
<!-- /wp:heading -->

<!-- wp:image {"align":"left","id":2214,"width":300,"height":200,"sizeSlug":"full","linkDestination":"none"} -->
<div class="wp-block-image"><figure class="alignleft size-full is-resized"><img src="https://newspack-dkoo.ngrok.io/wp-content/uploads/2021/02/automated_upload-18.jpg" alt="" class="wp-image-2214" width="300" height="200"/></figure></div>
<!-- /wp:image -->

<!-- wp:paragraph -->
<p>Proin sollicitudin dui non blandit aliquet. Praesent interdum ipsum luctus tincidunt commodo. Sed enim ex, efficitur vel pretium at, rhoncus id libero. Phasellus quis massa molestie, auctor nisl et, viverra purus. Aenean metus mi, vestibulum ut tellus ac, mollis pretium massa. Maecenas felis urna, gravida quis pharetra sit amet, gravida nec turpis. Nulla quis sem in odio elementum dapibus. Fusce malesuada mi a tortor eleifend elementum. Suspendisse consequat elit ac tristique convallis. Morbi ut aliquam dolor. Vestibulum metus tortor, commodo in leo aliquam, aliquam porttitor justo. Sed in laoreet nisi. Cras porta pretium dignissim. Integer dolor odio, dictum sed convallis et, efficitur in nunc. Phasellus accumsan, eros vitae sodales eleifend, justo tellus accumsan est, at ultrices enim eros ut nisl.</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph -->
<p>Duis quis diam ac erat imperdiet tempor. Pellentesque tristique augue fermentum, cursus nunc vitae, tempus lacus. Sed laoreet sagittis metus in imperdiet. Maecenas laoreet odio malesuada, lacinia lorem nec, sodales leo. Cras et sem sit amet lorem facilisis mattis. In hac habitasse platea dictumst. Donec egestas ante leo, sed pellentesque nunc convallis quis. Cras tincidunt at nulla ac ullamcorper. Ut rutrum ligula mauris, eget dignissim ipsum rutrum vitae. Sed nisl urna, semper ac justo ut, pharetra laoreet enim. Phasellus ac orci sodales, faucibus nisi in, sollicitudin leo. Donec fringilla placerat tortor. In hac habitasse platea dictumst. Pellentesque imperdiet diam et efficitur tristique.</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph -->
<p>Mauris id pellentesque nisi. Nulla velit tortor, consectetur a ex id, aliquam porta risus. Duis dapibus feugiat diam, sit amet ullamcorper massa finibus sed. Donec sem magna, luctus eu elit at, maximus mollis turpis. Aliquam consequat egestas est eu ornare. Vestibulum sit amet mi mattis, imperdiet augue a, scelerisque dui. Nunc vitae interdum est. Duis posuere sollicitudin nunc, non pharetra lorem maximus sed. Nulla nibh velit, consectetur quis luctus non, malesuada ac justo. Nulla molestie eleifend lectus, bibendum condimentum mauris imperdiet et. Mauris fringilla metus sit amet lacus sodales, sed pretium sem dignissim. Nulla id gravida turpis. Morbi rhoncus, elit non ultricies finibus, ipsum sem iaculis quam, quis feugiat arcu justo eget metus. Fusce porta fermentum libero, sed malesuada lorem.</p>
<!-- /wp:paragraph -->

<!-- wp:heading -->
<h2>Heading 5</h2>
<!-- /wp:heading -->

<!-- wp:image {"align":"left","id":2214,"width":300,"height":200,"sizeSlug":"full","linkDestination":"none"} -->
<div class="wp-block-image"><figure class="alignleft size-full is-resized"><img src="https://newspack-dkoo.ngrok.io/wp-content/uploads/2021/02/automated_upload-18.jpg" alt="" class="wp-image-2214" width="300" height="200"/></figure></div>
<!-- /wp:image -->

<!-- wp:heading -->
<h2>Another heading</h2>
<!-- /wp:heading -->
```

</details>

2. Publish at least one prompt (of any type) which will appear on the post.
3. View the post front-end in a new session. Observe that several blocks appear in duplicate (basically, any heading or floated image block that follows another heading or floated image block).

<img width="1107" alt="Screen Shot 2021-12-08 at 6 36 06 PM" src="https://user-images.githubusercontent.com/2230142/145318432-fe2e46c1-2573-40ad-be54-f57060e047de.png">

4. Check out this branch, refresh the post, confirm that the duplication no longer occurs.
5. Smoke test other posts to ensure that the prompt insertion still behaves as expected with a variety of post content.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
