### PR TITLE
fix: view.js conflict with mediaelement.js

### DIFF
--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -482,6 +482,13 @@ final class Newspack_Popups_Inserter {
 		if ( defined( 'IS_TEST_ENV' ) && IS_TEST_ENV ) {
 			return;
 		}
+
+		// Don't enqueue assets if prompts are disabled on this post.
+		$has_disabled_prompts = is_singular() && ! empty( get_post_meta( get_the_ID(), 'newspack_popups_has_disabled_popups', true ) );
+		if ( $has_disabled_prompts ) {
+			return;
+		}
+
 		$is_amp = function_exists( 'is_amp_endpoint' ) && is_amp_endpoint();
 		if ( ! $is_amp ) {
 			wp_register_script(

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -494,7 +494,7 @@ final class Newspack_Popups_Inserter {
 			wp_register_script(
 				'newspack-popups-view',
 				plugins_url( '../dist/view.js', __FILE__ ),
-				[ 'wp-dom-ready', 'wp-url' ],
+				[ 'wp-dom-ready', 'wp-url', 'mediaelement-core' ],
 				filemtime( dirname( NEWSPACK_POPUPS_PLUGIN_FILE ) . '/dist/view.js' ),
 				true
 			);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Does two things:

1. Fixes a conflict between this plugin's non-AMP `view.js` and the core `mediaelement-core` JS, when the latter is also enqueued on the page. Note that the podcast player block still doesn't seem to work when AMP is enabled, but this doesn't seem to be related to this plugin.
2. Avoids enqueuing front-end JS and CSS if the "Disable prompts on this post or page" option is enabled, since it won't be needed in that case.

Closes #729.

### How to test the changes in this Pull Request:

#### `mediaelement` conflict

1. Add a Jetpack Podcast Player to a post and configure it with a valid URL (try: https://feeds.megaphone.fm/no-place-like-home)
2. Disable AMP on the post.
3. View the post in an incognito window. On `master`, observe that the podcast player block is missing the media player component.
4. Check out this branch and refresh. Confirm that the media player loads correctly now, and that prompts still load as expected.

#### Avoid enqueuing unnecessary assets

1. On the post, check the "Disable prompts on this post or page" option.
2. View the post in an incognito window. On `master`, view source and observe that the `newspack-popups-view` JS and CSS files are still enqueued.
3. Check out this branch, refresh, confirm that those assets are no longer enqueued.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
