### PR TITLE
hotfix: donate form submission event

### DIFF
--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -865,7 +865,7 @@ final class Newspack_Popups_Model {
 
 		if ( $has_form ) {
 			$analytics_events[] = [
-				'amp_on'     => 'amp-form-submit-success',
+				'amp_on'     => 'amp-form-submit',
 				'on'         => 'submit',
 				'element'    => '#' . esc_attr( $element_id ) . ' form:not(.' . self::get_form_class( 'action', $element_id ) . ')', // Not an 'action' (dismissal) form.
 				'event_name' => __( 'Form Submission', 'newspack-popups' ),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This is a one-line fix that warrants quite a bit of explanation and testing.

There seems to be a race condition that happens when submitting a Donate block form on AMP pages. When submitting a Donate block form using the Newspack/WooCommerce Reader Revenue platform, the [handler](https://github.com/Automattic/newspack-plugin/blob/master/includes/class-donations.php#L536) performs some functionality and then does a [server redirect](https://github.com/Automattic/newspack-plugin/blob/master/includes/class-donations.php#L647) to the WooCommerce checkout page.

At the same time, when a form element is present in a prompt's content, a "Form Submission" event is reported when the form is submitted. On AMP pages, this event happens on the `amp-form-submit-success` trigger, which according to [AMP documentation](https://amp.dev/documentation/components/amp-form/#analytics) is fired when a successful response to the submission request is received (defined by AMP as having an HTTP response code of `2XX`).

The server redirect seems to prevent AMP from reading the response code most of the time, which results in the "Form Submission" event firing very rarely. This translates to extremely low conversion rates that don't match up to the actual donation transactions being recorded via WooCommerce.

This fix fires the "Form Submission" event for forms inside prompt content immediately on form submission (`amp-form-submit` trigger) instead of waiting for the `amp-form-submit-success` trigger. The `amp-form-submit-success` trigger does seem to fire as expected for forms that don't perform a server redirect, such as the prompt dismissal form, so we should be able to leave those intact.

One thing to note is that this may result in rare cases where the "Form Submission" event gets reported, but the form submission fails for technical reasons. This could happen if a server error prevents the redirect to WooCommerce checkout, for example. However, this risk seems much less egregious than not firing the event 90+% of the time.

An alternative solution to this would be to create a REST endpoint to serve as a form submission handler for forms submitted via AMP's `action-xhr` form attribute. This endpoint would get triggered by form submission only when the form is an `amp-form`. The `amp-form-submit-success` trigger is fired when the endpoint responds with a `2XX` code, after which we could continue to redirect to checkout. However, this would require an extra request for all in-prompt form submissions, as well as splitting behavior between AMP vs. non-AMP forms, which is something we probably want to avoid.

Closes #664.

### How to test the changes in this Pull Request:

1. Set up a Newspack test site and set up a Site Kit connection with Google. In **Site Kit > Settings**, fully connect a Google Analytics instance.
2. Publish a prompt that will be shown to everyone and insert a Donate block in the prompt's content.
3. In the same browser session where you're logged into your Newspack site, Lot into [Google Analytics](https://analytics.google.com). Go to **Realtime > Events** in the left sidebar and click on the "Events (Last 30 min)" tab. Keep this tab open—it will show events as soon as they're reported by your connected Newspack site:

<img width="1545" alt="Screen Shot 2022-01-31 at 4 49 54 PM" src="https://user-images.githubusercontent.com/2230142/151891903-3f68354d-cbdb-4bdc-88f0-024a9dbc8f3c.png">

4. In a new Incognito session, visit a page on your test site that will display the prompt. Ensure that the Google Analytics Realtime Events screen reports the "Load" and "Seen" events with event category "Newspack Announcement" as you view the prompt.
5. On `master`, click the Donate button in the prompt and observe that no "Form Submission" event is reported.
6. Check out this branch, go back to the page with your prompt, and click the Donate button again. This time confirm that the "Form Submission" event with event category "Newspack Announcement" is reported.
7. Repeat a few times to ensure that the submission event is reported each time you submit the form.
8. Smoke test other form submission events (such as a Mailchimp newsletter signup form inside a prompt, and dismissing a prompt via the dismiss button) to ensure that these events still get reported.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
