### PR TITLE
fix(preview): pass url params to links within single-prompt preview iframes

### DIFF
--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -569,6 +569,7 @@ final class Newspack_Popups {
 			'newspack-popups',
 			'newspack_popups_data',
 			[
+				'frontend_url'                 => get_site_url(),
 				'preview_post'                 => self::preview_post_permalink(),
 				'preview_archive'              => self::preview_archive_permalink(),
 				'segments'                     => Newspack_Popups_Segmentation::get_segments(),

--- a/src/editor/Preview.js
+++ b/src/editor/Preview.js
@@ -10,7 +10,6 @@ import { addQueryArgs } from '@wordpress/url';
 /**
  * External dependencies
  */
-import { stringify } from 'qs';
 import { WebPreview } from 'newspack-components';
 
 const PreviewSetting = ( { autosavePost, isSavingPost, postId, metaFields } ) => {

--- a/src/editor/Preview.js
+++ b/src/editor/Preview.js
@@ -33,16 +33,12 @@ const PreviewSetting = ( { autosavePost, isSavingPost, postId, metaFields } ) =>
 	const previewURL =
 		window.newspack_popups_data[ isArchivePagesPrompt ? 'preview_archive' : 'preview_post' ] || '/';
 
-	const decorateURL = urlToDecorate => {
-		return addQueryArgs( urlToDecorate, query );
-	};
-
 	const onWebPreviewLoad = iframeEl => {
 		if ( iframeEl ) {
 			[
 				...iframeEl.contentWindow.document.querySelectorAll( 'a[href^="' + frontendUrl + '"]' ),
 			].forEach( anchor => {
-				anchor.setAttribute( 'href', decorateURL( anchor.getAttribute( 'href' ) ) );
+				anchor.setAttribute( 'href', addQueryArgs( anchor.getAttribute( 'href' ), query ) );
 			} );
 			onLoad( iframeEl );
 		}

--- a/src/editor/Preview.js
+++ b/src/editor/Preview.js
@@ -15,7 +15,6 @@ import { WebPreview } from 'newspack-components';
 const PreviewSetting = ( { autosavePost, isSavingPost, postId, metaFields } ) => {
 	const previewQueryKeys = window.newspack_popups_data?.preview_query_keys || {};
 	const frontendUrl = window?.newspack_popups_data?.frontend_url || '/';
-	const onLoad = () => {};
 	const abbreviatedKeys = {};
 	Object.keys( metaFields ).forEach( key => {
 		if ( previewQueryKeys.hasOwnProperty( key ) ) {
@@ -40,7 +39,6 @@ const PreviewSetting = ( { autosavePost, isSavingPost, postId, metaFields } ) =>
 			].forEach( anchor => {
 				anchor.setAttribute( 'href', addQueryArgs( anchor.getAttribute( 'href' ), query ) );
 			} );
-			onLoad( iframeEl );
 		}
 	};
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

When previewing segments, we pass `view_as` query params on the preview iframe URL to any links within
the preview iframe content. We should do the same for preview iframes when previewing single
prompts. Currently, when previewing single prompts, the preview params aren't persisted as you navigate the site within the preview iframe, so things like Custom Placement or Single Prompt blocks won't render properly.

This updates the single-prompt preview component so that it passes preview query params to any links within the preview window, just like with the segment previews.

**Note:** This change won't prevent a Custom Placement or manual-only prompt from appearing as an inline prompt on the first post that appears in the preview window. This is because:

1. We don't want to force the user to hunt around the site to find a page that contains the block. The user can still click to a page containing the Custom Placement block, and it should now appear in that page where placed.
2. When previewing a Custom Placement or manual-only prompt, it's possible the prompt hasn't been placed anywhere, which would mean it wouldn't appear anywhere in the preview.

I think in most cases when previewing a prompt, the user will do so to get a general sense of what its content looks like. They may not want to hunt down a particular post or page where they placed it in order to preview. If they do want to see it in that exact context (such as if they placed it in a prominent place on the homepage and they want to see how it looks right there), they can now do so. Also, Custom Placement and manual-only prompts are likely to be used by a small number of power users only, so we should be able to explain the behavior to them if needed. We can revisit this decision if it ends up being too confusing.

Closes #663.

### How to test the changes in this Pull Request:

1. Publish a prompt to the "Everyone" segment and set its placement to a Custom Placement.
2. Add a Custom Placement block to a page or post and verify in an Incognito session that it renders the prompt as expected.
3. In the editor for the prompt, click Preview. In the preview window, observe that it appears in the preview post like an inline prompt (as intended—see note above).
4. Within the preview window, navigate to the page or post where you placed the Custom Placement block. Observe that the prompt does NOT appear where you placed it via block.
5. Check out this branch, repeat step 4, and confirm that it now appears in the page or post where you placed the block.
6. Repeat steps 1-4 with a manual-only prompt placed into a post via the Single Prompt block.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1201001433518097