### PR TITLE
fix(editor): update meta values when custom fields panel is active

### DIFF
--- a/src/editor/index.js
+++ b/src/editor/index.js
@@ -32,6 +32,19 @@ const mapDispatchToProps = dispatch => {
 	const { createNotice, removeNotice } = dispatch( 'core/notices' );
 	return {
 		onMetaFieldChange: ( key, value ) => {
+			const customFieldLabel = document.querySelector( `input[value="${ key }"` );
+			let customFieldValue;
+
+			if ( customFieldLabel ) {
+				customFieldValue = customFieldLabel.parentElement.nextElementSibling.querySelector(
+					'textarea'
+				);
+			}
+
+			if ( customFieldValue ) {
+				customFieldValue.value = value;
+			}
+
 			dispatch( 'core/editor' ).editPost( { meta: { [ key ]: value } } );
 		},
 		createNotice,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

I'm actually unsure of whether this should even be fixed, because it seems to be somewhat intended behavior in the block editor.

To summarize: if you open the block editor's built-in Custom Fields panel by clicking the three-vertical-dots icon in the upper-right corner of the editor, then clicking Preferences, then enabling the Custom Fields panel as shown:

<img width="517" alt="SXODCI" src="https://user-images.githubusercontent.com/2230142/153053318-e3a99150-26c6-444b-a7db-9778ba81ce05.png">

This enables a Custom Fields panel inside the block editor which shows all of the meta fields and their values for the post:

<img width="1538" alt="Screen Shot 2022-02-08 at 11 29 26 AM" src="https://user-images.githubusercontent.com/2230142/153052428-11d1200b-4b8c-4ad0-b0b8-58048ac7bcbd.png">

However, these inputs seem to override any controls that edit the same meta fields via `dispatch` methods. If you change sidebar controls that update meta values, but don't update the same value in the Custom Fields panel, the unchanged Custom Fields value will take precedence when saving the post. Conversely, if you update the Custom Fields value and save the post, this value will get saved.

This proof-of-concept is kind of a hacky way we could override this default behavior, by watching for meta changes in the `dispatch` call and automatically updating the value of the matching Custom Fields input. However, there are problems with this approach:

* It's a hacky solution, and relies on specific markup structure in the editor that may be subject to change in future WP versions
* Solving it in Campaigns would mean that the behavior differs from that of other plugins/themes. The Custom Fields panel shows **all** meta fields registered for the post, not just those registered by this plugin. So we'd be updating our custom fields for Campaigns, but any other plugin's UI that updates its own meta fields won't do the same. A better solution would be to somehow hook into the `dispatch` function whenever any meta value is updated in the block editor (regardless of the plugin's source), but I'm not sure how to do this without deeper research, and it still seems to fix intended WP editor behavior, in my opinion.
* I somehow doubt that almost anyone would want to use this Custom Fields panel over our UI. And if they do, it seems like an opportunity to educate them on what seems like intended WP editor behavior.

@Automattic/newspack-product thoughts? I would prefer to mark this issue as "Do not fix" and treat it as intended (if unintuitive) behavior instead of as a bug.

Closes #25.

### How to test the changes in this Pull Request:

Verify that #25 can't be reproduced. When updating prompt options in the sidebar UI, confirm that values for those fields in the Custom Fields panel are updated automatically, and that they persist after saving and refreshing the editor.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
