### PR TITLE
perf(segmentation): limit query results when fetching segmentation reach data

### DIFF
--- a/api/classes/class-lightweight-api.php
+++ b/api/classes/class-lightweight-api.php
@@ -332,7 +332,9 @@ class Lightweight_API {
 	 */
 	public function get_all_clients_data() {
 		global $wpdb;
-		$events_table_name   = Segmentation::get_events_table_name();
+		$events_table_name = Segmentation::get_events_table_name();
+
+		// Results are limited to the 1000 most recent rows for performance reasons.
 		$all_client_ids_rows = $wpdb->get_results( "SELECT DISTINCT client_id,id FROM $events_table_name ORDER BY id DESC LIMIT 1000" ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		$api                 = new Lightweight_API();
 		return array_reduce(

--- a/api/classes/class-lightweight-api.php
+++ b/api/classes/class-lightweight-api.php
@@ -333,7 +333,7 @@ class Lightweight_API {
 	public function get_all_clients_data() {
 		global $wpdb;
 		$events_table_name   = Segmentation::get_events_table_name();
-		$all_client_ids_rows = $wpdb->get_results( "SELECT DISTINCT client_id FROM $events_table_name" ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$all_client_ids_rows = $wpdb->get_results( "SELECT DISTINCT client_id,id FROM $events_table_name ORDER BY id DESC LIMIT 1000" ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		$api                 = new Lightweight_API();
 		return array_reduce(
 			$all_client_ids_rows,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

The `get_all_clients_data` method used by the API request to estimate a segment's reach based on reader activity currently gets literally all clients' reader activity data. On very high-traffic sites, this can be millions of rows' worth of data, which can cause the API request to timeout and/or fail.

This PR limits the number of rows returned to the 1000 most recent rows. It sorts on the indexed `id` column instead of the unindexed `created_at` column for hopefully better performance. 1000 rows should be enough reader data to calculate a reasonably accurate estimate of a segment's reach and should avoid the timeouts from fetching too much data at once.

Closes #627.

### How to test the changes in this Pull Request:

1. On a test site with a lot of reader activity data (ping me for credentials to such a test site), visit **Newspack > Campaigns > Segments** and create or edit a segment.
2. On `master`, in the dev tools Network tab, observe that the request for `/newspack/v1/wizard/newspack-popups-wizard/segmentation-reach` responds with a 500 error, and the segmentation reach message isn't shown.
3. Check out this branch and confirm that the request succeeds, and the message is shown:

<img width="1077" alt="Screen Shot 2022-02-08 at 3 13 50 PM" src="https://user-images.githubusercontent.com/2230142/153084551-fd7ea51b-21b1-4280-badb-4fecbb56ba55.png">

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
