### PR TITLE
chore: prevent distribution of unneeded files

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -40,6 +40,7 @@ yarn.lock
 *.zip
 
 node_modules
+.cache
 .git
 .github
 .circleci


### PR DESCRIPTION
.cache directory, created by `npm`, does not have to be distributed.