### PR TITLE
feat(api): remove forcing HTTP; tweak referer verification

### DIFF
--- a/api/classes/class-lightweight-api.php
+++ b/api/classes/class-lightweight-api.php
@@ -100,12 +100,12 @@ class Lightweight_API {
 		$valid_referers = [
 			$http_referer,
 		];
-		$http_host = ! empty( $_SERVER['HTTP_HOST'] ) ? $_SERVER['HTTP_HOST'] : null; // phpcs:ignore
+		$server_name = ! empty( $_SERVER['SERVER_NAME'] ) ? $_SERVER['SERVER_NAME'] : null; // phpcs:ignore
 		// Enable requests from AMP Cache.
 		if ( preg_match( '/\.cdn\.ampproject\.org/', $http_referer ) ) {
 			return true;
 		}
-		return ! empty( $http_referer ) && ! empty( $http_host ) && in_array( strtolower( $http_host ), $valid_referers, true );
+		return ! empty( $http_referer ) && ! empty( $server_name ) && in_array( strtolower( $server_name ), $valid_referers, true );
 	}
 
 	/**

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -1251,7 +1251,7 @@ final class Newspack_Popups_Model {
 	 * @return string Endpoint URL.
 	 */
 	public static function get_reader_endpoint() {
-		return str_replace( 'http:', 'https:', plugins_url( '../api/campaigns/index.php', __FILE__ ) );
+		return plugins_url( '../api/campaigns/index.php', __FILE__ );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Accommodations for E2E tetsing:
- HTTP_HOST will contain the port (e.g. if connecting from localhost:8000, as in E2E tests),
and SERVER_NAME will not.
- forcing HTTPS is removed – amp-access will work with HTTP (see https://github.com/Automattic/newspack-popups/pull/579)

### How to test the changes in this Pull Request:

View a front-end of a page with some prompts – ensure the prompts are visible, as before (to test the API change).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->