### PR TITLE
fix: ensure correct option is selected for trigger dropdown

### DIFF
--- a/src/editor/Sidebar.js
+++ b/src/editor/Sidebar.js
@@ -128,7 +128,7 @@ const Sidebar = ( {
 					<SelectControl
 						label={ __( 'Trigger', 'newspack-popups' ) }
 						help={ __( 'The event to trigger the prompt.', 'newspack-popups' ) }
-						selected={ trigger_type }
+						value={ trigger_type }
 						options={ [
 							{ label: __( 'Timer', 'newspack-popups' ), value: 'time' },
 							{ label: __( 'Scroll Progress', 'newspack-popups' ), value: 'scroll' },


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes an incorrectly-named prop in the `SelectControl` for prompt triggers.

Closes #748.

### How to test the changes in this Pull Request:

1. Confirm that #748 is not replicable.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
