### PR TITLE
fix: allow overlay_opacity to be set to 0 for prompts

### DIFF
--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -366,8 +366,21 @@ final class Newspack_Popups_Model {
 			'excluded_tags'                  => get_post_meta( $id, 'excluded_tags', true ),
 		];
 
+		// Remove empty options, except for those whose value might actually be 0.
+		$filtered_options = array_filter(
+			$post_options,
+			function( $value, $key ) {
+				if ( 'overlay_opacity' === $key ) {
+					return true;
+				}
+
+				return ! empty( $value );
+			},
+			ARRAY_FILTER_USE_BOTH
+		);
+
 		return wp_parse_args(
-			array_filter( $post_options ),
+			$filtered_options,
 			[
 				'background_color'               => '#FFFFFF',
 				'display_title'                  => false,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

If overlay opacity is set to 0, it will currently default to 30%. This change allows the option to be set to 0.

Closes #632.

### How to test the changes in this Pull Request:

1. Publish an overlay prompt and set the overlay opacity option to `0`.
2. Preview or view in an incognito session and confirm that the overlay is shown with a transparent background.
3. Test other values to ensure that the setting is honored at any number.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
