### PR TITLE
fix: prevent default category on term deletion

### DIFF
--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -984,7 +984,11 @@ final class Newspack_Popups {
 			return false;
 		}
 
-		$default_category_id           = (int) get_option( 'default_category', false );
+		$default_category_id = (int) get_option( 'default_category', false );
+		if ( false === $default_category_id ) {
+			return false;
+		}
+
 		$prompts_with_deleted_category = get_posts(
 			[
 				'category__in'     => $deleted_term,

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -985,7 +985,7 @@ final class Newspack_Popups {
 	public static function prevent_default_category_on_term_delete( $deleted_term, $taxonomy ) {
 		// We only care about categories.
 		if ( 'category' !== $taxonomy ) {
-			return false;
+			return;
 		}
 
 		$default_category_id = (int) get_option( 'default_category', 0 );

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -980,10 +980,14 @@ final class Newspack_Popups {
 		$default_category_id      = (int) get_option( 'default_category', false );
 		$default_category_prompts = get_posts(
 			[
-				'cat'            => $default_category_id,
 				'post_status'    => 'any',
 				'post_type'      => self::NEWSPACK_POPUPS_CPT,
 				'posts_per_page' => -1,
+				'tax_query'      => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
+					'taxonomy'         => 'category',
+					'terms'            => $default_category_id,
+					'include_children' => false,
+				],
 			]
 		);
 

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -990,7 +990,7 @@ final class Newspack_Popups {
 
 		$default_category_id = (int) get_option( 'default_category', 0 );
 		if ( empty( $default_category_id ) ) {
-			return false;
+			return;
 		}
 
 		$prompts_with_deleted_category = get_posts(
@@ -1005,7 +1005,7 @@ final class Newspack_Popups {
 		);
 
 		if ( empty( $prompts_with_deleted_category ) ) {
-			return false;
+			return;
 		}
 
 		// When the default category is assigned to a prompt and it wasn't previously assigned, remove it.
@@ -1025,8 +1025,6 @@ final class Newspack_Popups {
 			10,
 			4
 		);
-
-		return true;
 	}
 
 	/**

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -77,7 +77,7 @@ final class Newspack_Popups {
 			add_filter( 'display_post_states', [ __CLASS__, 'display_post_states' ], 10, 2 );
 			add_action( 'save_post_' . self::NEWSPACK_POPUPS_CPT, [ __CLASS__, 'popup_default_fields' ], 10, 3 );
 			add_action( 'transition_post_status', [ __CLASS__, 'prevent_default_category_on_publish' ], 10, 3 );
-			add_filter( 'pre_delete_term', [ __CLASS__, 'prevent_default_category_on_term_delete' ], 10, 2 );
+			add_action( 'pre_delete_term', [ __CLASS__, 'prevent_default_category_on_term_delete' ], 10, 2 );
 			add_filter( 'show_admin_bar', [ __CLASS__, 'show_admin_bar' ], 10, 2 ); // phpcs:ignore WordPressVIPMinimum.UserExperience.AdminBarRemoval.RemovalDetected
 
 			include_once dirname( __FILE__ ) . '/class-newspack-popups-model.php';
@@ -947,8 +947,12 @@ final class Newspack_Popups {
 	 * @param int $post_id ID of the post.
 	 */
 	private static function remove_default_category( $post_id ) {
-		$default_category_id = (int) get_option( 'default_category', false );
-		$post_categories     = wp_get_post_categories( $post_id );
+		$default_category_id = (int) get_option( 'default_category', 0 );
+		if ( empty( $default_category_id ) ) {
+			return;
+		}
+
+		$post_categories = wp_get_post_categories( $post_id );
 		if ( 1 === count( $post_categories ) && reset( $post_categories ) === $default_category_id ) {
 			wp_remove_object_terms( $post_id, $default_category_id, 'category' );
 		}
@@ -984,8 +988,8 @@ final class Newspack_Popups {
 			return false;
 		}
 
-		$default_category_id = (int) get_option( 'default_category', false );
-		if ( false === $default_category_id ) {
+		$default_category_id = (int) get_option( 'default_category', 0 );
+		if ( empty( $default_category_id ) ) {
 			return false;
 		}
 

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -983,7 +983,7 @@ final class Newspack_Popups {
 				'cat'            => $default_category_id,
 				'post_status'    => 'any',
 				'post_type'      => self::NEWSPACK_POPUPS_CPT,
-				'posts_per_page' => 100, // Assumes a site won't have more than 100 prompts.
+				'posts_per_page' => -1,
 			]
 		);
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

When a category is deleted, prevents any prompts that had only that category from being assigned the default category.

Also slightly changes behavior in an [existing callback](https://github.com/Automattic/newspack-popups/blob/master/includes/class-newspack-popups.php#L951-L959) that happens on prompt publication to remove the default category only if it's the only category assigned to that prompt. This means it's possible to intentionally assign the default category to a prompt if it's assigned along with at least one other category, which could be a valid use case scenario (although maybe unlikely).

An alternative solution might be to always remove the default category from prompts, which would basically prevent it from ever being assigned to prompts, but that seemed heavy-handed to me. Thoughts?

Closes #530.

### How to test the changes in this Pull Request:

1. Create a new category and assign it to a new draft prompt. Make sure the prompt has no other categories assigned.
2. On `master`, delete the new category.
3. Observe that the prompt has the default category assigned automatically (usually "Uncategorized").
4. Check out this branch, repeat steps 1 and 2. Confirm that the prompt has no categories assigned.
5. Publish the prompt and refresh the editor. Confirm that the prompt still has no categories assigned.
6. Create another new category and assign it to the prompt along with the default category.
7. Delete the new category and confirm that the prompt still has the default category assigned.
8. Revert the prompt to draft status.
9. Ensure that the prompt has the default category and at least one other category assigned.
10. Publish the prompt, refresh the editor, and confirm that the prompt still has all assigned categories, including the default category.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
