### PR TITLE
fix: count inner blocks' content toward post length

### DIFF
--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -339,18 +339,18 @@ final class Newspack_Popups_Inserter {
 
 			// Inject prompts before the group.
 			foreach ( $inline_popups as &$inline_popup ) {
-				if (
-					! $inline_popup['is_inserted'] &&
-					'scroll' === $inline_popup['options']['trigger_type'] &&
-					$pos > $inline_popup['precise_position']
-				) {
-					$output                     .= '<!-- wp:shortcode -->[newspack-popup id="' . $inline_popup['id'] . '"]<!-- /wp:shortcode -->';
-					$inline_popup['is_inserted'] = true;
-				} elseif (
-					! $inline_popup['is_inserted'] &&
-					'blocks_count' === $inline_popup['options']['trigger_type'] &&
-					$block_index >= $inline_popup['precise_position']
-				) {
+				if ( $inline_popup['is_inserted'] ) {
+					// Skip if already inserted.
+					continue;
+				}
+
+				$position          = $inline_popup['precise_position'];
+				$trigger_type      = $inline_popup['options']['trigger_type'];
+				$insert_at_zero    = 0 === $position; // If the position is 0, the prompt should always appear first.
+				$insert_for_scroll = 'scroll' === $trigger_type && $pos > $position;
+				$insert_for_blocks = 'blocks_count' === $trigger_type && $block_index >= $position;
+
+				if ( $insert_at_zero || $insert_for_scroll || $insert_for_blocks ) {
 					$output                     .= '<!-- wp:shortcode -->[newspack-popup id="' . $inline_popup['id'] . '"]<!-- /wp:shortcode -->';
 					$inline_popup['is_inserted'] = true;
 				}

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -216,7 +216,12 @@ final class Newspack_Popups_Inserter {
 		// For certain types of blocks, their innerHTML is not a good representation of the length of their content.
 		// For example, slideshows may have an arbitrary amount of slide content, but only show one slide at a time.
 		// For these blocks, let's ignore their length for purposes of inserting prompts.
-		$length_ignored_blocks = [ 'jetpack/slideshow', 'newspack-blocks/carousel', 'newspack-popups/single-prompt' ];
+		$length_ignored_blocks = [
+			'jetpack/slideshow',
+			'newspack-blocks/carousel',
+			'newspack-popups/single-prompt',
+			'core/group',
+		];
 
 		$parsed_blocks = self::convert_classic_blocks( parse_blocks( $content ) );
 

--- a/tests/test-content-insertion.php
+++ b/tests/test-content-insertion.php
@@ -388,4 +388,62 @@ Paragraph 2
 			'The popups are inserted into the content at expected positions.'
 		);
 	}
+
+	/**
+	 * Test prompt insertion at 0% with a single Group block.
+	 * Group blocks are treated as single blocks to provide editors with a way
+	 * to prevent prompt insertion between specific bits of content.
+	 */
+	public function test_prompt_insertion_zero_group() {
+		$post_content = '
+<!-- wp:group -->
+<div class="wp-block-group"><!-- wp:paragraph -->
+<p>Paragraph 1</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Paragraph 2</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Paragraph 3</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:group -->
+<div class="wp-block-group"><!-- wp:heading -->
+<h2 id="inner-group">Inner group</h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>Inner Paragraph 1</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Inner Paragraph 2</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:group -->
+
+<!-- wp:paragraph -->
+<p>Paragraph 4</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Paragraph 5</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:group -->';
+
+		self::assertEqualBlockNames(
+			[
+				'core/shortcode', // Popup 1 - inserted before the group block.
+				'core/group',
+				'core/shortcode', // Popup 2 - inserted after the group block.
+				'core/shortcode', // Popup 3.
+			],
+			Newspack_Popups_Inserter::insert_popups_in_post_content(
+				$post_content,
+				self::$popups
+			),
+			'The popups are inserted into the content at expected positions.'
+		);
+	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes an edge case that happens if an inline prompt with 0% scroll position is placed in a post consisting of only a single Group block. Also improves the insertion behavior surrounding blocks that contain inner blocks (not just Group blocks) so that the inner blocks' content is counted toward the block's total length. In practical terms this means that "container" blocks like Group and Column blocks will now have a more accurate content length when it comes to inserting inline prompts around them. These "container" blocks are still treated as single blocks, so prompts won't be inserted in between their inner blocks, which gives editors a way to ensure that prompts won't be inserted between certain content.

On top of this, also adds a failsafe condition where if the position for an inline prompt is set to `0`, it will be inserted first regardless of other conditions.

Closes #659.

### How to test the changes in this Pull Request:

1. Create an inline prompt with "Insertion position" set to **Percentage** and "Approximage position" set to **0**.
2. Create a post whose content is only a single Group block with any number of blocks inside. Ideally, include some nested Group blocks with their own content. You can use the following test content if needed:

<details>
<summary>Expand for test content</summary>

```html
<!-- wp:group -->
<div class="wp-block-group"><!-- wp:paragraph -->
<p>Paragraph 1</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph -->
<p>Paragraph 2</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph -->
<p>Paragraph 3</p>
<!-- /wp:paragraph -->

<!-- wp:group -->
<div class="wp-block-group"><!-- wp:heading -->
<h2 id="inner-group">Inner group</h2>
<!-- /wp:heading -->

<!-- wp:paragraph -->
<p>Inner Paragraph 1</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph -->
<p>Inner Paragraph 2</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->

<!-- wp:paragraph -->
<p>Paragraph 4</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph -->
<p>Paragraph 5</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->
```
</details>

3. On `master`, observe that the prompt appears after the Group block.
4. On this branch, confirm that it appears before the Group block.
5. Add some other content around the outermost Group block and smoke test inline prompt insertion with various values. Note that prompt insertion behavior will be a bit different now because we're counting inner blocks' content toward the total post length—if anything the behavior should be more visually accurate.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
