### PR TITLE
[HOLD] feat: default segments

### DIFF
--- a/includes/class-newspack-popups-segmentation.php
+++ b/includes/class-newspack-popups-segmentation.php
@@ -509,9 +509,9 @@ final class Newspack_Popups_Segmentation {
 	 * Create a segment.
 	 *
 	 * @param object  $segment A segment.
-	 * @param boolean $get_id If true, return only the created segment ID. Otherwise, return all segments.
+	 * @param boolean $return_id If true, return the created segment ID. Otherwise, return all segments.
 	 */
-	public static function create_segment( $segment, $get_id = false ) {
+	public static function create_segment( $segment, $return_id = false ) {
 		$segments              = self::get_segments();
 		$segment['id']         = uniqid();
 		$segment['created_at'] = gmdate( 'Y-m-d' );
@@ -520,7 +520,7 @@ final class Newspack_Popups_Segmentation {
 
 		update_option( self::SEGMENTS_OPTION_NAME, $segments );
 
-		if ( $get_id ) {
+		if ( $return_id ) {
 			return $segment['id'];
 		}
 

--- a/includes/class-newspack-popups-segmentation.php
+++ b/includes/class-newspack-popups-segmentation.php
@@ -426,25 +426,25 @@ final class Newspack_Popups_Segmentation {
 		$default_segments = get_option( self::DEFAULT_SEGMENTS_OPTION_NAME, [] );
 		$default_options  = [
 			'donors'           => [
-				'name'          => __( '[Newspack] Donors', 'newspack-popups' ),
+				'name'          => __( ' Donors', 'newspack-popups' ),
 				'configuration' => [
 					'is_donor' => true,
 				],
 			],
 			'frequent_readers' => [
-				'name'          => __( '[Newspack] Frequent Readers', 'newspack-popups' ),
+				'name'          => __( ' Frequent Readers', 'newspack-popups' ),
 				'configuration' => [
 					'min_posts' => 5,
 				],
 			],
 			'subscribers'      => [
-				'name'          => __( '[Newspack] Newsletter Subscribers', 'newspack-popups' ),
+				'name'          => __( ' Newsletter Subscribers', 'newspack-popups' ),
 				'configuration' => [
 					'is_subscribed' => true,
 				],
 			],
 			'everyone_else'    => [
-				'name'          => __( '[Newspack] Everyone Else', 'newspack-popups' ),
+				'name'          => __( ' Other Readers', 'newspack-popups' ),
 				'configuration' => [
 					'is_not_donor'      => true,
 					'is_not_subscribed' => true,

--- a/includes/class-newspack-popups-segmentation.php
+++ b/includes/class-newspack-popups-segmentation.php
@@ -353,7 +353,9 @@ final class Newspack_Popups_Segmentation {
 	 * Create default segments for sites that don't have any existing segments.
 	 */
 	public static function new_site_setup() {
-		if ( empty( self::get_segments() ) ) {
+		$segments         = self::get_segments();
+		$default_segments = self::get_default_segments();
+		if ( empty( $segments ) && empty( $default_segments ) ) {
 			self::create_default_segments();
 		}
 	}

--- a/includes/class-newspack-popups-segmentation.php
+++ b/includes/class-newspack-popups-segmentation.php
@@ -419,19 +419,19 @@ final class Newspack_Popups_Segmentation {
 		$default_segments = get_option( self::DEFAULT_SEGMENTS_OPTION_NAME, [] );
 		$default_options  = [
 			'donors'           => [
-				'name'          => __( ' Donors', 'newspack-popups' ),
+				'name'          => __( 'Donors', 'newspack-popups' ),
 				'configuration' => [
 					'is_donor' => true,
 				],
 			],
 			'frequent_readers' => [
-				'name'          => __( ' Frequent Readers', 'newspack-popups' ),
+				'name'          => __( 'Frequent Readers', 'newspack-popups' ),
 				'configuration' => [
 					'min_posts' => 5,
 				],
 			],
 			'subscribers'      => [
-				'name'          => __( ' Newsletter Subscribers', 'newspack-popups' ),
+				'name'          => __( 'Newsletter Subscribers', 'newspack-popups' ),
 				'configuration' => [
 					'is_subscribed' => true,
 				],

--- a/includes/class-newspack-popups-segmentation.php
+++ b/includes/class-newspack-popups-segmentation.php
@@ -36,23 +36,6 @@ final class Newspack_Popups_Segmentation {
 	const SEGMENTS_OPTION_NAME = 'newspack_popups_segments';
 
 	/**
-	 * Default config for a segment.
-	 */
-	const DEFAULT_SEGMENT_CONFIG = [
-		'min_posts'           => 0,
-		'max_posts'           => 0,
-		'min_session_posts'   => 0,
-		'max_session_posts'   => 0,
-		'is_subscribed'       => false,
-		'is_donor'            => false,
-		'is_not_subscribed'   => false,
-		'is_not_donor'        => false,
-		'favorite_categories' => [],
-		'referrers'           => '',
-		'referrers_not'       => '',
-	];
-
-	/**
 	 * Name of the option to store default segment IDs.
 	 */
 	const DEFAULT_SEGMENTS_OPTION_NAME = 'newspack_popups_default_segments';
@@ -444,7 +427,7 @@ final class Newspack_Popups_Segmentation {
 				],
 			],
 			'everyone_else'    => [
-				'name'          => __( ' Other Readers', 'newspack-popups' ),
+				'name'          => __( 'Other Readers', 'newspack-popups' ),
 				'configuration' => [
 					'is_not_donor'      => true,
 					'is_not_subscribed' => true,
@@ -453,8 +436,10 @@ final class Newspack_Popups_Segmentation {
 		];
 
 		foreach ( $default_options as $key => $segment ) {
+			require_once dirname( __FILE__ ) . '/../api/campaigns/class-campaign-data-utils.php';
+
 			// Ensure all config objects contain all option keys.
-			$segment['configuration'] = wp_parse_args( $segment['configuration'], self::DEFAULT_SEGMENT_CONFIG );
+			$segment['configuration'] = (array) Campaign_Data_Utils::canonize_segment( $segment['configuration'] );
 
 			// If the segment was already created and still exists, update it. Otherwise, create it.
 			if ( isset( $default_segments[ $key ] ) && self::get_segment( $default_segments[ $key ] ) ) {

--- a/includes/class-newspack-popups-segmentation.php
+++ b/includes/class-newspack-popups-segmentation.php
@@ -58,6 +58,7 @@ final class Newspack_Popups_Segmentation {
 	 */
 	public function __construct() {
 		add_action( 'init', [ __CLASS__, 'create_database_table' ] );
+		add_action( 'init', [ __CLASS__, 'new_site_setup' ] );
 		add_action( 'wp_footer', [ __CLASS__, 'insert_amp_analytics' ], 20 );
 
 		add_filter( 'newspack_custom_dimensions', [ __CLASS__, 'register_custom_dimensions' ] );
@@ -345,6 +346,15 @@ final class Newspack_Popups_Segmentation {
 			require_once ABSPATH . 'wp-admin/includes/upgrade.php';
 			dbDelta( $sql ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.dbDelta_dbdelta
 			$wpdb->query( $wpdb->prepare( "INSERT INTO `{$transients_table_name}` (option_name, option_value) SELECT option_name, option_value FROM `{$wpdb->options}` WHERE option_name LIKE %s", "_transient%-popup%" ) ); // phpcs:ignore
+		}
+	}
+
+	/**
+	 * Create default segments for sites that don't have any existing segments.
+	 */
+	public static function new_site_setup() {
+		if ( empty( self::get_segments() ) ) {
+			self::create_default_segments();
 		}
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Starts the "reasonable defaults" part of the roadmap. Allows site admins to generate a set of default segments with a button click. If they've already been created and edited, clicking the button will restore the default segments to the default configuration.

The reason for requiring some kind of user action (in this case a button click) is to accommodate sites that may have been up and running with Campaigns for a while now—we don't want to automatically generate new segments which may conflict with existing segments that are running live prompts.

Closes #673.

### How to test the changes in this Pull Request:

Before testing, make sure your Newspack Plugin is running https://github.com/Automattic/newspack-plugin/pull/1524.

1. On a fresh or existing site, visit **Newspack > Campaigns > Segments**. Confirm there's a new button at the bottom of the segments list:

<img width="1186" alt="Screen Shot 2022-02-22 at 5 04 31 PM" src="https://user-images.githubusercontent.com/2230142/155241591-4a490802-786c-4f4d-933c-f9dd5dddf819.png">

2. Click the button. Confirm you see a modal with a bit of explanation of what you're doing (@aschweigert: could use your help with reviewing/updating this copy):

<img width="747" alt="Screen Shot 2022-02-22 at 5 15 15 PM" src="https://user-images.githubusercontent.com/2230142/155241646-296bd62e-022e-4ca1-8618-45f2e60b5a30.png">

3. Click "OK". Confirm that a set of default segments (with prefix "[Newspack]") is generated. If you already had existing segments on the site, confirm that the default segments are generated with lower priority than the existing segments.
4. Edit some of the default segment names and settings, and reshuffle the priority. Delete at least one default segment.
5. Click "Reset default segments" and click "OK". Confirm that:
  - All existing segments retain their sorted priority
  - The default segment(s) you edited are now reverted to their original names and settings
  - The default segment(s) you deleted are restored

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
