### PR TITLE
fix: only count donation products for donor segmentation

### DIFF
--- a/includes/class-newspack-popups-segmentation.php
+++ b/includes/class-newspack-popups-segmentation.php
@@ -248,7 +248,7 @@ final class Newspack_Popups_Segmentation {
 				if ( count( $user_orders ) ) {
 					$orders = [];
 					foreach ( $user_orders as $order ) {
-						$order_data = $order->get_data();
+						$order_data  = $order->get_data();
 						$order_items = array_map(
 							function( $item ) {
 								return $item->get_product_id();

--- a/includes/class-newspack-popups-segmentation.php
+++ b/includes/class-newspack-popups-segmentation.php
@@ -236,20 +236,39 @@ final class Newspack_Popups_Segmentation {
 			$initial_client_report_url_params['mc_cid'] = sanitize_text_field( $_GET['mc_cid'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			$initial_client_report_url_params['mc_eid'] = sanitize_text_field( $_GET['mc_eid'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		}
-		if ( is_user_logged_in() && ! Newspack_Popups::is_preview_request() ) {
-			if ( function_exists( 'wc_get_orders' ) ) {
-				$user_orders = wc_get_orders( [ 'customer_id' => get_current_user_id() ] );
+
+		// Handle Newspack donations via WooCommerce.
+		if ( class_exists( '\Newspack\Donations' ) && is_user_logged_in() && ! Newspack_Popups::is_preview_request() ) {
+			$newspack_donation_product_id = (int) get_option( \Newspack\Donations::DONATION_PRODUCT_ID_OPTION, 0 );
+			if ( function_exists( 'wc_get_orders' ) && 0 !== $newspack_donation_product_id ) {
+				$user_orders               = wc_get_orders( [ 'customer_id' => get_current_user_id() ] );
+				$newspack_donation_product = wc_get_product( $newspack_donation_product_id );
+				$newspack_child_products   = $newspack_donation_product ? $newspack_donation_product->get_children() : [];
+
 				if ( count( $user_orders ) ) {
 					$orders = [];
 					foreach ( $user_orders as $order ) {
 						$order_data = $order->get_data();
-						$orders[]   = [
-							'order_id' => $order_data['id'],
-							'date'     => date_format( date_create( $order_data['date_created'] ), 'Y-m-d' ),
-							'amount'   => $order_data['total'],
-						];
+						$order_items = array_map(
+							function( $item ) {
+								return $item->get_product_id();
+							},
+							array_values( $order->get_items() )
+						);
+
+						// Only count orders that include donation products as donations.
+						if ( 0 < count( array_intersect( $order_items, $newspack_child_products ) ) ) {
+							$orders[] = [
+								'order_id' => $order_data['id'],
+								'date'     => date_format( date_create( $order_data['date_created'] ), 'Y-m-d' ),
+								'amount'   => $order_data['total'],
+							];
+						}
 					}
-					$initial_client_report_url_params['orders'] = wp_json_encode( $orders );
+
+					if ( count( $orders ) ) {
+						$initial_client_report_url_params['orders'] = wp_json_encode( $orders );
+					}
 				}
 			}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Currently, when segmenting readers as donors, we check if the reader is logged in and if they have any WooCommerce orders purchased under their user. However, we don't check whether those orders have anything to do with Newspack donations, so if a site is using WooCommerce to offer any other types of products, all customers are marked as donors whether or not they've actually donated.

This PR does an extra step of ensuring that the reader has purchased Newspack donation products before considering them donors. This won't fix things for readers who have already been marked donors, but it will fix things for new readers going forward.

### How to test the changes in this Pull Request:

1. On your test site, make sure your Reader Revenue platform is set to Newspack and that you have the required WooCommerce plugins installed and active.
2. Go to Products and create some additional products, separate from the Newspack Donate products.
3. Publish a prompt to a segment targeted to Donors only.
4. In a new incognito session, purchase one of the non-Newspack products (you may need to set up a shop page and use that in order to complete a purchase).
5. In the same session, browse through the site and observe that you see the prompt for Donors.
6. Check out this branch, and repeat steps 4-5 in a new incognito session.
7. This time, confirm that you don't see the prompt for Donors even after purchasing the non-Newspack product.
8. Complete a donation via a Newspack Donate block.
9. Browse through the site again and confirm that you see the prompt for Donors after purchasing the Newspack Donation product.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1201693377396073