### PR TITLE
feat: show prompts to logged-in admin and editor users

### DIFF
--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -642,9 +642,6 @@ final class Newspack_Popups_Inserter {
 	 * make reliable retrieval problematic.
 	 */
 	public static function insert_popups_amp_access() {
-		if ( ! Newspack_Popups_Segmentation::is_tracking() ) {
-			return;
-		}
 		$popups = array_filter(
 			Newspack_Popups_Model::retrieve_popups(
 				// Include drafts if it's a preview request.
@@ -924,12 +921,8 @@ final class Newspack_Popups_Inserter {
 
 		// Unless it's a preview request, perform some additional checks.
 		if ( ! Newspack_Popups::is_preview_request() ) {
-			// Hide prompts for admin users.
-			if ( Newspack_Popups::is_user_admin() ) {
-				return false;
-			}
-			// Hide overlay prompts in non-interactive mode, for non-admin users.
-			if ( ! Newspack_Popups::is_user_admin() && Newspack_Popups_Settings::is_non_interactive() && ! Newspack_Popups_Model::is_inline( $popup ) ) {
+			// Hide overlay prompts in non-interactive mode.
+			if ( Newspack_Popups_Settings::is_non_interactive() && ! Newspack_Popups_Model::is_inline( $popup ) ) {
 				return false;
 			}
 		}

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -753,7 +753,8 @@ final class Newspack_Popups_Model {
 	protected static function insert_event_tracking( $popup, $body, $element_id ) {
 		if (
 			Newspack_Popups::is_preview_request() ||
-			Newspack_Popups_Settings::is_non_interactive()
+			Newspack_Popups_Settings::is_non_interactive() ||
+			! Newspack_Popups::is_tracking()
 		) {
 			return '';
 		}
@@ -848,7 +849,7 @@ final class Newspack_Popups_Model {
 	 * @param string $element_id The id of the popup element.
 	 */
 	private static function get_analytics_events( $popup, $body, $element_id ) {
-		if ( Newspack_Popups::is_preview_request() ) {
+		if ( Newspack_Popups::is_preview_request() || ! Newspack_Popups::is_tracking() ) {
 			return [];
 		}
 

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -943,7 +943,7 @@ final class Newspack_Popups_Model {
 		if ( Newspack_Popups_Settings::is_non_interactive() ) {
 			return '';
 		}
-		if ( Newspack_Popups::previewed_popup_id() && Newspack_Popups::is_user_admin() ) {
+		if ( Newspack_Popups::previewed_popup_id() ) {
 			return '';
 		}
 		// The amp-access endpoint is queried only once (on page load), but after changing block settings,

--- a/includes/class-newspack-popups-segmentation.php
+++ b/includes/class-newspack-popups-segmentation.php
@@ -180,12 +180,10 @@ final class Newspack_Popups_Segmentation {
 
 	/**
 	 * Should tracking code be inserted?
+	 * We shouldn't be tracking analytics in the dashboard, in previews, or on the front-end by admin/editor users.
 	 */
 	public static function is_tracking() {
-		if ( Newspack_Popups::is_preview_request() ) {
-			return true;
-		}
-		if ( is_admin() || self::is_admin_user() || Newspack_Popups_Settings::is_non_interactive() ) {
+		if ( is_admin() || Newspack_Popups::is_user_admin() || Newspack_Popups_Settings::is_non_interactive() ) {
 			return false;
 		}
 		return true;

--- a/includes/class-newspack-popups-segmentation.php
+++ b/includes/class-newspack-popups-segmentation.php
@@ -179,31 +179,19 @@ final class Newspack_Popups_Segmentation {
 	}
 
 	/**
-	 * Should tracking code be inserted?
-	 * We shouldn't be tracking analytics in the dashboard, in previews, or on the front-end by admin/editor users.
-	 */
-	public static function is_tracking() {
-		if ( is_admin() || Newspack_Popups::is_user_admin() || Newspack_Popups_Settings::is_non_interactive() ) {
-			return false;
-		}
-		return true;
-	}
-
-	/**
 	 * Insert amp-analytics tracking code.
 	 * Has to be included on every page to set the cookie.
 	 *
 	 * This amp-analytics tag will not report any analytics, it's only responsible for settings the cookie
 	 * bearing the client ID, as well as handling the linker paramerer when navigating from a proxy site.
 	 *
+	 * Because this tag doesn't report any analytics but is used to look up the reader's activity, it
+	 * should be included in preview requests and logged-in admin/editor sessions.
+	 *
 	 * There is a known issue with amp-analytics & amp-access interoperation – more on that at
 	 * https://github.com/Automattic/newspack-popups/pull/224#discussion_r496655085.
 	 */
 	public static function insert_amp_analytics() {
-		if ( ! self::is_tracking() ) {
-			return;
-		}
-
 		$linker_id            = 'cid';
 		$amp_analytics_config = [
 			// Linker will append a query param to all internal links.

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -849,7 +849,15 @@ final class Newspack_Popups {
 	 * will not be fired for them.
 	 */
 	public static function is_user_admin() {
-		return is_user_logged_in() && current_user_can( 'edit_posts' );
+		/**
+		 * Filter to allow other plugins to decide which capability should be checked
+		 * to determine whether a user's activity should be tracked via Google Analytics.
+		 *
+		 * @param string $capability Capability to check. Default: edit_others_pages.
+		 * @return string Filtered capability string.
+		 */
+		$capability = apply_filters( 'newspack_popups_admin_user_capsbility', 'edit_others_pages' );
+		return is_user_logged_in() && current_user_can( $capability );
 	}
 
 	/**

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -844,7 +844,7 @@ final class Newspack_Popups {
 	}
 
 	/**
-	 * Is the user an admin/editor/author/contributor user?
+	 * Is the user an admin or editor user?
 	 * If so, prompts will be shown to these users while logged in, but analytics
 	 * will not be fired for them.
 	 */

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -856,7 +856,7 @@ final class Newspack_Popups {
 		 * @param string $capability Capability to check. Default: edit_others_pages.
 		 * @return string Filtered capability string.
 		 */
-		$capability = apply_filters( 'newspack_popups_admin_user_capsbility', 'edit_others_pages' );
+		$capability = apply_filters( 'newspack_popups_admin_user_capability', 'edit_others_pages' );
 		return is_user_logged_in() && current_user_can( $capability );
 	}
 

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -844,10 +844,12 @@ final class Newspack_Popups {
 	}
 
 	/**
-	 * Is the user an admin user?
+	 * Is the user an admin/editor/author/contributor user?
+	 * If so, prompts will be shown to these users while logged in, but analytics
+	 * will not be fired for them.
 	 */
 	public static function is_user_admin() {
-		return is_user_logged_in() && current_user_can( 'edit_others_pages' );
+		return is_user_logged_in() && current_user_can( 'edit_posts' );
 	}
 
 	/**

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -860,6 +860,17 @@ final class Newspack_Popups {
 	}
 
 	/**
+	 * Should tracking code be inserted?
+	 * We shouldn't be tracking analytics in the dashboard or on the front-end by admin/editor users.
+	 */
+	public static function is_tracking() {
+		if ( is_admin() || self::is_user_admin() || Newspack_Popups_Settings::is_non_interactive() ) {
+			return false;
+		}
+		return true;
+	}
+
+	/**
 	 * Create campaign.
 	 *
 	 * @param string $name New campaign name.

--- a/tests/test-insertion.php
+++ b/tests/test-insertion.php
@@ -230,7 +230,7 @@ class InsertionTest extends WP_UnitTestCase_PageWithPopups {
 		self::assertContains(
 			self::$popup_content,
 			$amp_layout_elements->item( 0 )->textContent,
-			'Includes the popup content.'
+			'Includes the popup content for non-logged-in users.'
 		);
 
 		$user_id = $this->factory->user->create( [ 'role' => 'administrator' ] );
@@ -238,10 +238,10 @@ class InsertionTest extends WP_UnitTestCase_PageWithPopups {
 
 		self::renderPost();
 		$amp_layout_elements = self::$dom_xpath->query( '//amp-layout' );
-		self::assertEquals(
-			0,
-			$amp_layout_elements->length,
-			'Does not include popups when the page is loaded by an admin.'
+		self::assertContains(
+			self::$popup_content,
+			$amp_layout_elements->item( 0 )->textContent,
+			'Also includes the popup content for logged-in admin users.'
 		);
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Changes prompt insertion logic so that logged-in admin and editor users see prompts just like regular readers. Like regular readers, admins and editors will only see prompts assigned to segments they match (so if an editor hasn't made any donations, they won't see donor-only prompts, for example).

Also prevents GA tracking code from firing for admins and editors, to hopefully prevent pollution of campaigns analytics data.

Closes #687.

### How to test the changes in this Pull Request:

1. Publish several prompts to several segments.
2. On `master`, as an admin user, browse the site's front-end. Observe that no prompts are displayed.
3. Check out this branch and browse again. Now confirm that prompts are displayed, as long as your reader activity matches their segments (so you may not see prompts shown to donors only, or to new readers).

#### Analytics

1. While browsing the site front-end as a logged-in admin user with this branch checked out, view source. Confirm that no `amp-analytics` tags are rendered with each prompt. This should prevent prompt interactions from being tracked while logged in.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
