### PR TITLE
feat: allow segmentation by user login status

### DIFF
--- a/api/campaigns/class-campaign-data-utils.php
+++ b/api/campaigns/class-campaign-data-utils.php
@@ -28,6 +28,15 @@ class Campaign_Data_Utils {
 	}
 
 	/**
+	 * Is client logged in?
+	 *
+	 * @param object $client_data Client data.
+	 */
+	public static function is_logged_in( $client_data ) {
+		return ! empty( $client_data['user_id'] );
+	}
+
+	/**
 	 * Compare page referrer to a list of referrers.
 	 *
 	 * @param string $page_referrer_url Referrer to compare to.
@@ -71,6 +80,8 @@ class Campaign_Data_Utils {
 				'is_not_subscribed'   => false,
 				'is_donor'            => false,
 				'is_not_donor'        => false,
+				'is_logged_in'        => false,
+				'is_not_logged_in'    => false,
 				'referrers'           => '',
 				'favorite_categories' => [],
 				'priority'            => PHP_INT_MAX,
@@ -107,6 +118,7 @@ class Campaign_Data_Utils {
 		);
 		$is_subscriber            = self::is_subscriber( $client_data, $referer_url );
 		$is_donor                 = self::is_donor( $client_data );
+		$is_logged_in             = self::is_logged_in( $client_data );
 		$campaign_segment         = self::canonize_segment( $campaign_segment );
 
 		// Read counts for categories.
@@ -164,6 +176,16 @@ class Campaign_Data_Utils {
 			$should_display = false;
 		}
 		if ( $campaign_segment->is_not_donor && $is_donor ) {
+			$should_display = false;
+		}
+
+		/**
+		 * By login status.
+		 */
+		if ( $campaign_segment->is_logged_in && ! $is_logged_in ) {
+			$should_display = false;
+		}
+		if ( $campaign_segment->is_not_logged_in && $is_logged_in ) {
 			$should_display = false;
 		}
 

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -642,9 +642,6 @@ final class Newspack_Popups_Inserter {
 	 * make reliable retrieval problematic.
 	 */
 	public static function insert_popups_amp_access() {
-		if ( ! Newspack_Popups_Segmentation::is_tracking() ) {
-			return;
-		}
 		$popups = array_filter(
 			Newspack_Popups_Model::retrieve_popups(
 				// Include drafts if it's a preview request.
@@ -924,12 +921,8 @@ final class Newspack_Popups_Inserter {
 
 		// Unless it's a preview request, perform some additional checks.
 		if ( ! Newspack_Popups::is_preview_request() ) {
-			// Hide prompts for admin users.
-			if ( Newspack_Popups::is_user_admin() ) {
-				return false;
-			}
-			// Hide overlay prompts in non-interactive mode, for non-admin users.
-			if ( ! Newspack_Popups::is_user_admin() && Newspack_Popups_Settings::is_non_interactive() && ! Newspack_Popups_Model::is_inline( $popup ) ) {
+			// Hide overlay prompts in non-interactive mode.
+			if ( Newspack_Popups_Settings::is_non_interactive() && ! Newspack_Popups_Model::is_inline( $popup ) ) {
 				return false;
 			}
 		}

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -753,7 +753,8 @@ final class Newspack_Popups_Model {
 	protected static function insert_event_tracking( $popup, $body, $element_id ) {
 		if (
 			Newspack_Popups::is_preview_request() ||
-			Newspack_Popups_Settings::is_non_interactive()
+			Newspack_Popups_Settings::is_non_interactive() ||
+			! Newspack_Popups::is_tracking()
 		) {
 			return '';
 		}
@@ -848,7 +849,7 @@ final class Newspack_Popups_Model {
 	 * @param string $element_id The id of the popup element.
 	 */
 	private static function get_analytics_events( $popup, $body, $element_id ) {
-		if ( Newspack_Popups::is_preview_request() ) {
+		if ( Newspack_Popups::is_preview_request() || ! Newspack_Popups::is_tracking() ) {
 			return [];
 		}
 

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -943,7 +943,7 @@ final class Newspack_Popups_Model {
 		if ( Newspack_Popups_Settings::is_non_interactive() ) {
 			return '';
 		}
-		if ( Newspack_Popups::previewed_popup_id() && Newspack_Popups::is_user_admin() ) {
+		if ( Newspack_Popups::previewed_popup_id() ) {
 			return '';
 		}
 		// The amp-access endpoint is queried only once (on page load), but after changing block settings,

--- a/includes/class-newspack-popups-segmentation.php
+++ b/includes/class-newspack-popups-segmentation.php
@@ -180,12 +180,10 @@ final class Newspack_Popups_Segmentation {
 
 	/**
 	 * Should tracking code be inserted?
+	 * We shouldn't be tracking analytics in the dashboard, in previews, or on the front-end by admin/editor users.
 	 */
 	public static function is_tracking() {
-		if ( Newspack_Popups::is_preview_request() ) {
-			return true;
-		}
-		if ( is_admin() || self::is_admin_user() || Newspack_Popups_Settings::is_non_interactive() ) {
+		if ( is_admin() || Newspack_Popups::is_user_admin() || Newspack_Popups_Settings::is_non_interactive() ) {
 			return false;
 		}
 		return true;

--- a/includes/class-newspack-popups-segmentation.php
+++ b/includes/class-newspack-popups-segmentation.php
@@ -179,31 +179,19 @@ final class Newspack_Popups_Segmentation {
 	}
 
 	/**
-	 * Should tracking code be inserted?
-	 * We shouldn't be tracking analytics in the dashboard, in previews, or on the front-end by admin/editor users.
-	 */
-	public static function is_tracking() {
-		if ( is_admin() || Newspack_Popups::is_user_admin() || Newspack_Popups_Settings::is_non_interactive() ) {
-			return false;
-		}
-		return true;
-	}
-
-	/**
 	 * Insert amp-analytics tracking code.
 	 * Has to be included on every page to set the cookie.
 	 *
 	 * This amp-analytics tag will not report any analytics, it's only responsible for settings the cookie
 	 * bearing the client ID, as well as handling the linker paramerer when navigating from a proxy site.
 	 *
+	 * Because this tag doesn't report any analytics but is used to look up the reader's activity, it
+	 * should be included in preview requests and logged-in admin/editor sessions.
+	 *
 	 * There is a known issue with amp-analytics & amp-access interoperation – more on that at
 	 * https://github.com/Automattic/newspack-popups/pull/224#discussion_r496655085.
 	 */
 	public static function insert_amp_analytics() {
-		if ( ! self::is_tracking() ) {
-			return;
-		}
-
 		$linker_id            = 'cid';
 		$amp_analytics_config = [
 			// Linker will append a query param to all internal links.

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -860,6 +860,17 @@ final class Newspack_Popups {
 	}
 
 	/**
+	 * Should tracking code be inserted?
+	 * We shouldn't be tracking analytics in the dashboard or on the front-end by admin/editor users.
+	 */
+	public static function is_tracking() {
+		if ( is_admin() || self::is_user_admin() || Newspack_Popups_Settings::is_non_interactive() ) {
+			return false;
+		}
+		return true;
+	}
+
+	/**
 	 * Create campaign.
 	 *
 	 * @param string $name New campaign name.

--- a/tests/test-api.php
+++ b/tests/test-api.php
@@ -57,21 +57,25 @@ class APITest extends WP_UnitTestCase {
 				'is_not_subscribed' => true,
 				'priority'          => 3,
 			],
+			'segmentLoggedIn'                     => [
+				'is_logged_in' => true,
+				'priority'     => 4,
+			],
 			'segmentWithReferrers'                => [
 				'referrers' => 'foobar.com, newspack.pub',
-				'priority'  => 4,
+				'priority'  => 5,
 			],
 			'anotherSegmentWithReferrers'         => [
 				'referrers' => 'bar.com',
-				'priority'  => 5,
+				'priority'  => 6,
 			],
 			'segmentWithNegativeReferrer'         => [
 				'referrers_not' => 'baz.com',
-				'priority'      => 6,
+				'priority'      => 7,
 			],
 			'segmentFavCategory42'                => [
 				'favorite_categories' => [ $category_1_id ],
-				'priority'            => 7,
+				'priority'            => 8,
 			],
 		];
 
@@ -1363,6 +1367,28 @@ class APITest extends WP_UnitTestCase {
 		);
 		self::assertTrue(
 			self::$maybe_show_campaign->should_campaign_be_shown( self::$client_id, $test_popup['payload'], self::$settings, '', '', [ 'segment' => self::$segment_ids['segmentSubscribers'] ] ),
+			'Assert visible when viewing as a segment member.'
+		);
+	}
+
+	/**
+	 * View as a segment – logged in.
+	 */
+	public function test_view_as_segment_logged_in() {
+		$test_popup = self::create_test_popup(
+			[
+				'placement'           => 'inline',
+				'frequency'           => 'always',
+				'selected_segment_id' => self::$segment_ids['segmentLoggedIn'],
+			]
+		);
+
+		self::assertFalse(
+			self::$maybe_show_campaign->should_campaign_be_shown( self::$client_id, $test_popup['payload'], self::$settings ),
+			'Assert not visible, as the client is not logged in.'
+		);
+		self::assertTrue(
+			self::$maybe_show_campaign->should_campaign_be_shown( self::$client_id, $test_popup['payload'], self::$settings, '', '', [ 'segment' => self::$segment_ids['segmentLoggedIn'] ] ),
 			'Assert visible when viewing as a segment member.'
 		);
 	}

--- a/tests/test-insertion.php
+++ b/tests/test-insertion.php
@@ -230,7 +230,7 @@ class InsertionTest extends WP_UnitTestCase_PageWithPopups {
 		self::assertContains(
 			self::$popup_content,
 			$amp_layout_elements->item( 0 )->textContent,
-			'Includes the popup content.'
+			'Includes the popup content for non-logged-in users.'
 		);
 
 		$user_id = $this->factory->user->create( [ 'role' => 'administrator' ] );
@@ -238,10 +238,10 @@ class InsertionTest extends WP_UnitTestCase_PageWithPopups {
 
 		self::renderPost();
 		$amp_layout_elements = self::$dom_xpath->query( '//amp-layout' );
-		self::assertEquals(
-			0,
-			$amp_layout_elements->length,
-			'Does not include popups when the page is loaded by an admin.'
+		self::assertContains(
+			self::$popup_content,
+			$amp_layout_elements->item( 0 )->textContent,
+			'Also includes the popup content for logged-in admin users.'
 		);
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

**Note:** #824 must be merged before reviewing/merging this branch.

Along with https://github.com/Automattic/newspack-plugin/pull/1563, adds a new segmentation feature for readers who have a user account. Allows you to target readers by whether or not they've logged in.

Note that a reader that has logged in and subsequently logged out is still considered a reader with a user account for the duration of their session—once a reader is known to own a user account, they will continue to match the "has user account" segment regardless of their current login state.

Closes #746.

### How to test the changes in this Pull Request:

1. Check out this branch and https://github.com/Automattic/newspack-plugin/pull/1563.
2. Visit **Newspack > Campaigns > Segments**. Add a new segment and give it a name.
3. Confirm there's a new dropdown field under "Reader Activity" for "User Account". Set it to "Has user account" and save. Sort the segment with top priority and assign a prompt to the segment.
4. In a new incognito session, visit the site front-end and confirm that you don't see the new "Has user account" prompt.
5. In the same session, log in as a WP user—this could be an admin, editor, or author user, or a WooCommerce customer who logs in via the My Account dashboard.
6. Revisit a post and confirm that you now see the prompt.
7. Edit the segment to give it the "Does not have user account" criterion.
8. Repeat steps 4–5 in a new incognito session, but this time confirm that you only see the prompt _before_ you log in, not afterward.
9. Also confirm that the option for "User Account" in existing segments is automatically set to "All users", and that their behavior is unchanged from before.
10. Also confirm that unit tests below are passing. 👇 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
