### PR TITLE
feat(analytics): add segment name to event_category

### DIFF
--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -853,11 +853,11 @@ final class Newspack_Popups_Model {
 			return [];
 		}
 
-		$popup_id       = $popup['id'];
-		$segment_ids    = isset( $popup['options'] ) && ! empty( $popup['options']['selected_segment_id'] ) ?
+		$popup_id            = $popup['id'];
+		$segment_ids         = isset( $popup['options'] ) && ! empty( $popup['options']['selected_segment_id'] ) ?
 			explode( ',', $popup['options']['selected_segment_id'] ) :
 			[];
-		$segments       = array_reduce(
+		$segments            = array_reduce(
 			$segment_ids,
 			function( $acc, $segment_id ) {
 				$segment = Newspack_Popups_Segmentation::get_segment( $segment_id );
@@ -868,14 +868,16 @@ final class Newspack_Popups_Model {
 			},
 			[]
 		);
-		$event_category = sprintf(
-			// Translators: Analytics label for Newspack prompts, including segments.
-			__( 'Newspack Prompt (%s)', 'newspack-popups' ),
+		$event_category      = __( 'Newspack Announcement', 'newspack-popups' );
+		$formatted_placement = ucwords( str_replace( '_', ' ', $popup['options']['placement'] ) );
+		$event_label         = sprintf(
+			// Translators: Analytics label with prompt details (placement, title, ID, targeted segments).
+			__( '%1$s: %2$s (%3$s) - %4$s', 'newspack-popups' ),
+			$formatted_placement,
+			$popup['title'],
+			$popup_id,
 			0 < count( $segments ) ? implode( '; ', $segments ) : __( 'Everyone', 'newspack-popups' )
 		);
-		$formatted_placement = ucwords( str_replace( '_', ' ', $popup['options']['placement'] ) );
-		$event_label         = $formatted_placement . ': ' . $popup['title'] . ' (' . $popup_id . ')';
-
 		$has_link                = preg_match( '/<a\s/', $body ) !== 0;
 		$has_form                = preg_match( '/<form\s/', $body ) !== 0;
 		$has_dismiss_form        = self::is_overlay( $popup );

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -853,8 +853,26 @@ final class Newspack_Popups_Model {
 			return [];
 		}
 
-		$popup_id            = $popup['id'];
-		$event_category      = 'Newspack Announcement';
+		$popup_id       = $popup['id'];
+		$segment_ids    = isset( $popup['options'] ) && ! empty( $popup['options']['selected_segment_id'] ) ?
+			explode( ',', $popup['options']['selected_segment_id'] ) :
+			[];
+		$segments       = array_reduce(
+			$segment_ids,
+			function( $acc, $segment_id ) {
+				$segment = Newspack_Popups_Segmentation::get_segment( $segment_id );
+				if ( $segment && isset( $segment['name'] ) ) {
+					$acc[] = $segment['name'];
+				}
+				return $acc;
+			},
+			[]
+		);
+		$event_category = sprintf(
+			// Translators: Analytics label for Newspack prompts, including segments.
+			__( 'Newspack Prompt (%s)', 'newspack-popups' ),
+			0 < count( $segments ) ? implode( '; ', $segments ) : __( 'Everyone', 'newspack-popups' )
+		);
 		$formatted_placement = ucwords( str_replace( '_', ' ', $popup['options']['placement'] ) );
 		$event_label         = $formatted_placement . ': ' . $popup['title'] . ' (' . $popup_id . ')';
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Makes two analytics-related changes:

1. !Changes the `event_category` label from `Newspack Announcement` to `Newspack Prompt` (@Automattic/newspack this is a potentially breaking change for sites running reports on `Newspack Announcement`—what are our collective thoughts on this?)~ Reverted this—see discussion below.
2. Adds a semicolon-delimited list of the prompt's segment(s) to each ~`event_category`~ event label, or "Everyone" if the prompt has no assigned segments

Closes #679.

### How to test the changes in this Pull Request:

1. Check out this branch and publish several prompts assigned to one, more than one, and zero segments.
3. In a new incognito window, view the page source and confirm that the analytics config now indicates the segments (or "Everyone").

<img width="930" alt="Screen Shot 2022-03-21 at 5 00 01 PM" src="https://user-images.githubusercontent.com/2230142/159376846-1bd02520-84e4-4105-9f69-0dd6172fcc08.png">

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
