### PR TITLE
feat: add "undismissible" option for inline prompts

### DIFF
--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -623,8 +623,12 @@ final class Newspack_Popups_Inserter {
 			't'   => $type,
 		];
 
-		if ( Newspack_Popups_Custom_Placements::is_custom_placement_or_manual( $popup ) ) {
+		if ( \Newspack_Popups_Custom_Placements::is_custom_placement_or_manual( $popup ) ) {
 			$popup_payload['c'] = $popup['options']['placement'];
+		}
+
+		if ( \Newspack_Popups_Model::is_undismissible_prompt( $popup ) ) {
+			$popup_payload['u'] = true;
 		}
 
 		return $popup_payload;

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -225,6 +225,7 @@ final class Newspack_Popups_Model {
 				'background_color'               => filter_input( INPUT_GET, 'n_bc', FILTER_SANITIZE_STRING ),
 				'display_title'                  => filter_input( INPUT_GET, 'n_ti', FILTER_VALIDATE_BOOLEAN ),
 				'hide_border'                    => filter_input( INPUT_GET, 'n_hb', FILTER_VALIDATE_BOOLEAN ),
+				'undismissible_prompt'           => filter_input( INPUT_GET, 'n_u', FILTER_VALIDATE_BOOLEAN ),
 				'dismiss_text'                   => filter_input( INPUT_GET, 'n_dt', FILTER_SANITIZE_STRING ),
 				'dismiss_text_alignment'         => filter_input( INPUT_GET, 'n_da', FILTER_SANITIZE_STRING ),
 				'frequency'                      => filter_input( INPUT_GET, 'n_fr', FILTER_SANITIZE_STRING ),
@@ -345,6 +346,7 @@ final class Newspack_Popups_Model {
 	public static function get_popup_options( $id, $options = null ) {
 		$post_options = isset( $options ) ? $options : [
 			'background_color'               => get_post_meta( $id, 'background_color', true ),
+			'undismissible_prompt'           => get_post_meta( $id, 'undismissible_prompt', true ),
 			'dismiss_text'                   => get_post_meta( $id, 'dismiss_text', true ),
 			'dismiss_text_alignment'         => get_post_meta( $id, 'dismiss_text_alignment', true ),
 			'display_title'                  => get_post_meta( $id, 'display_title', true ),
@@ -387,6 +389,7 @@ final class Newspack_Popups_Model {
 				'background_color'               => '#FFFFFF',
 				'display_title'                  => false,
 				'hide_border'                    => false,
+				'undismissible_prompt'           => false,
 				'dismiss_text'                   => '',
 				'dismiss_text_alignment'         => 'center',
 				'frequency'                      => 'always',
@@ -743,6 +746,21 @@ final class Newspack_Popups_Model {
 	}
 
 	/**
+	 * Is the prompt undismissible?
+	 * Only inline, custom placement, and manual-only prompts can be undismissible.
+	 *
+	 * @param object $popup The popup object.
+	 * @return boolean True if popup is undismissible.
+	 */
+	public static function is_undismissible_prompt( $popup ) {
+		if ( self::is_overlay( $popup ) ) {
+			return false;
+		}
+
+		return isset( $popup['options'] ) && isset( $popup['options']['undismissible_prompt'] ) && $popup['options']['undismissible_prompt'];
+	}
+
+	/**
 	 * Insert amp-analytics tracking code.
 	 *
 	 * @param object $popup The popup object.
@@ -1058,7 +1076,7 @@ final class Newspack_Popups_Model {
 					<h1 class="newspack-popup-title"><?php echo esc_html( $popup['title'] ); ?></h1>
 				<?php endif; ?>
 				<?php echo do_shortcode( $body ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
-				<?php if ( ! Newspack_Popups_Settings::is_non_interactive() ) : ?>
+				<?php if ( ! self::is_undismissible_prompt( $popup ) && ! Newspack_Popups_Settings::is_non_interactive() ) : ?>
 					<?php echo self::render_permanent_dismissal_form( $element_id, $popup ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 				<?php endif; ?>
 			</amp-layout>

--- a/includes/class-newspack-popups-settings.php
+++ b/includes/class-newspack-popups-settings.php
@@ -246,7 +246,7 @@ class Newspack_Popups_Settings {
 				'value'       => get_option( 'suppress_newsletter_campaigns', true ),
 				'default'     => true,
 				'description' => __( 'Suppress newsletter prompts for subscribers', 'newspack-popups' ),
-				'help'        => __( 'Automatically suppress any inline or overlay prompt that contains a newsletter signup block for readers coming from a newsletter email.', 'newspack-popups' ),
+				'help'        => __( 'Automatically suppress any dismissible prompt that contains a newsletter signup block for readers coming from a newsletter email.', 'newspack-popups' ),
 				'public'      => false,
 			],
 			[
@@ -257,7 +257,7 @@ class Newspack_Popups_Settings {
 				'default'     => true,
 				'description' => __( 'Suppress newsletter prompts if dismissed', 'newspack-popups' ),
 				'help'        => __(
-					'Automatically suppress any inline or overlay prompt that contains a newsletter signup block if at least one prompt with a signup block has been dismissed.',
+					'Automatically suppress any dismissible prompt that contains a newsletter signup block if at least one prompt with a signup block has been dismissed.',
 					'newspack-popups'
 				),
 			],
@@ -269,7 +269,7 @@ class Newspack_Popups_Settings {
 				'default'     => false,
 				'description' => __( 'Suppress donation prompts for donors', 'newspack-popups' ),
 				'help'        => __(
-					'Automatically suppress any inline or overlay prompt containing a Donate block if the reader has already donated.',
+					'Automatically suppress any dismissible prompt containing a Donate block if the reader has already donated.',
 					'newspack-popups'
 				),
 			],

--- a/includes/class-newspack-popups-settings.php
+++ b/includes/class-newspack-popups-settings.php
@@ -246,7 +246,7 @@ class Newspack_Popups_Settings {
 				'value'       => get_option( 'suppress_newsletter_campaigns', true ),
 				'default'     => true,
 				'description' => __( 'Suppress newsletter prompts for subscribers', 'newspack-popups' ),
-				'help'        => __( 'Automatically suppress any prompt that contains a newsletter signup block for readers coming from a newsletter email.', 'newspack-popups' ),
+				'help'        => __( 'Automatically suppress any inline or overlay prompt that contains a newsletter signup block for readers coming from a newsletter email.', 'newspack-popups' ),
 				'public'      => false,
 			],
 			[
@@ -257,7 +257,7 @@ class Newspack_Popups_Settings {
 				'default'     => true,
 				'description' => __( 'Suppress newsletter prompts if dismissed', 'newspack-popups' ),
 				'help'        => __(
-					'Automatically suppress any prompt that contains a newsletter signup block if at least one prompt with a signup block has been dismissed.',
+					'Automatically suppress any inline or overlay prompt that contains a newsletter signup block if at least one prompt with a signup block has been dismissed.',
 					'newspack-popups'
 				),
 			],
@@ -269,7 +269,7 @@ class Newspack_Popups_Settings {
 				'default'     => false,
 				'description' => __( 'Suppress donation prompts for donors', 'newspack-popups' ),
 				'help'        => __(
-					'Automatically suppress all prompts containing a Donate block if the reader has already donated.',
+					'Automatically suppress any inline or overlay prompt containing a Donate block if the reader has already donated.',
 					'newspack-popups'
 				),
 			],

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -25,6 +25,7 @@ final class Newspack_Popups {
 		'background_color'               => 'n_bc',
 		'display_title'                  => 'n_ti',
 		'hide_border'                    => 'n_hb',
+		'undismissible_prompt'           => 'n_u',
 		'dismiss_text'                   => 'n_dt',
 		'dismiss_text_alignment'         => 'n_da',
 		'frequency'                      => 'n_fr',
@@ -284,6 +285,19 @@ final class Newspack_Popups {
 				'object_subtype' => self::NEWSPACK_POPUPS_CPT,
 				'show_in_rest'   => true,
 				'type'           => 'string',
+				'single'         => true,
+				'auth_callback'  => '__return_true',
+			]
+		);
+
+		\register_meta(
+			'post',
+			'undismissible_prompt',
+			[
+				'object_subtype' => self::NEWSPACK_POPUPS_CPT,
+				'show_in_rest'   => true,
+				'type'           => 'boolean',
+				'default'        => false,
 				'single'         => true,
 				'auth_callback'  => '__return_true',
 			]

--- a/src/editor/DismissSidebar.js
+++ b/src/editor/DismissSidebar.js
@@ -26,7 +26,7 @@ const DismissSidebar = ( {
 				<ToggleControl
 					checked={ ! undismissible_prompt }
 					onChange={ () => onMetaFieldChange( 'undismissible_prompt', ! undismissible_prompt ) }
-					label={ __( 'Allow this prompt to be dismissed.', 'newspack-popups' ) }
+					label={ __( 'Allow this prompt to be dismissed', 'newspack-popups' ) }
 				/>
 			) }
 			{ ( isOverlayPlacement( placement ) || ! undismissible_prompt ) && (

--- a/src/editor/DismissSidebar.js
+++ b/src/editor/DismissSidebar.js
@@ -6,42 +6,63 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Fragment } from '@wordpress/element';
-import { SelectControl, TextControl } from '@wordpress/components';
+import { SelectControl, TextControl, ToggleControl } from '@wordpress/components';
 
-const DismissSidebar = ( { dismiss_text, dismiss_text_alignment, onMetaFieldChange } ) => {
+/**
+ * Internal dependencies
+ */
+import { isOverlayPlacement } from './utils';
+
+const DismissSidebar = ( {
+	dismiss_text,
+	dismiss_text_alignment,
+	onMetaFieldChange,
+	placement,
+	undismissible_prompt,
+} ) => {
 	return (
-		<Fragment>
-			<TextControl
-				label={ __( 'Label', 'newspack-popups' ) }
-				help={ __(
-					'When clicked, this button will permanently dismiss the prompt for the current reader.',
-					'newspack-popups'
-				) }
-				value={ dismiss_text }
-				onChange={ value => onMetaFieldChange( 'dismiss_text', value ) }
-			/>
-			<SelectControl
-				label={ __( 'Alignment', 'newspack-popups' ) }
-				id="newspack-popups-dimiss-button-alignment"
-				onChange={ value => onMetaFieldChange( 'dismiss_text_alignment', value ) }
-				value={ dismiss_text_alignment }
-				options={ [
-					{
-						label: __( 'Center', 'newspack-popups' ),
-						value: '',
-					},
-					{
-						label: __( 'Left', 'newspack-popups' ),
-						value: 'left',
-					},
-					{
-						label: __( 'Right', 'newspack-popups' ),
-						value: 'right',
-					},
-				] }
-			/>
-		</Fragment>
+		<>
+			{ ! isOverlayPlacement( placement ) && (
+				<ToggleControl
+					checked={ ! undismissible_prompt }
+					onChange={ () => onMetaFieldChange( 'undismissible_prompt', ! undismissible_prompt ) }
+					label={ __( 'Allow this prompt to be dismissed.', 'newspack-popups' ) }
+				/>
+			) }
+			{ ( isOverlayPlacement( placement ) || ! undismissible_prompt ) && (
+				<>
+					<TextControl
+						label={ __( 'Label', 'newspack-popups' ) }
+						help={ __(
+							'When clicked, this button will permanently dismiss the prompt for the current reader.',
+							'newspack-popups'
+						) }
+						value={ dismiss_text }
+						onChange={ value => onMetaFieldChange( 'dismiss_text', value ) }
+					/>
+					<SelectControl
+						label={ __( 'Alignment', 'newspack-popups' ) }
+						id="newspack-popups-dimiss-button-alignment"
+						onChange={ value => onMetaFieldChange( 'dismiss_text_alignment', value ) }
+						value={ dismiss_text_alignment }
+						options={ [
+							{
+								label: __( 'Center', 'newspack-popups' ),
+								value: '',
+							},
+							{
+								label: __( 'Left', 'newspack-popups' ),
+								value: 'left',
+							},
+							{
+								label: __( 'Right', 'newspack-popups' ),
+								value: 'right',
+							},
+						] }
+					/>
+				</>
+			) }
+		</>
 	);
 };
 

--- a/src/editor/EditorAdditions.js
+++ b/src/editor/EditorAdditions.js
@@ -11,11 +11,18 @@ import { useEffect } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { isOverlay, updateEditorColors } from './utils';
+import { isOverlayPlacement, updateEditorColors } from './utils';
 
 const EditorAdditions = () => {
 	const meta = useSelect( select => select( 'core/editor' ).getEditedPostAttribute( 'meta' ) );
-	const { dismiss_text, dismiss_text_alignment, background_color, overlay_size, placement } = meta;
+	const {
+		undismissible_prompt,
+		dismiss_text,
+		dismiss_text_alignment,
+		background_color,
+		overlay_size,
+		placement,
+	} = meta;
 
 	// Update editor colors to match popup colors.
 	useEffect( () => {
@@ -28,7 +35,7 @@ const EditorAdditions = () => {
 			'.newspack-popups__not-interested-button-preview'
 		);
 
-		if ( ! dismiss_text ) {
+		if ( undismissible_prompt || ! dismiss_text ) {
 			if ( dismissButtonPreview ) {
 				dismissButtonPreview.parentNode.removeChild( dismissButtonPreview );
 			}
@@ -53,7 +60,7 @@ const EditorAdditions = () => {
 				'newspack-popups__not-interested-button-preview wp-block ' + alignClass;
 			dismissButtonPreview.textContent = dismiss_text;
 		}
-	}, [ dismiss_text, dismiss_text_alignment ] );
+	}, [ undismissible_prompt, dismiss_text, dismiss_text_alignment ] );
 
 	// Setting editor size as per the popup size.
 	useEffect( () => {
@@ -65,7 +72,7 @@ const EditorAdditions = () => {
 				}
 			} );
 
-			if ( isOverlay( placement ) ) {
+			if ( isOverlayPlacement( placement ) ) {
 				blockEditor.classList.add( `is-size-${ overlay_size }` );
 			}
 		}

--- a/src/editor/Sidebar.js
+++ b/src/editor/Sidebar.js
@@ -23,7 +23,13 @@ import { without } from 'lodash';
 /**
  * Internal dependencies
  */
-import { isCustomPlacement, getPlacementHelpMessage } from '../editor/utils';
+import {
+	isCustomPlacement,
+	isInlinePlacement,
+	isManualOnlyPlacement,
+	isOverlayPlacement,
+	getPlacementHelpMessage,
+} from './utils';
 import PositionPlacementControl from './PositionPlacementControl';
 
 const Sidebar = props => {
@@ -41,12 +47,11 @@ const Sidebar = props => {
 		archive_insertion_posts_count,
 		archive_insertion_is_repeating,
 		isOverlay,
-		isInlinePlacement,
 		archive_page_types = [],
 	} = props;
 	const updatePlacement = value => {
 		onMetaFieldChange( 'placement', value );
-		if ( ! isInlinePlacement( value ) && frequency === 'always' ) {
+		if ( isOverlayPlacement( value ) && frequency === 'always' ) {
 			onMetaFieldChange( 'frequency', 'once' );
 		}
 	};
@@ -233,7 +238,9 @@ const Sidebar = props => {
 				checked={ display_title }
 				onChange={ value => onMetaFieldChange( 'display_title', value ) }
 			/>
-			{ ( placement === 'inline' || placement === 'manual' || isCustomPlacement( placement ) ) && (
+			{ ( isInlinePlacement( placement ) ||
+				isManualOnlyPlacement( placement ) ||
+				isCustomPlacement( placement ) ) && (
 				<ToggleControl
 					label={ __( 'Hide Prompt Border', 'newspack-popups' ) }
 					checked={ hide_border }

--- a/src/editor/utils.js
+++ b/src/editor/utils.js
@@ -11,6 +11,7 @@ export const optionsFieldsSelector = select => {
 	const {
 		background_color,
 		frequency,
+		undismissible_prompt,
 		dismiss_text,
 		dismiss_text_alignment,
 		display_title,
@@ -33,23 +34,11 @@ export const optionsFieldsSelector = select => {
 		excluded_tags,
 	} = meta || {};
 
-	const isInlinePlacement = placementValue =>
-		-1 ===
-		[
-			'top_left',
-			'top',
-			'top_right',
-			'center_left',
-			'center',
-			'center_right',
-			'bottom_left',
-			'bottom',
-			'bottom_right',
-		].indexOf( placementValue );
-	const isOverlay = ! isInlinePlacement( placement );
+	const isOverlay = isOverlayPlacement( placement );
 
 	return {
 		background_color,
+		undismissible_prompt,
 		dismiss_text,
 		dismiss_text_alignment,
 		display_title,
@@ -67,7 +56,6 @@ export const optionsFieldsSelector = select => {
 		archive_insertion_is_repeating,
 		utm_suppression,
 		selected_segment_id,
-		isInlinePlacement,
 		isOverlay,
 		post_types,
 		archive_page_types,
@@ -137,6 +125,27 @@ export const updateEditorColors = backgroundColor => {
 };
 
 /**
+ * Is the given placement value an overlay placement?
+ *
+ * @param {string} placementValue Placement of the prompt.
+ * @return {boolean} Whether or not the prompt has an overlay placement.
+ */
+export const isOverlayPlacement = placementValue => {
+	const overlayPlacements = window.newspack_popups_data?.overlay_placements || [];
+	return -1 < overlayPlacements.indexOf( placementValue );
+};
+
+/**
+ * Is the placement inline?
+ * Not including Custom Placement or Manual-Only prompts.
+ *
+ * @param {string} placementValue Placement value of the prompt.
+ * @return {boolean} True if placementValue is an inline placement.
+ */
+export const isInlinePlacement = placementValue =>
+	-1 < [ 'inline', 'above_header', 'archives' ].indexOf( placementValue );
+
+/**
  * Is the given placement value a custom placement?
  *
  * @param {string} placementValue Placement of the prompt.
@@ -148,15 +157,12 @@ export const isCustomPlacement = placementValue => {
 };
 
 /**
- * Is the given placement value an overlay placement?
+ * Is the given placement value a manual-only placement?
  *
  * @param {string} placementValue Placement of the prompt.
- * @return {boolean} Whether or not the prompt has an overlay placement.
+ * @return {boolean} Whether or not the prompt is manual-only.
  */
-export const isOverlay = placementValue => {
-	const overlayPlacements = window.newspack_popups_data?.overlay_placements || [];
-	return -1 < overlayPlacements.indexOf( placementValue );
-};
+export const isManualOnlyPlacement = placementValue => 'manual' === placementValue;
 
 /**
  * Given a placement value, construct a context-sensitive help message to display in the editor sidebar.

--- a/tests/test-model.php
+++ b/tests/test-model.php
@@ -32,6 +32,7 @@ class ModelTest extends WP_UnitTestCase {
 				'background_color'               => '#FFFFFF',
 				'display_title'                  => false,
 				'hide_border'                    => false,
+				'undismissible_prompt'           => false,
 				'dismiss_text'                   => '',
 				'dismiss_text_alignment'         => 'center',
 				'frequency'                      => 'always',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Current UI allows editors to make "virtually" undismissible prompts by simply not entering any text in the Dismiss Button Text field. In this case, the prompt can't be dismissed with a button click, but it will still be suppressed based on other factors such as newsletter subscription, donation, etc. This is not ideal for publishers who include prompts as more or less static design elements in specific areas, such as on the homepage.

This PR adds a new option to explicitly make inline, Custom Placement, and Manual-Only prompts "undismissible" prompts. There's a new toggle switch, which is ON by default, which allows these prompts to be dismissed. This represents the status quo/current behavior, so sites already using prompts won't experience any change in behavior for existing prompts.

<img width="283" alt="Screen Shot 2022-03-23 at 11 29 06 AM" src="https://user-images.githubusercontent.com/2230142/159760140-0021b87f-1d52-4700-8fc2-9a9116a0bf9f.png">

Toggling this option OFF will make the prompt "undismissible," which results in the following behavior:

- The prompt will not display any "dismiss" button.
- The prompt will not follow the usual permanent suppression rules. For example, even if an undismissible prompt contains a newsletter signup form, and the reader has dismissed another newsletter prompt, the undismissible prompt will continue to be shown. I've added unit tests to cover all of these suppression cases.
- Even if a prompt was previously dismissed by the reader before this new option existed, if the new dismiss option is turned off the prompt will now continue to be shown.
- Undismissible prompts will still follow the rules of frequency and segmentation, as before. So an undismissible prompt with the "once" frequency will only be shown once, then will be suppressed as usual. An undismissible prompt targeted to a specific segment will still only be shown to readers matching that segment.
- Overlay prompts are always dismissible.

Closes #822.

### How to test the changes in this Pull Request:

1. Check out this branch and edit an existing inline, custom placement, or manual-only prompt. Expand the "Dismiss Button Settings" sidebar and confirm the new toggle option, which should be on by default for existing and new prompts.
2. Do a smoke test to confirm that existing prompts continue to behave as before, with no change in expected behavior. Make sure to keep one prompt around that has a newsletter signup block and is still dismissible with a visible dismiss button.
3. Create a new prompt for each inline placement (inline, custom placement, and manual), or edit the existing prompts. Make sure they contain newsletter signup blocks, and ensure that each will render on a particular page. Toggle OFF the new option to "allow this prompt to be dismissed" and confirm that the dismiss button fields (and preview in the block area) disappear. Save.
4. In a new incognito window, view the page where the undismissible prompts are shown. confirm that they're shown without a dismiss button.
5. Dismiss the dismissible newsletter prompt and refresh the page with the undismissible prompts. Confirm that the ones with newsletter signup blocks are still shown, even if your "Suppress newsletter prompts if dismissed" option is enabled.
6. If you like, you can repeat steps 4–5 but with `utm_medium=email` in the URL, Donate blocks for a donor reader, and with a UTM suppression value and confirm that the undismissible prompts are never automatically suppressed. These cases should all be covered by unit tests.
7. Confirm all unit tests are still passing. 👇 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
