### PR TITLE
feat: support other newsletter signup forms

### DIFF
--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -803,8 +803,10 @@ final class Newspack_Popups_Model {
 		}
 
 		// Custom forms.
-		if ( preg_match( '/newspack-subscribe-form/', $body ) !== 0 ) {
-			$subscribe_form_selector = apply_filters( 'newspack_campaigns_form_class', '.newspack-subscribe-form' );
+		$newspack_form_class           = apply_filters( 'newspack_campaigns_form_class', '.newspack-subscribe-form' );
+		$newspack_form_class_minus_dot = '.' === substr( $newspack_form_class, 0, 1 ) ? substr( $newspack_form_class, 1 ) : $newspack_form_class; // Strip the "." class selector.
+		if ( preg_match( '/' . $newspack_form_class_minus_dot . '/', $body ) !== 0 ) {
+			$subscribe_form_selector = $newspack_form_class;
 			$email_form_field_name   = apply_filters( 'newspack_campaigns_email_form_field_name', 'email', $subscribe_form_selector );
 		}
 

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -795,7 +795,14 @@ final class Newspack_Popups_Model {
 		} elseif ( preg_match( '/\[gravityform/', $body ) !== 0 ) {
 			// Gravity Forms block.
 			$subscribe_form_selector = apply_filters( 'newspack_campaigns_form_class', '.gform_wrapper form' );
-			$email_form_field_name   = apply_filters( 'newspack_campaigns_email_form_field_name', 'input_1', $subscribe_form_selector ); // Gravity Forms doesn't allow you to edit the name attribute for fields, so we'll assume that the first input field is the email address.
+
+			/**
+			 * Gravity Forms doesn't allow you to edit the name attribute for fields,
+			 * so we'll assume that the first input field is the email address.
+			 * If your prompt contains a Gravity Form that you do NOT want to track,
+			 * as a subscribe form, return a falsy value such as `null` in the callback.
+			 */
+			$email_form_field_name = apply_filters( 'newspack_campaigns_email_form_field_name', 'input_1', $subscribe_form_selector );
 		} else {
 			// Custom forms.
 			$newspack_form_class           = apply_filters( 'newspack_campaigns_form_class', '.newspack-subscribe-form' );

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -859,7 +859,7 @@ final class Newspack_Popups_Model {
 		$event_label         = $formatted_placement . ': ' . $popup['title'] . ' (' . $popup_id . ')';
 
 		$has_link                = preg_match( '/<a\s/', $body ) !== 0;
-		$has_form                = preg_match( '/<form\s/', $body ) !== 0;
+		$has_form                = preg_match( '/<form\s|\[gravityforms\s/', $body ) !== 0;
 		$has_dismiss_form        = self::is_overlay( $popup );
 		$has_not_interested_form = $popup['options']['dismiss_text'];
 

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -918,7 +918,7 @@ final class Newspack_Popups_Model {
 		$has_link                = preg_match( '/<a\s/', $body ) !== 0;
 		$newspack_form_class     = apply_filters( 'newspack_campaigns_form_class', '.newspack-subscribe-form' );
 		$newspack_form_class     = '.' === substr( $newspack_form_class, 0, 1 ) ? substr( $newspack_form_class, 1 ) : $newspack_form_class; // Strip the "." class selector.
-		$has_form                = preg_match( '/<form\s|\[gravityforms\s|' . $newspack_form_class . '/', $body ) !== 0;
+		$has_form                = preg_match( '/<form\s|mc4wp-form|\[gravityforms\s|' . $newspack_form_class . '/', $body ) !== 0;
 		$has_dismiss_form        = self::is_overlay( $popup );
 		$has_not_interested_form = $popup['options']['dismiss_text'];
 

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -784,30 +784,26 @@ final class Newspack_Popups_Model {
 		$subscribe_form_selector = '';
 		$email_form_field_name   = '';
 
-		// Jetpack Mailchimp block.
 		if ( preg_match( '/wp-block-jetpack-mailchimp/', $body ) !== 0 ) {
+			// Jetpack Mailchimp block.
 			$subscribe_form_selector = apply_filters( 'newspack_campaigns_form_class', '.wp-block-jetpack-mailchimp form' );
 			$email_form_field_name   = apply_filters( 'newspack_campaigns_email_form_field_name', 'email', $subscribe_form_selector );
-		}
-
-		// MC4WP form.
-		if ( preg_match( '/mc4wp-form/', $body ) !== 0 ) {
+		} elseif ( preg_match( '/mc4wp-form/', $body ) !== 0 ) {
+			// MC4WP form.
 			$subscribe_form_selector = apply_filters( 'newspack_campaigns_form_class', '.mc4wp-form' );
 			$email_form_field_name   = apply_filters( 'newspack_campaigns_email_form_field_name', 'EMAIL', $subscribe_form_selector );
-		}
-
-		// Gravity Forms block.
-		if ( preg_match( '/\[gravityform/', $body ) !== 0 ) {
+		} elseif ( preg_match( '/\[gravityform/', $body ) !== 0 ) {
+			// Gravity Forms block.
 			$subscribe_form_selector = apply_filters( 'newspack_campaigns_form_class', '.gform_wrapper form' );
 			$email_form_field_name   = apply_filters( 'newspack_campaigns_email_form_field_name', 'input_1', $subscribe_form_selector ); // Gravity Forms doesn't allow you to edit the name attribute for fields, so we'll assume that the first input field is the email address.
-		}
-
-		// Custom forms.
-		$newspack_form_class           = apply_filters( 'newspack_campaigns_form_class', '.newspack-subscribe-form' );
-		$newspack_form_class_minus_dot = '.' === substr( $newspack_form_class, 0, 1 ) ? substr( $newspack_form_class, 1 ) : $newspack_form_class; // Strip the "." class selector.
-		if ( preg_match( '/' . $newspack_form_class_minus_dot . '/', $body ) !== 0 ) {
-			$subscribe_form_selector = $newspack_form_class;
-			$email_form_field_name   = apply_filters( 'newspack_campaigns_email_form_field_name', 'email', $subscribe_form_selector );
+		} else {
+			// Custom forms.
+			$newspack_form_class           = apply_filters( 'newspack_campaigns_form_class', '.newspack-subscribe-form' );
+			$newspack_form_class_minus_dot = '.' === substr( $newspack_form_class, 0, 1 ) ? substr( $newspack_form_class, 1 ) : $newspack_form_class; // Strip the "." class selector.
+			if ( preg_match( '/' . $newspack_form_class_minus_dot . '/', $body ) !== 0 ) {
+				$subscribe_form_selector = $newspack_form_class;
+				$email_form_field_name   = apply_filters( 'newspack_campaigns_email_form_field_name', 'email', $subscribe_form_selector );
+			}
 		}
 
 		$amp_analytics_config = [

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -782,29 +782,30 @@ final class Newspack_Popups_Model {
 
 		// Newsletter subscription forms.
 		$subscribe_form_selector = '';
-		$email_form_field_name   = 'email';
+		$email_form_field_name   = '';
 
 		// Jetpack Mailchimp block.
 		if ( preg_match( '/wp-block-jetpack-mailchimp/', $body ) !== 0 ) {
-			$subscribe_form_selector = '.wp-block-jetpack-mailchimp form';
+			$subscribe_form_selector = apply_filters( 'newspack_campaigns_form_class', '.wp-block-jetpack-mailchimp form' );
+			$email_form_field_name   = apply_filters( 'newspack_campaigns_email_form_field_name', 'email', $subscribe_form_selector );
 		}
 
 		// MC4WP form.
 		if ( preg_match( '/mc4wp-form/', $body ) !== 0 ) {
-			$subscribe_form_selector = '.mc4wp-form';
-			$email_form_field_name   = 'EMAIL';
+			$subscribe_form_selector = apply_filters( 'newspack_campaigns_form_class', '.mc4wp-form' );
+			$email_form_field_name   = apply_filters( 'newspack_campaigns_email_form_field_name', 'EMAIL', $subscribe_form_selector );
 		}
 
-		// GravityForms block.
+		// Gravity Forms block.
 		if ( preg_match( '/\[gravityform/', $body ) !== 0 ) {
-			$subscribe_form_selector = '.gform_wrapper form';
-			$email_form_field_name   = 'input_1'; // GravityForms doesn't allow you to edit the name attribute for fields, so we'll assume that the first input field is the email address.
+			$subscribe_form_selector = apply_filters( 'newspack_campaigns_form_class', '.gform_wrapper form' );
+			$email_form_field_name   = apply_filters( 'newspack_campaigns_email_form_field_name', 'input_1', $subscribe_form_selector ); // Gravity Forms doesn't allow you to edit the name attribute for fields, so we'll assume that the first input field is the email address.
 		}
 
 		// Custom forms.
 		if ( preg_match( '/newspack-subscribe-form/', $body ) !== 0 ) {
-			$subscribe_form_selector = '.' . apply_filters( 'newspack_campaigns_form_class', 'newspack-subscribe-form' );
-			$email_form_field_name   = apply_filters( 'newspack_campaigns_email_form_field_name', 'email' );
+			$subscribe_form_selector = apply_filters( 'newspack_campaigns_form_class', '.newspack-subscribe-form' );
+			$email_form_field_name   = apply_filters( 'newspack_campaigns_email_form_field_name', 'email', $subscribe_form_selector );
 		}
 
 		$amp_analytics_config = [
@@ -828,7 +829,7 @@ final class Newspack_Popups_Model {
 				],
 			],
 		];
-		if ( $subscribe_form_selector ) {
+		if ( $subscribe_form_selector && $email_form_field_name ) {
 			$amp_analytics_config['triggers']['formSubmitSuccess'] = [
 				'on'             => 'amp-form-submit-success',
 				'request'        => 'event',
@@ -913,7 +914,8 @@ final class Newspack_Popups_Model {
 			0 < count( $segments ) ? implode( '; ', $segments ) : __( 'Everyone', 'newspack-popups' )
 		);
 		$has_link                = preg_match( '/<a\s/', $body ) !== 0;
-		$newspack_form_class     = apply_filters( 'newspack_campaigns_form_class', 'newspack-subscribe-form' );
+		$newspack_form_class     = apply_filters( 'newspack_campaigns_form_class', '.newspack-subscribe-form' );
+		$newspack_form_class     = '.' === substr( $newspack_form_class, 0, 1 ) ? substr( $newspack_form_class, 1 ) : $newspack_form_class; // Strip the "." class selector.
 		$has_form                = preg_match( '/<form\s|\[gravityforms\s|' . $newspack_form_class . '/', $body ) !== 0;
 		$has_dismiss_form        = self::is_overlay( $popup );
 		$has_not_interested_form = $popup['options']['dismiss_text'];


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

The plugin currently fully tracks only Jetpack Mailchimp block forms as newsletter subscribe form submissions. This PR adds handling for MC4WP forms, Gravity Forms, and arbitrary forms, the latter two via a `.newspack-subscribe-form` class name. The class name and the name of the field containing the user's email address are now filterable via the following filters:

* `newspack_campaigns_form_class` - The class name of the subscribe form.
* `newspack_campaigns_form_selector` - The CSS selector used to target the form for tracking submit events. If the form being tracked is a Jetpack Mailchimp or MC4WP form, it will be the selector for those form types (which generate consistent markup). Otherwise it will use the result of `newspack_campaigns_form_class` to build a selector.
* `newspack_campaigns_email_form_field_name` - The value of the `name` attribute of the input field containing the user's email address. The value of this field will be reported as the user's email address upon form submission. This filter also reports the value of the selector as the second argument so you have an idea of whether a form in each prompt is a Jetpack block, MC4WP block, a Gravity Form, or a custom form.

**Note:** ~The Gravity Forms UI does not allow for customization of input `name` attribute values, so the default implementation assumes that the first field in any Gravity Form block is the email address. You can use the `newspack_campaigns_email_form_field_name` filter to alter this assumption if your Gravity Form has a different field structure. Because of this behavior, any Gravity Form inside a prompt will be assumed to be a newsletter subscribe form unless the `newspack_campaigns_email_form_field_name` filter returns a falsy value.~ 7a53a80 fixes this issue by requiring Gravity Forms forms to have the `newspack-subscribe-form` (specifically the filtered result of `newspack_campaigns_form_class`) class name applied via form settings, as well as a field of type `email`. This is to prevent false positives from tracking Gravity Forms forms that may not be intended as subscribe forms.

Closes #791.

### How to test the changes in this Pull Request:

Make sure you test with a site that's fully connected to Jetpack, Mailchimp, and Google Analytics via Site Kit. Note that you may need to test this with a live staging site rather than a local environment. ngrok environments in particular may not be able to connect to GA and therefore may not print all of the event config needed to test.

1. Create a prompt and insert a Jetpack Mailchimp form block.
2. View the prompt in an incognito session and view source. Search for `"on":"amp-form-submit"` and confirm there are two event config objects in source: one should have an event name of `Form Submission` and the other should have an `extraUrlParams` property containing the client ID, email address input name, and other data.
3. Install Gravity Forms (DM me for a license key) and create a "newsletter subscribe" form with an email address input field. In form settings, apply the `newspack-subscribe-form` class name to the form. Replace the Jetpack Mailchimp block in your prompt with a Gravity Forms block pointing to your newsletter form.
4. Repeat step 2 and confirm that there are still two event config objects in source with selectors matching the form markup. 
5. Install the MC4WP plugin and set it up with a Mailchimp API key (DM me if you need one). Create a form pointing to your Mailchimp list and containing at least one input field with a `name="email"` attribute. Replace the form in your prompt with a "Mailchimp for WordPress Form" block pointing to your MC4WP form.
6. Repeat step 2 again and confirm that there are still two event config objects with selectors matching the form markup.
7. Edit your prompt and replace the form block with an HTML block containing the following HTML:

```html
<form class="newspack-subscribe-form">
	<input type="email" name="email" placeholder="Email address" />
	<button>Submit</button>
</form>
```
8. Repeat step 2 again and confirm that there are still two event config objects with selectors matching the form markup.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
