### PR TITLE
fix: report views when seen, not just interacted with

### DIFF
--- a/api/campaigns/class-maybe-show-campaign.php
+++ b/api/campaigns/class-maybe-show-campaign.php
@@ -152,6 +152,18 @@ class Maybe_Show_Campaign extends Lightweight_API {
 				}
 			}
 
+			// If prompt was shown, report a view.
+			if ( $campaign_should_be_shown ) {
+				$campaign_data = $this->get_campaign_data( $client_id, $campaign->id );
+				$campaign_data['count']++;
+				$campaign_data['last_viewed'] = time();
+				$client_data_update           = [
+					'prompts' => [ "$campaign->id" => $campaign_data ],
+				];
+
+				$this->save_client_data( $client_id, $client_data_update );
+			}
+
 			$response[ $campaign->id ] = $campaign_should_be_shown;
 		}
 

--- a/api/campaigns/class-report-campaign-data.php
+++ b/api/campaigns/class-report-campaign-data.php
@@ -41,6 +41,9 @@ class Report_Campaign_Data extends Lightweight_API {
 		$campaign_data      = $this->get_campaign_data( $client_id, $campaign_id );
 		$client_data_update = [];
 
+		$campaign_data['count']++;
+		$campaign_data['last_viewed'] = time();
+
 		// Handle permanent suppression.
 		if ( $this->get_request_param( 'suppress_forever', $request ) ) {
 			$campaign_data['suppress_forever'] = true;

--- a/api/campaigns/class-report-campaign-data.php
+++ b/api/campaigns/class-report-campaign-data.php
@@ -41,9 +41,6 @@ class Report_Campaign_Data extends Lightweight_API {
 		$campaign_data      = $this->get_campaign_data( $client_id, $campaign_id );
 		$client_data_update = [];
 
-		$campaign_data['count']++;
-		$campaign_data['last_viewed'] = time();
-
 		// Handle permanent suppression.
 		if ( $this->get_request_param( 'suppress_forever', $request ) ) {
 			$campaign_data['suppress_forever'] = true;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Apparently, prompt views are only being reported on `POST` requests, which means that prompts were only reported as viewed if the reader interacted with the prompt (e.g. by dismissing it). This caused prompts with the "once" or "once a day" frequency to not be properly suppressed after being viewed (but not dismissed) once.

### How to test the changes in this Pull Request:

1. On `master`, publish two inline prompts, one with the "Once" frequency and the other with the "Once a day" frequency.
2. In a new incognito session, navigate through several posts without dismissing the prompts. Observe that they appear on every post.
3. Check out this branch, repeat step 2, and confirm that the prompts are shown only once.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
