### PR TITLE
fix: hide empty paragraph blocks

### DIFF
--- a/src/view/style.scss
+++ b/src/view/style.scss
@@ -373,6 +373,14 @@ $size__large: 1264px;
 	}
 }
 
+// Hide empty Paragraph Blocks
+.newspack-lightbox,
+.newspack-inline-popup {
+	p:empty {
+		display: none;
+	}
+}
+
 // This is needed for the scroll-triggered popups to function properly.
 // (#page-position-marker element is an absolutely-placed child of .entry-content)
 /* stylelint-disable-next-line no-duplicate-selectors */


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Sometimes the Editor adds an empty paragraph block at the end of a page. When looking at the front-end we end up with an empty `<p/>` that adds some unwanted extra margin.

### How to test the changes in this Pull Request:

1. Create/Edit a prompt
2. Insert an empty Paragrpah block
3. Check the front-end, the empty `<p/>` should have some sort of margin
4. Switch to this branch and refresh
5. Check the front-end, the empty `<p/>` should not be an issue anymore

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
