### PR TITLE
Add specific class to editor when prompt is inline

### DIFF
--- a/src/editor/EditorAdditions.js
+++ b/src/editor/EditorAdditions.js
@@ -62,18 +62,22 @@ const EditorAdditions = () => {
 		}
 	}, [ undismissible_prompt, dismiss_text, dismiss_text_alignment ] );
 
-	// Setting editor size as per the popup size.
+	// Setting editor size as per the overlay size or add inline placement.
 	useEffect( () => {
 		const blockEditor = document.querySelector( '.block-editor-block-list__layout' );
 		if ( blockEditor ) {
 			blockEditor.classList.forEach( className => {
 				if ( className.startsWith( 'is-size-' ) ) {
 					blockEditor.classList.remove( className );
+				} else {
+					blockEditor.classList.remove( 'is-placement-inline' );
 				}
 			} );
 
 			if ( isOverlayPlacement( placement ) ) {
 				blockEditor.classList.add( `is-size-${ overlay_size }` );
+			} else {
+				blockEditor.classList.add( 'is-placement-inline' );
 			}
 		}
 	}, [ overlay_size, placement ] );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

By adding a class of `is-placement-inline` to the Editor, we will able to provide specific CSS for some patterns, whether they are inline or not.

### How to test the changes in this Pull Request:

1. Switch to this branch
2. Check the list of classes for `block-editor-block-list__layout`
3. Toggle between inline and overlay (play with overlay sizes as well)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
