### PR TITLE
fix: make "scroll" the default inline trigger_type

### DIFF
--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -380,7 +380,7 @@ final class Newspack_Popups_Inserter {
 				$position          = $inline_popup['precise_position'];
 				$trigger_type      = $inline_popup['options']['trigger_type'];
 				$insert_at_zero    = 0 === $position; // If the position is 0, the prompt should always appear first.
-				$insert_for_scroll = 'scroll' === $trigger_type && $pos > $position;
+				$insert_for_scroll = 'blocks_count' !== $trigger_type && $pos > $position;
 				$insert_for_blocks = 'blocks_count' === $trigger_type && $block_index >= $position;
 
 				if ( $insert_at_zero || $insert_for_scroll || $insert_for_blocks ) {

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -606,6 +606,7 @@ final class Newspack_Popups_Model {
 				case 'scroll':
 					$popup['options']['trigger_delay'] = 0;
 					break;
+				case 'blocks_count':
 				case 'time':
 				default:
 					$popup['options']['trigger_scroll_progress'] = 0;

--- a/src/editor/Sidebar.js
+++ b/src/editor/Sidebar.js
@@ -176,21 +176,20 @@ const Sidebar = props => {
 						] }
 						onChange={ value => onMetaFieldChange( 'trigger_type', value ) }
 					/>
-					{ 'scroll' === trigger_type && (
+					{ 'blocks_count' === trigger_type ? (
+						<RangeControl
+							label={ __( 'Number of blocks before the prompt', 'newspack-popups' ) }
+							value={ trigger_blocks_count }
+							onChange={ value => onMetaFieldChange( 'trigger_blocks_count', value ) }
+							min={ 0 }
+						/>
+					) : (
 						<RangeControl
 							label={ __( 'Approximate Position (in percent)', 'newspack-popups' ) }
 							value={ trigger_scroll_progress }
 							onChange={ value => onMetaFieldChange( 'trigger_scroll_progress', value ) }
 							min={ 0 }
 							max={ 100 }
-						/>
-					) }
-					{ 'blocks_count' === trigger_type && (
-						<RangeControl
-							label={ __( 'Number of blocks before the prompt', 'newspack-popups' ) }
-							value={ trigger_blocks_count }
-							onChange={ value => onMetaFieldChange( 'trigger_blocks_count', value ) }
-							min={ 0 }
 						/>
 					) }
 				</>

--- a/src/editor/Sidebar.js
+++ b/src/editor/Sidebar.js
@@ -144,22 +144,21 @@ const Sidebar = props => {
 						] }
 						onChange={ value => onMetaFieldChange( 'trigger_type', value ) }
 					/>
-					{ 'time' === trigger_type && (
-						<RangeControl
-							label={ __( 'Delay (seconds)', 'newspack-popups' ) }
-							value={ trigger_delay }
-							onChange={ value => onMetaFieldChange( 'trigger_delay', value ) }
-							min={ 0 }
-							max={ 60 }
-						/>
-					) }
-					{ 'scroll' === trigger_type && (
+					{ 'scroll' === trigger_type ? (
 						<RangeControl
 							label={ __( 'Scroll Progress (percent)', 'newspack-popups' ) }
 							value={ trigger_scroll_progress }
 							onChange={ value => onMetaFieldChange( 'trigger_scroll_progress', value ) }
 							min={ 1 }
 							max={ 100 }
+						/>
+					) : (
+						<RangeControl
+							label={ __( 'Delay (seconds)', 'newspack-popups' ) }
+							value={ trigger_delay }
+							onChange={ value => onMetaFieldChange( 'trigger_delay', value ) }
+							min={ 0 }
+							max={ 60 }
 						/>
 					) }
 				</>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes an edge case where an inline prompt can get stuck with an invalid "insertion position" or `trigger_type` value, which causes the `RangeControl` used to set the insertion position to not appear at all in the editor, and the prompt to always appear at the very end of the content.

Prior to #755 `scroll` was really the only valid `trigger_type` value for inline prompts, so all inline prompts behaved the same way regardless of what that value was. After #842, a second `blocks_count` option was added, but it's still possible for a prompt to be saved as an overlay, then converted to an inline prompt, and have `trigger_type` be set to `time` as a result. This is the edge case fixed by this PR. The fix is to make any value other than `blocks_count` behave like `scroll`, effectively making this the default/fallback behavior.

Closes #842.

### How to test the changes in this Pull Request:

1. Publish an overlay prompt with the "Trigger" option set to "Timer".
2. After the post is saved, change the "Prompt Type" to "Inline". This puts the the prompt into a state where it's inserted as an inline prompt, but its `trigger_type` value is still set to `time`, an invalid value for inline prompts.
3. On `master`, in the editor under the "Prompt Settings" sidebar, observe that the `RangeControl` to set the precise insertion position is not rendered at all.
4. On the front-end, observe that the prompt gets inserted like an inline prompt at the end of every article.
5. Check out this branch. Confirm that in the editor, the "Insertion Position" is set to "Scroll" and the `RangeControl` appears with the default value of 30%.
6. Confirm on the front-end that the prompt gets inserted at 30% of the content, which is the default inline prompt behavior.
7. Conversely, set the "Insertion Position" option to "Blocks Count" and save, then convert the "Prompt Type" to an Overlay. This puts the prompt into a state where it's an overlay with a `trigger_type` of `blocks_count`, an invalid value for overlays.
8. Confirm that in the editor, the "Trigger" is shown as the default value "Timer".
9. Confirm on the front-end that the overlay appears after a 3 second delay, the default delay.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
