### PR TITLE
fix: insertion of prompts around Group blocks

### DIFF
--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -366,7 +366,8 @@ final class Newspack_Popups_Inserter {
 					// Give length-ignored blocks a length of 1 so that prompts at 0% can still be inserted before them.
 					$pos++;
 				} else {
-					$pos += strlen( wp_strip_all_tags( $block['innerHTML'] ) );
+					$block_content = self::get_block_content( $block );
+					$pos          += strlen( wp_strip_all_tags( $block_content ) );
 				}
 			}
 

--- a/tests/test-content-insertion.php
+++ b/tests/test-content-insertion.php
@@ -435,9 +435,87 @@ Paragraph 2
 		self::assertEqualBlockNames(
 			[
 				'core/shortcode', // Popup 1 - inserted before the group block.
+				'core/shortcode', // Popup 2 - inserted before the group block.
 				'core/group',
-				'core/shortcode', // Popup 2 - inserted after the group block.
 				'core/shortcode', // Popup 3.
+			],
+			Newspack_Popups_Inserter::insert_popups_in_post_content(
+				$post_content,
+				self::$popups
+			),
+			'The popups are inserted into the content at expected positions.'
+		);
+	}
+
+	/**
+	 * Test prompt insertion at 0% with multiple top-level Group blocks.
+	 */
+	public function test_prompt_insertion_multiple_groups() {
+		$post_content = '
+	<!-- wp:group -->
+	<div class="wp-block-group"><!-- wp:paragraph -->
+	<p>Paragraph 1</p>
+	<!-- /wp:paragraph -->
+
+	<!-- wp:paragraph -->
+	<p>Paragraph 2</p>
+	<!-- /wp:paragraph --></div>
+	<!-- /wp:group -->
+
+	<!-- wp:group -->
+	<div class="wp-block-group">
+	<!-- wp:paragraph -->
+	<p>Paragraph 3</p>
+	<!-- /wp:paragraph -->
+
+	<!-- wp:paragraph -->
+	<p>Paragraph 4</p>
+	<!-- /wp:paragraph --></div>
+	<!-- /wp:group -->
+
+	<!-- wp:group -->
+	<div class="wp-block-group">
+	<!-- wp:paragraph -->
+	<p>Paragraph 5</p>
+	<!-- /wp:paragraph -->
+
+	<!-- wp:paragraph -->
+	<p>Paragraph 6</p>
+	<!-- /wp:paragraph --></div>
+	<!-- /wp:group -->
+
+	<!-- wp:group -->
+	<div class="wp-block-group">
+	<!-- wp:paragraph -->
+	<p>Paragraph 7</p>
+	<!-- /wp:paragraph -->
+
+	<!-- wp:paragraph -->
+	<p>Paragraph 8</p>
+	<!-- /wp:paragraph --></div>
+	<!-- /wp:group -->
+
+	<!-- wp:group -->
+	<div class="wp-block-group">
+	<!-- wp:paragraph -->
+	<p>Paragraph 9</p>
+	<!-- /wp:paragraph -->
+
+	<!-- wp:paragraph -->
+	<p>Paragraph 10</p>
+	<!-- /wp:paragraph --></div>
+	<!-- /wp:group -->';
+
+		self::assertEqualBlockNames(
+			[
+				'core/shortcode', // Popup 1 - 0%.
+				'core/group',
+				'core/group',
+				'core/group',
+				'core/shortcode', // Popup 2 - 70%.
+				'core/group',
+				'core/group',
+				'core/shortcode', // Popup 3 - 100%.
 			],
 			Newspack_Popups_Inserter::insert_popups_in_post_content(
 				$post_content,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes the insertion algorithm of inline blocks around Group blocks. Previously the length of the Group's inner blocks wasn't factored into the total article length calculation, so inline prompts wouldn't get properly inserted into posts consisting mostly of multiple Groups.

### How to test the changes in this Pull Request:

1. Create a post consisting of several top-level Group blocks. Or copy the following test content:

<details>
<summary>Expand to copy</summary>

```html
<!-- wp:paragraph -->
<p>Nam tellus duis magna finibus penatibus eleifend maecenas aptent, senectus quam egestas dictum dapibus eu risus maximus, ligula lacus cras malesuada ipsum montes bibendum. Donec hendrerit aenean in pharetra suspendisse conubia ligula sollicitudin quis placerat varius sodales, natoque mattis mollis per ad dapibus taciti ut platea tempor. Aenean integer duis consectetur nam dignissim nullam leo semper, viverra venenatis placerat convallis scelerisque lectus.</p>
<!-- /wp:paragraph -->

<!-- wp:group -->
<div class="wp-block-group"><!-- wp:paragraph -->
<p>Fermentum sed condimentum magnis habitant mi penatibus platea ridiculus mus maecenas est magna, pharetra elementum sem non vivamus diam lacus egestas nascetur felis. Vehicula lectus condimentum curabitur quam semper est sollicitudin, parturient rutrum id</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph -->
<p> vivamus dis per. Viverra porta sit hendrerit vivamus dapibus pellentesque dictumst duis, et interdum pulvinar sed maximus senectus convallis etiam, vitae sem sollicitudin augue imperdiet quis arcu. Inceptos ridiculus felis dignissim ullamcorper massa porta semper facilisi consectetur duis eros, ultrices placerat nisi velit urna nascetur est dis ipsum penat</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph -->
<p>ibus. Velit erat ligula quisque aliquam pulvinar dignissim luctus vel commodo sagittis bibendum scelerisque sem a enim, senectus parturient litora ornare aenean imperdiet ipsum sed ridiculus lorem dictumst pellentesque sapien.</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->

<!-- wp:group -->
<div class="wp-block-group"><!-- wp:paragraph -->
<p>A mauris pellentesque eros accumsan dui fusce scelerisque litora nam efficitur massa tempor vestibulum, ex sagittis cubilia ullamcorper dis maximus leo conse</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph -->
<p>ctetur potenti quam finibus. Quisque commodo phasellus suscipit molestie proin rutrum fringilla id congue mus tempor class primis, mattis maximus hendrerit tellus duis vestibulum sed in platea natoque vitae. At ante sagittis parturient conubia posuere ullamcorper maecenas fringilla finibus erat quisque aliquet, pulvinar gravida facilisi interdum praesent est commodo molestie v</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph -->
<p>itae semper sociosqu. Nulla potenti risus quam tempus est litora vitae duis class tellus cursus tortor condimentum, euismod sodales dapibus etiam integer in phasellus scelerisque lectus nunc erat.</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->

<!-- wp:group -->
<div class="wp-block-group"><!-- wp:paragraph -->
<p>Lectus molestie a rutrum montes scelerisque lacus praesent id sociosqu aliquam, hac quisque taciti vehicula mi erat ligula magnis est. Porttitor sem leo hendrerit condimentum metus ridiculus class efficitur praesent faucibus cursus, a ultrices rutrum egestas lacus ligula blandit elementum malesuada dictum.</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->

<!-- wp:group -->
<div class="wp-block-group"><!-- wp:paragraph -->
<p>Purus dictumst vulputate quam mauris integer aenean mattis maximus finibus pretium neque eleifend, lacus lorem hac lectus velit egestas porttitor venenatis nunc eros enim. Dapibus fringilla sodales libero aptent ornare pulvinar curabitur maximus est pretiu</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph -->
<p>m aliquam dolor litora blandit suspendisse, per nascetur egestas pellentesque tellus massa condimentum interdum lectus parturient hac magnis diam consectetur. Efficitur pharetra tempor ipsum maximus rhoncus primis dui, ultricies feugiat volutpat vitae vivamus. Egestas tristique enim gravida tellus finibus neque suspendisse sagittis eu dolor mollis, molestie fringilla purus aptent mauris senectus commodo parturient ex vivamus.</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->
```

</details>

2. Publish an inline prompt and set the insertion logic to "Percentage" at 50%.
3. On `master`, view on the front-end and observe that the prompt gets inserted at the very end of the article.
4. Check out this branch, refresh, and confirm that the prompt gets inserted at roughly 50% of the content, as expected.
5. Test with various percentages and Block Count criteria to confirm that nothing else looks off.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
