### PR TITLE
fix: revert group insertion fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.52.1-hotfix.1](https://github.com/Automattic/newspack-popups/compare/v1.52.0...v1.52.1-hotfix.1) (2022-04-20)
+
+
+### Reverts
+
+* Revert "fix: insertion of prompts around Group blocks (#855)" ([b9917f2](https://github.com/Automattic/newspack-popups/commit/b9917f2f7e9c17bad96c8bb0385dbf144d10344b)), closes [#855](https://github.com/Automattic/newspack-popups/issues/855)
+
 # [1.52.0](https://github.com/Automattic/newspack-popups/compare/v1.51.0...v1.52.0) (2022-04-20)
 
 

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -366,8 +366,7 @@ final class Newspack_Popups_Inserter {
 					// Give length-ignored blocks a length of 1 so that prompts at 0% can still be inserted before them.
 					$pos++;
 				} else {
-					$block_content = self::get_block_content( $block );
-					$pos          += strlen( wp_strip_all_tags( $block_content ) );
+					$pos += strlen( wp_strip_all_tags( $block['innerHTML'] ) );
 				}
 			}
 

--- a/newspack-popups.php
+++ b/newspack-popups.php
@@ -7,7 +7,7 @@
  * Author URI:      https://newspack.blog
  * Text Domain:     newspack-popups
  * Domain Path:     /languages
- * Version:         1.52.0
+ * Version:         1.52.1-hotfix.1
  *
  * @package         Newspack_Popups
  */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "newspack-popups",
-  "version": "1.52.0",
+  "version": "1.52.1-hotfix.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "newspack-popups",
-      "version": "1.52.0",
+      "version": "1.52.1-hotfix.1",
       "dependencies": {
         "classnames": "^2.3.1",
         "intersection-observer": "^0.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "newspack-popups",
-  "version": "1.52.0",
+  "version": "1.52.1-hotfix.1",
   "main": "Gruntfile.js",
   "author": "Automattic",
   "scripts": {

--- a/tests/test-content-insertion.php
+++ b/tests/test-content-insertion.php
@@ -435,87 +435,9 @@ Paragraph 2
 		self::assertEqualBlockNames(
 			[
 				'core/shortcode', // Popup 1 - inserted before the group block.
-				'core/shortcode', // Popup 2 - inserted before the group block.
 				'core/group',
+				'core/shortcode', // Popup 2 - inserted after the group block.
 				'core/shortcode', // Popup 3.
-			],
-			Newspack_Popups_Inserter::insert_popups_in_post_content(
-				$post_content,
-				self::$popups
-			),
-			'The popups are inserted into the content at expected positions.'
-		);
-	}
-
-	/**
-	 * Test prompt insertion at 0% with multiple top-level Group blocks.
-	 */
-	public function test_prompt_insertion_multiple_groups() {
-		$post_content = '
-	<!-- wp:group -->
-	<div class="wp-block-group"><!-- wp:paragraph -->
-	<p>Paragraph 1</p>
-	<!-- /wp:paragraph -->
-
-	<!-- wp:paragraph -->
-	<p>Paragraph 2</p>
-	<!-- /wp:paragraph --></div>
-	<!-- /wp:group -->
-
-	<!-- wp:group -->
-	<div class="wp-block-group">
-	<!-- wp:paragraph -->
-	<p>Paragraph 3</p>
-	<!-- /wp:paragraph -->
-
-	<!-- wp:paragraph -->
-	<p>Paragraph 4</p>
-	<!-- /wp:paragraph --></div>
-	<!-- /wp:group -->
-
-	<!-- wp:group -->
-	<div class="wp-block-group">
-	<!-- wp:paragraph -->
-	<p>Paragraph 5</p>
-	<!-- /wp:paragraph -->
-
-	<!-- wp:paragraph -->
-	<p>Paragraph 6</p>
-	<!-- /wp:paragraph --></div>
-	<!-- /wp:group -->
-
-	<!-- wp:group -->
-	<div class="wp-block-group">
-	<!-- wp:paragraph -->
-	<p>Paragraph 7</p>
-	<!-- /wp:paragraph -->
-
-	<!-- wp:paragraph -->
-	<p>Paragraph 8</p>
-	<!-- /wp:paragraph --></div>
-	<!-- /wp:group -->
-
-	<!-- wp:group -->
-	<div class="wp-block-group">
-	<!-- wp:paragraph -->
-	<p>Paragraph 9</p>
-	<!-- /wp:paragraph -->
-
-	<!-- wp:paragraph -->
-	<p>Paragraph 10</p>
-	<!-- /wp:paragraph --></div>
-	<!-- /wp:group -->';
-
-		self::assertEqualBlockNames(
-			[
-				'core/shortcode', // Popup 1 - 0%.
-				'core/group',
-				'core/group',
-				'core/group',
-				'core/shortcode', // Popup 2 - 70%.
-				'core/group',
-				'core/group',
-				'core/shortcode', // Popup 3 - 100%.
 			],
 			Newspack_Popups_Inserter::insert_popups_in_post_content(
 				$post_content,


### PR DESCRIPTION
This reverts commit 6ae5ea90c664e359d80e116253a2a675fe200b69.

### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

#855 improved the insertion behavior of inline prompts around Group blocks, taking into account the length of Groups' inner blocks. However, this has resulted in changed prompt placement on many homepages, most of which consist almost entirely of Group blocks. Many publishers have complained about the new placement, so this may be an instance in which the fix is not actually desired. Let's revert it for now.

### How to test the changes in this Pull Request:

1. Publish a post consisting of several top-level Group blocks containing a few other blocks like paragraphs, etc.
2. Publish an inline prompt at 50% placement.
3. On `master`, observe that the prompt appears halfway down the page.
4. On this branch, confirm that the prompt renders at the very end of the page, which is actually desired by many publishers for the homepage.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
