### PR TITLE
fix(analytics): remove redundant trackPageView trigger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.52.2-hotfix.1](https://github.com/Automattic/newspack-popups/compare/v1.52.1...v1.52.2-hotfix.1) (2022-05-03)
+
+
+### Bug Fixes
+
+* **analytics:** remove redundant trackPageView trigger ([5c59d67](https://github.com/Automattic/newspack-popups/commit/5c59d67c021b88b4474b7ad69147d20953bfc37c))
+
 ## [1.52.1](https://github.com/Automattic/newspack-popups/compare/v1.52.0...v1.52.1) (2022-04-20)
 
 

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -844,22 +844,7 @@ final class Newspack_Popups_Model {
 			'requests' => [
 				'event' => esc_url( $endpoint ),
 			],
-			'triggers' => [
-				'trackPageview' => [
-					'on'             => 'visible',
-					'request'        => 'event',
-					'visibilitySpec' => [
-						'selector'             => '#' . esc_attr( $element_id ),
-						'visiblePercentageMin' => 90,
-						'totalTimeMin'         => 500,
-						'continuousTimeMin'    => 200,
-					],
-					'extraUrlParams' => [
-						'popup_id' => esc_attr( self::canonize_popup_id( $popup['id'] ) ),
-						'cid'      => 'CLIENT_ID(' . esc_attr( Newspack_Popups_Segmentation::NEWSPACK_SEGMENTATION_CID_NAME ) . ')',
-					],
-				],
-			],
+			'triggers' => [],
 		];
 		if ( $subscribe_form_selector && $email_form_field_name ) {
 			$amp_analytics_config['triggers']['formSubmitSuccess'] = [

--- a/newspack-popups.php
+++ b/newspack-popups.php
@@ -7,7 +7,7 @@
  * Author URI:      https://newspack.blog
  * Text Domain:     newspack-popups
  * Domain Path:     /languages
- * Version:         1.52.1
+ * Version:         1.52.2-hotfix.1
  *
  * @package         Newspack_Popups
  */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "newspack-popups",
-  "version": "1.52.1",
+  "version": "1.52.2-hotfix.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "newspack-popups",
-      "version": "1.52.1",
+      "version": "1.52.2-hotfix.1",
       "dependencies": {
         "classnames": "^2.3.1",
         "intersection-observer": "^0.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "newspack-popups",
-  "version": "1.52.1",
+  "version": "1.52.2-hotfix.1",
   "main": "Gruntfile.js",
   "author": "Automattic",
   "scripts": {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Removes the `trackPageView` analytics trigger that has been resulting in double page view counts on some sites. This seems to be redundant with the existing "Seen" event that reports that a prompt has been visible for at least one second, anyway.

### How to test the changes in this Pull Request:

1. On `master`, publish a prompt and view on the front-end. View source and observe that you see a `trackPageView` trigger similar to the following:

```json
{"requests":{"event":"https:\/\/newspack.test\/wp-content\/plugins\/newspack-popups\/includes\/..\/api\/campaigns\/index.php"},"triggers":{"trackPageview":{"on":"visible","request":"event","visibilitySpec":{"selector":"#cade","visiblePercentageMin":90,"totalTimeMin":500,"continuousTimeMin":200}...
```

3. In the dev tools Network panel, filter by `t=pageview` and observe that you see two pageview requests per page load.
4. Check out this branch, refresh, and confirm that you don't see the `trackPageview` trigger in source, and that you only see one `pageview` request per page load.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
