### PR TITLE
feat(api): improve web crawler handling

### DIFF
--- a/api/classes/class-lightweight-api.php
+++ b/api/classes/class-lightweight-api.php
@@ -46,7 +46,7 @@ class Lightweight_API {
 	 */
 	public function __construct() {
 		if ( $this->is_a_web_crawler() ) {
-			header( 'X-Robots-Tag: noindex', false );
+			header( 'X-Robots-Tag: noindex' );
 			exit;
 		}
 		if ( ! $this->verify_referer() ) {

--- a/api/classes/class-lightweight-api.php
+++ b/api/classes/class-lightweight-api.php
@@ -46,7 +46,8 @@ class Lightweight_API {
 	 */
 	public function __construct() {
 		if ( $this->is_a_web_crawler() ) {
-			$this->error( 'invalid_referer' );
+			header( 'X-Robots-Tag: noindex', false );
+			exit;
 		}
 		if ( ! $this->verify_referer() ) {
 			$this->error( 'invalid_referer' );

--- a/tests/test-api.php
+++ b/tests/test-api.php
@@ -1836,6 +1836,7 @@ class APITest extends WP_UnitTestCase {
 			$api->is_a_web_crawler(),
 			'Return true if the user agent is of a web crawler.'
 		);
+		$_SERVER['HTTP_USER_AGENT'] = 'Test'; // phpcs:ignore
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

The standard way of discouraging crawlers from indexing [seems to be](https://developers.google.com/search/docs/advanced/crawling/block-indexing) "noindexing" rather than returning a 400 error. This PR changes the behaviour towards bots crawling the API.

### How to test the changes in this Pull Request:

1. Add a line to `return true;` from `is_a_web_crawler` API method
2. On `master`, observe API requests from the front-end get `400` error response
3. Switch to this branch, observe the response is `200` with a `X-Robots-Tag: noindex` header

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->