### PR TITLE
refactor: segmentation data

### DIFF
--- a/api/campaigns/class-campaign-data-utils.php
+++ b/api/campaigns/class-campaign-data-utils.php
@@ -114,7 +114,9 @@ class Campaign_Data_Utils {
 			array_filter(
 				$reader_events,
 				function ( $event ) {
-					return 'article_view' === $event['type'];
+					$hour_ago   = strtotime( '-1 hour', time() );
+					$event_time = strtotime( $event['date_created'] );
+					return 'article_view' === $event['type'] && $event_time > $hour_ago;
 				}
 			)
 		);

--- a/api/campaigns/class-campaign-data-utils.php
+++ b/api/campaigns/class-campaign-data-utils.php
@@ -120,6 +120,7 @@ class Campaign_Data_Utils {
 		);
 
 		// Read counts for categories.
+		$favorite_category_matches_segment = false;
 		if ( $reader_data['categories_read'] ) {
 			$categories_read_counts = $reader_data['categories_read'];
 			arsort( $categories_read_counts );
@@ -167,12 +168,18 @@ class Campaign_Data_Utils {
 		}
 
 		/**
-		 * By login status.
+		 * By login status. is_logged_in and is_not_logged_in are legacy option names
+		 * that have been renamed has_user_account and no_user_account, for clarity.
 		 */
-		if ( ( $campaign_segment->has_user_account || $campaign_segment->is_logged_in ) && ! $has_user_account ) {
+		$segment_has_user_account = ( isset( $campaign_segment->has_user_account ) && $campaign_segment->has_user_account ) ||
+			( isset( $campaign_segment->is_logged_in ) && $campaign_segment->is_logged_in );
+		$segment_no_user_account  = ( isset( $campaign_segment->no_user_account ) && $campaign_segment->no_user_account ) ||
+		( isset( $campaign_segment->is_not_logged_in ) && $campaign_segment->is_not_logged_in );
+
+		if ( $segment_has_user_account && ! $has_user_account ) {
 			$should_display = false;
 		}
-		if ( ( $campaign_segment->no_user_account || $campaign_segment->is_not_logged_in ) && $has_user_account ) {
+		if ( $segment_no_user_account && $has_user_account ) {
 			$should_display = false;
 		}
 

--- a/api/campaigns/class-campaign-data-utils.php
+++ b/api/campaigns/class-campaign-data-utils.php
@@ -150,15 +150,12 @@ class Campaign_Data_Utils {
 
 		// Read counts for categories.
 		$favorite_category_matches_segment = false;
-		$categories_read_counts            = array_reduce(
-			$reader_data,
-			function( $acc, $item ) {
-				if ( 'term_count' === $item['type'] && 'category' === $item['context'] ) {
-					$acc = $item['value'];
-				}
-			},
-			false
-		);
+		$categories_read_counts            = false;
+		foreach ( $reader_data as $item ) {
+			if ( 'term_count' === $item['type'] && 'category' === $item['context'] ) {
+				$categories_read_counts = $item['value'];
+			}
+		}
 		if ( $categories_read_counts ) {
 			arsort( $categories_read_counts );
 			$favorite_category_matches_segment = in_array( key( $categories_read_counts ), $campaign_segment->favorite_categories );

--- a/api/campaigns/class-campaign-data-utils.php
+++ b/api/campaigns/class-campaign-data-utils.php
@@ -83,8 +83,8 @@ class Campaign_Data_Utils {
 				'is_not_subscribed'   => false,
 				'is_donor'            => false,
 				'is_not_donor'        => false,
-				'is_logged_in'        => false,
-				'is_not_logged_in'    => false,
+				'has_user_account'    => false,
+				'no_user_account'     => false,
 				'referrers'           => '',
 				'favorite_categories' => [],
 				'priority'            => PHP_INT_MAX,
@@ -109,7 +109,7 @@ class Campaign_Data_Utils {
 		$is_donor                    = self::is_donor( $reader_events );
 		$has_user_account            = self::has_user_account( $reader_data );
 		$campaign_segment            = self::canonize_segment( $campaign_segment );
-		$article_views_count         = $reader_data['article_views'];
+		$article_views_count         = (int) $reader_data['article_views'];
 		$article_views_count_session = count(
 			array_filter(
 				$reader_events,
@@ -129,7 +129,7 @@ class Campaign_Data_Utils {
 		/**
 		 * By article view count.
 		 */
-		if ( $campaign_segment->min_posts > 0 && $campaign_segment->min_posts > $posts_rearticle_views_countad_count ) {
+		if ( $campaign_segment->min_posts > 0 && $campaign_segment->min_posts > $article_views_count ) {
 			$should_display = false;
 		}
 		if ( $campaign_segment->max_posts > 0 && $campaign_segment->max_posts < $article_views_count ) {
@@ -169,10 +169,10 @@ class Campaign_Data_Utils {
 		/**
 		 * By login status.
 		 */
-		if ( $campaign_segment->is_logged_in && ! $has_user_account ) {
+		if ( ( $campaign_segment->has_user_account || $campaign_segment->is_logged_in ) && ! $has_user_account ) {
 			$should_display = false;
 		}
-		if ( $campaign_segment->is_not_logged_in && $has_user_account ) {
+		if ( ( $campaign_segment->no_user_account || $campaign_segment->is_not_logged_in ) && $has_user_account ) {
 			$should_display = false;
 		}
 

--- a/api/campaigns/class-campaign-data-utils.php
+++ b/api/campaigns/class-campaign-data-utils.php
@@ -30,8 +30,8 @@ class Campaign_Data_Utils {
 		return 0 < count(
 			array_filter(
 				$reader_events,
-				function( $item ) {
-					return 'subscription' === $item['type'];
+				function( $event ) {
+					return 'subscription' === $event['type'];
 				}
 			)
 		);
@@ -46,8 +46,8 @@ class Campaign_Data_Utils {
 		return 0 < count(
 			array_filter(
 				$reader_events,
-				function( $item ) {
-					return 'donation' === $item['type'];
+				function( $event ) {
+					return 'donation' === $event['type'];
 				}
 			)
 		);
@@ -62,8 +62,8 @@ class Campaign_Data_Utils {
 		return 0 < count(
 			array_filter(
 				$reader_events,
-				function( $item ) {
-					return 'user_account' === $item['type'];
+				function( $event ) {
+					return 'user_account' === $event['type'];
 				}
 			)
 		);
@@ -121,10 +121,10 @@ class Campaign_Data_Utils {
 		return count(
 			array_filter(
 				$reader_events,
-				function ( $item ) use ( $non_singular_contexts ) {
-					$hour_ago  = strtotime( '-1 hour', time() );
-					$item_time = strtotime( $item['date_created'] );
-					return 'view' === $item['type'] && ! in_array( $item['context'], $non_singular_contexts, true ) && $item_time > $hour_ago;
+				function ( $event ) use ( $non_singular_contexts ) {
+					$hour_ago   = strtotime( '-1 hour', time() );
+					$event_time = strtotime( $event['date_created'] );
+					return 'view' === $event['type'] && ! in_array( $event['context'], $non_singular_contexts, true ) && $event_time > $hour_ago;
 				}
 			)
 		);

--- a/api/campaigns/class-campaign-data-utils.php
+++ b/api/campaigns/class-campaign-data-utils.php
@@ -51,7 +51,7 @@ class Campaign_Data_Utils {
 			array_filter(
 				$reader_data,
 				function( $item ) {
-					return 'user_id' === $item['type'];
+					return 'user_account' === $item['type'];
 				}
 			)
 		);

--- a/api/campaigns/class-maybe-show-campaign.php
+++ b/api/campaigns/class-maybe-show-campaign.php
@@ -217,7 +217,7 @@ class Maybe_Show_Campaign extends Lightweight_API {
 			$now = time();
 		}
 
-		$seen_events    = $this->get_reader_data( $client_id, 'prompt', 'seen' );
+		$seen_events    = $this->get_reader_data( $client_id, 'prompt_seen', $popup->id );
 		$should_display = true;
 
 		// Handle referer-based conditions.
@@ -260,12 +260,11 @@ class Maybe_Show_Campaign extends Lightweight_API {
 				[];
 
 			$popup_segment = Campaign_Data_Utils::canonize_segment( $popup_segment );
-			$reader_data   = $this->get_reader_data( $client_id );
 
 			// Check whether client matches the prompt's segment.
 			$segment_matches = Campaign_Data_Utils::does_reader_match_segment(
 				$popup_segment,
-				$reader_data,
+				$this->get_reader_data( $client_id ),
 				$referer_url,
 				$page_referer_url
 			);

--- a/api/campaigns/class-maybe-show-campaign.php
+++ b/api/campaigns/class-maybe-show-campaign.php
@@ -26,7 +26,7 @@ class Maybe_Show_Campaign extends Lightweight_API {
 		}
 		$popups    = json_decode( $_REQUEST['popups'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		$settings  = json_decode( $_REQUEST['settings'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-		$visit     = (array) json_decode( $_REQUEST['visit'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.InputNotValidated
+		$visit     = json_decode( $_REQUEST['visit'], true ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.InputNotValidated
 		$response  = [];
 		$client_id = $_REQUEST['cid']; // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 
@@ -182,7 +182,7 @@ class Maybe_Show_Campaign extends Lightweight_API {
 		}
 
 		$reader                   = $this->get_reader( $client_id );
-		$reader_events            = $this->get_reader_events( $client_id );
+		$reader_events            = $this->get_reader_events( $client_id, [ 'subscription', 'donation', 'user_account', 'view' ] );
 		$best_segment_priority    = PHP_INT_MAX;
 		$best_priority_segment_id = null;
 
@@ -285,7 +285,7 @@ class Maybe_Show_Campaign extends Lightweight_API {
 			$segment_matches = Campaign_Data_Utils::does_reader_match_segment(
 				$popup_segment,
 				$this->get_reader( $client_id ),
-				$this->get_reader_events( $client_id ),
+				$this->get_reader_events( $client_id, [ 'subscription', 'donation', 'user_account', 'view' ] ),
 				$referer_url,
 				$page_referer_url
 			);

--- a/api/campaigns/class-maybe-show-campaign.php
+++ b/api/campaigns/class-maybe-show-campaign.php
@@ -46,11 +46,14 @@ class Maybe_Show_Campaign extends Lightweight_API {
 			if ( isset( $visit['post_id'] ) ) {
 				$read_event['value']['post_id'] = $visit['post_id'];
 			}
+			if ( isset( $visit['request'] ) ) {
+				$read_event['value']['request'] = $visit['request'];
+			}
 			if ( isset( $visit['categories'] ) ) {
 				$read_event['value']['categories'] = $visit['categories'];
 			}
-			if ( isset( $visit['post_type'] ) ) {
-				$read_event['context'] = $visit['post_type'];
+			if ( isset( $visit['post_type'] ) || isset( $visit['request_type'] ) ) {
+				$read_event['context'] = isset( $visit['post_type'] ) ? $visit['post_type'] : $visit['request_type'];
 			}
 
 			$reader = $this->get_reader( $client_id );

--- a/api/campaigns/class-maybe-show-campaign.php
+++ b/api/campaigns/class-maybe-show-campaign.php
@@ -37,27 +37,27 @@ class Maybe_Show_Campaign extends Lightweight_API {
 
 		// Log an article or page view event.
 		if ( $visit && ( ! defined( 'DISABLE_CAMPAIGN_EVENT_LOGGING' ) || true !== DISABLE_CAMPAIGN_EVENT_LOGGING ) ) {
-			$read_event = [
+			$view_event = [
 				'type'  => 'view',
 				'value' => [],
 			];
 			if ( isset( $visit['post_id'] ) ) {
-				$read_event['value']['post_id'] = $visit['post_id'];
+				$view_event['value']['post_id'] = $visit['post_id'];
 			}
 			if ( isset( $visit['categories'] ) ) {
-				$read_event['value']['categories'] = $visit['categories'];
+				$view_event['value']['categories'] = $visit['categories'];
 			}
 			if ( isset( $visit['request'] ) ) {
-				$read_event['value']['request'] = $visit['request'];
+				$view_event['value']['request'] = $visit['request'];
 			}
 			if ( isset( $visit['post_type'] ) || isset( $visit['request_type'] ) ) {
-				$read_event['context'] = isset( $visit['post_type'] ) ? $visit['post_type'] : $visit['request_type'];
+				$view_event['context'] = isset( $visit['post_type'] ) ? $visit['post_type'] : $visit['request_type'];
 			}
 
 			$reader = $this->get_reader( $client_id );
 
 			if ( isset( $reader['client_id'] ) ) {
-				$this->save_reader_events( $client_id, [ $read_event ] );
+				$this->save_reader_events( $client_id, [ $view_event ] );
 			}
 		}
 

--- a/api/campaigns/class-maybe-show-campaign.php
+++ b/api/campaigns/class-maybe-show-campaign.php
@@ -344,7 +344,6 @@ class Maybe_Show_Campaign extends Lightweight_API {
 		}
 
 		// Handle frequency.
-		// TODO: Log a prompt seen event.
 		$frequency = $popup->f;
 		if ( 'once' === $frequency && count( $seen_events ) >= 1 ) {
 			$should_display = false;

--- a/api/campaigns/class-report-campaign-data.php
+++ b/api/campaigns/class-report-campaign-data.php
@@ -38,11 +38,12 @@ class Report_Campaign_Data extends Lightweight_API {
 	public function report_campaign( $request ) {
 		$client_id = $this->get_request_param( 'cid', $request );
 		$popup_id  = $this->get_request_param( 'popup_id', $request );
+		$action    = $this->get_request_param( 'dismiss', $request ) ? 'prompt_dismissed' : 'prompt_seen';
 		$events    = [
 			[
 				'client_id'    => $client_id,
 				'date_created' => gmdate( 'Y-m-d H:i:s' ),
-				'type'         => 'prompt_seen',
+				'type'         => $action,
 				'event_value'  => [ 'id' => $popup_id ],
 			],
 		];

--- a/api/campaigns/class-report-campaign-data.php
+++ b/api/campaigns/class-report-campaign-data.php
@@ -54,6 +54,7 @@ class Report_Campaign_Data extends Lightweight_API {
 		}
 
 		// Update prompts data.
+		// TODO: Log an email signup event.
 		$client_data_update['prompts'] = [ "$campaign_id" => $campaign_data ];
 		$this->save_client_data( $client_id, $client_data_update );
 	}

--- a/api/campaigns/class-report-campaign-data.php
+++ b/api/campaigns/class-report-campaign-data.php
@@ -57,7 +57,7 @@ class Report_Campaign_Data extends Lightweight_API {
 			];
 		}
 
-		$this->save_reader_data( $client_id, $data );
+		$this->save_reader_events( $client_id, $data );
 	}
 }
 new Report_Campaign_Data();

--- a/api/campaigns/class-report-campaign-data.php
+++ b/api/campaigns/class-report-campaign-data.php
@@ -32,34 +32,32 @@ class Report_Campaign_Data extends Lightweight_API {
 
 	/**
 	 * Handle reporting campaign data – views and subscriptions.
-	 * TODO: Rethink this model to concatenate views/dismissals by prompt id to avoid creating new rows for each interaction.
 	 *
 	 * @param object $request A request.
 	 */
 	public function report_campaign( $request ) {
 		$client_id = $this->get_request_param( 'cid', $request );
 		$popup_id  = $this->get_request_param( 'popup_id', $request );
-		$action    = $this->get_request_param( 'dismiss', $request ) ? 'dismissed' : 'seen';
-		$events    = [
+		$action    = $this->get_request_param( 'dismiss', $request ) ? 'prompt_dismissed' : 'prompt_seen';
+		$data      = [
 			[
 				'client_id' => $client_id,
-				'type'      => 'prompt',
-				'context'   => $action,
-				'value'     => [ 'id' => $popup_id ],
+				'type'      => $action,
+				'context'   => $popup_id,
 			],
 		];
 
 		// Log a newsletter subscription event.
 		$email_address = $this->get_request_param( 'email', $request );
 		if ( $email_address ) {
-			$events[] = [
+			$data[] = [
 				'client_id' => $client_id,
 				'type'      => 'subscription',
 				'value'     => [ 'email' => $email_address ],
 			];
 		}
 
-		$this->save_reader_data( $client_id, $events );
+		$this->save_reader_data( $client_id, $data );
 	}
 }
 new Report_Campaign_Data();

--- a/api/campaigns/class-report-campaign-data.php
+++ b/api/campaigns/class-report-campaign-data.php
@@ -39,7 +39,7 @@ class Report_Campaign_Data extends Lightweight_API {
 		$client_id = $this->get_request_param( 'cid', $request );
 		$popup_id  = $this->get_request_param( 'popup_id', $request );
 		$action    = $this->get_request_param( 'dismiss', $request ) ? 'prompt_dismissed' : 'prompt_seen';
-		$data      = [
+		$events    = [
 			[
 				'client_id' => $client_id,
 				'type'      => $action,
@@ -50,14 +50,21 @@ class Report_Campaign_Data extends Lightweight_API {
 		// Log a newsletter subscription event.
 		$email_address = $this->get_request_param( 'email', $request );
 		if ( $email_address ) {
-			$data[] = [
+			$subscription_event = [
 				'client_id' => $client_id,
 				'type'      => 'subscription',
-				'value'     => [ 'email' => $email_address ],
+				'context'   => $email_address,
 			];
+			$esp                = $this->get_request_param( 'esp', $request );
+
+			if ( $esp ) {
+				$subscription_event['value']['esp'] = $esp;
+			}
+
+			$events[] = $subscription_event;
 		}
 
-		$this->save_reader_events( $client_id, $data );
+		$this->save_reader_events( $client_id, $events );
 	}
 }
 new Report_Campaign_Data();

--- a/api/campaigns/class-report-campaign-data.php
+++ b/api/campaigns/class-report-campaign-data.php
@@ -32,19 +32,20 @@ class Report_Campaign_Data extends Lightweight_API {
 
 	/**
 	 * Handle reporting campaign data – views and subscriptions.
+	 * TODO: Rethink this model to concatenate views/dismissals by prompt id to avoid creating new rows for each interaction.
 	 *
 	 * @param object $request A request.
 	 */
 	public function report_campaign( $request ) {
 		$client_id = $this->get_request_param( 'cid', $request );
 		$popup_id  = $this->get_request_param( 'popup_id', $request );
-		$action    = $this->get_request_param( 'dismiss', $request ) ? 'prompt_dismissed' : 'prompt_seen';
+		$action    = $this->get_request_param( 'dismiss', $request ) ? 'dismissed' : 'seen';
 		$events    = [
 			[
-				'client_id'    => $client_id,
-				'date_created' => gmdate( 'Y-m-d H:i:s' ),
-				'type'         => $action,
-				'event_value'  => [ 'id' => $popup_id ],
+				'client_id' => $client_id,
+				'type'      => 'prompt',
+				'context'   => $action,
+				'value'     => [ 'id' => $popup_id ],
 			],
 		];
 
@@ -52,14 +53,13 @@ class Report_Campaign_Data extends Lightweight_API {
 		$email_address = $this->get_request_param( 'email', $request );
 		if ( $email_address ) {
 			$events[] = [
-				'client_id'    => $client_id,
-				'date_created' => gmdate( 'Y-m-d H:i:s' ),
-				'type'         => 'subscription',
-				'event_value'  => [ 'email' => $email_address ],
+				'client_id' => $client_id,
+				'type'      => 'subscription',
+				'value'     => [ 'email' => $email_address ],
 			];
 		}
 
-		$this->save_reader_events( $client_id, $events );
+		$this->save_reader_data( $client_id, $events );
 	}
 }
 new Report_Campaign_Data();

--- a/api/classes/class-lightweight-api.php
+++ b/api/classes/class-lightweight-api.php
@@ -653,6 +653,8 @@ class Lightweight_API {
 		}
 
 		// Deduplicate views from the past hour.
+		// TODO: Should repeat views of things like archives and search results be deduplicated?
+		// TODO: Should non-post singular views be considered article views? If not, that's changing behavior of "articles viewed" segmentation factors.
 		$existing_data = $this->get_reader_data( $client_id );
 		$already_read  = $this->filter_data_by_type( $existing_data, 'view' );
 		$already_read  = array_column(

--- a/api/classes/class-lightweight-api.php
+++ b/api/classes/class-lightweight-api.php
@@ -371,7 +371,7 @@ class Lightweight_API {
 	 * @return boolean True if saved, false if not.
 	 */
 	public function save_reader_events( $client_id, $events ) {
-		if ( empty( $client_id ) || is_string( $client_id ) || empty( $events ) ) {
+		if ( empty( $client_id ) || ! is_string( $client_id ) || empty( $events ) ) {
 			return false;
 		}
 
@@ -582,7 +582,7 @@ class Lightweight_API {
 	 * @return boolean True if updated., false if not.
 	 */
 	public function save_reader_data( $client_id, $reader_data = [] ) {
-		if ( empty( $client_id ) || is_string( $client_id ) || empty( $reader_data ) ) {
+		if ( empty( $client_id ) || ! is_string( $client_id ) || empty( $reader_data ) ) {
 			return false;
 		}
 

--- a/api/classes/class-lightweight-api.php
+++ b/api/classes/class-lightweight-api.php
@@ -53,10 +53,11 @@ class Lightweight_API {
 	 * @var reader_data_blueprint
 	 */
 	public $reader_data_blueprint = [
-		'id'      => null,
-		'type'    => null,
-		'context' => null,
-		'value'   => null,
+		'id'           => null,
+		'date_created' => null,
+		'type'         => null,
+		'context'      => null,
+		'value'        => null,
 	];
 
 	/**
@@ -786,6 +787,10 @@ class Lightweight_API {
 			function( $item ) use ( $client_id, $reader_data_blueprint ) {
 				$item              = wp_parse_args( $item, $reader_data_blueprint );
 				$item['client_id'] = $client_id;
+
+				if ( empty( $item['date_created'] ) ) {
+					$item['date_created'] = gmdate( 'Y-m-d H:i:s' );
+				}
 
 				if ( isset( $item['value'] ) ) {
 					$item['value'] = wp_json_encode( $item['value'] );

--- a/api/classes/class-lightweight-api.php
+++ b/api/classes/class-lightweight-api.php
@@ -476,7 +476,7 @@ class Lightweight_API {
 			$events_table_name = Segmentation::get_events_table_name();
 			$write_result      = $wpdb->query( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 				$wpdb->prepare(
-					"INSERT INTO $events_table_name ($columns) VALUES $placeholders", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+					"INSERT INTO $events_table_name ($columns) VALUES $placeholders", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
 					$values
 				)
 			);
@@ -545,7 +545,7 @@ class Lightweight_API {
 		// Write to the DB.
 		$write_result = $wpdb->query( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 			$wpdb->prepare(
-				"INSERT INTO $readers_table_name ($columns_to_update, date_created) VALUES ($placeholders, current_timestamp()) ON DUPLICATE KEY UPDATE $duplicate_placeholders", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				"INSERT INTO $readers_table_name ($columns_to_update, date_created) VALUES ($placeholders, current_timestamp()) ON DUPLICATE KEY UPDATE $duplicate_placeholders", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
 				$values_to_update
 			)
 		);

--- a/api/classes/class-lightweight-api.php
+++ b/api/classes/class-lightweight-api.php
@@ -782,10 +782,10 @@ class Lightweight_API {
 	 */
 	public function get_all_readers_data() {
 		global $wpdb;
-		$raders_table_name = Segmentation::get_readers_table_name();
+		$readers_table_name = Segmentation::get_readers_table_name();
 
 		// Results are limited to the 1000 most recent rows for performance reasons.
-		$all_client_ids_rows = $wpdb->get_results( "SELECT DISTINCT client_id,date_modified FROM $readers_table_name ORDER BY date_modified DESC LIMIT 1000" ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$all_client_ids_rows = $wpdb->get_results( "SELECT DISTINCT client_id,date_modified FROM $readers_table_name WHERE is_preview IS NULL ORDER BY date_modified DESC LIMIT 1000" ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		$api                 = new Lightweight_API();
 		return array_reduce(
 			$all_client_ids_rows,

--- a/api/classes/class-lightweight-api.php
+++ b/api/classes/class-lightweight-api.php
@@ -383,6 +383,7 @@ class Lightweight_API {
 				function( $item ) {
 					$item                = (array) $item;
 					$item['event_value'] = (array) maybe_unserialize( $item['event_value'] );
+					$item['is_preview']  = (bool) $item['is_preview'];
 					return $item;
 				},
 				$events_from_db

--- a/api/classes/class-lightweight-api.php
+++ b/api/classes/class-lightweight-api.php
@@ -647,7 +647,7 @@ class Lightweight_API {
 		// Write to the DB.
 		$write_result = $wpdb->query( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 			$wpdb->prepare(
-				"INSERT INTO $readers_table_name ($columns_to_update, date_created) VALUES ($placeholders, current_timestamp()) ON DUPLICATE KEY UPDATE $duplicate_placeholders", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
+				"INSERT INTO $readers_table_name ($columns_to_update, date_created) VALUES ($placeholders, current_timestamp()) ON DUPLICATE KEY UPDATE $duplicate_placeholders, date_modified = current_timestamp()", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
 				$values_to_update
 			)
 		);

--- a/api/classes/class-lightweight-api.php
+++ b/api/classes/class-lightweight-api.php
@@ -1,15 +1,17 @@
 <?php
 /**
- * Newspack Campaigns lightweight API
+ * Newspack Campaigns lightweight API.
  *
  * @package Newspack
- * @phpcs:disable WordPress.DB.RestrictedClasses.mysql__PDO
  */
 
+/**
+ * Create the base Lightweight_API class.
+ */
 require_once dirname( __FILE__ ) . '/../segmentation/class-segmentation-report.php';
 
 /**
- * API endpoints
+ * API endpoints.
  */
 class Lightweight_API {
 

--- a/api/classes/class-lightweight-api.php
+++ b/api/classes/class-lightweight-api.php
@@ -347,12 +347,14 @@ class Lightweight_API {
 				},
 				$events_from_db
 			);
+			$events         = array_diff( $events, $events_from_db );
 			$events         = array_merge( $events, $events_from_db );
 		}
 
 		// Rebuild cache.
 		if ( ! empty( $events ) ) {
 			wp_cache_set( 'reader_events', $events, $client_id );
+			$this->debug['events'] = $events;
 		}
 
 		return $this->filter_events_by_type( $events, $event_type );
@@ -563,8 +565,7 @@ class Lightweight_API {
 		}
 
 		// Rebuild cache.
-		$all_events            = array_merge( $existing_events, $events );
-		$this->debug['events'] = array_merge( $this->debug['events'], $all_events );
+		$all_events = array_merge( $existing_events, $events );
 
 		return wp_cache_set(
 			'reader_events',

--- a/api/classes/class-lightweight-api.php
+++ b/api/classes/class-lightweight-api.php
@@ -712,14 +712,14 @@ class Lightweight_API {
 				$reader_data['views'] = [];
 			}
 
-			foreach ( $new_views as $read_event ) {
-				if ( ! isset( $reader_data['views'][ $read_event['context'] ] ) ) {
-					$reader_data['views'][ $read_event['context'] ] = 0;
+			foreach ( $new_views as $view_event ) {
+				if ( ! isset( $reader_data['views'][ $view_event['context'] ] ) ) {
+					$reader_data['views'][ $view_event['context'] ] = 0;
 				}
-				$reader_data['views'][ $read_event['context'] ] ++;
+				$reader_data['views'][ $view_event['context'] ] ++;
 
-				if ( isset( $read_event['value']['categories'] ) ) {
-					$categories = explode( ',', $read_event['value']['categories'] );
+				if ( isset( $view_event['value']['categories'] ) ) {
+					$categories = explode( ',', $view_event['value']['categories'] );
 					if ( ! isset( $reader_data['category'] ) ) {
 						$reader_data['category'] = [];
 					}

--- a/api/classes/class-lightweight-api.php
+++ b/api/classes/class-lightweight-api.php
@@ -551,19 +551,6 @@ class Lightweight_API {
 	 * @return array Filtered array of data items.
 	 */
 	public function filter_events_by_type( $events = [], $types = null, $contexts = null ) {
-		// Unserialize event values.
-		if ( ! empty( $events ) ) {
-			$events = array_map(
-				function( $event ) {
-					if ( ! empty( $event['value'] ) && ! is_array( $event['value'] ) ) {
-						$event['value'] = json_decode( $event['value'], true );
-					}
-					return $event;
-				},
-				$events
-			);
-		}
-
 		if ( null === $types && null === $contexts ) {
 			return $events;
 		}
@@ -621,6 +608,7 @@ class Lightweight_API {
 				function( $event ) {
 					$event = (array) $event;
 
+					// Unserialize event values.
 					if ( ! empty( $event['value'] ) && ! is_array( $event['value'] ) ) {
 						$event['value'] = json_decode( $event['value'], true );
 					}

--- a/api/classes/class-lightweight-api.php
+++ b/api/classes/class-lightweight-api.php
@@ -582,7 +582,7 @@ class Lightweight_API {
 	 * @return boolean True if updated., false if not.
 	 */
 	public function save_reader_data( $client_id, $reader_data = [] ) {
-		if ( empty( $client_id ) || ! is_string( $client_id ) || empty( $reader_data ) ) {
+		if ( empty( $client_id ) || ! is_string( $client_id ) ) {
 			return false;
 		}
 

--- a/api/classes/class-lightweight-api.php
+++ b/api/classes/class-lightweight-api.php
@@ -371,6 +371,19 @@ class Lightweight_API {
 	 * @return boolean True if saved, false if not.
 	 */
 	public function save_reader_events( $client_id, $events ) {
+		if ( empty( $client_id ) || is_string( $client_id ) || empty( $events ) ) {
+			return false;
+		}
+
+		// Ensure client ID exists and matches across all events.
+		$events = array_map(
+			function( $event ) use ( $client_id ) {
+				$event['client_id'] = $client_id;
+				return $event;
+			},
+			$events
+		);
+
 		$existing_events = $this->get_reader_events( $client_id );
 		$is_preview      = $this->is_preview( $client_id );
 		$already_read    = array_column(
@@ -569,6 +582,10 @@ class Lightweight_API {
 	 * @return boolean True if updated., false if not.
 	 */
 	public function save_reader_data( $client_id, $reader_data = [] ) {
+		if ( empty( $client_id ) || is_string( $client_id ) || empty( $reader_data ) ) {
+			return false;
+		}
+
 		global $wpdb;
 
 		// Ensure that we're only updating valid columns.

--- a/api/classes/class-lightweight-api.php
+++ b/api/classes/class-lightweight-api.php
@@ -708,7 +708,12 @@ class Lightweight_API {
 			'value'
 		);
 		$already_read_singular    = array_column( $event_values, 'post_id' );
-		$already_read_nonsingular = array_column( $event_values, 'request' );
+		$already_read_nonsingular = array_map(
+			function( $request_value ) {
+				return wp_json_encode( $request_value );
+			},
+			array_column( $event_values, 'request' )
+		);
 		$already_read             = array_merge( $already_read_singular, $already_read_nonsingular );
 
 		// Filter out recently seen views.
@@ -717,7 +722,7 @@ class Lightweight_API {
 				$events,
 				function( $event ) use ( $already_read ) {
 					if ( 'view' === $event['type'] && isset( $event['context'] ) && isset( $event['value'] ) ) {
-						$current_page = isset( $event['value']['post_id'] ) ? $event['value']['post_id'] : $event['value']['request'];
+						$current_page = isset( $event['value']['post_id'] ) ? $event['value']['post_id'] : wp_json_encode( $event['value'] ['request'] );
 						return ! in_array( $current_page, $already_read, true );
 					}
 

--- a/api/classes/class-lightweight-api.php
+++ b/api/classes/class-lightweight-api.php
@@ -419,7 +419,7 @@ class Lightweight_API {
 		}
 
 		// Unserialize reader_data value.
-		if ( isset( $reader['reader_data'] ) && ! is_array( $reader['reader_data'] ) ) {
+		if ( isset( $reader['reader_data'] ) && is_string( $reader['reader_data'] ) ) {
 			$reader['reader_data'] = json_decode( $reader['reader_data'], true );
 		}
 
@@ -551,6 +551,19 @@ class Lightweight_API {
 	 * @return array Filtered array of data items.
 	 */
 	public function filter_events_by_type( $events = [], $types = null, $contexts = null ) {
+		// Unserialize event values.
+		if ( ! empty( $events ) ) {
+			$events = array_map(
+				function( $event ) {
+					if ( ! empty( $event['value'] ) && is_string( $event['value'] ) ) {
+						$event['value'] = json_decode( $event['value'], true );
+					}
+					return $event;
+				},
+				$events
+			);
+		}
+
 		if ( null === $types && null === $contexts ) {
 			return $events;
 		}
@@ -608,8 +621,7 @@ class Lightweight_API {
 				function( $event ) {
 					$event = (array) $event;
 
-					// Unserialize event values.
-					if ( ! empty( $event['value'] ) && ! is_array( $event['value'] ) ) {
+					if ( ! empty( $event['value'] ) && is_string( $event['value'] ) ) {
 						$event['value'] = json_decode( $event['value'], true );
 					}
 

--- a/api/segmentation/class-segmentation-client-data.php
+++ b/api/segmentation/class-segmentation-client-data.php
@@ -134,6 +134,7 @@ class Segmentation_Client_Data extends Lightweight_API {
 			}
 		}
 
+		// TODO: Update client data and events.
 		if ( ! empty( $client_data_update ) ) {
 			$this->save_client_data( $client_id, $client_data_update );
 		}

--- a/api/segmentation/class-segmentation-client-data.php
+++ b/api/segmentation/class-segmentation-client-data.php
@@ -44,10 +44,20 @@ class Segmentation_Client_Data extends Lightweight_API {
 			if ( 'string' === gettype( $donation ) ) {
 				$donation = (array) json_decode( $donation );
 			}
-			$reader_events[] = [
+
+			$donation_event = [
 				'type'  => 'donation',
 				'value' => $donation,
 			];
+
+			if ( isset( $donation['order_id'] ) ) {
+				$donation_event['context'] = 'woocommerce';
+			}
+			if ( isset( $donation['stripe_id'] ) ) {
+				$donation_event['context'] = 'stripe';
+			}
+
+			$reader_events[] = $donation_event;
 		}
 
 		// Add a subscription to client.

--- a/api/segmentation/class-segmentation-client-data.php
+++ b/api/segmentation/class-segmentation-client-data.php
@@ -80,8 +80,26 @@ class Segmentation_Client_Data extends Lightweight_API {
 		// Get user ID if they have a user account.
 		$user_id = $this->get_request_param( 'user_id', $request );
 		if ( $user_id ) {
-			$reader_data['user_id'] = $user_id;
+			$existing_user_accounts = $this->get_reader_data( $client_id, 'user_account', 'wp' );
+			$add_user_account       = true;
+
+			// Only add a new user account if it hasn't already been logged for this client.
+			foreach ( $existing_user_accounts as $existing_user_account ) {
+				if ( isset( $existing_user_account['value']['user_id'] ) && $existing_user_account['value']['user_id'] === $user_id ) {
+					$add_user_account = false;
+				}
+			}
+
+			if ( $add_user_account ) {
+				$reader_data[] = [
+					'client_id' => $client_id,
+					'type'      => 'user_account',
+					'context'   => 'wp',
+					'value'     => [ 'user_id' => $user_id ],
+				];
+			}
 		}
+
 		// Add donations data from WC orders.
 		$orders = $this->get_request_param( 'orders', $request );
 		if ( $orders ) {

--- a/api/segmentation/class-segmentation-custom-ga-config.php
+++ b/api/segmentation/class-segmentation-custom-ga-config.php
@@ -48,15 +48,15 @@ class Segmentation_Custom_GA_Config extends Lightweight_API {
 
 		$custom_dimensions_values = [];
 
-		$api         = new Lightweight_API();
-		$reader_data = $api->get_reader_data( $client_id );
+		$api           = new Lightweight_API();
+		$reader_events = $api->get_reader_events( $client_id );
 
 		foreach ( $custom_dimensions as $custom_dimension ) {
 			// Strip the `ga:` prefix from gaID.
 			$dimension_id = substr( $custom_dimension->gaID, 3 ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 			switch ( $custom_dimension->role ) {
 				case Segmentation::CUSTOM_DIMENSIONS_OPTION_NAME_READER_FREQUENCY:
-					$read_count = Campaign_Data_Utils::get_post_view_count( $reader_data );
+					$read_count = Campaign_Data_Utils::get_post_view_count( $reader_events );
 					// Tiers mimick NCI's – https://news-consumer-insights.appspot.com.
 					$read_count_tier = 'casual';
 					if ( $read_count > 1 && $read_count <= 14 ) {
@@ -67,10 +67,10 @@ class Segmentation_Custom_GA_Config extends Lightweight_API {
 					$custom_dimensions_values[ $dimension_id ] = $read_count_tier;
 					break;
 				case Segmentation::CUSTOM_DIMENSIONS_OPTION_NAME_IS_SUBSCRIBER:
-					$custom_dimensions_values[ $dimension_id ] = Campaign_Data_Utils::is_subscriber( $reader_data ) ? 'true' : 'false';
+					$custom_dimensions_values[ $dimension_id ] = Campaign_Data_Utils::is_subscriber( $reader_events ) ? 'true' : 'false';
 					break;
 				case Segmentation::CUSTOM_DIMENSIONS_OPTION_NAME_IS_DONOR:
-					$custom_dimensions_values[ $dimension_id ] = Campaign_Data_Utils::is_donor( $reader_data ) ? 'true' : 'false';
+					$custom_dimensions_values[ $dimension_id ] = Campaign_Data_Utils::is_donor( $reader_events ) ? 'true' : 'false';
 					break;
 			}
 		}

--- a/api/segmentation/class-segmentation-custom-ga-config.php
+++ b/api/segmentation/class-segmentation-custom-ga-config.php
@@ -56,7 +56,7 @@ class Segmentation_Custom_GA_Config extends Lightweight_API {
 			$dimension_id = substr( $custom_dimension->gaID, 3 ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 			switch ( $custom_dimension->role ) {
 				case Segmentation::CUSTOM_DIMENSIONS_OPTION_NAME_READER_FREQUENCY:
-					$read_count = Campaign_Data_Utils::get_post_view_count( $reader_events );
+					$read_count = Campaign_Data_Utils::get_post_view_count( $api->get_reader( $client_id ) );
 					// Tiers mimick NCI's – https://news-consumer-insights.appspot.com.
 					$read_count_tier = 'casual';
 					if ( $read_count > 1 && $read_count <= 14 ) {

--- a/api/segmentation/class-segmentation-custom-ga-config.php
+++ b/api/segmentation/class-segmentation-custom-ga-config.php
@@ -48,16 +48,15 @@ class Segmentation_Custom_GA_Config extends Lightweight_API {
 
 		$custom_dimensions_values = [];
 
-		$api           = new Lightweight_API();
-		$reader_data   = $api->get_reader_data( $client_id );
-		$reader_events = $api->get_reader_events( $client_id );
+		$api         = new Lightweight_API();
+		$reader_data = $api->get_reader_data( $client_id );
 
 		foreach ( $custom_dimensions as $custom_dimension ) {
 			// Strip the `ga:` prefix from gaID.
 			$dimension_id = substr( $custom_dimension->gaID, 3 ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 			switch ( $custom_dimension->role ) {
 				case Segmentation::CUSTOM_DIMENSIONS_OPTION_NAME_READER_FREQUENCY:
-					$read_count = $reader_data['article_views'];
+					$read_count = Campaign_Data_Utils::get_post_view_count( $reader_data );
 					// Tiers mimick NCI's – https://news-consumer-insights.appspot.com.
 					$read_count_tier = 'casual';
 					if ( $read_count > 1 && $read_count <= 14 ) {
@@ -68,10 +67,10 @@ class Segmentation_Custom_GA_Config extends Lightweight_API {
 					$custom_dimensions_values[ $dimension_id ] = $read_count_tier;
 					break;
 				case Segmentation::CUSTOM_DIMENSIONS_OPTION_NAME_IS_SUBSCRIBER:
-					$custom_dimensions_values[ $dimension_id ] = Campaign_Data_Utils::is_subscriber( $reader_events ) ? 'true' : 'false';
+					$custom_dimensions_values[ $dimension_id ] = Campaign_Data_Utils::is_subscriber( $reader_data ) ? 'true' : 'false';
 					break;
 				case Segmentation::CUSTOM_DIMENSIONS_OPTION_NAME_IS_DONOR:
-					$custom_dimensions_values[ $dimension_id ] = Campaign_Data_Utils::is_donor( $reader_events ) ? 'true' : 'false';
+					$custom_dimensions_values[ $dimension_id ] = Campaign_Data_Utils::is_donor( $reader_data ) ? 'true' : 'false';
 					break;
 			}
 		}

--- a/api/segmentation/class-segmentation-custom-ga-config.php
+++ b/api/segmentation/class-segmentation-custom-ga-config.php
@@ -48,8 +48,9 @@ class Segmentation_Custom_GA_Config extends Lightweight_API {
 
 		$custom_dimensions_values = [];
 
-		$api           = new Lightweight_API();
-		$reader_events = $api->get_reader_events( $client_id );
+		$api                 = new Lightweight_API();
+		$subscription_events = $api->get_reader_events( $client_id, 'subscription' );
+		$donation_events     = $api->get_reader_events( $client_id, 'donation' );
 
 		foreach ( $custom_dimensions as $custom_dimension ) {
 			// Strip the `ga:` prefix from gaID.
@@ -67,10 +68,10 @@ class Segmentation_Custom_GA_Config extends Lightweight_API {
 					$custom_dimensions_values[ $dimension_id ] = $read_count_tier;
 					break;
 				case Segmentation::CUSTOM_DIMENSIONS_OPTION_NAME_IS_SUBSCRIBER:
-					$custom_dimensions_values[ $dimension_id ] = Campaign_Data_Utils::is_subscriber( $reader_events ) ? 'true' : 'false';
+					$custom_dimensions_values[ $dimension_id ] = Campaign_Data_Utils::is_subscriber( $subscription_events ) ? 'true' : 'false';
 					break;
 				case Segmentation::CUSTOM_DIMENSIONS_OPTION_NAME_IS_DONOR:
-					$custom_dimensions_values[ $dimension_id ] = Campaign_Data_Utils::is_donor( $reader_events ) ? 'true' : 'false';
+					$custom_dimensions_values[ $dimension_id ] = Campaign_Data_Utils::is_donor( $donation_events ) ? 'true' : 'false';
 					break;
 			}
 		}

--- a/api/segmentation/class-segmentation-custom-ga-config.php
+++ b/api/segmentation/class-segmentation-custom-ga-config.php
@@ -48,15 +48,16 @@ class Segmentation_Custom_GA_Config extends Lightweight_API {
 
 		$custom_dimensions_values = [];
 
-		$api         = new Lightweight_API();
-		$client_data = $api->get_client_data( $client_id );
+		$api           = new Lightweight_API();
+		$reader_data   = $api->get_reader_data( $client_id );
+		$reader_events = $api->get_reader_events( $client_id );
 
 		foreach ( $custom_dimensions as $custom_dimension ) {
 			// Strip the `ga:` prefix from gaID.
 			$dimension_id = substr( $custom_dimension->gaID, 3 ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 			switch ( $custom_dimension->role ) {
 				case Segmentation::CUSTOM_DIMENSIONS_OPTION_NAME_READER_FREQUENCY:
-					$read_count = count( $client_data['posts_read'] );
+					$read_count = $reader_data['article_views'];
 					// Tiers mimick NCI's – https://news-consumer-insights.appspot.com.
 					$read_count_tier = 'casual';
 					if ( $read_count > 1 && $read_count <= 14 ) {
@@ -67,10 +68,10 @@ class Segmentation_Custom_GA_Config extends Lightweight_API {
 					$custom_dimensions_values[ $dimension_id ] = $read_count_tier;
 					break;
 				case Segmentation::CUSTOM_DIMENSIONS_OPTION_NAME_IS_SUBSCRIBER:
-					$custom_dimensions_values[ $dimension_id ] = Campaign_Data_Utils::is_subscriber( $client_data ) ? 'true' : 'false';
+					$custom_dimensions_values[ $dimension_id ] = Campaign_Data_Utils::is_subscriber( $reader_events ) ? 'true' : 'false';
 					break;
 				case Segmentation::CUSTOM_DIMENSIONS_OPTION_NAME_IS_DONOR:
-					$custom_dimensions_values[ $dimension_id ] = Campaign_Data_Utils::is_donor( $client_data ) ? 'true' : 'false';
+					$custom_dimensions_values[ $dimension_id ] = Campaign_Data_Utils::is_donor( $reader_events ) ? 'true' : 'false';
 					break;
 			}
 		}

--- a/api/segmentation/class-segmentation-report.php
+++ b/api/segmentation/class-segmentation-report.php
@@ -31,7 +31,6 @@ class Segmentation_Report {
 				$line = implode(
 					'|',
 					[
-						isset( $event['id'] ) ? $event['id'] : '',
 						$event['client_id'],
 						isset( $event['type'] ) ? $event['type'] : '',
 						isset( $event['context'] ) ? $event['context'] : '',

--- a/api/segmentation/class-segmentation-report.php
+++ b/api/segmentation/class-segmentation-report.php
@@ -12,27 +12,33 @@ class Segmentation_Report {
 	/**
 	 * Handle visitor.
 	 *
-	 * @param object $event A reader event to log.
-	 *               $event['client_id'] Client ID associated with the event.
-	 *               $event['date_created'] Timestamp of the event. Optional.
-	 *               $event['event_type'] Type of event.
-	 *               $event['event_value'] Data associated with the event.
+	 * @param array $events Array of reader events to log.
+	 *              ['client_id'] Client ID associated with the event.
+	 *              ['date_created'] Timestamp of the event. Optional.
+	 *              ['type'] Type of event.
+	 *              ['event_value'] Data associated with the event.
 	 */
-	public static function log_reader_event( $event ) {
-		// Add line to log file.
-		$line = implode(
-			';',
-			[
-				$event['client_id'],
-				isset( $event['date_created'] ) ? $event['date_created'] : gmdate( 'Y-m-d H:i:s', time() ),
-				$event['event_type'],
-				isset( $event['event_value'] ) ? maybe_serialize( $event['event_value'] ) : '',
-			]
-		);
+	public static function log_reader_events( $events ) {
+		$lines = '';
+		foreach ( $events as $event ) {
+			// Add line to log file.
+			$line = implode(
+				'|',
+				[
+					$event['client_id'],
+					isset( $event['date_created'] ) ? $event['date_created'] : gmdate( 'Y-m-d H:i:s', time() ),
+					$event['type'],
+					isset( $event['event_value'] ) ? maybe_serialize( $event['event_value'] ) : '',
+					isset( $event['is_preview'] ) ? 1 : 0,
+				]
+			);
+
+			$lines .= $line . PHP_EOL;
+		}
 
 		file_put_contents( // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_file_put_contents
 			Segmentation::get_log_file_path(),
-			$line . PHP_EOL,
+			$lines,
 			FILE_APPEND
 		);
 	}

--- a/api/segmentation/class-segmentation-report.php
+++ b/api/segmentation/class-segmentation-report.php
@@ -24,6 +24,10 @@ class Segmentation_Report {
 		foreach ( $events as $event ) {
 			// Add line to log file.
 			if ( ! empty( $event['client_id'] ) ) {
+				$value = '';
+				if ( isset( $event['value'] ) ) {
+					$value = is_array( $event['value'] ) ? wp_json_encode( $event['value'] ) : $event['value'];
+				}
 				$line = implode(
 					'|',
 					[
@@ -31,7 +35,7 @@ class Segmentation_Report {
 						$event['client_id'],
 						isset( $event['type'] ) ? $event['type'] : '',
 						isset( $event['context'] ) ? $event['context'] : '',
-						isset( $event['value'] ) ? $event['value'] : '',
+						$value,
 					]
 				);
 

--- a/api/segmentation/class-segmentation-report.php
+++ b/api/segmentation/class-segmentation-report.php
@@ -12,27 +12,28 @@ class Segmentation_Report {
 	/**
 	 * Handle visitor.
 	 *
-	 * @param object $payload a payload.
+	 * @param object $event A reader event to log.
+	 *               $event['client_id'] Client ID associated with the event.
+	 *               $event['date_created'] Timestamp of the event. Optional.
+	 *               $event['event_type'] Type of event.
+	 *               $event['event_value'] Data associated with the event.
 	 */
-	public static function log_single_visit( $payload ) {
-		if ( $payload['is_post'] ) {
-			// Add line to log file.
-			$line = implode(
-				';',
-				[
-					'post_read',
-					$payload['clientId'],
-					isset( $payload['date'] ) ? $payload['date'] : gmdate( 'Y-m-d H:i:s', time() ),
-					$payload['post_id'],
-					$payload['categories'],
-				]
-			);
+	public static function log_reader_event( $event ) {
+		// Add line to log file.
+		$line = implode(
+			';',
+			[
+				$event['client_id'],
+				isset( $event['date_created'] ) ? $event['date_created'] : gmdate( 'Y-m-d H:i:s', time() ),
+				$event['event_type'],
+				isset( $event['event_value'] ) ? maybe_serialize( $event['event_value'] ) : '',
+			]
+		);
 
-			file_put_contents( // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_file_put_contents
-				Segmentation::get_log_file_path(),
-				$line . PHP_EOL,
-				FILE_APPEND
-			);
-		}
+		file_put_contents( // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_file_put_contents
+			Segmentation::get_log_file_path(),
+			$line . PHP_EOL,
+			FILE_APPEND
+		);
 	}
 }

--- a/api/segmentation/class-segmentation-report.php
+++ b/api/segmentation/class-segmentation-report.php
@@ -22,6 +22,7 @@ class Segmentation_Report {
 		$lines = '';
 		foreach ( $events as $event ) {
 			// Add line to log file.
+			// TODO: reformat rows with context and id
 			$line = implode(
 				'|',
 				[

--- a/api/segmentation/class-segmentation-report.php
+++ b/api/segmentation/class-segmentation-report.php
@@ -32,6 +32,7 @@ class Segmentation_Report {
 					'|',
 					[
 						$event['client_id'],
+						isset( $event['date_created'] ) ? $event['date_created'] : gmdate( 'Y-m-d H:i:s' ),
 						isset( $event['type'] ) ? $event['type'] : '',
 						isset( $event['context'] ) ? $event['context'] : '',
 						$value,

--- a/api/segmentation/class-segmentation-report.php
+++ b/api/segmentation/class-segmentation-report.php
@@ -29,7 +29,7 @@ class Segmentation_Report {
 					isset( $event['date_created'] ) ? $event['date_created'] : gmdate( 'Y-m-d H:i:s', time() ),
 					$event['type'],
 					isset( $event['event_value'] ) ? maybe_serialize( $event['event_value'] ) : '',
-					isset( $event['is_preview'] ) ? 1 : 0,
+					isset( $event['is_preview'] ) && $event['is_preview'] ? 1 : 0,
 				]
 			);
 

--- a/api/segmentation/class-segmentation-report.php
+++ b/api/segmentation/class-segmentation-report.php
@@ -16,25 +16,27 @@ class Segmentation_Report {
 	 *              ['client_id'] Client ID associated with the event.
 	 *              ['date_created'] Timestamp of the event. Optional.
 	 *              ['type'] Type of event.
-	 *              ['event_value'] Data associated with the event.
+	 *              ['context'] Context of event.
+	 *              ['value'] Data associated with the event.
 	 */
 	public static function log_reader_events( $events ) {
 		$lines = '';
 		foreach ( $events as $event ) {
 			// Add line to log file.
-			// TODO: reformat rows with context and id
-			$line = implode(
-				'|',
-				[
-					$event['client_id'],
-					isset( $event['date_created'] ) ? $event['date_created'] : gmdate( 'Y-m-d H:i:s', time() ),
-					$event['type'],
-					isset( $event['event_value'] ) ? maybe_serialize( $event['event_value'] ) : '',
-					isset( $event['is_preview'] ) && $event['is_preview'] ? 1 : 0,
-				]
-			);
+			if ( ! empty( $event['client_id'] ) ) {
+				$line = implode(
+					'|',
+					[
+						isset( $event['id'] ) ? $event['id'] : '',
+						$event['client_id'],
+						isset( $event['type'] ) ? $event['type'] : '',
+						isset( $event['context'] ) ? $event['context'] : '',
+						isset( $event['value'] ) ? $event['value'] : '',
+					]
+				);
 
-			$lines .= $line . PHP_EOL;
+				$lines .= $line . PHP_EOL;
+			}
 		}
 
 		file_put_contents( // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_file_put_contents

--- a/api/segmentation/class-segmentation.php
+++ b/api/segmentation/class-segmentation.php
@@ -51,11 +51,11 @@ class Segmentation {
 	}
 
 	/**
-	 * Get reader data table name.
+	 * Get reader events table name.
 	 */
-	public static function get_reader_data_table_name() {
+	public static function get_reader_events_table_name() {
 		global $wpdb;
-		return $wpdb->prefix . 'newspack_campaigns_reader_data';
+		return $wpdb->prefix . 'newspack_campaigns_reader_events';
 	}
 
 	/**

--- a/api/segmentation/class-segmentation.php
+++ b/api/segmentation/class-segmentation.php
@@ -27,19 +27,35 @@ class Segmentation {
 	}
 
 	/**
-	 * Get events table name.
+	 * Get legacy events table name.
 	 */
-	public static function get_events_table_name() {
+	public static function get_events_table_name_legacy() {
 		global $wpdb;
 		return $wpdb->prefix . 'newspack_campaigns_events';
 	}
 
 	/**
-	 * Get transients table name.
+	 * Get legacy readers table name.
 	 */
-	public static function get_transients_table_name() {
+	public static function get_readers_table_name_legacy() {
 		global $wpdb;
 		return $wpdb->prefix . 'newspack_campaigns_transients';
+	}
+
+	/**
+	 * Get readers table name.
+	 */
+	public static function get_readers_table_name() {
+		global $wpdb;
+		return $wpdb->prefix . 'newspack_campaigns_readers';
+	}
+
+	/**
+	 * Get events table name.
+	 */
+	public static function get_events_table_name() {
+		global $wpdb;
+		return $wpdb->prefix . 'newspack_campaigns_reader_events';
 	}
 
 	/**

--- a/api/segmentation/class-segmentation.php
+++ b/api/segmentation/class-segmentation.php
@@ -51,11 +51,11 @@ class Segmentation {
 	}
 
 	/**
-	 * Get events table name.
+	 * Get reader data table name.
 	 */
-	public static function get_events_table_name() {
+	public static function get_reader_data_table_name() {
 		global $wpdb;
-		return $wpdb->prefix . 'newspack_campaigns_reader_events';
+		return $wpdb->prefix . 'newspack_campaigns_reader_data';
 	}
 
 	/**

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -755,7 +755,7 @@ final class Newspack_Popups_Inserter {
 			[
 				'post_id'    => esc_attr( get_the_ID() ),
 				'categories' => esc_attr( $category_ids ),
-				'is_post'    => is_single(),
+				'is_post'    => is_singular(),
 			]
 		);
 		if ( isset( $_GET['newspack-campaigns-debug'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -748,16 +748,21 @@ final class Newspack_Popups_Inserter {
 			(object) []
 		);
 
+		$visit = [ 'is_post' => false ];
+
+		if ( is_singular() ) {
+			$visit['is_post']    = true;
+			$visit['post_id']    = get_the_ID();
+			$visit['categories'] = esc_attr( $category_ids );
+		} else {
+			global $wp;
+			$visit['post_id'] = $wp->request;
+		}
+
 		$popups_access_provider['authorization'] .= '&ref=DOCUMENT_REFERRER';
 		$popups_access_provider['authorization'] .= '&popups=' . wp_json_encode( $popups_configs );
 		$popups_access_provider['authorization'] .= '&settings=' . wp_json_encode( $settings );
-		$popups_access_provider['authorization'] .= '&visit=' . wp_json_encode(
-			[
-				'post_id'    => esc_attr( get_the_ID() ),
-				'categories' => esc_attr( $category_ids ),
-				'is_post'    => is_singular(),
-			]
-		);
+		$popups_access_provider['authorization'] .= '&visit=' . wp_json_encode( $visit );
 		if ( isset( $_GET['newspack-campaigns-debug'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 			$popups_access_provider['authorization'] .= '&debug';
 		}

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -758,7 +758,7 @@ final class Newspack_Popups_Inserter {
 		} else {
 			global $wp;
 			$non_singular_query_type = 'unknown';
-			$request                 = wp_json_encode( $wp->query_vars );
+			$request                 = $wp->query_vars;
 
 			if ( is_archive() ) {
 				$non_singular_query_type = 'archive';

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -749,20 +749,22 @@ final class Newspack_Popups_Inserter {
 		);
 
 		if ( is_singular() ) {
-			$visit['post_type']  = get_post_type();
-			$visit['post_id']    = get_the_ID();
-			$visit['categories'] = esc_attr( $category_ids );
+			$visit['post_type'] = get_post_type();
+			$visit['post_id']   = get_the_ID();
+
+			if ( ! empty( $category_ids ) ) {
+				$visit['categories'] = esc_attr( $category_ids );
+			}
 		} else {
 			global $wp;
 			$non_singular_query_type = 'unknown';
-			$param                   = $wp->request;
+			$request                 = wp_json_encode( $wp->query_vars );
 
 			if ( is_archive() ) {
 				$non_singular_query_type = 'archive';
 			}
 			if ( is_search() ) {
 				$non_singular_query_type = 'search';
-				$param                   = get_search_query();
 			}
 			if ( is_feed() ) {
 				$non_singular_query_type = 'feed';
@@ -774,7 +776,7 @@ final class Newspack_Popups_Inserter {
 				$non_singular_query_type = '404';
 			}
 
-			$visit['request']      = $param;
+			$visit['request']      = $request;
 			$visit['request_type'] = $non_singular_query_type;
 		}
 

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -748,15 +748,32 @@ final class Newspack_Popups_Inserter {
 			(object) []
 		);
 
-		$visit = [ 'is_post' => false ];
-
 		if ( is_singular() ) {
-			$visit['is_post']    = true;
+			$visit['post_type']  = get_post_type();
 			$visit['post_id']    = get_the_ID();
 			$visit['categories'] = esc_attr( $category_ids );
 		} else {
 			global $wp;
-			$visit['post_id'] = $wp->request;
+			$non_singular_query_type = 'unknown';
+
+			if ( is_archive() ) {
+				$non_singular_query_type = 'archive';
+			}
+			if ( is_search() ) {
+				$non_singular_query_type = 'search';
+			}
+			if ( is_feed() ) {
+				$non_singular_query_type = 'feed';
+			}
+			if ( is_home() ) {
+				$non_singular_query_type = 'posts_page';
+			}
+			if ( is_404() ) {
+				$non_singular_query_type = '404';
+			}
+
+			$visit['post_id']   = $wp->request; // TODO: populate with search query if a search
+			$visit['post_type'] = $non_singular_query_type;
 		}
 
 		$popups_access_provider['authorization'] .= '&ref=DOCUMENT_REFERRER';

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -755,12 +755,14 @@ final class Newspack_Popups_Inserter {
 		} else {
 			global $wp;
 			$non_singular_query_type = 'unknown';
+			$param                   = $wp->request;
 
 			if ( is_archive() ) {
 				$non_singular_query_type = 'archive';
 			}
 			if ( is_search() ) {
 				$non_singular_query_type = 'search';
+				$param                   = get_search_query();
 			}
 			if ( is_feed() ) {
 				$non_singular_query_type = 'feed';
@@ -772,8 +774,8 @@ final class Newspack_Popups_Inserter {
 				$non_singular_query_type = '404';
 			}
 
-			$visit['post_id']   = $wp->request; // TODO: populate with search query if a search
-			$visit['post_type'] = $non_singular_query_type;
+			$visit['request']      = $param;
+			$visit['request_type'] = $non_singular_query_type;
 		}
 
 		$popups_access_provider['authorization'] .= '&ref=DOCUMENT_REFERRER';

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -1036,7 +1036,6 @@ final class Newspack_Popups_Model {
 		$endpoint             = self::get_reader_endpoint();
 		$display_title        = $popup['options']['display_title'];
 		$hide_border          = $popup['options']['hide_border'];
-		$hidden_fields        = self::get_hidden_fields( $popup );
 		$is_newsletter_prompt = self::has_newsletter_prompt( $popup );
 		$classes              = [ 'newspack-popup' ];
 		$classes[]            = 'above_header' === $popup['options']['placement'] ? 'newspack-above-header-popup' : null;
@@ -1322,6 +1321,11 @@ final class Newspack_Popups_Model {
 			name="is_newsletter_popup"
 			type="hidden"
 			value="<?php echo esc_attr( self::has_newsletter_prompt( $popup ) ); ?>"
+		/>
+		<input
+			name="dismiss"
+			type="hidden"
+			value="1"
 		/>
 		<?php
 		return ob_get_clean();

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -761,15 +761,18 @@ final class Newspack_Popups_Model {
 		 * @param string $class_name The class name to look for.
 		 */
 		$newspack_form_class = apply_filters( 'newspack_campaigns_form_class', 'newspack-subscribe-form' );
+		$esp                 = null;
 
 		if ( preg_match( '/wp-block-jetpack-mailchimp/', $body ) !== 0 ) {
 			// Jetpack Mailchimp block.
 			$subscribe_form_selector = apply_filters( 'newspack_campaigns_form_selector', '.wp-block-jetpack-mailchimp form' );
 			$email_form_field_name   = apply_filters( 'newspack_campaigns_email_form_field_name', 'email', $subscribe_form_selector );
+			$esp                     = 'mailchimp';
 		} elseif ( preg_match( '/mc4wp-form/', $body ) !== 0 ) {
 			// MC4WP form.
 			$subscribe_form_selector = apply_filters( 'newspack_campaigns_form_selector', '.mc4wp-form' );
 			$email_form_field_name   = apply_filters( 'newspack_campaigns_email_form_field_name', 'EMAIL', $subscribe_form_selector );
+			$esp                     = 'mailchimp';
 		} elseif ( preg_match( '/\[gravityforms\s(.*)\]/', $body, $gravity_form_attributes ) !== 0 && class_exists( '\GFAPI' ) ) {
 			// Gravity Forms block produces a shortcode. Check for a form ID attribute on the shortcode.
 			$has_id = preg_match( '/id="(\d*)"/', $gravity_form_attributes[1], $id_matches );
@@ -831,16 +834,22 @@ final class Newspack_Popups_Model {
 			],
 		];
 		if ( $subscribe_form_selector && $email_form_field_name ) {
+			$extra_params = [
+				'popup_id'            => esc_attr( self::canonize_popup_id( $popup['id'] ) ),
+				'cid'                 => 'CLIENT_ID(' . esc_attr( Newspack_Popups_Segmentation::NEWSPACK_SEGMENTATION_CID_NAME ) . ')',
+				'mailing_list_status' => 'subscribed',
+				'email'               => '${formFields[' . esc_attr( $email_form_field_name ) . ']}',
+			];
+
+			if ( ! empty( $esp ) ) {
+				$extra_params['esp'] = $esp;
+			}
+
 			$amp_analytics_config['triggers']['formSubmitSuccess'] = [
 				'on'             => 'amp-form-submit-success',
 				'request'        => 'event',
 				'selector'       => '#' . esc_attr( $element_id ) . ' ' . esc_attr( $subscribe_form_selector ),
-				'extraUrlParams' => [
-					'popup_id'            => esc_attr( self::canonize_popup_id( $popup['id'] ) ),
-					'cid'                 => 'CLIENT_ID(' . esc_attr( Newspack_Popups_Segmentation::NEWSPACK_SEGMENTATION_CID_NAME ) . ')',
-					'mailing_list_status' => 'subscribed',
-					'email'               => '${formFields[' . esc_attr( $email_form_field_name ) . ']}',
-				],
+				'extraUrlParams' => $extra_params,
 			];
 		}
 

--- a/includes/class-newspack-popups-parse-logs.php
+++ b/includes/class-newspack-popups-parse-logs.php
@@ -144,7 +144,7 @@ final class Newspack_Popups_Parse_Logs {
 					$event_type   = 'article_view';
 					$event_value  = maybe_serialize(
 						[
-							'post_id'    => $result[3],
+							'post_id'    => (int) $result[3],
 							'categories' => $result[4],
 						]
 					);

--- a/includes/class-newspack-popups-parse-logs.php
+++ b/includes/class-newspack-popups-parse-logs.php
@@ -46,7 +46,6 @@ final class Newspack_Popups_Parse_Logs {
 		}
 	}
 
-
 	/**
 	 * Add a CRON interval of one minute.
 	 *

--- a/includes/class-newspack-popups-parse-logs.php
+++ b/includes/class-newspack-popups-parse-logs.php
@@ -89,14 +89,12 @@ final class Newspack_Popups_Parse_Logs {
 			foreach ( $lines as $line ) {
 				$result = explode( '|', $line );
 				if ( isset( $result[1] ) ) {
-					$id        = $result[0];
-					$client_id = $result[1];
-					$type      = $result[2];
-					$context   = $result[3];
-					$value     = $result[4];
+					$client_id = $result[0];
+					$type      = $result[1];
+					$context   = $result[2];
+					$value     = $result[3];
 				} else {
 					// Handle legacy format.
-					$id           = '';
 					$result       = explode( ';', $line );
 					$client_id    = $result[1];
 					$date_created = $result[2];
@@ -111,7 +109,6 @@ final class Newspack_Popups_Parse_Logs {
 				}
 
 				$items[] = [
-					'id'        => $id,
 					'client_id' => $client_id,
 					'type'      => $type,
 					'context'   => $context,

--- a/includes/class-newspack-popups-parse-logs.php
+++ b/includes/class-newspack-popups-parse-logs.php
@@ -99,7 +99,7 @@ final class Newspack_Popups_Parse_Logs {
 		$sql = $wpdb->prepare( "$query ", $values ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
 
 		// Update the event if a the duplicate has a different date.
-		$sql .= ' ON DUPLICATE KEY UPDATE created_at = VALUES(created_at)';
+		$sql .= ' ON DUPLICATE KEY UPDATE date_created = VALUES(date_created)';
 
 		$wpdb->query( $sql ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
 	}
@@ -109,7 +109,6 @@ final class Newspack_Popups_Parse_Logs {
 	 */
 	public static function parse_events_logs() {
 		global $wpdb;
-
 
 		if ( ! file_exists( Segmentation::get_log_file_path() ) ) {
 			return;
@@ -131,14 +130,14 @@ final class Newspack_Popups_Parse_Logs {
 			$events_rows = [];
 
 			foreach ( $lines as $line ) {
-				$result     = explode( ';', $line );
-				$event_type = $result[0];
-				$client_id  = $result[1];
-				$date       = $result[2];
-				$post_id    = $result[3];
-				$categories = $result[4];
+				$result       = explode( '|', $line );
+				$client_id    = $result[0];
+				$date_created = $result[1];
+				$event_type   = $result[2];
+				$event_value  = $result[3];
+				$is_preview   = $result[4];
 
-				$events_rows[] = [ $event_type, $client_id, $date, $post_id, $categories ];
+				$events_rows[] = [ $client_id, $date_created, $event_type, $event_value, $is_preview ];
 			}
 
 			try {
@@ -146,11 +145,11 @@ final class Newspack_Popups_Parse_Logs {
 					Segmentation::get_events_table_name(),
 					$events_rows,
 					[
-						'type',
 						'client_id',
-						'created_at',
-						'post_id',
-						'category_ids',
+						'date_created',
+						'type',
+						'event_value',
+						'is_preview',
 					],
 					'( %s, %s, %s, %s, %s )'
 				);

--- a/includes/class-newspack-popups-parse-logs.php
+++ b/includes/class-newspack-popups-parse-logs.php
@@ -129,12 +129,27 @@ final class Newspack_Popups_Parse_Logs {
 			$events_rows = [];
 
 			foreach ( $lines as $line ) {
-				$result       = explode( '|', $line );
-				$client_id    = $result[0];
-				$date_created = $result[1];
-				$event_type   = $result[2];
-				$event_value  = $result[3];
-				$is_preview   = $result[4];
+				$result = explode( '|', $line );
+				if ( isset( $result[1] ) ) {
+					$client_id    = $result[0];
+					$date_created = $result[1];
+					$event_type   = $result[2];
+					$event_value  = $result[3];
+					$is_preview   = $result[4];
+				} else {
+					// Handle legacy format.
+					$result       = explode( ';', $line );
+					$client_id    = $result[1];
+					$date_created = $result[2];
+					$event_type   = 'article_view';
+					$event_value  = maybe_serialize(
+						[
+							'post_id'    => $result[3],
+							'categories' => $result[4],
+						]
+					);
+					$is_preview   = 'preview' === substr( $client_id, 0, 7 );
+				}
 
 				$events_rows[] = [ $client_id, $date_created, $event_type, $event_value, $is_preview ];
 			}

--- a/includes/class-newspack-popups-parse-logs.php
+++ b/includes/class-newspack-popups-parse-logs.php
@@ -96,6 +96,7 @@ final class Newspack_Popups_Parse_Logs {
 					$value     = $result[4];
 				} else {
 					// Handle legacy format.
+					$id           = '';
 					$result       = explode( ';', $line );
 					$client_id    = $result[1];
 					$date_created = $result[2];

--- a/includes/class-newspack-popups-parse-logs.php
+++ b/includes/class-newspack-popups-parse-logs.php
@@ -60,51 +60,8 @@ final class Newspack_Popups_Parse_Logs {
 	}
 
 	/**
-	 * Insert multiple rows in one DB transaction.
-	 *
-	 * @param string $table_name Table name.
-	 * @param array  $rows Rows to insert.
-	 * @param array  $column_names Names of the columns.
-	 * @param array  $placeholder Row placeholder for wpdb->prepare (e.g. `(%s, %s)`).
-	 */
-	public static function bulk_db_insert( $table_name, $rows, $column_names, $placeholder ) {
-		if ( 0 === count( $rows ) ) {
-			return;
-		}
-
-		global $wpdb;
-
-		$column_names = implode( ', ', $column_names );
-		$query        = "INSERT INTO $table_name ($column_names) VALUES ";
-		$query       .= implode(
-			', ',
-			array_map(
-				function( $row ) use ( $placeholder ) {
-					return $placeholder;
-				},
-				$rows
-			)
-		);
-
-		// Flatten the rows two-dimensional array.
-		$values = array_reduce(
-			$rows,
-			function( $acc, $arr ) {
-				return array_merge( $acc, $arr );
-			},
-			[]
-		);
-
-		$sql = $wpdb->prepare( "$query ", $values ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
-
-		// Update the event if a the duplicate has a different date.
-		$sql .= ' ON DUPLICATE KEY UPDATE date_created = VALUES(date_created)';
-
-		$wpdb->query( $sql ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
-	}
-
-	/**
 	 * Parse the log file, write data to the DB, and remove the file.
+	 * TODO: reformat rows with context and id
 	 */
 	public static function parse_events_logs() {
 		global $wpdb;
@@ -155,8 +112,8 @@ final class Newspack_Popups_Parse_Logs {
 			}
 
 			try {
-				self::bulk_db_insert(
-					Segmentation::get_events_table_name(),
+				Segmentation::bulk_db_insert(
+					Segmentation::get_reader_data_table_name(),
 					$events_rows,
 					[
 						'client_id',

--- a/includes/class-newspack-popups-parse-logs.php
+++ b/includes/class-newspack-popups-parse-logs.php
@@ -89,10 +89,11 @@ final class Newspack_Popups_Parse_Logs {
 			foreach ( $lines as $line ) {
 				$result = explode( '|', $line );
 				if ( isset( $result[1] ) ) {
-					$client_id = $result[0];
-					$type      = $result[1];
-					$context   = $result[2];
-					$value     = $result[3];
+					$client_id    = $result[0];
+					$date_created = $result[1];
+					$type         = $result[2];
+					$context      = $result[3];
+					$value        = $result[4];
 				} else {
 					// Handle legacy format.
 					$result       = explode( ';', $line );
@@ -109,10 +110,11 @@ final class Newspack_Popups_Parse_Logs {
 				}
 
 				$events[] = [
-					'client_id' => $client_id,
-					'type'      => $type,
-					'context'   => $context,
-					'value'     => $value,
+					'client_id'    => $client_id,
+					'date_created' => $date_created,
+					'type'         => $type,
+					'context'      => $context,
+					'value'        => $value,
 				];
 			}
 

--- a/includes/class-newspack-popups-segmentation.php
+++ b/includes/class-newspack-popups-segmentation.php
@@ -670,7 +670,7 @@ final class Newspack_Popups_Segmentation {
 
 		if ( ! empty( $values ) ) {
 			$sql = $wpdb->prepare(
-				"$query LIMIT $max_rows", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				"$query LIMIT $max_rows", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
 				$values
 			);
 		} else {
@@ -679,7 +679,7 @@ final class Newspack_Popups_Segmentation {
 
 		while ( $processed > 0 ) {
 			$start     = microtime( true );
-			$processed = $wpdb->query( $sql ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.DirectQuery
+			$processed = $wpdb->query( $sql ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.PreparedSQL.NotPrepared
 			$took      = microtime( true ) - $start;
 			$total    += $processed;
 

--- a/includes/class-newspack-popups-segmentation.php
+++ b/includes/class-newspack-popups-segmentation.php
@@ -560,9 +560,9 @@ final class Newspack_Popups_Segmentation {
 		require_once dirname( __FILE__ ) . '/../api/campaigns/class-campaign-data-utils.php';
 		require_once dirname( __FILE__ ) . '/../api/classes/class-lightweight-api.php';
 
+		$api             = new Lightweight_API();
 		$all_client_data = wp_cache_get( 'newspack_popups_all_clients_data', 'newspack-popups' );
 		if ( false === $all_client_data ) {
-			$api             = new Lightweight_API();
 			$all_client_data = $api->get_all_readers_data();
 			wp_cache_set( 'newspack_popups_all_clients_data', $all_client_data, 'newspack-popups' );
 		}

--- a/includes/class-newspack-popups-segmentation.php
+++ b/includes/class-newspack-popups-segmentation.php
@@ -386,10 +386,6 @@ final class Newspack_Popups_Segmentation {
 			require_once ABSPATH . 'wp-admin/includes/upgrade.php';
 			dbDelta( $sql ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.dbDelta_dbdelta
 		}
-
-		// TODO: If legacy tables exist and are empty, drop them.
-		$legacy_readers_table_name = Segmentation::get_readers_table_name_legacy();
-		$legacy_events_table_name  = Segmentation::get_readers_table_name_legacy();
 	}
 
 	/**
@@ -581,16 +577,17 @@ final class Newspack_Popups_Segmentation {
 		$all_client_data = wp_cache_get( 'newspack_popups_all_clients_data', 'newspack-popups' );
 		if ( false === $all_client_data ) {
 			$api             = new Lightweight_API();
-			$all_client_data = $api->get_all_clients_data_legacy();
+			$all_client_data = $api->get_all_readers_data();
 			wp_cache_set( 'newspack_popups_all_clients_data', $all_client_data, 'newspack-popups' );
 		}
 
 		$client_in_segment = array_filter(
 			$all_client_data,
-			function ( $client_data ) use ( $segment_config ) {
-				return Campaign_Data_Utils::does_client_match_segment(
+			function ( $client_id ) use ( $api, $segment_config ) {
+				return Campaign_Data_Utils::does_reader_match_segment(
 					$segment_config,
-					$client_data
+					$api->get_reader_data( $client_id ),
+					$api->get_reader_events( $client_id )
 				);
 			}
 		);

--- a/includes/class-newspack-popups-segmentation.php
+++ b/includes/class-newspack-popups-segmentation.php
@@ -243,8 +243,14 @@ final class Newspack_Popups_Segmentation {
 			$initial_client_report_url_params['mc_eid'] = sanitize_text_field( $_GET['mc_eid'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		}
 
-		// Handle Newspack donations via WooCommerce.
+		// Handle user accounts and Newspack donations via WooCommerce.
 		if ( is_user_logged_in() && ! Newspack_Popups::is_preview_request() ) {
+			// If the user is logged in, store their user ID.
+			$user_id = get_current_user_id();
+			if ( $user_id ) {
+				$initial_client_report_url_params['user_id'] = $user_id;
+			}
+
 			$newspack_donation_product_id = class_exists( '\Newspack\Donations' ) ?
 				(int) get_option( \Newspack\Donations::DONATION_PRODUCT_ID_OPTION, 0 ) :
 				0;
@@ -288,8 +294,6 @@ final class Newspack_Popups_Segmentation {
 					}
 				}
 			}
-
-			$initial_client_report_url_params['user_id'] = get_current_user_id();
 		}
 
 		// If visiting the donor landing page, mark the visitor as donor.
@@ -370,7 +374,7 @@ final class Newspack_Popups_Segmentation {
 			client_id varchar(100) NOT NULL,
 			date_created datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
 			type varchar(20) NOT NULL,
-			context varchar(20) NOT NULL,
+			context varchar(100) NOT NULL,
 			value longtext,
 			PRIMARY KEY  id (id),
 			KEY client_id_type_context (client_id, type, context),
@@ -579,7 +583,7 @@ final class Newspack_Popups_Segmentation {
 				return Campaign_Data_Utils::does_reader_match_segment(
 					$segment_config,
 					$api->get_reader( $client_id ),
-					$api->get_reader_events( $client_id )
+					$api->get_reader_events( $client_id, [ 'subscription', 'donation', 'user_account', 'view' ] )
 				);
 			}
 		);

--- a/includes/class-newspack-popups-segmentation.php
+++ b/includes/class-newspack-popups-segmentation.php
@@ -288,7 +288,8 @@ final class Newspack_Popups_Segmentation {
 		}
 
 		// If visiting the donor landing page, mark the visitor as donor.
-		if ( intval( Newspack_Popups_Settings::donor_landing_page() ) === get_queried_object_id() ) {
+		$donor_landing_page = intval( Newspack_Popups_Settings::donor_landing_page() );
+		if ( ! empty( $donor_landing_page ) && get_queried_object_id() === $donor_landing_page ) {
 			$initial_client_report_url_params['donation'] = wp_json_encode(
 				[
 					'offsite_has_donated' => true,

--- a/includes/class-newspack-popups-segmentation.php
+++ b/includes/class-newspack-popups-segmentation.php
@@ -675,7 +675,6 @@ final class Newspack_Popups_Segmentation {
 	/**
 	 * Run the given query with chunks of up to 1000 rows, sleeping in between chunks.
 	 * This helps avoid replication lag from deleting many records at once.
-	 * See: https://opengrok.a8c.com/source/xref/wpcom/wp-content/lib/jetpack-pit/class.jetpack-sync-postmeta-cleanup.php?r=5dbfee70#211
 	 *
 	 * @param string $query The query string to execute.
 	 * @param array  $values If $query contains %s or %d placeholders, an array of values replace them.
@@ -771,7 +770,7 @@ final class Newspack_Popups_Segmentation {
 
 		// Remove prompt_seen events older than $days days.
 		$removed_row_counts_prompt_seen_events = self::query_with_sleep(
-			"DELETE FROM $events_table_name WHERE type = 'prompt_seen' AND date_created < now() - interval $days DAY"
+			"DELETE FROM $events_table_name WHERE ( type = 'prompt_seen' OR type = 'prompt_dismissed' ) AND date_created < now() - interval $days DAY"
 		);
 
 		if ( defined( 'IS_TEST_ENV' ) && IS_TEST_ENV ) {

--- a/includes/class-newspack-popups-segmentation.php
+++ b/includes/class-newspack-popups-segmentation.php
@@ -720,8 +720,8 @@ final class Newspack_Popups_Segmentation {
 		$events_table_name  = Segmentation::get_events_table_name();
 
 		// Remove all preview sessions data.
-		$removed_preview_readers = self::query_with_sleep( "DELETE FROM $readers_table_name WHERE is_preview = 1 ORDER BY date_created ASC" );
-		$removed_preview_events  = self::query_with_sleep( "DELETE FROM $events_table_name WHERE is_preview = 1 ORDER BY date_created ASC" );
+		$removed_preview_readers = self::query_with_sleep( "DELETE FROM $readers_table_name WHERE is_preview = 1" );
+		$removed_preview_events  = self::query_with_sleep( "DELETE FROM $events_table_name WHERE is_preview = 1" );
 
 		// Remove reader data if not containing donations nor subscriptions, and not updated in $days days.
 		$days                     = 30;

--- a/tests/test-api.php
+++ b/tests/test-api.php
@@ -759,7 +759,7 @@ class APITest extends WP_UnitTestCase {
 			[
 				self::create_event( [ 'post_id' => 4 ] ),
 				self::create_event( [ 'post_id' => 5 ] ),
-				self::create_event( [ 'post_id' => 6 ] ),
+				self::create_event( [ 'post_id' => 6 ], false, 'view', 'page' ), // All singular post types are counted as articles.
 			]
 		);
 

--- a/tests/test-api.php
+++ b/tests/test-api.php
@@ -152,7 +152,7 @@ class APITest extends WP_UnitTestCase {
 		);
 
 		// Report 3 articles read.
-		self::$maybe_show_campaign->save_reader_data(
+		self::$maybe_show_campaign->save_reader_events(
 			self::$client_id,
 			[
 				self::create_event( [ 'post_id' => 1 ] ),
@@ -342,35 +342,25 @@ class APITest extends WP_UnitTestCase {
 			'categories' => '12,13',
 		];
 
-		$api->save_reader_data(
+		$api->save_reader_events(
 			self::$client_id,
 			[ self::create_event( $read_post ) ]
 		);
 
-		$reader_data = $api->get_reader_data_persistent( self::$client_id );
+		$reader = $api->get_reader( self::$client_id );
 
-		self::assertArraySubset(
-			[
-				'client_id' => self::$client_id,
-				'type'      => 'view_count',
-				'context'   => 'post',
-				'value'     => [ 'count' => 1 ],
-			],
-			$reader_data[0],
+		self::assertEquals(
+			1,
+			$reader['reader_data']['views']['post'],
 			'Returns view count after a post view was reported.'
 		);
 
-		self::assertArraySubset(
+		self::assertEquals(
 			[
-				'client_id' => self::$client_id,
-				'type'      => 'term_count',
-				'context'   => 'category',
-				'value'     => [
-					'12' => 1,
-					'13' => 1,
-				],
+				'12' => 1,
+				'13' => 1,
 			],
-			$reader_data[1],
+			$reader['reader_data']['category'],
 			'Returns category view count after a post view was reported.'
 		);
 
@@ -401,7 +391,7 @@ class APITest extends WP_UnitTestCase {
 		$client_id = 'client_' . uniqid();
 
 		// Report 3 articles read.
-		$api->save_reader_data(
+		$api->save_reader_events(
 			$client_id,
 			[
 				self::create_event( [ 'post_id' => 1 ] ),
@@ -410,10 +400,10 @@ class APITest extends WP_UnitTestCase {
 			]
 		);
 
-		$reader_data = $api->get_reader_data( $client_id, 'view_count', 'post' );
+		$reader = $api->get_reader( $client_id );
 
 		self::assertEquals(
-			$reader_data[0]['value']['count'],
+			$reader['reader_data']['views']['post'],
 			3,
 			'Returns expected data after saving new events.'
 		);
@@ -435,17 +425,16 @@ class APITest extends WP_UnitTestCase {
 			]
 		);
 		$seen_event = [
-			'client_id'     => $client_id,
-			'date_created'  => gmdate( 'Y-m-d H:i:s' ),
-			'date_modified' => gmdate( 'Y-m-d H:i:s' ),
-			'type'          => 'prompt_seen',
-			'context'       => $popup_id,
-			'value'         => '',
+			'client_id'    => $client_id,
+			'date_created' => gmdate( 'Y-m-d H:i:s' ),
+			'type'         => 'prompt_seen',
+			'context'      => $popup_id,
+			'value'        => '',
 		];
 
 		self::assertArraySubset(
 			$seen_event,
-			$api->get_reader_data( $client_id, 'prompt_seen' )[0],
+			$api->get_reader_events( $client_id, 'prompt_seen' )[0],
 			'Returns prompt data after a prompt is reported.'
 		);
 
@@ -458,17 +447,16 @@ class APITest extends WP_UnitTestCase {
 		);
 
 		$new_seen_event = [
-			'client_id'     => $client_id,
-			'date_created'  => gmdate( 'Y-m-d H:i:s' ),
-			'date_modified' => gmdate( 'Y-m-d H:i:s' ),
-			'type'          => 'prompt_seen',
-			'context'       => $popup_id,
-			'value'         => '',
+			'client_id'    => $client_id,
+			'date_created' => gmdate( 'Y-m-d H:i:s' ),
+			'type'         => 'prompt_seen',
+			'context'      => $popup_id,
+			'value'        => '',
 		];
 
 		self::assertArraySubset(
 			$new_seen_event,
-			$api->get_reader_data( $client_id, 'prompt_seen' )[1],
+			$api->get_reader_events( $client_id, 'prompt_seen' )[1],
 			'Returns prompt data.'
 		);
 
@@ -485,17 +473,16 @@ class APITest extends WP_UnitTestCase {
 			]
 		);
 		$third_seen_event = [
-			'client_id'     => $client_id,
-			'date_created'  => gmdate( 'Y-m-d H:i:s' ),
-			'date_modified' => gmdate( 'Y-m-d H:i:s' ),
-			'type'          => 'prompt_seen',
-			'context'       => $new_popup_id,
-			'value'         => '',
+			'client_id'    => $client_id,
+			'date_created' => gmdate( 'Y-m-d H:i:s' ),
+			'type'         => 'prompt_seen',
+			'context'      => $new_popup_id,
+			'value'        => '',
 		];
 
 		self::assertArraySubset(
 			$third_seen_event,
-			$api->get_reader_data( $client_id, 'prompt_seen' )[2],
+			$api->get_reader_events( $client_id, 'prompt_seen' )[2],
 			'Returns data in expected shape.'
 		);
 	}
@@ -545,13 +532,13 @@ class APITest extends WP_UnitTestCase {
 
 		self::assertArraySubset(
 			$donate_event_1,
-			$api->get_reader_data( $client_id, 'donation' )[0],
+			$api->get_reader_events( $client_id, 'donation' )[0],
 			'Returns data with donation data after a donation is reported.'
 		);
 
 		self::assertArraySubset(
 			$donate_event_2,
-			$api->get_reader_data( $client_id, 'donation' )[1],
+			$api->get_reader_events( $client_id, 'donation' )[1],
 			'Returns data with donation data after a donation is reported.'
 		);
 	}
@@ -601,7 +588,7 @@ class APITest extends WP_UnitTestCase {
 
 		self::assertArraySubset(
 			$subscribe_event,
-			self::$report_campaign_data->get_reader_data( self::$client_id, 'subscription' )[0],
+			self::$report_campaign_data->get_reader_events( self::$client_id, 'subscription' )[0],
 			'The events data after a subscription contains the provided email address.'
 		);
 	}
@@ -739,7 +726,7 @@ class APITest extends WP_UnitTestCase {
 		);
 
 		// Report 3 articles read.
-		self::$maybe_show_campaign->save_reader_data(
+		self::$maybe_show_campaign->save_reader_events(
 			self::$client_id,
 			[
 				self::create_event( [ 'post_id' => 1 ] ),
@@ -754,7 +741,7 @@ class APITest extends WP_UnitTestCase {
 		);
 
 		// Report more than 5 articles read.
-		self::$maybe_show_campaign->save_reader_data(
+		self::$maybe_show_campaign->save_reader_events(
 			self::$client_id,
 			[
 				self::create_event( [ 'post_id' => 4 ] ),
@@ -787,7 +774,7 @@ class APITest extends WP_UnitTestCase {
 		);
 
 		// Report 3 articles read.
-		self::$maybe_show_campaign->save_reader_data(
+		self::$maybe_show_campaign->save_reader_events(
 			self::$client_id,
 			[
 				self::create_event( [ 'post_id' => 1 ] ),
@@ -833,7 +820,7 @@ class APITest extends WP_UnitTestCase {
 		);
 
 		// Report 3 articles read.
-		self::$maybe_show_campaign->save_reader_data(
+		self::$maybe_show_campaign->save_reader_events(
 			self::$client_id,
 			[
 				self::create_event( [ 'post_id' => 1 ] ),
@@ -879,7 +866,7 @@ class APITest extends WP_UnitTestCase {
 		);
 
 		// Report 2 articles read before current session.
-		self::$maybe_show_campaign->save_reader_data(
+		self::$maybe_show_campaign->save_reader_events(
 			self::$client_id,
 			[
 				self::create_event( [ 'post_id' => 1 ], gmdate( 'Y-m-d H:i:s', strtotime( '-1 day', time() ) ) ),
@@ -893,7 +880,7 @@ class APITest extends WP_UnitTestCase {
 		);
 
 		// Report 3 articles read in the session.
-		self::$maybe_show_campaign->save_reader_data(
+		self::$maybe_show_campaign->save_reader_events(
 			self::$client_id,
 			[
 				self::create_event( [ 'post_id' => 3 ] ),
@@ -908,7 +895,7 @@ class APITest extends WP_UnitTestCase {
 		);
 
 		// Report more than 5 articles read in the session.
-		self::$maybe_show_campaign->save_reader_data(
+		self::$maybe_show_campaign->save_reader_events(
 			self::$client_id,
 			[
 				self::create_event( [ 'post_id' => 6 ] ),
@@ -1012,7 +999,7 @@ class APITest extends WP_UnitTestCase {
 		);
 
 		// Report an article read.
-		self::$maybe_show_campaign->save_reader_data(
+		self::$maybe_show_campaign->save_reader_events(
 			self::$client_id,
 			[
 				self::create_event( [ 'post_id' => 1 ] ),
@@ -1025,7 +1012,7 @@ class APITest extends WP_UnitTestCase {
 		);
 
 		// Report 2 articles from the favorite category read.
-		self::$maybe_show_campaign->save_reader_data(
+		self::$maybe_show_campaign->save_reader_events(
 			self::$client_id,
 			[
 				self::create_event(
@@ -1125,7 +1112,7 @@ class APITest extends WP_UnitTestCase {
 			]
 		);
 
-		$api->save_reader_data(
+		$api->save_reader_events(
 			self::$client_id,
 			[
 				self::create_event( [ 'post_id' => 1 ], false, '42' ),

--- a/tests/test-api.php
+++ b/tests/test-api.php
@@ -352,8 +352,8 @@ class APITest extends WP_UnitTestCase {
 			[
 				'is_preview'      => null,
 				'user_id'         => null,
-				'article_views'   => '1',
-				'page_views'      => '0',
+				'article_views'   => 1,
+				'page_views'      => 0,
 				'categories_read' => [
 					'12' => 1,
 					'13' => 1,
@@ -379,11 +379,11 @@ class APITest extends WP_UnitTestCase {
 			[
 				'is_preview'      => null,
 				'user_id'         => null,
-				'article_views'   => '1',
-				'page_views'      => '0',
+				'article_views'   => 1,
+				'page_views'      => 0,
 				'categories_read' => [
-					'12' => '1',
-					'13' => '1',
+					'12' => 1,
+					'13' => 1,
 				],
 				'client_id'       => self::$client_id,
 			],

--- a/tests/test-api.php
+++ b/tests/test-api.php
@@ -440,7 +440,7 @@ class APITest extends WP_UnitTestCase {
 			'date_modified' => gmdate( 'Y-m-d H:i:s' ),
 			'type'          => 'prompt_seen',
 			'context'       => $popup_id,
-			'value'         => [],
+			'value'         => '',
 		];
 
 		self::assertArraySubset(
@@ -463,7 +463,7 @@ class APITest extends WP_UnitTestCase {
 			'date_modified' => gmdate( 'Y-m-d H:i:s' ),
 			'type'          => 'prompt_seen',
 			'context'       => $popup_id,
-			'value'         => [],
+			'value'         => '',
 		];
 
 		self::assertArraySubset(
@@ -490,7 +490,7 @@ class APITest extends WP_UnitTestCase {
 			'date_modified' => gmdate( 'Y-m-d H:i:s' ),
 			'type'          => 'prompt_seen',
 			'context'       => $new_popup_id,
-			'value'         => [],
+			'value'         => '',
 		];
 
 		self::assertArraySubset(

--- a/tests/test-api.php
+++ b/tests/test-api.php
@@ -58,8 +58,8 @@ class APITest extends WP_UnitTestCase {
 				'priority'          => 3,
 			],
 			'segmentLoggedIn'                     => [
-				'is_logged_in' => true,
-				'priority'     => 4,
+				'has_user_account' => true,
+				'priority'         => 4,
 			],
 			'segmentWithReferrers'                => [
 				'referrers' => 'foobar.com, newspack.pub',

--- a/tests/test-api.php
+++ b/tests/test-api.php
@@ -580,10 +580,7 @@ class APITest extends WP_UnitTestCase {
 		$subscribe_event = [
 			'client_id' => self::$client_id,
 			'type'      => 'subscription',
-			'context'   => '',
-			'value'     => [
-				'email' => $email_address,
-			],
+			'context'   => $email_address,
 		];
 
 		self::assertArraySubset(

--- a/tests/test-api.php
+++ b/tests/test-api.php
@@ -53,13 +53,13 @@ class APITest extends WP_UnitTestCase {
 				'is_subscribed' => true,
 				'priority'      => 2,
 			],
-			'segmentNonSubscribers'               => [
-				'is_not_subscribed' => true,
-				'priority'          => 3,
-			],
 			'segmentLoggedIn'                     => [
 				'has_user_account' => true,
-				'priority'         => 4,
+				'priority'         => 3,
+			],
+			'segmentNonSubscribers'               => [
+				'is_not_subscribed' => true,
+				'priority'          => 4,
 			],
 			'segmentWithReferrers'                => [
 				'referrers' => 'foobar.com, newspack.pub',
@@ -687,6 +687,37 @@ class APITest extends WP_UnitTestCase {
 		self::assertTrue(
 			self::$maybe_show_campaign->should_popup_be_shown( self::$client_id, $test_popup_with_segment['payload'], self::$settings ),
 			'Assert visible.'
+		);
+	}
+
+	/**
+	 * User account segment.
+	 */
+	public function test_segment_user_account() {
+		$test_popup = self::create_test_popup(
+			[
+				'placement'           => 'inline',
+				'frequency'           => 'always',
+				'selected_segment_id' => self::$segment_ids['segmentLoggedIn'],
+			]
+		);
+
+		self::assertFalse(
+			self::$maybe_show_campaign->should_popup_be_shown( self::$client_id, $test_popup['payload'], self::$settings ),
+			'Assert not visible, since user has no account.'
+		);
+
+		// Report a login.
+		self::$report_client_data->report_client_data(
+			[
+				'client_id' => self::$client_id,
+				'user_id'   => 123,
+			]
+		);
+
+		self::assertTrue(
+			self::$maybe_show_campaign->should_popup_be_shown( self::$client_id, $test_popup['payload'], self::$settings ),
+			'Assert visible, since user has an account.'
 		);
 	}
 

--- a/tests/test-api.php
+++ b/tests/test-api.php
@@ -151,7 +151,7 @@ class APITest extends WP_UnitTestCase {
 		);
 
 		// Report 3 articles read.
-		self::$maybe_show_campaign->save_reader_events(
+		self::$maybe_show_campaign->save_reader_data(
 			self::$client_id,
 			[
 				self::create_event( [ 'post_id' => 1 ] ),
@@ -328,8 +328,8 @@ class APITest extends WP_UnitTestCase {
 		$api = new Lightweight_API();
 
 		self::assertEquals(
-			$api->get_reader_data( self::$client_id ),
-			$api->reader_data_blueprint,
+			$api->get_reader( self::$client_id ),
+			$api->reader_blueprint,
 			'Returns expected data blueprint in absence of saved data.'
 		);
 
@@ -338,12 +338,12 @@ class APITest extends WP_UnitTestCase {
 			'categories' => '12,13',
 		];
 
-		$api->save_reader_events(
+		$api->save_reader_data(
 			self::$client_id,
 			[ self::create_event( $read_post ) ]
 		);
 
-		$reader_data = $api->get_reader_data( self::$client_id );
+		$reader_data = $api->get_reader( self::$client_id );
 		unset( $reader_data['date_created'] );
 		unset( $reader_data['date_modified'] );
 
@@ -363,14 +363,14 @@ class APITest extends WP_UnitTestCase {
 			'Returns data with saved post after an article reading was reported.'
 		);
 
-		$api->save_reader_data(
+		$api->save_reader(
 			self::$client_id,
 			[
 				'some_other_data' => 42,
 			]
 		);
 
-		$reader_data = $api->get_reader_data( self::$client_id );
+		$reader_data = $api->get_reader( self::$client_id );
 		unset( $reader_data['date_created'] );
 		unset( $reader_data['date_modified'] );
 
@@ -399,7 +399,7 @@ class APITest extends WP_UnitTestCase {
 		$client_id = 'client_' . uniqid();
 
 		// Report 3 articles read.
-		$api->save_reader_events(
+		$api->save_reader_data(
 			$client_id,
 			[
 				self::create_event( [ 'post_id' => 1 ] ),
@@ -408,7 +408,7 @@ class APITest extends WP_UnitTestCase {
 			]
 		);
 
-		$reader_data = $api->get_reader_data( $client_id );
+		$reader_data = $api->get_reader( $client_id );
 
 		self::assertEquals(
 			$reader_data['article_views'],
@@ -443,7 +443,7 @@ class APITest extends WP_UnitTestCase {
 		];
 
 		self::assertEquals(
-			$api->get_reader_events( $client_id, 'prompt_seen' ),
+			$api->get_reader_data( $client_id, 'prompt_seen' ),
 			[ $seen_event ],
 			'Returns prompt data after a prompt is reported.'
 		);
@@ -467,7 +467,7 @@ class APITest extends WP_UnitTestCase {
 		];
 
 		self::assertEquals(
-			$api->get_reader_events( $client_id, 'prompt_seen' ),
+			$api->get_reader_data( $client_id, 'prompt_seen' ),
 			[ $seen_event, $new_seen_event ],
 			'Returns prompt data.'
 		);
@@ -494,7 +494,7 @@ class APITest extends WP_UnitTestCase {
 			'is_preview'   => null,
 		];
 		self::assertEquals(
-			$api->get_reader_events( $client_id, 'prompt_seen' ),
+			$api->get_reader_data( $client_id, 'prompt_seen' ),
 			[ $seen_event, $new_seen_event, $third_seen_event ],
 			'Returns data in expected shape.'
 		);
@@ -548,7 +548,7 @@ class APITest extends WP_UnitTestCase {
 		];
 
 		self::assertEquals(
-			$api->get_reader_events( $client_id, 'donation' ),
+			$api->get_reader_data( $client_id, 'donation' ),
 			[ $donate_event_1, $donate_event_2 ],
 			'Returns data with donation data after a donation is reported.'
 		);
@@ -567,8 +567,8 @@ class APITest extends WP_UnitTestCase {
 		);
 
 		self::assertEquals(
-			self::$report_campaign_data->get_reader_data( self::$client_id ),
-			self::$report_campaign_data->reader_data_blueprint,
+			self::$report_campaign_data->get_reader( self::$client_id ),
+			self::$report_campaign_data->reader_blueprint,
 			'The initial reader data has expected shape.'
 		);
 
@@ -596,7 +596,7 @@ class APITest extends WP_UnitTestCase {
 		];
 
 		self::assertEquals(
-			self::$report_campaign_data->get_reader_events( self::$client_id, 'subscription' ),
+			self::$report_campaign_data->get_reader_data( self::$client_id, 'subscription' ),
 			[ $subscribe_event ],
 			'The events data after a subscription contains the provided email address.'
 		);
@@ -704,7 +704,7 @@ class APITest extends WP_UnitTestCase {
 		);
 
 		// Report 3 articles read.
-		self::$maybe_show_campaign->save_reader_events(
+		self::$maybe_show_campaign->save_reader_data(
 			self::$client_id,
 			[
 				self::create_event( [ 'post_id' => 1 ] ),
@@ -719,7 +719,7 @@ class APITest extends WP_UnitTestCase {
 		);
 
 		// Report more than 5 articles read.
-		self::$maybe_show_campaign->save_reader_events(
+		self::$maybe_show_campaign->save_reader_data(
 			self::$client_id,
 			[
 				self::create_event( [ 'post_id' => 4 ] ),
@@ -752,7 +752,7 @@ class APITest extends WP_UnitTestCase {
 		);
 
 		// Report 3 articles read.
-		self::$maybe_show_campaign->save_reader_events(
+		self::$maybe_show_campaign->save_reader_data(
 			self::$client_id,
 			[
 				self::create_event( [ 'post_id' => 1 ] ),
@@ -798,7 +798,7 @@ class APITest extends WP_UnitTestCase {
 		);
 
 		// Report 3 articles read.
-		self::$maybe_show_campaign->save_reader_events(
+		self::$maybe_show_campaign->save_reader_data(
 			self::$client_id,
 			[
 				self::create_event( [ 'post_id' => 1 ] ),
@@ -844,7 +844,7 @@ class APITest extends WP_UnitTestCase {
 		);
 
 		// Report 2 articles read before current session.
-		self::$maybe_show_campaign->save_reader_events(
+		self::$maybe_show_campaign->save_reader_data(
 			self::$client_id,
 			[
 				self::create_event( [ 'post_id' => 1 ], gmdate( 'Y-m-d H:i:s', strtotime( '-1 day', time() ) ) ),
@@ -858,7 +858,7 @@ class APITest extends WP_UnitTestCase {
 		);
 
 		// Report 3 articles read in the session.
-		self::$maybe_show_campaign->save_reader_events(
+		self::$maybe_show_campaign->save_reader_data(
 			self::$client_id,
 			[
 				self::create_event( [ 'post_id' => 3 ] ),
@@ -873,7 +873,7 @@ class APITest extends WP_UnitTestCase {
 		);
 
 		// Report more than 5 articles read in the session.
-		self::$maybe_show_campaign->save_reader_events(
+		self::$maybe_show_campaign->save_reader_data(
 			self::$client_id,
 			[
 				self::create_event( [ 'post_id' => 6 ] ),
@@ -977,7 +977,7 @@ class APITest extends WP_UnitTestCase {
 		);
 
 		// Report an article read.
-		self::$maybe_show_campaign->save_reader_events(
+		self::$maybe_show_campaign->save_reader_data(
 			self::$client_id,
 			[
 				self::create_event( [ 'post_id' => 1 ] ),
@@ -990,7 +990,7 @@ class APITest extends WP_UnitTestCase {
 		);
 
 		// Report 2 articles from the favorite category read.
-		self::$maybe_show_campaign->save_reader_events(
+		self::$maybe_show_campaign->save_reader_data(
 			self::$client_id,
 			[
 				self::create_event(
@@ -1090,7 +1090,7 @@ class APITest extends WP_UnitTestCase {
 			]
 		);
 
-		$api->save_reader_events(
+		$api->save_reader_data(
 			self::$client_id,
 			[
 				self::create_event( [ 'post_id' => 1 ], false, '42' ),

--- a/tests/test-segmentation.php
+++ b/tests/test-segmentation.php
@@ -271,9 +271,7 @@ class SegmentationTest extends WP_UnitTestCase {
 				[
 					'client_id' => 'test-subscriber',
 					'type'      => 'subscription',
-					'value'     => [
-						'email' => 'test@testing.com',
-					],
+					'context'   => 'test@testing.com',
 				],
 			]
 		);

--- a/tests/test-segmentation.php
+++ b/tests/test-segmentation.php
@@ -15,9 +15,9 @@ class SegmentationTest extends WP_UnitTestCase {
 
 	public function setUp() { // phpcs:ignore Squiz.Commenting.FunctionComment.Missing
 		global $wpdb;
-		$reader_data_table_name = Segmentation::get_reader_data_table_name();
-		$readers_table_name     = Segmentation::get_readers_table_name();
-		$wpdb->query( "DELETE FROM $reader_data_table_name;" ); // phpcs:ignore
+		$reader_events_table_name = Segmentation::get_reader_events_table_name();
+		$readers_table_name       = Segmentation::get_readers_table_name();
+		$wpdb->query( "DELETE FROM $reader_events_table_name;" ); // phpcs:ignore
 		$wpdb->query( "DELETE FROM $readers_table_name;" ); // phpcs:ignore
 		if ( file_exists( Segmentation::get_log_file_path() ) ) {
 			unlink( Segmentation::get_log_file_path() ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_unlink
@@ -56,7 +56,6 @@ class SegmentationTest extends WP_UnitTestCase {
 		$expected_log_line = implode(
 			'|',
 			[
-				'',
 				self::$post_read_payload['client_id'],
 				self::$post_read_payload['type'],
 				self::$post_read_payload['context'],
@@ -111,7 +110,7 @@ class SegmentationTest extends WP_UnitTestCase {
 				self::$post_read_payload,
 				$second_event,
 			],
-			$api->get_reader_data( self::$post_read_payload['client_id'] ),
+			$api->get_reader_events( self::$post_read_payload['client_id'] ),
 			'Both new and legacy formats are parsed into events.'
 		);
 	}
@@ -141,7 +140,7 @@ class SegmentationTest extends WP_UnitTestCase {
 			)
 		);
 		$maybe_show_campaign = new Maybe_Show_Campaign();
-		$read_posts          = $maybe_show_campaign->get_reader_data( self::$post_read_payload['client_id'], 'view', 'post' );
+		$read_posts          = $maybe_show_campaign->get_reader_events( self::$post_read_payload['client_id'], 'view', 'post' );
 
 		self::assertEquals(
 			1,
@@ -167,7 +166,7 @@ class SegmentationTest extends WP_UnitTestCase {
 			)
 		);
 		$maybe_show_campaign = new Maybe_Show_Campaign();
-		$read_posts          = $maybe_show_campaign->get_reader_data( self::$post_read_payload['client_id'], 'view', 'post' );
+		$read_posts          = $maybe_show_campaign->get_reader_events( self::$post_read_payload['client_id'], 'view', 'post' );
 
 		self::assertEquals(
 			2,
@@ -188,8 +187,8 @@ class SegmentationTest extends WP_UnitTestCase {
 		);
 
 		$maybe_show_campaign = new Maybe_Show_Campaign();
-		$read_posts          = $maybe_show_campaign->get_reader_data( self::$post_read_payload['client_id'], 'view', 'post' );
-		$page_views          = $maybe_show_campaign->get_reader_data( self::$post_read_payload['client_id'], 'view', 'page' );
+		$read_posts          = $maybe_show_campaign->get_reader_events( self::$post_read_payload['client_id'], 'view', 'post' );
+		$page_views          = $maybe_show_campaign->get_reader_events( self::$post_read_payload['client_id'], 'view', 'page' );
 
 		self::assertEquals(
 			2,
@@ -251,7 +250,7 @@ class SegmentationTest extends WP_UnitTestCase {
 
 		// Add the donor client data.
 		$api_campaign_handler->save_reader( 'test-donor' );
-		$api_campaign_handler->save_reader_data(
+		$api_campaign_handler->save_reader_events(
 			'test-donor',
 			[
 				[
@@ -266,7 +265,7 @@ class SegmentationTest extends WP_UnitTestCase {
 
 		// Add and backdate the subscriber client data.
 		$api_campaign_handler->save_reader( 'test-subscriber' );
-		$api_campaign_handler->save_reader_data(
+		$api_campaign_handler->save_reader_events(
 			'test-subscriber',
 			[
 				[
@@ -282,7 +281,7 @@ class SegmentationTest extends WP_UnitTestCase {
 
 		// Add the one time reader client data.
 		$api_campaign_handler->save_reader( 'test-one-time-reader' );
-		$api_campaign_handler->save_reader_data(
+		$api_campaign_handler->save_reader_events(
 			'test-one-time-reader',
 			[
 				[
@@ -299,7 +298,7 @@ class SegmentationTest extends WP_UnitTestCase {
 
 		// Add and backdate the one time reader client data.
 		$api_campaign_handler->save_reader( 'test-one-time-reader-backdated' );
-		$api_campaign_handler->save_reader_data(
+		$api_campaign_handler->save_reader_events(
 			'test-one-time-reader-backdated',
 			[
 				[

--- a/tests/test-segmentation.php
+++ b/tests/test-segmentation.php
@@ -23,20 +23,23 @@ class SegmentationTest extends WP_UnitTestCase {
 			unlink( Segmentation::get_log_file_path() ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_unlink
 		}
 		self::$post_read_payload = [
-			'is_post'    => true,
-			'clientId'   => 'test-' . uniqid(),
-			'post_id'    => '42',
-			'categories' => '5,6',
-			'created_at' => gmdate( 'Y-m-d H:i:s' ),
+			'client_id'    => 'test-' . uniqid(),
+			'date_created' => gmdate( 'Y-m-d H:i:s' ),
+			'type'         => 'article_view',
+			'event_value'  => [
+				'post_id'    => 42,
+				'categories' => '5,6',
+			],
+			'is_preview'   => false,
 		];
 		self::$request           = [
-			'cid'      => self::$post_read_payload['clientId'],
+			'cid'      => self::$post_read_payload['client_id'],
 			'popups'   => wp_json_encode( [] ),
 			'settings' => wp_json_encode( [] ),
 			'visit'    => wp_json_encode(
 				[
-					'post_id'    => self::$post_read_payload['post_id'],
-					'categories' => self::$post_read_payload['categories'],
+					'post_id'    => self::$post_read_payload['event_value']['post_id'],
+					'categories' => self::$post_read_payload['event_value']['categories'],
 					'is_post'    => true,
 					'date'       => gmdate( 'Y-m-d', time() ),
 				]
@@ -48,39 +51,46 @@ class SegmentationTest extends WP_UnitTestCase {
 	 * Log file updating with a post_read event.
 	 */
 	public function test_log_visit() {
-		Segmentation_Report::log_single_visit( self::$post_read_payload );
+		$api = new Lightweight_API();
+		Segmentation_Report::log_reader_events( [ self::$post_read_payload ] );
 
 		$expected_log_line = implode(
-			';',
+			'|',
 			[
-				'post_read',
-				self::$post_read_payload['clientId'],
-				gmdate( 'Y-m-d H:i:s', time() ),
-				self::$post_read_payload['post_id'],
-				self::$post_read_payload['categories'],
+				self::$post_read_payload['client_id'],
+				self::$post_read_payload['date_created'],
+				self::$post_read_payload['type'],
+				maybe_serialize( self::$post_read_payload['event_value'] ),
+				0,
 			]
-		) . "\n";
+		);
 
 		self::assertEquals(
-			$expected_log_line,
+			$expected_log_line . "\n",
 			file_get_contents( Segmentation::get_log_file_path() ),
 			'Log file contains the expected line.'
 		);
 
-		Segmentation_Report::log_single_visit(
-			array_merge(
-				self::$post_read_payload,
-				[
-					'is_post' => false,
-				]
-			)
-		);
-
-		self::assertEquals(
-			$expected_log_line,
-			file_get_contents( Segmentation::get_log_file_path() ),
-			'Log file is not updated after a non-post visit is reported.'
-		);
+		$second_event    = [
+			'client_id'    => self::$post_read_payload['client_id'],
+			'date_created' => self::$post_read_payload['date_created'],
+			'type'         => 'article_view',
+			'event_value'  => [
+				'post_id'    => 43,
+				'categories' => '7,8',
+			],
+			'is_preview'   => false,
+		];
+		$legacy_log_line = implode(
+			';',
+			[
+				'post_read',
+				self::$post_read_payload['client_id'],
+				self::$post_read_payload['date_created'],
+				$second_event['event_value']['post_id'],
+				$second_event['event_value']['categories'],
+			]
+		) . "\n";
 
 		Newspack_Popups_Parse_Logs::parse_events_logs();
 
@@ -88,6 +98,23 @@ class SegmentationTest extends WP_UnitTestCase {
 			'',
 			file_get_contents( Segmentation::get_log_file_path() ),
 			'Log file is emptied after parsing logs.'
+		);
+
+		file_put_contents( // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_file_put_contents
+			Segmentation::get_log_file_path(),
+			$legacy_log_line,
+			FILE_APPEND
+		);
+
+		Newspack_Popups_Parse_Logs::parse_events_logs();
+
+		self::assertEquals(
+			$api->get_reader_events( self::$post_read_payload['client_id'] ),
+			[
+				self::$post_read_payload,
+				$second_event,
+			],
+			'Both new and legacy formats are parsed into events.'
 		);
 	}
 
@@ -103,8 +130,7 @@ class SegmentationTest extends WP_UnitTestCase {
 
 		// And a duplicate.
 		$maybe_show_campaign = new Maybe_Show_Campaign();
-
-		$date = gmdate( 'Y-m-d', strtotime( '+1 week' ) );
+		$date                = gmdate( 'Y-m-d', strtotime( '+1 week' ) );
 
 		// Duplicate article read, but on a different date.
 		$_REQUEST            = self::$request;
@@ -117,8 +143,7 @@ class SegmentationTest extends WP_UnitTestCase {
 			)
 		);
 		$maybe_show_campaign = new Maybe_Show_Campaign();
-
-		$read_posts = $maybe_show_campaign->get_client_data( self::$post_read_payload['clientId'] )['posts_read'];
+		$read_posts          = $maybe_show_campaign->get_reader_events( self::$post_read_payload['client_id'], 'article_view' );
 
 		self::assertEquals(
 			1,
@@ -127,11 +152,7 @@ class SegmentationTest extends WP_UnitTestCase {
 		);
 
 		self::assertEquals(
-			[
-				'post_id'      => self::$post_read_payload['post_id'],
-				'category_ids' => self::$post_read_payload['categories'],
-				'created_at'   => self::$post_read_payload['created_at'],
-			],
+			self::$post_read_payload,
 			$read_posts[0],
 			'The read posts array contains the reported post.'
 		);
@@ -148,8 +169,7 @@ class SegmentationTest extends WP_UnitTestCase {
 			)
 		);
 		$maybe_show_campaign = new Maybe_Show_Campaign();
-
-		$read_posts = $maybe_show_campaign->get_client_data( self::$post_read_payload['clientId'] )['posts_read'];
+		$read_posts          = $maybe_show_campaign->get_reader_events( self::$post_read_payload['client_id'], 'article_view' );
 
 		self::assertEquals(
 			2,
@@ -158,8 +178,8 @@ class SegmentationTest extends WP_UnitTestCase {
 		);
 
 		// Now a non-post visit.
-		$_REQUEST            = self::$request;
-		$_REQUEST['visit']   = wp_json_encode(
+		$_REQUEST          = self::$request;
+		$_REQUEST['visit'] = wp_json_encode(
 			array_merge(
 				(array) json_decode( self::$request['visit'] ),
 				[
@@ -168,13 +188,30 @@ class SegmentationTest extends WP_UnitTestCase {
 				]
 			)
 		);
+
 		$maybe_show_campaign = new Maybe_Show_Campaign();
-		$read_posts          = $maybe_show_campaign->get_client_data( self::$post_read_payload['clientId'] )['posts_read'];
+		$read_posts          = $maybe_show_campaign->get_reader_events( self::$post_read_payload['client_id'], 'article_view' );
+		$page_views          = $maybe_show_campaign->get_reader_events( self::$post_read_payload['client_id'], 'page_view' );
 
 		self::assertEquals(
 			2,
 			count( $read_posts ),
 			'The read posts array is not updated after a non-post visit was made.'
+		);
+
+		self::assertEquals(
+			[
+				'client_id'    => self::$post_read_payload['client_id'],
+				'date_created' => self::$post_read_payload['date_created'],
+				'type'         => 'page_view',
+				'event_value'  => [
+					'post_id'    => '12345',
+					'categories' => '5,6',
+				],
+				'is_preview'   => false,
+			],
+			$page_views[0],
+			'Non-article visits are logged as page views.'
 		);
 	}
 
@@ -211,55 +248,80 @@ class SegmentationTest extends WP_UnitTestCase {
 	 */
 	public function test_data_pruning() {
 		global $wpdb;
-		$readers_table_name = Segmentation::get_readers_table_name();
-
 		$api_campaign_handler = new Maybe_Show_Campaign();
+		$readers_table_name   = Segmentation::get_readers_table_name();
+		$wpdb->query( "DELETE FROM $readers_table_name;" ); // phpcs:ignore
 
 		// Add the donor client data.
-		$api_campaign_handler->save_client_data(
+		$api_campaign_handler->save_reader_data( 'test-donor' );
+		$api_campaign_handler->save_reader_events(
 			'test-donor',
 			[
-				'donation' => [ 'amount' => 100 ],
+				[
+					'client_id'    => 'test-donor',
+					'date_created' => gmdate( 'Y-m-d H:i:s' ),
+					'type'         => 'donation',
+					'event_value'  => [
+						'amount' => 100,
+					],
+				],
 			]
 		);
 
 		// Add and backdate the subscriber client data.
-		$api_campaign_handler->save_client_data(
+		$api_campaign_handler->save_reader_data( 'test-subscriber' );
+		$api_campaign_handler->save_reader_events(
 			'test-subscriber',
 			[
-				'email_subscriptions' => [ 'address' => 'test@testing.com' ],
+				[
+					'client_id'    => 'test-subscriber',
+					'date_created' => gmdate( 'Y-m-d H:i:s' ),
+					'type'         => 'subscription',
+					'event_value'  => [
+						'email' => 'test@testing.com',
+					],
+				],
 			]
 		);
-		$wpdb->query( "UPDATE $readers_table_name SET `date` = '2020-04-29 15:39:13' WHERE `option_name` = '_transient_test-subcriber';" ); // phpcs:ignore
+		$wpdb->query( "UPDATE $readers_table_name SET `date_modified` = '2020-04-29 15:39:13' WHERE `client_id` = 'test-subscriber';" ); // phpcs:ignore
 
-		// Add and backdate the one time reader client data.
-		$api_campaign_handler->save_client_data(
+		// Add the one time reader client data.
+		$api_campaign_handler->save_reader_data( 'test-one-time-reader' );
+		$api_campaign_handler->save_reader_events(
 			'test-one-time-reader',
 			[
-				'posts_read' => [
-					[
-						'post_id'      => '142',
-						'category_ids' => '',
+				[
+					'client_id'    => 'test-one-time-reader',
+					'date_created' => gmdate( 'Y-m-d H:i:s' ),
+					'type'         => 'article_view',
+					'event_value'  => [
+						'post_id'    => '142',
+						'categories' => '',
 					],
 				],
 			]
 		);
 
 		// Add and backdate the one time reader client data.
-		$api_campaign_handler->save_client_data(
+		$api_campaign_handler->save_reader_data( 'test-one-time-reader-backdated' );
+		$api_campaign_handler->save_reader_events(
 			'test-one-time-reader-backdated',
 			[
-				'posts_read' => [
-					[
-						'post_id'      => '142',
-						'category_ids' => '',
+				[
+					'client_id'    => 'test-one-time-reader-backdated',
+					'date_created' => gmdate( 'Y-m-d H:i:s' ),
+					'type'         => 'article_view',
+					'event_value'  => [
+						'post_id'    => '142',
+						'categories' => '',
 					],
 				],
 			]
 		);
-		$wpdb->query( "UPDATE $readers_table_name SET `date` = '2020-04-29 15:39:13' WHERE `option_name` = '_transient_test-one-time-reader-backdated';" ); // phpcs:ignore
+		$wpdb->query( "UPDATE $readers_table_name SET `date_modified` = '2020-04-29 15:39:13' WHERE `client_id` = 'test-one-time-reader-backdated';" ); // phpcs:ignore
 
-		$all_readers_rows = $wpdb->get_results( "SELECT option_name FROM $readers_table_name" ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$all_readers_rows = $wpdb->get_results( "SELECT client_id FROM $readers_table_name" ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+
 		self::assertEquals(
 			4,
 			count( $all_readers_rows ),
@@ -269,20 +331,20 @@ class SegmentationTest extends WP_UnitTestCase {
 		// Prune the data.
 		Newspack_Popups_Segmentation::prune_data();
 
-		$all_readers_rows = $wpdb->get_results( "SELECT option_name FROM $readers_table_name" ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$all_readers_rows = $wpdb->get_results( "SELECT client_id FROM $readers_table_name" ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		self::assertEquals(
 			[
 				// Donor was not removed.
 				(object) [
-					'option_name' => '_transient_test-donor',
+					'client_id' => 'test-donor',
 				],
 				// One time reader was not removed, since they visited in the last 30 days.
 				(object) [
-					'option_name' => '_transient_test-one-time-reader',
+					'client_id' => 'test-one-time-reader',
 				],
 				// Subscriber was not removed, despite not visiting since >30 days.
 				(object) [
-					'option_name' => '_transient_test-subscriber',
+					'client_id' => 'test-subscriber',
 				],
 			],
 			$all_readers_rows,

--- a/tests/test-segmentation.php
+++ b/tests/test-segmentation.php
@@ -107,8 +107,8 @@ class SegmentationTest extends WP_UnitTestCase {
 
 		self::assertArraySubset(
 			[
-				self::$post_read_payload,
 				$second_event,
+				self::$post_read_payload,
 			],
 			$api->get_reader_events( self::$post_read_payload['client_id'] ),
 			'Both new and legacy formats are parsed into events.'

--- a/tests/test-segmentation.php
+++ b/tests/test-segmentation.php
@@ -15,9 +15,9 @@ class SegmentationTest extends WP_UnitTestCase {
 
 	public function setUp() { // phpcs:ignore Squiz.Commenting.FunctionComment.Missing
 		global $wpdb;
-		$events_table_name  = Segmentation::get_events_table_name();
-		$readers_table_name = Segmentation::get_readers_table_name();
-		$wpdb->query( "DELETE FROM $events_table_name;" ); // phpcs:ignore
+		$reader_data_table_name = Segmentation::get_reader_data_table_name();
+		$readers_table_name     = Segmentation::get_readers_table_name();
+		$wpdb->query( "DELETE FROM $reader_data_table_name;" ); // phpcs:ignore
 		$wpdb->query( "DELETE FROM $readers_table_name;" ); // phpcs:ignore
 		if ( file_exists( Segmentation::get_log_file_path() ) ) {
 			unlink( Segmentation::get_log_file_path() ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_unlink
@@ -109,7 +109,7 @@ class SegmentationTest extends WP_UnitTestCase {
 		Newspack_Popups_Parse_Logs::parse_events_logs();
 
 		self::assertEquals(
-			$api->get_reader_events( self::$post_read_payload['client_id'] ),
+			$api->get_reader_data( self::$post_read_payload['client_id'] ),
 			[
 				self::$post_read_payload,
 				$second_event,
@@ -143,7 +143,7 @@ class SegmentationTest extends WP_UnitTestCase {
 			)
 		);
 		$maybe_show_campaign = new Maybe_Show_Campaign();
-		$read_posts          = $maybe_show_campaign->get_reader_events( self::$post_read_payload['client_id'], 'article_view' );
+		$read_posts          = $maybe_show_campaign->get_reader_data( self::$post_read_payload['client_id'], 'article_view' );
 
 		self::assertEquals(
 			1,
@@ -169,7 +169,7 @@ class SegmentationTest extends WP_UnitTestCase {
 			)
 		);
 		$maybe_show_campaign = new Maybe_Show_Campaign();
-		$read_posts          = $maybe_show_campaign->get_reader_events( self::$post_read_payload['client_id'], 'article_view' );
+		$read_posts          = $maybe_show_campaign->get_reader_data( self::$post_read_payload['client_id'], 'article_view' );
 
 		self::assertEquals(
 			2,
@@ -190,8 +190,8 @@ class SegmentationTest extends WP_UnitTestCase {
 		);
 
 		$maybe_show_campaign = new Maybe_Show_Campaign();
-		$read_posts          = $maybe_show_campaign->get_reader_events( self::$post_read_payload['client_id'], 'article_view' );
-		$page_views          = $maybe_show_campaign->get_reader_events( self::$post_read_payload['client_id'], 'page_view' );
+		$read_posts          = $maybe_show_campaign->get_reader_data( self::$post_read_payload['client_id'], 'article_view' );
+		$page_views          = $maybe_show_campaign->get_reader_data( self::$post_read_payload['client_id'], 'page_view' );
 
 		self::assertEquals(
 			2,
@@ -253,8 +253,8 @@ class SegmentationTest extends WP_UnitTestCase {
 		$wpdb->query( "DELETE FROM $readers_table_name;" ); // phpcs:ignore
 
 		// Add the donor client data.
-		$api_campaign_handler->save_reader_data( 'test-donor' );
-		$api_campaign_handler->save_reader_events(
+		$api_campaign_handler->save_reader( 'test-donor' );
+		$api_campaign_handler->save_reader_data(
 			'test-donor',
 			[
 				[
@@ -269,8 +269,8 @@ class SegmentationTest extends WP_UnitTestCase {
 		);
 
 		// Add and backdate the subscriber client data.
-		$api_campaign_handler->save_reader_data( 'test-subscriber' );
-		$api_campaign_handler->save_reader_events(
+		$api_campaign_handler->save_reader( 'test-subscriber' );
+		$api_campaign_handler->save_reader_data(
 			'test-subscriber',
 			[
 				[
@@ -286,8 +286,8 @@ class SegmentationTest extends WP_UnitTestCase {
 		$wpdb->query( "UPDATE $readers_table_name SET `date_modified` = '2020-04-29 15:39:13' WHERE `client_id` = 'test-subscriber';" ); // phpcs:ignore
 
 		// Add the one time reader client data.
-		$api_campaign_handler->save_reader_data( 'test-one-time-reader' );
-		$api_campaign_handler->save_reader_events(
+		$api_campaign_handler->save_reader( 'test-one-time-reader' );
+		$api_campaign_handler->save_reader_data(
 			'test-one-time-reader',
 			[
 				[
@@ -303,8 +303,8 @@ class SegmentationTest extends WP_UnitTestCase {
 		);
 
 		// Add and backdate the one time reader client data.
-		$api_campaign_handler->save_reader_data( 'test-one-time-reader-backdated' );
-		$api_campaign_handler->save_reader_events(
+		$api_campaign_handler->save_reader( 'test-one-time-reader-backdated' );
+		$api_campaign_handler->save_reader_data(
 			'test-one-time-reader-backdated',
 			[
 				[

--- a/tests/test-segmentation.php
+++ b/tests/test-segmentation.php
@@ -40,7 +40,7 @@ class SegmentationTest extends WP_UnitTestCase {
 					'post_id'    => self::$post_read_payload['value']['post_id'],
 					'post_type'  => 'post',
 					'categories' => self::$post_read_payload['value']['categories'],
-					'date'       => gmdate( 'Y-m-d', time() ),
+					'date'       => gmdate( 'Y-m-d', strtotime( '-1 day', time() ) ),
 				]
 			),
 		];

--- a/tests/test-segmentation.php
+++ b/tests/test-segmentation.php
@@ -15,10 +15,10 @@ class SegmentationTest extends WP_UnitTestCase {
 
 	public function setUp() { // phpcs:ignore Squiz.Commenting.FunctionComment.Missing
 		global $wpdb;
-		$events_table_name     = Segmentation::get_events_table_name();
-		$transients_table_name = Segmentation::get_transients_table_name();
+		$events_table_name  = Segmentation::get_events_table_name();
+		$readers_table_name = Segmentation::get_readers_table_name();
 		$wpdb->query( "DELETE FROM $events_table_name;" ); // phpcs:ignore
-		$wpdb->query( "DELETE FROM $transients_table_name;" ); // phpcs:ignore
+		$wpdb->query( "DELETE FROM $readers_table_name;" ); // phpcs:ignore
 		if ( file_exists( Segmentation::get_log_file_path() ) ) {
 			unlink( Segmentation::get_log_file_path() ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_unlink
 		}
@@ -211,7 +211,7 @@ class SegmentationTest extends WP_UnitTestCase {
 	 */
 	public function test_data_pruning() {
 		global $wpdb;
-		$transients_table_name = Segmentation::get_transients_table_name();
+		$readers_table_name = Segmentation::get_readers_table_name();
 
 		$api_campaign_handler = new Maybe_Show_Campaign();
 
@@ -230,7 +230,7 @@ class SegmentationTest extends WP_UnitTestCase {
 				'email_subscriptions' => [ 'address' => 'test@testing.com' ],
 			]
 		);
-		$wpdb->query( "UPDATE $transients_table_name SET `date` = '2020-04-29 15:39:13' WHERE `option_name` = '_transient_test-subcriber';" ); // phpcs:ignore
+		$wpdb->query( "UPDATE $readers_table_name SET `date` = '2020-04-29 15:39:13' WHERE `option_name` = '_transient_test-subcriber';" ); // phpcs:ignore
 
 		// Add and backdate the one time reader client data.
 		$api_campaign_handler->save_client_data(
@@ -257,9 +257,9 @@ class SegmentationTest extends WP_UnitTestCase {
 				],
 			]
 		);
-		$wpdb->query( "UPDATE $transients_table_name SET `date` = '2020-04-29 15:39:13' WHERE `option_name` = '_transient_test-one-time-reader-backdated';" ); // phpcs:ignore
+		$wpdb->query( "UPDATE $readers_table_name SET `date` = '2020-04-29 15:39:13' WHERE `option_name` = '_transient_test-one-time-reader-backdated';" ); // phpcs:ignore
 
-		$all_readers_rows = $wpdb->get_results( "SELECT option_name FROM $transients_table_name" ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$all_readers_rows = $wpdb->get_results( "SELECT option_name FROM $readers_table_name" ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		self::assertEquals(
 			4,
 			count( $all_readers_rows ),
@@ -269,7 +269,7 @@ class SegmentationTest extends WP_UnitTestCase {
 		// Prune the data.
 		Newspack_Popups_Segmentation::prune_data();
 
-		$all_readers_rows = $wpdb->get_results( "SELECT option_name FROM $transients_table_name" ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$all_readers_rows = $wpdb->get_results( "SELECT option_name FROM $readers_table_name" ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		self::assertEquals(
 			[
 				// Donor was not removed.

--- a/tests/test-segmentation.php
+++ b/tests/test-segmentation.php
@@ -23,10 +23,11 @@ class SegmentationTest extends WP_UnitTestCase {
 			unlink( Segmentation::get_log_file_path() ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_unlink
 		}
 		self::$post_read_payload = [
-			'client_id' => 'test-' . uniqid(),
-			'type'      => 'view',
-			'context'   => 'post',
-			'value'     => [
+			'client_id'    => 'test-' . uniqid(),
+			'date_created' => gmdate( 'Y-m-d H:i:s' ),
+			'type'         => 'view',
+			'context'      => 'post',
+			'value'        => [
 				'post_id'    => 42,
 				'categories' => '5,6',
 			],
@@ -40,7 +41,7 @@ class SegmentationTest extends WP_UnitTestCase {
 					'post_id'    => self::$post_read_payload['value']['post_id'],
 					'post_type'  => 'post',
 					'categories' => self::$post_read_payload['value']['categories'],
-					'date'       => gmdate( 'Y-m-d', strtotime( '-1 day', time() ) ),
+					'date'       => gmdate( 'Y-m-d', time() ),
 				]
 			),
 		];
@@ -57,6 +58,7 @@ class SegmentationTest extends WP_UnitTestCase {
 			'|',
 			[
 				self::$post_read_payload['client_id'],
+				self::$post_read_payload['date_created'],
 				self::$post_read_payload['type'],
 				self::$post_read_payload['context'],
 				wp_json_encode( self::$post_read_payload['value'] ),
@@ -83,7 +85,7 @@ class SegmentationTest extends WP_UnitTestCase {
 			[
 				'post_read',
 				self::$post_read_payload['client_id'],
-				gmdate( 'Y-m-d', time() ),
+				gmdate( 'Y-m-d', strtotime( '-1 day', time() ) ),
 				$second_event['value']['post_id'],
 				$second_event['value']['categories'],
 			]
@@ -107,8 +109,8 @@ class SegmentationTest extends WP_UnitTestCase {
 
 		self::assertArraySubset(
 			[
-				$second_event,
 				self::$post_read_payload,
+				$second_event,
 			],
 			$api->get_reader_events( self::$post_read_payload['client_id'] ),
 			'Both new and legacy formats are parsed into events.'


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR implements a significant refactor of segmentation data storage and retrieval for improved performance. It does the following:

* Creates two new tables with a column and index structure optimized for performance:
  - The "readers" table replaces the legacy "transients" table and normalizes data that was previously serialized in a single column into separate, indexable columns
  - The "reader events" table replaces the legacy "events" table and stores info on not just `post_read` events, but also non-article page views, prompt views, donations, and newsletter subscriptions. In the future, when we're able to support a JS-based alternative to `amp-access`, this table may be offloaded from the server to `localStorage`.
  - Because the above are stored as events, we no longer replicate the data in the readers table, except for keeping a count of read categories, article views, and non-article page views. A reader is now considered a donor if they have at least one "donation" event associated with their unique client ID, for example.
  - The legacy readers table is retained, but existing readers who visit the site will be migrated to the new model and their legacy data deleted. Migrated data includes a lifetime count of posts and categories read, donations, and subscriptions. Prompt views and dismissals will not be migrated as we no longer need to store permanent suppression data. Old data lacking donations and subscriptions will be purged after 30 days.
  - The legacy events table can be dropped if it exists. (**Note:** I didn't implement this in case we need to roll back the refactor. We can push a new PR to drop these tables once we confirm the refactor is successful.) Since `post_read` events are no longer needed after 1 hour, this table can be safely deprecated. It will result in a 1-hour period where all returning readers are treated as not having seen any prompts, after which the new data model will start tracking prompt views as usual. I doubt this will be noticeable to most readers.
  - The previous legacy handling (v1 transients data) is deprecated, since no existing Newspack sites should have any data in the original model at this point.
* Improved data purging logic: we purge article and page view events every hour (as opposed to every 30 days) as we only need to keep a record of unique post IDs and timestamps during a single session. Prompt view events are kept for 30 days (to facilitate upcoming new frequency options for daily/weekly/monthly periods), and donation/subscription events are kept permanently.

The above changes should give us some significant performance boosts:

* We avoid the use of `LIKE` queries and instead base all queries on indexed columns
* We avoid unlimited `DELETE` queries and instead chunk rows to delete into groups of 1000, to avoid replication lag
* We avoid potentially unlimited row lengths caused by the current serialized data model
* We should hopefully limit the growth of the events table by purging article/page view events more often, although this may be offset by moving prompt views/donations/subscriptions to this table
* We still rely on the persistent WP cache (if available) for retrieving reader and events data per page view. Events are logged to a flat file and parsed to the DB every 15 minutes. This behavior is unchanged from the current.

The refactor should result in few if any reader-facing changes, except for faster site performance at scale. The exceptions:

* A "session" is now considered one whole hour instead of 45 minutes. This is simply because WP cron supports the `hourly` period, but it shouldn't make a huge difference in segmentation behavior. 45 minutes was an arbitrary choice to begin with.
* `post_read` events are renamed as `article_view` for clarity. The behavior is the same—a view of a singular post of any public-facing post type is considered an article view.
* Non-article page views (archives, search results) are now tracked as `page_view`. This will become important for upcoming prompt frequency options based on total page views.
* Article/page views are now only de-deduplicated for the current session, instead of for the lifetime of the reader. For example, if you visit or refresh the same post multiple times within an hour, that will still count as only a single article view. If you visit that same article again the next day, it will count as a new article view. This is closer to how Google Analytics counts page views per session, and will be important for upcoming prompt frequency options based on page views.
* We no longer store subscription/donation data on the reader data itself, instead storing these as separate events that can be cross-queried using the client ID. In the future, if we move the events data to `localStorage`, we may want to retain subscription and donation data on the server so we don't lose that data if the browser cache is purged.

### How to test the changes in this Pull Request:

It's hard to quantify the performance improvements that this refactor should enable without running the plugin at scale, so we should plan to test this refactor with a small number of sites before rolling out completely. Other than performance issues:

* This refactor should result in **no reader-facing changes**. So please thoroughly test all important prompt and segmentation features as a reader and ensure that nothing unexpected happens.
* Also test the editor experience, particularly the Campaigns Analytics dashboard, and make sure you see nothing unexpected there, too.
* Due diligence: test the data migration handling by running the plugin on `master` first. 
  1. In a new incognito window, visit several posts with categories, subscribe via a newsletter signup prompt, and donate via a donate prompt. Note which posts/categories you viewed so you can confirm those views are migrated to the new model.
  2. inspect your DB tables directly via Adminer or Sequel Pro and note the client ID for your reader activity as created in the `wp_newspack_campaigns_transients` table.
  3. Switch to this branch and **in the same incognito window** (so that your client ID remains the same) continue navigating the site and confirm that you still see the prompts you'd expect to see based on your segment.
  4. Inspect your DB tables and confirm that a row is created for your client ID in the `wp_newspack_campaigns_readers` table that carries over the previously viewed posts and categories. Also confirm that events were created for your client ID in the `wp_newspack_campaigns_events` table for your subscription and donation.
* Also make sure to test in both AMP and non-AMP mode.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
