### PR TITLE
fix: overlays should have a background by default

### DIFF
--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -229,7 +229,7 @@ final class Newspack_Popups_Model {
 				'overlay_color'                  => filter_input( INPUT_GET, 'n_oc', FILTER_SANITIZE_STRING ),
 				'overlay_opacity'                => filter_input( INPUT_GET, 'n_oo', FILTER_SANITIZE_STRING ),
 				'overlay_size'                   => filter_input( INPUT_GET, 'n_os', FILTER_SANITIZE_STRING ),
-				'no_overlay_background'          => filter_input( INPUT_GET, 'n_bg', FILTER_SANITIZE_STRING ),
+				'no_overlay_background'          => filter_input( INPUT_GET, 'n_bg', FILTER_VALIDATE_BOOLEAN ),
 				'placement'                      => filter_input( INPUT_GET, 'n_pl', FILTER_SANITIZE_STRING ),
 				'trigger_type'                   => filter_input( INPUT_GET, 'n_tt', FILTER_SANITIZE_STRING ),
 				'trigger_delay'                  => filter_input( INPUT_GET, 'n_td', FILTER_SANITIZE_STRING ),

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -753,7 +753,7 @@ final class Newspack_Popups {
 		update_post_meta( $post_id, 'overlay_color', '#000000' );
 		update_post_meta( $post_id, 'overlay_opacity', 30 );
 		update_post_meta( $post_id, 'overlay_size', $overlay_size );
-		update_post_meta( $post_id, 'no_overlay_background', true );
+		update_post_meta( $post_id, 'no_overlay_background', false );
 		update_post_meta( $post_id, 'placement', $placement );
 		update_post_meta( $post_id, 'trigger_type', $trigger_type );
 		update_post_meta( $post_id, 'trigger_delay', 3 );

--- a/tests/test-model.php
+++ b/tests/test-model.php
@@ -36,7 +36,7 @@ class ModelTest extends WP_UnitTestCase {
 				'overlay_color'                  => '#000000',
 				'overlay_opacity'                => '30',
 				'overlay_size'                   => 'medium',
-				'no_overlay_background'          => true,
+				'no_overlay_background'          => false,
 				'placement'                      => 'inline',
 				'trigger_type'                   => 'scroll',
 				'trigger_delay'                  => '3',


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

#867 added a new option for overlay prompts to decide whether display the overlay background, meaning the site under the prompt is interactive. To avoid changing the behavior of pre-existing prompts, the background should be on by default, so that pre-existing prompts and new prompts should always display overlay backgrounds. However, a logical error in #867 meant that the reverse was true. This PR fixes the logical error and restores the overlay background for pre-existing and new prompts.

### How to test the changes in this Pull Request:

1. On `master`, create a new overlay prompt and open the "Colors" sidebar. Observe that the "Show overlay background" option is turned off. Preview the prompt and observe that the prompt is shown without a background.
2. Check out this branch and repeat step 1. Confirm that the option is now turned on by default, and that the background shows when previewed.
3. Turn off the "Show overlay background" option and preview again, confirming that the background is not displayed when the option is intentionally turned off.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
