### PR TITLE
fix: non-AMP signup forms

### DIFF
--- a/src/view/index.js
+++ b/src/view/index.js
@@ -191,7 +191,9 @@ if ( typeof window !== 'undefined' ) {
 		// But don't manage analytics events until the client ID is available.
 		waitUntil( getClientIDValue, manageAnalyticsEvents );
 
-		const popupsElements = [ ...document.querySelectorAll( '.newspack-popup' ) ];
+		const popupsElements = [
+			...document.querySelectorAll( '.newspack-lightbox, .newspack-inline-popup' ),
+		];
 		popupsElements.forEach( campaign => {
 			manageForms( campaign );
 		} );

--- a/src/view/utils/index.js
+++ b/src/view/utils/index.js
@@ -71,8 +71,8 @@ export const parseDynamicURL = url => {
 export const processFormData = ( data, formElement ) => {
 	Object.keys( data ).forEach( key => {
 		let value = data[ key ];
-		if ( value === '${formFields[email]}' ) {
-			const inputEl = formElement.querySelector( '[name="email"]' );
+		if ( -1 < value.indexOf( '${formFields' ) ) {
+			const inputEl = formElement.querySelector( '[name="email"], [type="email"]' );
 			if ( inputEl ) {
 				value = inputEl.value;
 			}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes two bugs affecting prompts in non-AMP environments.

* ab9ddd0 improves the JS selector for dismiss form elements to avoid attaching duplicate event listeners to the same form. This is happening because the `.newspack-popup` class exists on both the prompt's outer `amp-layout` container and its inner `div`. This doesn't really affect any behavior in `master` but it does affect #869 since that refactor logs each prompt dismissal as a discrete event rather than in an array keyed by prompt ID.
* 4e2388c fixes a bug where email input values aren't being properly captured for MC4WP and Gravity Forms newsletter forms in non-AMP mode only. Instead of the user-inputted email address, the input value is being logged as an AMP input value placeholder, e.g. `${formFields['email']}`.

### How to test the changes in this Pull Request:

#### Non-AMP email capture

1. Turn off AMP mode and publish a prompt containing a MC4WP email signup form or Gravity Forms form (must have a `.newspack-subscribe-form` class name as specified in #836). You'll want to test both, but only one instance of a signup form is handled inside each prompt, so they need to be in separate prompts or tested in sequence. 
2. On `master`, in a new incognito window, enter a test email address and submit the form.
3. Wait a minute and use Adminer or Sequel Pro to inspect the `wp_newspack_campaigns_transients` table data. Find the row that corresponds to your incognito session's client ID and observe that the `email_subscriptions` array in the `option_value` column contains a placeholder value like `${formFields['email']}` instead of the actual email address.
4. Checkout this branch, rebuild, and repeat steps 2-3. This time confirm that the email address is logged to the DB as inputted.

#### Duplicate form submit event listeners

1. Check out #869 and publish at least one overlay prompt.
2. In a new incognito session, view the prompt and dismiss it with the X close button.
3. Using Adminer or Sequel Pro, inspect the `wp_newspack_campaigns_reader_events` table data. Observe that two `prompt_dismissed` events are logged with identical timestamps for the single dismissal in step 2.
4. Check out this branch, repeat steps 2-3 and confirm that only one dismissal event is logged.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
