### PR TITLE
feat: disable prompts by default for protected pages

### DIFF
--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -1166,41 +1166,24 @@ final class Newspack_Popups {
 
 	/**
 	 * Disable prompts by default if the given post ID is a protected page,
-	 * e.g. My Account, Donate, Privacy Policy, etc.
+	 * e.g. My Account, Donate, Privacy Policy, etc. other than the homepage or blog page.
 	 * Protected pages are defined in the \Newspack\Patches class.
 	 */
 	public static function disable_prompts_for_protected_pages() {
 		if ( class_exists( '\Newspack\Patches' ) ) {
 			$protected_page_ids = \Newspack\Patches::get_protected_page_ids();
+			$front_page_id      = intval( get_option( 'page_on_front', -1 ) );
+			$blog_posts_id      = intval( get_option( 'page_for_posts', -1 ) );
 			foreach ( $protected_page_ids as $page_id ) {
-				if ( ! in_array( 'newspack_popups_has_disabled_popups', array_keys( get_post_meta( $page_id ) ), true ) ) {
+				if (
+					$page_id !== $front_page_id &&
+					$page_id !== $blog_posts_id &&
+					! in_array( 'newspack_popups_has_disabled_popups', array_keys( get_post_meta( $page_id ) ), true )
+				) {
 					update_post_meta( $page_id, 'newspack_popups_has_disabled_popups', true );
 				}
 			}
 		}
-	}
-
-	/**
-	 * Check whether
-	 *
-	 * @param int $post_id Post ID to check.
-	 *
-	 * @return boolean True if the current post is a protected page,
-	 *                 false if not or if the Newspack plugin isn't active.
-	 */
-	public static function is_protected_page( $post_id = null ) {
-		$is_protected_page = false;
-
-		if ( class_exists( '\Newspack\Patches' ) ) {
-			if ( null === $post_id ) {
-				$post_id = get_the_ID();
-			}
-
-			$protected_page_ids = \Newspack\Patches::get_protected_page_ids();
-			$is_protected_page  = in_array( $post_id, $protected_page_ids, true );
-		}
-
-		return $is_protected_page;
 	}
 }
 Newspack_Popups::instance();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Disables prompts by default on special/protected pages, such as My Account, Privacy Policy, Donation, etc. other than the homepage and blog posts page.

Also makes the "Disable prompts on this post or page" option available to all post types that can possibly show prompts.

Requires https://github.com/Automattic/newspack-plugin/pull/1686.

### How to test the changes in this Pull Request:

1. Using WP CLI, ensure that the `newspack_popups_has_disabled_popups` meta value doesn't exist on a protected page by running `wp post meta delete newspack_popups_has_disabled_popups <post_id>`. See `\Newspack\Patches` class for a list of protected pages.
2. Edit the page and confirm that by default, the "Disable prompts on this post or page" is turned on. Also confirm that this behavior is true on the front-end and that no prompts are displayed.
3. Confirm that you can still toggle the option off to intentionally force prompts to appear on those protected pages.
4. Confirm that behavior for non-protected pages and posts remains the same—"Disable prompts on this post or page" should be `false` by default, and prompts should load as usual unless the option is turned on.
5. Bonus: confirm that the "Disable prompts on this post or page" option now exists for any public-facing post type, not jsut posts and pages.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
