### PR TITLE
fix: check subscriber status earlier and restore utm_medium=email logic

### DIFF
--- a/api/campaigns/class-campaign-data-utils.php
+++ b/api/campaigns/class-campaign-data-utils.php
@@ -10,12 +10,24 @@
  */
 class Campaign_Data_Utils {
 	/**
+	 * Is the URL from a newsletter?
+	 *
+	 * @param string $url A URL.
+	 */
+	public static function is_url_from_email( $url ) {
+		return stripos( $url, 'utm_medium=email' ) !== false;
+	}
+
+	/**
 	 * Is client a subscriber?
 	 *
 	 * @param object $client_data Client data.
+	 * @param string $url Referrer URL.
+	 *
+	 * @return boolean
 	 */
-	public static function is_subscriber( $client_data ) {
-		return ! empty( $client_data['email_subscriptions'] );
+	public static function is_subscriber( $client_data, $url = '' ) {
+		return ! empty( $client_data['email_subscriptions'] ) || self::is_url_from_email( $url );
 	}
 
 	/**
@@ -105,7 +117,7 @@ class Campaign_Data_Utils {
 				}
 			)
 		);
-		$is_subscriber            = self::is_subscriber( $client_data );
+		$is_subscriber            = self::is_subscriber( $client_data, $referer_url );
 		$is_donor                 = self::is_donor( $client_data );
 		$is_logged_in             = self::is_logged_in( $client_data );
 		$campaign_segment         = self::canonize_segment( $campaign_segment );

--- a/api/campaigns/class-maybe-show-campaign.php
+++ b/api/campaigns/class-maybe-show-campaign.php
@@ -52,7 +52,7 @@ class Maybe_Show_Campaign extends Lightweight_API {
 			$mailchimp_campaign_id   = $this->get_url_param( 'mc_cid', $referer_url );
 			$mailchimp_subscriber_id = $this->get_url_param( 'mc_eid', $referer_url );
 			if ( $mailchimp_campaign_id && $mailchimp_subscriber_id ) {
-				$this->report_mailchimp( $client_id, $mailchimp_campaign_id, $mailchimp_subscriber_id );
+				$this->get_mailchimp_client_data( $client_id, $mailchimp_campaign_id, $mailchimp_subscriber_id );
 			} elseif ( Campaign_Data_Utils::is_url_from_email( $referer_url ) ) {
 				// If reader is coming from a newsletter email, consider them a subscriber.
 				$updated_client_data['email_subscriptions'] = [

--- a/api/classes/class-lightweight-api.php
+++ b/api/classes/class-lightweight-api.php
@@ -6,6 +6,10 @@
  * @phpcs:disable WordPress.DB.RestrictedClasses.mysql__PDO
  */
 
+require_once __DIR__ . '/../../vendor/autoload.php';
+
+use \DrewM\MailChimp\MailChimp;
+
 /**
  * API endpoints
  */
@@ -394,6 +398,26 @@ class Lightweight_API {
 	}
 
 	/**
+	 * Get URL query param.
+	 *
+	 * @param string $param Param name.
+	 * @param string $url URL to parse.
+	 *
+	 * @return string|boolean Value of the param, or false if it's not in the URL.
+	 */
+	public function get_url_param( $param, $url ) {
+		$parsed_url = parse_url( $url ); // phpcs:ignore WordPress.WP.AlternativeFunctions.parse_url_parse_url
+		if ( ! empty( $parsed_url['query'] ) ) {
+			parse_str( $parsed_url['query'], $query );
+			if ( ! empty( $query[ $param ] ) ) {
+				return $query[ $param ];
+			}
+		}
+
+		return false;
+	}
+
+	/**
 	 * Get POST request payload.
 	 */
 	public function get_post_payload() {
@@ -411,6 +435,81 @@ class Lightweight_API {
 			return $_GET; // phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.NonceVerification.Recommended
 		}
 		return $payload;
+	}
+
+	/**
+	 * Report Mailchimp data.
+	 *
+	 * @param string $client_id Client ID.
+	 * @param string $mailchimp_campaign_id Campaign ID extracted from mc_cid param.
+	 * @param string $mailchimp_subscriber_id Campaign ID extracted from mc_eid param.
+	 */
+	public function report_mailchimp( $client_id, $mailchimp_campaign_id, $mailchimp_subscriber_id ) {
+		$client_data_update                   = [];
+		$mailchimp_api_key_option_name        = 'newspack_mailchimp_api_key';
+		$mailchimp_api_key_option_name_legacy = 'newspack_newsletters_mailchimp_api_key';
+		global $wpdb;
+		$mailchimp_api_key = $wpdb->get_row( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+			$wpdb->prepare( "SELECT option_value FROM `$wpdb->options` WHERE option_name IN (%s,%s) ORDER BY FIELD(%s,%s)", $mailchimp_api_key_option_name, $mailchimp_api_key_option_name_legacy, $mailchimp_api_key_option_name, $mailchimp_api_key_option_name_legacy )
+		);
+		if ( $mailchimp_api_key ) {
+			$mc            = new Mailchimp( $mailchimp_api_key->option_value );
+			$campaign_data = $mc->get( "campaigns/$mailchimp_campaign_id" );
+			if ( isset( $campaign_data['recipients'], $campaign_data['recipients']['list_id'] ) ) {
+				$list_id = $campaign_data['recipients']['list_id'];
+				$members = $mc->get( "/lists/$list_id/members", [ 'unique_email_id' => $mailchimp_subscriber_id ] )['members'];
+
+				if ( ! empty( $members ) ) {
+					$subscriber                                  = $members[0];
+					$client_data_update['email_subscriptions'][] = [
+						'email' => $subscriber['email_address'],
+					];
+
+					if ( ! isset( $subscriber['merge_fields'] ) ) {
+						return;
+					}
+
+					$donor_merge_field_option_name      = 'newspack_popups_mc_donor_merge_field';
+					$donor_merge_fields                 = $wpdb->get_row( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+						$wpdb->prepare( "SELECT option_value FROM `$wpdb->options` WHERE option_name = %s LIMIT 1", $donor_merge_field_option_name )
+					);
+					$donor_merge_fields                 = isset( $donor_merge_fields->option_value ) ? explode( ',', $donor_merge_fields->option_value ) : [ 'DONAT' ];
+					$has_donated_according_to_mailchimp = array_reduce(
+						// Get all merge fields whose name contains one of the Donor Merge Field option strings.
+						array_filter(
+							array_keys( $subscriber['merge_fields'] ),
+							function ( $merge_field ) use ( $donor_merge_fields ) {
+								$matches = false;
+								foreach ( $donor_merge_fields as $donor_merge_field ) {
+									if ( strpos( $merge_field, trim( $donor_merge_field ) ) !== false ) {
+										$matches = true;
+									}
+								}
+								return $matches;
+							}
+						),
+						// If any of these fields is "true", the subscriber has donated.
+						function ( $result, $donation_merge_field_name ) use ( $subscriber ) {
+							if ( 'true' === $subscriber['merge_fields'][ $donation_merge_field_name ] ) {
+								$result = true;
+							}
+							return $result;
+						},
+						false
+					);
+
+					if ( $has_donated_according_to_mailchimp ) {
+						$client_data_update['donations'][] = [
+							'mailchimp_has_donated' => true,
+						];
+					}
+				}
+			}
+		}
+
+		if ( ! empty( $client_data_update ) ) {
+			$this->save_client_data( $client_id, $client_data_update );
+		}
 	}
 
 	/**

--- a/api/classes/class-lightweight-api.php
+++ b/api/classes/class-lightweight-api.php
@@ -441,13 +441,13 @@ class Lightweight_API {
 	}
 
 	/**
-	 * Report Mailchimp data.
+	 * Get Mailchimp client data via API and sync to reader events.
 	 *
 	 * @param string $client_id Client ID.
 	 * @param string $mailchimp_campaign_id Campaign ID extracted from mc_cid param.
 	 * @param string $mailchimp_subscriber_id Campaign ID extracted from mc_eid param.
 	 */
-	public function report_mailchimp( $client_id, $mailchimp_campaign_id, $mailchimp_subscriber_id ) {
+	public function get_mailchimp_client_data( $client_id, $mailchimp_campaign_id, $mailchimp_subscriber_id ) {
 		$client_data_update                   = [];
 		$mailchimp_api_key_option_name        = 'newspack_mailchimp_api_key';
 		$mailchimp_api_key_option_name_legacy = 'newspack_newsletters_mailchimp_api_key';

--- a/api/classes/class-lightweight-api.php
+++ b/api/classes/class-lightweight-api.php
@@ -1,9 +1,12 @@
 <?php
 /**
- * Newspack Campaigns lightweight API
+ * Newspack Campaigns lightweight API.
  *
  * @package Newspack
- * @phpcs:disable WordPress.DB.RestrictedClasses.mysql__PDO
+ */
+
+/**
+ * Create the base Lightweight_API class.
  */
 
 require_once __DIR__ . '/../../vendor/autoload.php';
@@ -11,7 +14,7 @@ require_once __DIR__ . '/../../vendor/autoload.php';
 use \DrewM\MailChimp\MailChimp;
 
 /**
- * API endpoints
+ * API endpoints.
  */
 class Lightweight_API {
 

--- a/api/segmentation/class-segmentation-client-data.php
+++ b/api/segmentation/class-segmentation-client-data.php
@@ -10,10 +10,6 @@
  */
 require_once dirname( __FILE__ ) . '/../classes/class-lightweight-api.php';
 
-require_once __DIR__ . '/../../vendor/autoload.php';
-
-use \DrewM\MailChimp\MailChimp;
-
 /**
  * POST endpoint to report client data.
  */
@@ -72,66 +68,7 @@ class Segmentation_Client_Data extends Lightweight_API {
 		$mailchimp_campaign_id   = $this->get_request_param( 'mc_cid', $request );
 		$mailchimp_subscriber_id = $this->get_request_param( 'mc_eid', $request );
 		if ( $mailchimp_campaign_id && $mailchimp_subscriber_id ) {
-			$mailchimp_api_key_option_name        = 'newspack_mailchimp_api_key';
-			$mailchimp_api_key_option_name_legacy = 'newspack_newsletters_mailchimp_api_key';
-			global $wpdb;
-			$mailchimp_api_key = $wpdb->get_row( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-				$wpdb->prepare( "SELECT option_value FROM `$wpdb->options` WHERE option_name IN (%s,%s) ORDER BY FIELD(%s,%s)", $mailchimp_api_key_option_name, $mailchimp_api_key_option_name_legacy, $mailchimp_api_key_option_name, $mailchimp_api_key_option_name_legacy )
-			);
-			if ( $mailchimp_api_key ) {
-				$mc            = new Mailchimp( $mailchimp_api_key->option_value );
-				$campaign_data = $mc->get( "campaigns/$mailchimp_campaign_id" );
-				if ( isset( $campaign_data['recipients'], $campaign_data['recipients']['list_id'] ) ) {
-					$list_id = $campaign_data['recipients']['list_id'];
-					$members = $mc->get( "/lists/$list_id/members", [ 'unique_email_id' => $mailchimp_subscriber_id ] )['members'];
-
-					if ( ! empty( $members ) ) {
-						$subscriber                                  = $members[0];
-						$client_data_update['email_subscriptions'][] = [
-							'email' => $subscriber['email_address'],
-						];
-
-						if ( ! isset( $subscriber['merge_fields'] ) ) {
-							return;
-						}
-
-						$donor_merge_field_option_name      = 'newspack_popups_mc_donor_merge_field';
-						$donor_merge_fields                 = $wpdb->get_row( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-							$wpdb->prepare( "SELECT option_value FROM `$wpdb->options` WHERE option_name = %s LIMIT 1", $donor_merge_field_option_name )
-						);
-						$donor_merge_fields                 = isset( $donor_merge_fields->option_value ) ? explode( ',', $donor_merge_fields->option_value ) : [ 'DONAT' ];
-						$has_donated_according_to_mailchimp = array_reduce(
-							// Get all merge fields whose name contains one of the Donor Merge Field option strings.
-							array_filter(
-								array_keys( $subscriber['merge_fields'] ),
-								function ( $merge_field ) use ( $donor_merge_fields ) {
-									$matches = false;
-									foreach ( $donor_merge_fields as $donor_merge_field ) {
-										if ( strpos( $merge_field, trim( $donor_merge_field ) ) !== false ) {
-											$matches = true;
-										}
-									}
-									return $matches;
-								}
-							),
-							// If any of these fields is "true", the subscriber has donated.
-							function ( $result, $donation_merge_field_name ) use ( $subscriber ) {
-								if ( 'true' === $subscriber['merge_fields'][ $donation_merge_field_name ] ) {
-									$result = true;
-								}
-								return $result;
-							},
-							false
-						);
-
-						if ( $has_donated_according_to_mailchimp ) {
-							$client_data_update['donations'][] = [
-								'mailchimp_has_donated' => true,
-							];
-						}
-					}
-				}
-			}
+			$this->report_mailchimp( $client_id, $mailchimp_campaign_id, $mailchimp_subscriber_id );
 		}
 
 		if ( ! empty( $client_data_update ) ) {

--- a/api/segmentation/class-segmentation-client-data.php
+++ b/api/segmentation/class-segmentation-client-data.php
@@ -64,13 +64,6 @@ class Segmentation_Client_Data extends Lightweight_API {
 			$client_data_update['donations'] = json_decode( $orders );
 		}
 
-		// Fetch Mailchimp data.
-		$mailchimp_campaign_id   = $this->get_request_param( 'mc_cid', $request );
-		$mailchimp_subscriber_id = $this->get_request_param( 'mc_eid', $request );
-		if ( $mailchimp_campaign_id && $mailchimp_subscriber_id ) {
-			$this->get_mailchimp_client_data( $client_id, $mailchimp_campaign_id, $mailchimp_subscriber_id );
-		}
-
 		if ( ! empty( $client_data_update ) ) {
 			$this->save_client_data( $client_id, $client_data_update );
 		}

--- a/api/segmentation/class-segmentation-client-data.php
+++ b/api/segmentation/class-segmentation-client-data.php
@@ -68,7 +68,7 @@ class Segmentation_Client_Data extends Lightweight_API {
 		$mailchimp_campaign_id   = $this->get_request_param( 'mc_cid', $request );
 		$mailchimp_subscriber_id = $this->get_request_param( 'mc_eid', $request );
 		if ( $mailchimp_campaign_id && $mailchimp_subscriber_id ) {
-			$this->report_mailchimp( $client_id, $mailchimp_campaign_id, $mailchimp_subscriber_id );
+			$this->get_mailchimp_client_data( $client_id, $mailchimp_campaign_id, $mailchimp_subscriber_id );
 		}
 
 		if ( ! empty( $client_data_update ) ) {

--- a/tests/test-api.php
+++ b/tests/test-api.php
@@ -653,6 +653,32 @@ class APITest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Suppression of a subscriber-segmented campaign via utm_medium=email param.
+	 */
+	public function test_only_subscriber_via_referer() {
+		$test_popup = self::create_test_popup(
+			[
+				'placement'           => 'inline',
+				'frequency'           => 'always',
+				'selected_segment_id' => self::$segment_ids['segmentSubscribers'],
+			]
+		);
+
+		$url_with_medium = 'https://test-url/?utm_medium=email';
+
+		self::assertFalse(
+			self::$maybe_show_campaign->should_campaign_be_shown( self::$client_id, $test_popup['payload'], self::$settings ),
+			'Assert initially not visible.'
+		);
+
+
+		self::assertTrue(
+			self::$maybe_show_campaign->should_campaign_be_shown( self::$client_id, $test_popup['payload'], self::$settings, $url_with_medium ),
+			'Assert shown after with the proper URL param.'
+		);
+	}
+
+	/**
 	 * Suppression of a non-subscriber-segmented campaign.
 	 */
 	public function test_non_subscriber_suppression() {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

#866 removed permanent suppression features as well as the logic that treated visitors coming to the site via any URL with a `utm_medium=email` param as a subscriber. However, removing both has resulted in some unwanted behavior for readers who visit sites via a newsletter link, but in a new or cache-cleared browser session. For these readers, prompt display logic is executed before their Mailchimp subscriber or donor status is evaluated, meaning they will be segmented as a subscriber/donor only after the first page load.

This PR evaluates the Mailchimp subscriber and donor status before executing segmentation logic, so that by the time the plugin decides which segment's prompts to display, a reader who arrives via a Mailchimp URL should already be known to be a subscriber/donor.

This PR also restores the logic that looks for the `utm_medium=email` param in the referrer URL. However, instead of using this info to permanently suppress all newsletter-related prompts, it more simply causes the reader to be segmented as a subscriber. This does mean that readers who are not actually subscribers but who visit the site via a forwarded newsletter email, or who simply append the `utm_medium=email` param to a URL, will be considered subscribers. But this is already true for any visitor who visits the site via a forwarded Mailchimp email, as their Mailchimp subscriber status is parsed from Mailchimp URL params upon the first reported prompt view. So this plugs a functionality hole for readers who arrive at the site in a new session from a non-Mailchimp email newsletter, who would previously not be segmented as subscribers.

Note that if this gets merged, #869 will need to reimplement these changes in the new data model.

### How to test the changes in this Pull Request:

1. Check out this branch on a site that's connected to Mailchimp.
2. Set up two segments, one for non-subscribers and one for subscribers, and publish a prompt in each. Make sure the prompt for non-subscribers includes a Mailchimp signup form.
3. In a new browser session, visit the site and append `?utm_medium=email` to the URL.
4. Confirm that you see the prompt for subscribers on the first page load, and on every subsequent page load.
5. Send a newsletter from the site to yourself via Mailchimp.
6. Copy a URL from the sent newsletter to a new browser session. Confirm that you see the prompt for subscribers on the first page load, and on every subsequent page load.
7. Send a newsletter from the site to yourself via another ESP, such as Campaign Monitor.
8. Copy a URL from the sent newsletter to a new browser session. Confirm that you see the prompt for subscribers on the first page load, and on every subsequent page load. This is because all ESPs append `?utm_medium=email` to URLs within the email.
9. In a new browser session, sign up via the Mailchimp signup form in the prompt for non-subscribers.
10. Navigate through the site and confirm that you see the prompt for subscribers on subsequent page loads.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
