### PR TITLE
fix: misnamed variable in GA non-AMP config filter

### DIFF
--- a/includes/class-newspack-popups-segmentation.php
+++ b/includes/class-newspack-popups-segmentation.php
@@ -75,9 +75,9 @@ final class Newspack_Popups_Segmentation {
 	/**
 	 * Remove pageview reporting from non-AMP Analytics GTAG config.
 	 *
-	 * @param array $gtag_amp GTAG Analytics config.
+	 * @param array $gtag_opt GTAG Analytics config.
 	 */
-	public static function remove_pageview_reporting( $gtag_amp ) {
+	public static function remove_pageview_reporting( $gtag_opt ) {
 		$gtag_opt['send_page_view'] = false;
 		return $gtag_opt;
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

_Note: supersedes #895._

Fixes a misnamed variable in a filter affecting non-AMP Analytics config. In most cases this won't cause any errors because [the main Newspack plugin also does the same thing](https://github.com/Automattic/newspack-plugin/blob/master/includes/class-analytics.php#L527), but if any other plugins use this same filter the bug may cause subsequent filter callbacks to fail.

### How to test the changes in this Pull Request:

Nothing really to test—verify that the variable used in the filter matches the named function argument.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
