### PR TITLE
feat: use existing options to restrict display size of overlay prompts

### DIFF
--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -1167,7 +1167,7 @@ final class Newspack_Popups_Model {
 					action-xhr="<?php echo esc_url( $endpoint ); ?>"
 					target="_top">
 					<?php echo $hidden_fields; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
-					<button style="opacity: <?php echo floatval( $overlay_opacity ); ?>;background-color:<?php echo esc_attr( $overlay_color ); ?>;" class="newspack-lightbox-shim" on="tap:<?php echo esc_attr( $element_id ); ?>.hide"></button>
+					<button style="opacity: <?php echo floatval( $overlay_opacity ); ?>; ?>;" class="newspack-lightbox-shim" on="tap:<?php echo esc_attr( $element_id ); ?>.hide"></button>
 				</form>
 			<?php endif; ?>
 		</amp-layout>
@@ -1279,8 +1279,9 @@ final class Newspack_Popups_Model {
 	 * @return string Inline styles attribute.
 	 */
 	public static function container_style( $popup ) {
-		$background_color = $popup['options']['background_color'];
-		$foreground_color = self::foreground_color_for_background( $background_color );
+		$hide_border      = $popup['options']['hide_border'];
+		$background_color = $hide_border ? 'transparent' : $popup['options']['background_color'];
+		$foreground_color = $hide_border ? 'inherit' : self::foreground_color_for_background( $background_color );
 		return 'background-color:' . $background_color . ';color:' . $foreground_color;
 	}
 

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -1155,7 +1155,7 @@ final class Newspack_Popups_Model {
 						action-xhr="<?php echo esc_url( $endpoint ); ?>"
 						target="_top">
 						<?php echo $hidden_fields; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
-						<button on="tap:<?php echo esc_attr( $element_id ); ?>.hide" class="newspack-lightbox__close" aria-label="<?php esc_html_e( 'Close Pop-up', 'newspack-popups' ); // phpcs:ignore WordPressVIPMinimum.Security.ProperEscapingFunction.htmlAttrNotByEscHTML ?>" style="<?php echo esc_attr( self::container_style( $popup ) ); ?>">
+						<button on="tap:<?php echo esc_attr( $element_id ); ?>.hide" class="newspack-lightbox__close" aria-label="<?php esc_html_e( 'Close Pop-up', 'newspack-popups' ); // phpcs:ignore WordPressVIPMinimum.Security.ProperEscapingFunction.htmlAttrNotByEscHTML ?>">
 							<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" role="img" aria-hidden="true" focusable="false"><path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12 19 6.41z"/></svg>
 						</button>
 					</form>
@@ -1167,7 +1167,7 @@ final class Newspack_Popups_Model {
 					action-xhr="<?php echo esc_url( $endpoint ); ?>"
 					target="_top">
 					<?php echo $hidden_fields; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
-					<button style="opacity: <?php echo floatval( $overlay_opacity ); ?>; ?>;" class="newspack-lightbox-shim" on="tap:<?php echo esc_attr( $element_id ); ?>.hide"></button>
+					<button style="opacity: <?php echo floatval( $overlay_opacity ); ?>;background-color:<?php echo esc_attr( $overlay_color ); ?>;" class="newspack-lightbox-shim" on="tap:<?php echo esc_attr( $element_id ); ?>.hide"></button>
 				</form>
 			<?php endif; ?>
 		</amp-layout>

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -1144,8 +1144,8 @@ final class Newspack_Popups_Model {
 			tabindex="0"
 			id="<?php echo esc_attr( $element_id ); ?>"
 		>
-			<div class="<?php echo esc_attr( implode( ' ', $wrapper_classes ) ); ?>" data-popup-status="<?php echo esc_attr( $popup['status'] ); ?>" style="<?php echo esc_attr( self::container_style( $popup ) ); ?>">
-				<div class="newspack-popup">
+			<div class="<?php echo esc_attr( implode( ' ', $wrapper_classes ) ); ?>" data-popup-status="<?php echo esc_attr( $popup['status'] ); ?>" style="<?php echo ! $hide_border ? esc_attr( self::container_style( $popup ) ) : ''; ?>">
+				<div class="newspack-popup" style="<?php echo $hide_border ? esc_attr( self::container_style( $popup ) ) : ''; ?>">
 					<?php if ( ! empty( $popup['title'] ) && $display_title ) : ?>
 						<h1 class="newspack-popup-title"><?php echo esc_html( $popup['title'] ); ?></h1>
 					<?php endif; ?>
@@ -1280,8 +1280,8 @@ final class Newspack_Popups_Model {
 	 */
 	public static function container_style( $popup ) {
 		$hide_border      = $popup['options']['hide_border'];
-		$background_color = $hide_border ? 'transparent' : $popup['options']['background_color'];
-		$foreground_color = $hide_border ? 'inherit' : self::foreground_color_for_background( $background_color );
+		$background_color = $popup['options']['background_color'];
+		$foreground_color = self::foreground_color_for_background( $background_color );
 		return 'background-color:' . $background_color . ';color:' . $foreground_color;
 	}
 

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -284,6 +284,7 @@ final class Newspack_Popups {
 				'object_subtype' => self::NEWSPACK_POPUPS_CPT,
 				'show_in_rest'   => true,
 				'type'           => 'string',
+				'default'        => 'medium',
 				'single'         => true,
 				'auth_callback'  => '__return_true',
 			]

--- a/src/editor/Sidebar.js
+++ b/src/editor/Sidebar.js
@@ -23,13 +23,7 @@ import { without } from 'lodash';
 /**
  * Internal dependencies
  */
-import {
-	isCustomPlacement,
-	isInlinePlacement,
-	isManualOnlyPlacement,
-	isOverlayPlacement,
-	getPlacementHelpMessage,
-} from './utils';
+import { isOverlayPlacement, getPlacementHelpMessage } from './utils';
 import PositionPlacementControl from './PositionPlacementControl';
 
 const Sidebar = props => {
@@ -236,15 +230,11 @@ const Sidebar = props => {
 				checked={ display_title }
 				onChange={ value => onMetaFieldChange( 'display_title', value ) }
 			/>
-			{ ( isInlinePlacement( placement ) ||
-				isManualOnlyPlacement( placement ) ||
-				isCustomPlacement( placement ) ) && (
-				<ToggleControl
-					label={ __( 'Hide Prompt Border', 'newspack-popups' ) }
-					checked={ hide_border }
-					onChange={ value => onMetaFieldChange( 'hide_border', value ) }
-				/>
-			) }
+			<ToggleControl
+				label={ __( 'Hide Prompt Border', 'newspack-popups' ) }
+				checked={ hide_border }
+				onChange={ value => onMetaFieldChange( 'hide_border', value ) }
+			/>
 		</>
 	);
 };

--- a/src/view/style.scss
+++ b/src/view/style.scss
@@ -90,11 +90,12 @@ $size__large: 1264px;
 
 	&.newspack-lightbox-no-border {
 		.newspack-popup-wrapper {
+			background-color: transparent;
 			box-shadow: none;
 		}
 		.newspack-popup {
+			box-shadow: 0 0 1em 0.5em rgba( black, 0.1 );
 			margin: 32px;
-			padding: 0;
 		}
 	}
 

--- a/src/view/style.scss
+++ b/src/view/style.scss
@@ -70,6 +70,7 @@ $size__large: 1264px;
 		background: transparent;
 		margin: 0 auto;
 		max-width: $size__medium;
+		overflow: auto;
 		padding: 32px;
 
 		> *:first-child {
@@ -84,6 +85,16 @@ $size__large: 1264px;
 			> *:last-child {
 				margin-bottom: 0;
 			}
+		}
+	}
+
+	&.newspack-lightbox-no-border {
+		.newspack-popup-wrapper {
+			box-shadow: none;
+		}
+		.newspack-popup {
+			margin: 32px;
+			padding: 0;
 		}
 	}
 
@@ -167,6 +178,9 @@ $size__large: 1264px;
 				width: $size__x-small;
 			}
 		}
+		.newspack-popup {
+			max-height: 50vh;
+		}
 	}
 
 	&.newspack-lightbox-size-small {
@@ -176,6 +190,9 @@ $size__large: 1264px;
 				width: $size__small;
 			}
 		}
+		.newspack-popup {
+			max-height: 60vh;
+		}
 	}
 
 	&.newspack-lightbox-size-medium {
@@ -184,6 +201,9 @@ $size__large: 1264px;
 				min-width: $size__medium;
 				width: $size__medium;
 			}
+		}
+		.newspack-popup {
+			max-height: 80vh;
 		}
 	}
 

--- a/src/view/style.scss
+++ b/src/view/style.scss
@@ -100,7 +100,7 @@ $size__large: 1264px;
 
 	.newspack-lightbox__close {
 		align-items: center;
-		background: white;
+		background-color: transparent;
 		border: none;
 		border-radius: 0;
 		box-shadow: none;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Uses the existing "hide border" and "overlay size" options to improve the display of overlay prompts in small viewports. Currently there's no way to prevent an overlay prompt from taking up the entire viewport at smaller screen sizes if its content is long enough, so these changes provide some means of ensuring that the prompt size can be limited independently of content length.

The "hide border" option was originally only available for inline prompts, but it makes sense to allow it for overlays as well. This PR enables that option for overlays and applies appropriate CSS to hide the white border around the overlay content, replacing it with a transparent margin of the same size.

The "overlay size" option now restricts the max-height of overlays as a percentage of viewport height. If the height of the prompt content exceeds this max height, the content will become scrollable.

* `x-small` maxes out at 50% of the viewport height.
* `small` maxes out at 60%.
* `medium` maxes out at 80%.
* `large` and `full-width` max out at 100%, so they can potentially fill the entire viewport if desired.

### How to test the changes in this Pull Request:

1. Check out this PR.
2. Create an overlay prompt with a lot of content. In the **Prompt Settings** sidebar, confirm that the "Hide Prompt Border" option is now available for overlays, off by default. Turn it on.
3. Preview the prompt. Confirm that the prompt is displayed without a white border wrapper.
4. Change the viewport size to mobile and confirm that the prompt content does not extend all the way to the outer edges of the viewport, but is set in 32px (the same size as the white border if the border were displayed).
5. Edit the prompt again and test each "Overlay size" option. Preview each size and confirm that the prompt height maxes out at an appropriate max-height for each size, with overflow content becoming scrollable. Test at all viewport sizes but pay special attention to the mobile experience.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
