### PR TITLE
feat(segmentation): handle pre-authenticated users

### DIFF
--- a/api/segmentation/class-segmentation-client-data.php
+++ b/api/segmentation/class-segmentation-client-data.php
@@ -81,23 +81,12 @@ class Segmentation_Client_Data extends Lightweight_API {
 			];
 		}
 
-		$user_account_context = false;
-
-		// Get auth intention value if they are pre-authenticated.
-		$pre_auth_value = $this->get_request_param( 'pre_auth_value', $request );
-		if ( $pre_auth_value ) {
-			$user_account_context = $pre_auth_value;
-		}
-
 		// Get user ID if they have a user account.
 		$user_id = $this->get_request_param( 'user_id', $request );
 		if ( $user_id ) {
-			$user_account_context = $user_id;
-		}
-
-		if ( $user_account_context ) {
 			$existing_user_accounts = $this->get_reader_events( $client_id, 'user_account', $user_id );
 			$add_user_account       = true;
+
 			// Only add a new user account if it hasn't already been logged for this client.
 			if ( 0 < count( $existing_user_accounts ) ) {
 				$add_user_account = false;
@@ -106,7 +95,7 @@ class Segmentation_Client_Data extends Lightweight_API {
 			if ( $add_user_account ) {
 				$reader_events[] = [
 					'type'    => 'user_account',
-					'context' => $user_account_context,
+					'context' => $user_id,
 				];
 			}
 		}

--- a/api/segmentation/class-segmentation-client-data.php
+++ b/api/segmentation/class-segmentation-client-data.php
@@ -81,12 +81,23 @@ class Segmentation_Client_Data extends Lightweight_API {
 			];
 		}
 
+		$user_account_context = false;
+
+		// Get auth intention value if they are pre-authenticated.
+		$pre_auth_value = $this->get_request_param( 'pre_auth_value', $request );
+		if ( $pre_auth_value ) {
+			$user_account_context = $pre_auth_value;
+		}
+
 		// Get user ID if they have a user account.
 		$user_id = $this->get_request_param( 'user_id', $request );
 		if ( $user_id ) {
+			$user_account_context = $user_id;
+		}
+
+		if ( $user_account_context ) {
 			$existing_user_accounts = $this->get_reader_events( $client_id, 'user_account', $user_id );
 			$add_user_account       = true;
-
 			// Only add a new user account if it hasn't already been logged for this client.
 			if ( 0 < count( $existing_user_accounts ) ) {
 				$add_user_account = false;
@@ -95,7 +106,7 @@ class Segmentation_Client_Data extends Lightweight_API {
 			if ( $add_user_account ) {
 				$reader_events[] = [
 					'type'    => 'user_account',
-					'context' => $user_id,
+					'context' => $user_account_context,
 				];
 			}
 		}

--- a/includes/class-newspack-popups-segmentation.php
+++ b/includes/class-newspack-popups-segmentation.php
@@ -83,6 +83,8 @@ final class Newspack_Popups_Segmentation {
 			self::cron_deactivate(); // To avoid duplicate execution when transitioning from daily to hourly schedule.
 			wp_schedule_event( time(), 'hourly', 'newspack_popups_segmentation_data_prune' );
 		}
+
+		add_action( 'newspack_registered_reader', [ __CLASS__, 'handle_registered_reader' ], 10, 3 );
 	}
 
 	/**
@@ -818,6 +820,31 @@ final class Newspack_Popups_Segmentation {
 		}
 		if ( $removed_row_counts_prompt_seen_events ) {
 			error_log( 'Newspack Campaigns: Data pruning – removed ' . $removed_row_counts_prompt_seen_events . ' prompt seen events from ' . $reader_events_table_name . ' table.' ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+		}
+	}
+
+	/**
+	 * Handle reader registration.
+	 *
+	 * @param string $email Email address.
+	 * @param bool   $authenticate Whether the user was authenticated.
+	 * @param int    $user_id New user ID.
+	 */
+	public static function handle_registered_reader( $email, $authenticate, $user_id ) {
+		if ( $authenticate ) {
+			try {
+				require_once dirname( __FILE__ ) . '/../api/classes/class-lightweight-api.php';
+				$api           = new Lightweight_API();
+				$reader_events = [
+					[
+						'type'    => 'user_account',
+						'context' => $user_id,
+					],
+				];
+				$api->save_reader_events( self::get_client_id(), $reader_events );
+			} catch ( \Throwable $th ) {
+				\Newspack\Logger::log( 'Error when saving reader data on registration: ' . $th->getMessage() );
+			}
 		}
 	}
 }

--- a/includes/class-newspack-popups-segmentation.php
+++ b/includes/class-newspack-popups-segmentation.php
@@ -245,14 +245,6 @@ final class Newspack_Popups_Segmentation {
 			$initial_client_report_url_params['mc_eid'] = sanitize_text_field( $_GET['mc_eid'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		}
 
-		// Handle pre-authentication (Reader Activation feature).
-		if ( ! is_user_logged_in() && class_exists( 'Newspack\Reader_Activation' ) && \Newspack\Reader_Activation::is_enabled() ) {
-			$auth_intention_value = \Newspack\Reader_Activation::get_auth_intention_value();
-			if ( $auth_intention_value ) {
-				$initial_client_report_url_params['pre_auth_value'] = $auth_intention_value;
-			}
-		}
-
 		// Handle user accounts and Newspack donations via WooCommerce.
 		if ( is_user_logged_in() && ! Newspack_Popups::is_preview_request() ) {
 			// If the user is logged in, store their user ID.

--- a/includes/class-newspack-popups-segmentation.php
+++ b/includes/class-newspack-popups-segmentation.php
@@ -243,6 +243,14 @@ final class Newspack_Popups_Segmentation {
 			$initial_client_report_url_params['mc_eid'] = sanitize_text_field( $_GET['mc_eid'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		}
 
+		// Handle pre-authentication (Reader Activation feature).
+		if ( ! is_user_logged_in() && class_exists( 'Newspack\Reader_Activation' ) && \Newspack\Reader_Activation::is_enabled() ) {
+			$auth_intention_value = \Newspack\Reader_Activation::get_auth_intention_value();
+			if ( $auth_intention_value ) {
+				$initial_client_report_url_params['pre_auth_value'] = $auth_intention_value;
+			}
+		}
+
 		// Handle user accounts and Newspack donations via WooCommerce.
 		if ( is_user_logged_in() && ! Newspack_Popups::is_preview_request() ) {
 			// If the user is logged in, store their user ID.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #903.

### How to test the changes in this Pull Request:

1. Create a prompt segmented to users who have an account
2. Enable Reader Activation (`NEWSPACK_EXPERIMENTAL_READER_ACTIVATION` env. variable)
3. In a new session, observe the prompt is not displayed
4. Pre-authenticate by entering existing user's email in Registration block
5. Navigate to another page, observe the prompt displayed

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->