### PR TITLE
fix: retrieve events from persistent cache, if available

### DIFF
--- a/api/classes/class-lightweight-api.php
+++ b/api/classes/class-lightweight-api.php
@@ -663,6 +663,22 @@ class Lightweight_API {
 	}
 
 	/**
+	 * Get reader events from the persistent cache, if available.
+	 *
+	 * @param string $client_id Single client ID associated with the current reader.
+	 *
+	 * @return array Array of reader events for the given client ID.
+	 */
+	public static function get_reader_events_from_cache( $client_id ) {
+		$events = wp_cache_get( 'reader_events', $client_id );
+		if ( ! $events ) {
+			$events = [];
+		}
+
+		return $events;
+	}
+
+	/**
 	 * Retrieve data for a specific reader from the cache or DB.
 	 *
 	 * @param string|array      $client_ids Client IDs of the reader.
@@ -683,16 +699,16 @@ class Lightweight_API {
 			$context = [ $context ];
 		}
 
-		$events = wp_cache_get( 'reader_events', $client_ids[0] );
-		if ( ! $events ) {
-			$events = [];
-		}
+		$events = [];
 
 		// Check the cache first.
 		if ( ! $this->ignore_cache ) {
+			$events = $this->get_reader_events_from_cache( $client_ids[0] );
+
 			if ( ! empty( $events ) ) {
 				$get_cached_events = true;
 
+				// If cached events are missing events of any type/context, fetch from the DB so we don't miss anything.
 				foreach ( $type as $single_type ) {
 					$filtered_events = $this->filter_events_by_type( $events, $single_type );
 
@@ -709,12 +725,13 @@ class Lightweight_API {
 
 		$filtered_events = $this->get_reader_events_from_db( $client_ids, $type, $context );
 		$unique_ids      = [];
-		$all_events      = array_merge( $filtered_events, $events );
+		$all_events      = array_merge( $events, $filtered_events );
 		$all_events      = array_values(
 			array_filter(
 				$all_events,
 				function( $event ) use ( &$unique_ids ) {
-					if ( ! in_array( $event['id'], $unique_ids ) ) {
+
+					if ( ! isset( $event['id'] ) || ! in_array( $event['id'], $unique_ids ) ) {
 						$unique_ids[] = $event['id'];
 						return true;
 					}
@@ -724,11 +741,7 @@ class Lightweight_API {
 			)
 		);
 
-		// Rebuild cache.
-		if ( ! empty( $all_events ) ) {
-			wp_cache_set( 'reader_events', $all_events, $client_ids[0] );
-			$this->debug['reader_events'] = $all_events;
-		}
+		$this->debug['reader_events'] = $all_events;
 
 		return $filtered_events;
 	}
@@ -846,6 +859,12 @@ class Lightweight_API {
 				return false;
 			}
 		} else {
+			// Rebuild cache.
+			$cached_events                = $this->get_reader_events_from_cache( $client_id );
+			$all_events                   = array_merge( $cached_events, $events );
+			$write_result                 = wp_cache_set( 'reader_events', $all_events, $client_id );
+			$this->debug['reader_events'] = $all_events;
+
 			// Write items to the flat file to be parsed to the DB at a later point.
 			Segmentation_Report::log_reader_events( $events );
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

#869 had this working at some point, but it underwent so many changes that it got lost along the way.

When fetching and storing reader data and events, if a persistent cache is available, the plugin should attempt to store and retrieve such data in the persistent cache to minimize DB interactions. This PR restores a missing `wp_cache_set` call in the `save_reader_events` method, and also ensures that cached events that lack an `id` value (meaning they haven't yet been saved to the DB) persist in the cache across pageviews.

On sites that do not have a persistent cache available, data will still be read from and written to the DB directly.

### How to test the changes in this Pull Request:

1. Install the plugin from `master` onto a site that has memcached enabled. Publish an overlay prompt with a "Once" or "Once a day" frequency.
2. In a new session, observe that the prompt is displayed on every pageview. You can also inspect the `debug` object on the Campaigns API response to observe that the `reader_events` array is always empty—this is because events are not being properly stored in the persistent cache. This effectively means that reader events aren't "real-time" and won't be read until they're bulk-inserted into the DB from the flat log file every 15 minutes.
3. Install the plugin from this branch and repeat step 2. Navigate through a few pages to ensure that several pageviews, prompt views, and dismissals are logged. This time confirm that the prompt is displayed only once, as expected, and that the `debug` object's `reader_events` is updated whenever new events are saved.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
