### PR TITLE
fix: simplify WC donation handling

### DIFF
--- a/api/campaigns/class-campaign-data-utils.php
+++ b/api/campaigns/class-campaign-data-utils.php
@@ -23,6 +23,22 @@ class Campaign_Data_Utils {
 	];
 
 	/**
+	 * Get an instance of the lightweight API that can be called directly by other plugin classes.
+	 * Requires nonce verfication to prevent CSRF attacks.
+	 *
+	 * @param string $nonce Nonce string to authenticate the request. If not valid, the request will fail.
+	 *
+	 * @return object|boolean If the nonce is valid, an instance of the API. Otherwise, false.
+	 */
+	public static function get_api( $nonce ) {
+		if ( \wp_verify_nonce( $nonce, 'newspack_campaigns_lightweight_api' ) ) {
+			return new \Lightweight_API( $nonce );
+		}
+
+		return false;
+	}
+
+	/**
 	 * Is the URL from a newsletter?
 	 *
 	 * @param string $url A URL.

--- a/api/classes/class-lightweight-api.php
+++ b/api/classes/class-lightweight-api.php
@@ -65,14 +65,16 @@ class Lightweight_API {
 	/**
 	 * Constructor.
 	 *
+	 * @param string|null $nonce If API is being instantiated directly by WP, it needs nonce verification.
+	 *
 	 * @codeCoverageIgnore
 	 */
-	public function __construct() {
+	public function __construct( $nonce = null ) {
 		if ( $this->is_a_web_crawler() ) {
 			header( 'X-Robots-Tag: noindex' );
 			exit;
 		}
-		if ( ! $this->verify_referer() ) {
+		if ( ! $this->verify_referer( $nonce ) ) {
 			$this->error( 'invalid_referer' );
 		}
 		$this->debug = [
@@ -123,8 +125,16 @@ class Lightweight_API {
 
 	/**
 	 * Verify referer is valid.
+	 *
+	 * @param string|null $nonce If API is being instantiated directly by WP, it needs nonce verification.
+	 *
+	 * @return boolean|void True if the nonce or referer is valid; otherwise kill the request.
 	 */
-	public function verify_referer() {
+	public function verify_referer( $nonce = null ) {
+		if ( $nonce ) {
+			return \wp_verify_nonce( $nonce, 'newspack_campaigns_lightweight_api' );
+		}
+
 		$http_referer = ! empty( $_SERVER['HTTP_REFERER'] ) ? parse_url( $_SERVER['HTTP_REFERER'] , PHP_URL_HOST ) : null; // phpcs:ignore
 		$valid_referers = [
 			$http_referer,

--- a/api/segmentation/class-segmentation-client-data.php
+++ b/api/segmentation/class-segmentation-client-data.php
@@ -127,7 +127,7 @@ class Segmentation_Client_Data extends Lightweight_API {
 			}
 		}
 
-		// Add donations data from WC orders.
+		// Add donations data from past WC orders.
 		$orders = $this->get_request_param( 'orders', $request );
 		if ( $orders ) {
 			// Lookup existing orders so we don't log duplicate events.

--- a/includes/class-newspack-popups-donations.php
+++ b/includes/class-newspack-popups-donations.php
@@ -143,8 +143,9 @@ final class Newspack_Popups_Donations {
 	 * When a new WooCommerce order is created with the client ID meta,
 	 * log a new donation event to that client ID.
 	 *
-	 * @param int      $order_id Order ID.
-	 * @param WC_Order $order Order object.
+	 * @param int         $order_id Order ID.
+	 * @param WC_Order    $order Order object.
+	 * @param string|null $client_id Client ID to associate with the donation. If not passed, will attempt to get from the current session.
 	 */
 	public static function create_donation_event( $order_id, $order, $client_id = null ) {
 		if ( ! $client_id ) {

--- a/includes/class-newspack-popups-donations.php
+++ b/includes/class-newspack-popups-donations.php
@@ -75,25 +75,6 @@ final class Newspack_Popups_Donations {
 	}
 
 	/**
-	 * Add a hidden billing field with client id.
-	 *
-	 * @param Array $form_fields WC form fields.
-	 */
-	public static function woocommerce_billing_fields( $form_fields ) {
-		$client_id = \Newspack_Popups_Segmentation::get_client_id();
-
-		if ( $client_id ) {
-			$form_fields[ \Newspack_Popups_Segmentation::NEWSPACK_SEGMENTATION_CID_NAME ] = [
-				'type'    => 'text',
-				'default' => $client_id,
-				'class'   => [ 'hide' ],
-			];
-		}
-
-		return $form_fields;
-	}
-
-	/**
 	 * Given an array of WC orders, get relevant data to log with reader events.
 	 * Only return data for orders that match Newspack donation products.
 	 *

--- a/includes/class-newspack-popups-newsletters.php
+++ b/includes/class-newspack-popups-newsletters.php
@@ -7,6 +7,8 @@
 
 defined( 'ABSPATH' ) || exit;
 
+require_once dirname( __FILE__ ) . '/../api/campaigns/class-campaign-data-utils.php';
+
 /**
  * Main Newspack Popups Newsletters Class.
  */
@@ -63,12 +65,16 @@ final class Newspack_Popups_Newsletters {
 				],
 			];
 
-			Newspack_Popups_Segmentation::update_client_data(
-				Newspack_Popups_Segmentation::get_client_id(),
-				[
-					'reader_events' => [ $subscription_event ],
-				]
-			);
+
+			$client_id = isset( $contact['client_id'] ) ? $contact['client_id'] : \Newspack_Popups_Segmentation::get_client_id();
+			$nonce     = \wp_create_nonce( 'newspack_campaigns_lightweight_api' );
+			$api       = \Campaign_Data_Utils::get_api( $nonce );
+
+			if ( ! $api || ! $client_id ) {
+				return;
+			}
+
+			$api->save_reader_events( $client_id, [ $subscription_event ] );
 		}
 	}
 }

--- a/includes/class-newspack-popups-segmentation.php
+++ b/includes/class-newspack-popups-segmentation.php
@@ -250,50 +250,6 @@ final class Newspack_Popups_Segmentation {
 			if ( $user_id ) {
 				$initial_client_report_url_params['user_id'] = $user_id;
 			}
-
-			$newspack_donation_product_id = class_exists( '\Newspack\Donations' ) ?
-				(int) get_option( \Newspack\Donations::DONATION_PRODUCT_ID_OPTION, 0 ) :
-				0;
-
-			if ( class_exists( 'WooCommerce' ) ) {
-				$user_orders               = wc_get_orders( [ 'customer_id' => get_current_user_id() ] );
-				$newspack_donation_product = $newspack_donation_product_id ? wc_get_product( $newspack_donation_product_id ) : null;
-				$newspack_child_products   = $newspack_donation_product ? $newspack_donation_product->get_children() : [];
-
-				/**
-				 * Allows other plugins to designate additional WooCommerce products by ID that should be considered donations.
-				 *
-				 * @param int[] $product_ids Array of WooCommerce product IDs.
-				 */
-				$other_donation_products = apply_filters( 'newspack_popups_donation_products', [] );
-				$all_donation_products   = array_values( array_merge( $newspack_child_products, $other_donation_products ) );
-
-				if ( count( $user_orders ) ) {
-					$orders = [];
-					foreach ( $user_orders as $order ) {
-						$order_data  = $order->get_data();
-						$order_items = array_map(
-							function( $item ) {
-								return $item->get_product_id();
-							},
-							array_values( $order->get_items() )
-						);
-
-						// Only count orders that include donation products as donations.
-						if ( 0 < count( array_intersect( $order_items, $all_donation_products ) ) ) {
-							$orders[] = [
-								'order_id' => $order_data['id'],
-								'date'     => date_format( date_create( $order_data['date_created'] ), 'Y-m-d' ),
-								'amount'   => $order_data['total'],
-							];
-						}
-					}
-
-					if ( count( $orders ) ) {
-						$initial_client_report_url_params['orders'] = wp_json_encode( $orders );
-					}
-				}
-			}
 		}
 
 		// If visiting the donor landing page, mark the visitor as donor.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

I recently started running into issues getting single, non-authenticated WooCommerce donation orders logged as donation events. In the process, I decided to simplify the plugin's handling of WC donation orders in general.

#### Current state

There are two ways the plugin looks for orders:

1. If the reader completes a recurring donation, they are automatically authenticated as a WooCommerce customer. For all logged-in WP users, the plugin fetches all orders associated with the logged-in user and upserts the orders as donation events. This seems wasteful and redundant as this happens on every logged-in session page load.
2. If the reader completes a single donation while not logged in, the plugin looks for a webhook callback on `order.created` and creates a donation event with the order details. This started failing for me sometime during the past week due to unauthenticated request errors on WP's part. Perhaps something has changed to cause these webhook callbacks to be treated as unauthenticated requests?

#### Proposed simplification

Instead of handling both cases separately, the plugin instead uses the ~[`woocommerce_checkout_order_created`](https://woocommerce.github.io/code-reference/files/woocommerce-includes-class-wc-checkout.html#source-view.405)~ [woocommerce_new_order](https://woocommerce.github.io/code-reference/files/woocommerce-includes-data-stores-class-wc-order-data-store-cpt.html#source-view.89) action hook to log a donation event anytime a new order is generated by WooCommerce. In my mind this is a superior way to handle donation orders as we don't need to do any deduplication or handle recurring or single donations in a different way.

Because the webhook may still be active for sites already using Campaigns, this also takes the step of deleting it, if it exists, to avoid potential data duplication.

### How to test the changes in this Pull Request:

1. On this branch, set your Reader Revenue platform to "Newspack".
4. In new incognito sessions, test multiple single and recurring donations.
5. Confirm that `donation` events are created for each completed order per client ID.
6. Confirm also that the sessions are recognized as being part of the "Donors" segment (sees prompts targeted to a "Donors only" segment).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
