### PR TITLE
feat: featured images for overlay prompts

### DIFF
--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -1136,11 +1136,13 @@ final class Newspack_Popups_Model {
 		$no_overlay_background = $popup['options']['no_overlay_background'];
 		$hidden_fields         = self::get_hidden_fields( $popup );
 		$is_newsletter_prompt  = self::has_newsletter_prompt( $popup );
+		$has_featured_image    = has_post_thumbnail( $popup['id'] );
 		$classes               = array( 'newspack-lightbox', 'newspack-popup', 'newspack-lightbox-placement-' . $popup['options']['placement'], 'newspack-lightbox-size-' . $overlay_size );
 		$classes[]             = ( ! empty( $popup['title'] ) && $display_title ) ? 'newspack-lightbox-has-title' : null;
 		$classes[]             = $hide_border ? 'newspack-lightbox-no-border' : null;
 		$classes[]             = $is_newsletter_prompt ? 'newspack-newsletter-prompt-overlay' : null;
 		$classes[]             = $no_overlay_background ? 'newspack-lightbox-no-overlay' : null;
+		$classes[]             = $has_featured_image ? 'has-featured-image' : null;
 		$wrapper_classes       = [ 'newspack-popup-wrapper' ];
 		$wrapper_classes[]     = 'publish' !== $popup['status'] ? 'newspack-inactive-popup-status' : null;
 		$is_scroll_triggered   = 'scroll' === $popup['options']['trigger_type'];
@@ -1153,8 +1155,6 @@ final class Newspack_Popups_Model {
 		);
 
 		$animation_id = 'a_' . $element_id;
-
-		$has_featured_image = has_post_thumbnail( $popup['id'] );
 
 		ob_start();
 		?>

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -1154,6 +1154,8 @@ final class Newspack_Popups_Model {
 
 		$animation_id = 'a_' . $element_id;
 
+		$has_featured_image = has_post_thumbnail( $popup['id'] );
+
 		ob_start();
 		?>
 		<amp-layout
@@ -1166,10 +1168,17 @@ final class Newspack_Popups_Model {
 		>
 			<div class="<?php echo esc_attr( implode( ' ', $wrapper_classes ) ); ?>" data-popup-status="<?php echo esc_attr( $popup['status'] ); ?>" style="<?php echo ! $hide_border ? esc_attr( self::container_style( $popup ) ) : ''; ?>">
 				<div class="newspack-popup" style="<?php echo $hide_border ? esc_attr( self::container_style( $popup ) ) : ''; ?>">
-					<?php if ( ! empty( $popup['title'] ) && $display_title ) : ?>
-						<h1 class="newspack-popup-title"><?php echo esc_html( $popup['title'] ); ?></h1>
+					<?php if ( $has_featured_image ) : ?>
+						<div class="newspack-popup__featured-image">
+							<?php echo get_the_post_thumbnail( $popup['id'], 'large' ); ?>
+						</div>
 					<?php endif; ?>
-					<?php echo do_shortcode( $body ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+					<div class="newspack-popup__content">
+						<?php if ( ! empty( $popup['title'] ) && $display_title ) : ?>
+							<h1 class="newspack-popup-title"><?php echo esc_html( $popup['title'] ); ?></h1>
+						<?php endif; ?>
+						<?php echo do_shortcode( $body ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+					</div>
 					<form class="popup-dismiss-form <?php echo esc_attr( self::get_form_class( 'dismiss', $element_id ) ); ?> popup-action-form <?php echo esc_attr( self::get_form_class( 'action', $element_id ) ); ?>"
 						method="POST"
 						action-xhr="<?php echo esc_url( $endpoint ); ?>"

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -1142,7 +1142,7 @@ final class Newspack_Popups_Model {
 		$classes[]             = $hide_border ? 'newspack-lightbox-no-border' : null;
 		$classes[]             = $is_newsletter_prompt ? 'newspack-newsletter-prompt-overlay' : null;
 		$classes[]             = $no_overlay_background ? 'newspack-lightbox-no-overlay' : null;
-		$classes[]             = $has_featured_image ? 'has-featured-image' : null;
+		$classes[]             = $has_featured_image ? 'newspack-lightbox-featured-image' : null;
 		$wrapper_classes       = [ 'newspack-popup-wrapper' ];
 		$wrapper_classes[]     = 'publish' !== $popup['status'] ? 'newspack-inactive-popup-status' : null;
 		$is_scroll_triggered   = 'scroll' === $popup['options']['trigger_type'];

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -123,7 +123,7 @@ final class Newspack_Popups {
 			'public'       => false,
 			'show_ui'      => true,
 			'show_in_rest' => true,
-			'supports'     => [ 'editor', 'title', 'custom-fields' ],
+			'supports'     => [ 'editor', 'title', 'custom-fields', 'thumbnail' ],
 			'taxonomies'   => [ 'category', 'post_tag' ],
 			'menu_icon'    => 'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjQiIGhlaWdodD0iMjQiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgdmlld0JveD0iMCAwIDI0IDI0IiByb2xlPSJpbWciIGFyaWEtaGlkZGVuPSJ0cnVlIiBmb2N1c2FibGU9ImZhbHNlIj48cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik02Ljg2MyAxMy42NDRMNSAxMy4yNWgtLjVhLjUuNSAwIDAxLS41LS41di0zYS41LjUgMCAwMS41LS41SDVMMTggNi41aDJWMTZoLTJsLTMuODU0LS44MTUuMDI2LjAwOGEzLjc1IDMuNzUgMCAwMS03LjMxLTEuNTQ5em0xLjQ3Ny4zMTNhMi4yNTEgMi4yNTEgMCAwMDQuMzU2LjkyMWwtNC4zNTYtLjkyMXptLTIuODQtMy4yOEwxOC4xNTcgOGguMzQzdjYuNWgtLjM0M0w1LjUgMTEuODIzdi0xLjE0NnoiIGNsaXAtcnVsZT0iZXZlbm9kZCIgZmlsbD0id2hpdGUiPjwvcGF0aD48L3N2Zz4K',
 		];

--- a/src/view/style.scss
+++ b/src/view/style.scss
@@ -15,6 +15,10 @@ $size__small: 544px;
 $size__medium: 784px;
 $size__large: 1264px;
 
+// Widths
+$width__mobile: 600px;
+$width__tablet: 782px;
+
 .newspack-lightbox {
 	align-items: center;
 	bottom: 0;
@@ -35,11 +39,11 @@ $size__large: 1264px;
 	z-index: 99999;
 
 	.admin-bar & {
-		@media only screen and ( min-width: 601px ) {
+		@media only screen and ( min-width: #{$width__mobile + 1} ) {
 			padding-top: 46px !important;
 		}
 
-		@media only screen and ( min-width: 783px ) {
+		@media only screen and ( min-width: #{$width__tablet + 1} ) {
 			padding-top: 32px !important;
 		}
 	}
@@ -75,16 +79,19 @@ $size__large: 1264px;
 		overflow: auto;
 
 		&__content {
-			padding: 17px;
-			@media only screen and ( min-width: 601px ) {
-				padding: 32px;
+			padding: $overlay__gap;
+			@media only screen and ( min-width: $width__mobile ) {
+				padding: #{2 * $overlay__gap};
 			}
 		}
 		&__featured-image {
-			max-height: 200px;
+			display: none;
+			max-height: #{13 * $overlay__gap};
 			overflow: hidden;
-			img {
-				transform: translateY( -50% ) translateY( 100px );
+			@media only screen and ( min-width: $width__tablet ) {
+				align-items: center;
+				display: flex;
+				justify-content: center;
 			}
 		}
 
@@ -141,8 +148,31 @@ $size__large: 1264px;
 		}
 
 		&:focus {
-			outline: 1px solid;
+			outline: 1.5px solid;
 			outline-offset: -1px;
+		}
+	}
+
+	&.has-featured-image {
+		@media only screen and ( min-width: $width__tablet ) {
+			.newspack-lightbox__close {
+				background-color: rgba( black, 0.25 );
+				border-radius: 3px;
+				color: white;
+				height: 48px;
+				margin: 8px;
+				width: 48px;
+
+				&:active,
+				&:hover {
+					background-color: rgba( black, 0.75 );
+					opacity: 1;
+				}
+
+				&:focus {
+					outline-offset: 2px;
+				}
+			}
 		}
 	}
 
@@ -299,7 +329,7 @@ $size__large: 1264px;
 				padding-left: 0;
 				padding-right: 0;
 
-				@media only screen and ( min-width: 600px ) {
+				@media only screen and ( min-width: $width__mobile ) {
 					&.wp-block-columns {
 						margin-left: -16px;
 						margin-right: -16px;

--- a/src/view/style.scss
+++ b/src/view/style.scss
@@ -73,15 +73,22 @@ $size__large: 1264px;
 		margin: 0 auto;
 		max-width: $size__medium;
 		overflow: auto;
-		padding: 17px;
-		@media only screen and ( min-width: 601px ) {
-			padding: 32px;
+
+		&__content {
+			padding: 17px;
+			@media only screen and ( min-width: 601px ) {
+				padding: 32px;
+			}
+		}
+		&__featured-image {
+			max-height: 200px;
+			overflow: hidden;
+			img {
+				transform: translateY( -50% ) translateY( 100px );
+			}
 		}
 
-		> *:first-child {
-			margin-top: 0;
-		}
-
+		&__content,
 		.wp-block-column {
 			> *:first-child {
 				margin-top: 0;

--- a/src/view/style.scss
+++ b/src/view/style.scss
@@ -153,7 +153,7 @@ $width__tablet: 782px;
 		}
 	}
 
-	&.has-featured-image {
+	&-featured-image {
 		@media only screen and ( min-width: $width__tablet ) {
 			.newspack-lightbox__close {
 				background-color: rgba( black, 0.25 );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds featured image support for overlay prompts. Support for inline prompts coming up (https://github.com/Automattic/newspack-popups/pull/925).

Closes #914 

### How to test the changes in this Pull Request:

1. Create a new prompt, observe a featured image can be added
2. View the frontend, observe the featured image is displayed if the prompt is an overlay one
3. Observe the featured image is centred in a 208px high element above prompt content

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->