### PR TITLE
feat: featured image support for inline popups

### DIFF
--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -1156,6 +1156,8 @@ final class Newspack_Popups_Model {
 
 		$animation_id = 'a_' . $element_id;
 
+		$has_featured_image = has_post_thumbnail( $popup['id'] );
+
 		ob_start();
 		?>
 		<amp-layout

--- a/src/view/style.scss
+++ b/src/view/style.scss
@@ -84,27 +84,6 @@ $width__tablet: 782px;
 				padding: #{2 * $overlay__gap};
 			}
 		}
-		&__featured-image {
-			display: none;
-			max-height: #{13 * $overlay__gap};
-			overflow: hidden;
-			@media only screen and ( min-width: $width__tablet ) {
-				align-items: center;
-				display: flex;
-				justify-content: center;
-			}
-		}
-
-		&__content,
-		.wp-block-column {
-			> *:first-child {
-				margin-top: 0;
-			}
-
-			> *:last-child {
-				margin-bottom: 0;
-			}
-		}
 	}
 
 	&.newspack-lightbox-no-border {
@@ -371,6 +350,10 @@ $width__tablet: 782px;
 		border: none;
 		padding: 0;
 	}
+
+	.newspack-popup__featured-image {
+		margin-bottom: 0.75rem;
+	}
 }
 
 .newspack-inactive-popup-status {
@@ -398,6 +381,31 @@ $width__tablet: 782px;
 
 	&:focus {
 		outline: none;
+	}
+}
+
+// Universal styles for all popups.
+.newspack-popup {
+	&__featured-image {
+		display: none;
+		max-height: #{13 * $overlay__gap};
+		overflow: hidden;
+		@media only screen and ( min-width: $width__tablet ) {
+			align-items: center;
+			display: flex;
+			justify-content: center;
+		}
+	}
+
+	&__content,
+	.wp-block-column {
+		> *:first-child {
+			margin-top: 0;
+		}
+
+		> *:last-child {
+			margin-bottom: 0;
+		}
 	}
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Building on https://github.com/Automattic/newspack-popups/pull/924, adds featured image support for inline popups, too.

### How to test the changes in this Pull Request:

1. Switch Newspack Theme to `feat/prompt-styles` branch (https://github.com/Automattic/newspack-theme/pull/1887)
1. Create a new prompt, observe a featured image can be added
2. View the frontend, observe the featured image is displayed
3. Observe the featured image is centred in a 200px high element above prompt content

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->