### PR TITLE
feat: handle no lists update

### DIFF
--- a/includes/class-newspack-popups-newsletters.php
+++ b/includes/class-newspack-popups-newsletters.php
@@ -77,7 +77,7 @@ final class Newspack_Popups_Newsletters {
 	 * @param bool|WP_Error  $result   True if the contact was added or error if failed.
 	 */
 	public static function handle_newsletter_subscription( $provider, $contact, $lists, $result ) {
-		if ( \is_wp_error( $result ) || ! $result || false == $lists || empty( $lists ) ) {
+		if ( \is_wp_error( $result ) || ! $result || empty( $lists ) ) {
 			return;
 		}
 		$subscription_event = [

--- a/includes/class-newspack-popups-newsletters.php
+++ b/includes/class-newspack-popups-newsletters.php
@@ -65,39 +65,40 @@ final class Newspack_Popups_Newsletters {
 	/**
 	 * Update reader events when the Newspack Newsletters subscribe form adds a contact to a list.
 	 *
-	 * @param string        $provider The provider name.
-	 * @param array         $contact  {
-	 *    Contact information.
+	 * @param string         $provider The provider name.
+	 * @param array          $contact  {
+	 *     Contact information.
 	 *
 	 *    @type string   $email    Contact email address.
 	 *    @type string   $name     Contact name. Optional.
 	 *    @type string[] $metadata Contact additional metadata. Optional.
 	 * }
-	 * @param string[]      $lists    Array of list IDs to subscribe the contact to.
-	 * @param bool|WP_Error $result   True if the contact was added or error if failed.
+	 * @param string[]|false $lists    Array of list IDs to subscribe the contact to.
+	 * @param bool|WP_Error  $result   True if the contact was added or error if failed.
 	 */
 	public static function handle_newsletter_subscription( $provider, $contact, $lists, $result ) {
-		if ( ! \is_wp_error( $result ) && $result ) {
-			$subscription_event = [
-				'type'    => 'subscription',
-				'context' => $contact['email'],
-				'value'   => [
-					'esp'   => $provider,
-					'lists' => $lists,
-				],
-			];
-
-
-			$client_id = isset( $contact['client_id'] ) ? $contact['client_id'] : \Newspack_Popups_Segmentation::get_client_id();
-			$nonce     = \wp_create_nonce( 'newspack_campaigns_lightweight_api' );
-			$api       = \Campaign_Data_Utils::get_api( $nonce );
-
-			if ( ! $api || ! $client_id ) {
-				return;
-			}
-
-			$api->save_reader_events( $client_id, [ $subscription_event ] );
+		if ( \is_wp_error( $result ) || ! $result || false == $lists || empty( $lists ) ) {
+			return;
 		}
+		$subscription_event = [
+			'type'    => 'subscription',
+			'context' => $contact['email'],
+			'value'   => [
+				'esp'   => $provider,
+				'lists' => $lists,
+			],
+		];
+
+
+		$client_id = isset( $contact['client_id'] ) ? $contact['client_id'] : \Newspack_Popups_Segmentation::get_client_id();
+		$nonce     = \wp_create_nonce( 'newspack_campaigns_lightweight_api' );
+		$api       = \Campaign_Data_Utils::get_api( $nonce );
+
+		if ( ! $api || ! $client_id ) {
+			return;
+		}
+
+		$api->save_reader_events( $client_id, [ $subscription_event ] );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

With the change in https://github.com/Automattic/newspack-newsletters/pull/900, the newsletter contact can be updated w/out a change to lists selection. This PR brings the relevant hook handler up to date, making sure the reader event is not added in this case. 

### How to test the changes in this Pull Request:

Ensure the reader is still segmented as subscriber after subscribing

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->