### PR TITLE
feat: read ESP donation metadata on login and supply to segmentation

### DIFF
--- a/includes/class-newspack-popups-newsletters.php
+++ b/includes/class-newspack-popups-newsletters.php
@@ -46,7 +46,7 @@ final class Newspack_Popups_Newsletters {
 	public function __construct() {
 		\add_action( 'newspack_newsletters_add_contact', [ __CLASS__, 'handle_newsletter_subscription' ], 10, 4 );
 		\add_action( 'wp_login', [ __CLASS__, 'status_check_on_login' ], 10, 2 );
-		\add_action( 'newspack_registered_reader', [ __CLASS__, 'check_reader_newsletter_subscription_status' ] );
+		\add_action( 'newspack_registered_reader', [ __CLASS__, 'create_reader_event_from_esp_data' ] );
 	}
 
 	/**
@@ -56,10 +56,13 @@ final class Newspack_Popups_Newsletters {
 	 * @param WP_User $user User object.
 	 */
 	public static function status_check_on_login( $user_login, $user ) {
+		if ( ! method_exists( '\Newspack\Reader_Activation', 'is_user_reader' ) ) {
+			return;
+		}
 		if ( ! \Newspack\Reader_Activation::is_user_reader( $user ) ) {
 			return;
 		}
-		self::check_reader_newsletter_subscription_status( $user->user_email );
+		self::create_reader_event_from_esp_data( $user->user_email );
 	}
 
 	/**
@@ -107,7 +110,7 @@ final class Newspack_Popups_Newsletters {
 	 *
 	 * @param string|null $email_address Email address or null if not set.
 	 */
-	public static function check_reader_newsletter_subscription_status( $email_address ) {
+	public static function create_reader_event_from_esp_data( $email_address ) {
 		if ( self::$is_checking_status ) {
 			return;
 		}
@@ -116,39 +119,63 @@ final class Newspack_Popups_Newsletters {
 		if ( ! $email_address || ! class_exists( '\Newspack_Newsletters' ) || ! class_exists( '\Newspack_Newsletters_Subscription' ) ) {
 			return;
 		}
+
 		$nonce = \wp_create_nonce( 'newspack_campaigns_lightweight_api' );
 		$api   = Campaign_Data_Utils::get_api( $nonce );
-
 		if ( ! $api ) {
 			return;
 		}
 
-		$client_id = Newspack_Popups_Segmentation::get_client_id();
+		$client_id           = Newspack_Popups_Segmentation::get_client_id();
+		$events_to_add       = [];
+		$newsletter_provider = \Newspack_Newsletters::get_service_provider();
 
 		// If the reader is already known to be a newsletter subscriber, no need to proceed.
-		$newsletter_events = $api->get_reader_events( $client_id, 'subscription', $email_address );
-		if ( ! empty( $newsletter_events ) ) {
-			return;
+		$has_subscription_events = ! empty( $api->get_reader_events( $client_id, 'subscription', $email_address ) );
+		if ( ! $has_subscription_events ) {
+			// Look up the email address as a contact with the connected ESP. If not a contact, no need to proceed.
+			$subscribed_lists = \Newspack_Newsletters_Subscription::get_contact_lists( $email_address );
+			if ( ! is_wp_error( $subscribed_lists ) && ! empty( $subscribed_lists ) && is_array( $subscribed_lists ) ) {
+				// The reader is subscribed to one or more lists, so they should be segmented as a subscriber.
+				$events_to_add[] = [
+					'type'    => 'subscription',
+					'context' => $email_address,
+					'value'   => [
+						'esp'   => $newsletter_provider->service,
+						'lists' => $subscribed_lists,
+					],
+				];
+			}
 		}
 
-		// Look up the email address as a contact with the connected ESP. If not a contact, no need to proceed.
-		$subscribed_lists = \Newspack_Newsletters_Subscription::get_contact_lists( $email_address );
-		if ( is_wp_error( $subscribed_lists ) || empty( $subscribed_lists ) || ! is_array( $subscribed_lists ) ) {
-			return;
+		// If the reader is already known to be a donor, no need to proceed.
+		$has_donation_events = ! empty( $api->get_reader_events( $client_id, 'donation', $email_address ) );
+		if ( ! $has_donation_events ) {
+			$contact_details = \Newspack_Newsletters_Subscription::get_contact_data( $email_address, true );
+			if ( ! is_wp_error( $contact_details ) && isset( $contact_details['metadata'] ) ) {
+				$metadata        = $contact_details['metadata'];
+				$donation_amount = 0;
+
+				if ( isset( $metadata['NP_LAST_PAYMENT_AMOUNT'] ) ) {
+					$donation_amount = (int) $metadata['NP_LAST_PAYMENT_AMOUNT'];
+				} elseif ( isset( $metadata['TOTAL_SPENT'] ) ) {
+					$donation_amount = (int) $metadata['TOTAL_SPENT'];
+				}
+				if ( 0 < $donation_amount ) {
+					$events_to_add[] = [
+						'type'    => 'donation',
+						'context' => $newsletter_provider->service,
+						'value'   => [
+							'amount' => $donation_amount,
+						],
+					];
+				}
+			}
 		}
 
-		// The reader is subscribed to one or more lists, so they should be segmented as a subscriber.
-		$provider           = \Newspack_Newsletters::get_service_provider();
-		$subscription_event = [
-			'type'    => 'subscription',
-			'context' => $email_address,
-			'value'   => [
-				'esp'   => $provider->service,
-				'lists' => $subscribed_lists,
-			],
-		];
-
-		$api->save_reader_events( $client_id, [ $subscription_event ] );
+		if ( ! empty( $events_to_add ) ) {
+			$api->save_reader_events( $client_id, $events_to_add );
+		}
 	}
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds donation-related metadata fetching from the ESP, on login.

Closes https://github.com/Automattic/newspack-issues/issues/236

### How to test the changes in this Pull Request:

1. Switch Newsletters plugin to `feat/contact-data-details` branch (https://github.com/Automattic/newspack-newsletters/pull/901)
2. Manually add a contact in ActiveCampaign ESP, and fill in `NP_Last Payment Amount` or `Total Spent` fields
3. Register on the site as this user and observe prompts segmented to donors are displayed

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->