### PR TITLE
fix: segment matching when no segment is the best-priority

### DIFF
--- a/api/campaigns/class-maybe-show-campaign.php
+++ b/api/campaigns/class-maybe-show-campaign.php
@@ -29,6 +29,7 @@ class Maybe_Show_Campaign extends Lightweight_API {
 		$visit     = json_decode( $_REQUEST['visit'], true ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.InputNotValidated
 		$response  = [];
 		$client_id = $_REQUEST['cid']; // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		$user_id   = isset( $_REQUEST['uid'] ) ? absint( $_REQUEST['uid'] ) : null; // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 
 		$view_as_spec = [];
 		if ( ! empty( $_REQUEST['view_as'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
@@ -39,6 +40,17 @@ class Maybe_Show_Campaign extends Lightweight_API {
 		if ( ! defined( 'DISABLE_CAMPAIGN_EVENT_LOGGING' ) || true !== DISABLE_CAMPAIGN_EVENT_LOGGING ) {
 			$reader_events = [];
 			$view_event    = $this->convert_visit_to_event( $client_id, $visit );
+
+			// Handle user accounts.
+			if ( $user_id ) {
+				$existing_user_accounts = $this->get_reader_events( $client_id, 'user_account', $user_id );
+				if ( 0 === count( $existing_user_accounts ) ) {
+					$reader_events[] = [
+						'type'    => 'user_account',
+						'context' => $user_id,
+					];
+				}
+			}
 
 			// Filter out recently seen views.
 			if ( ! empty( $view_event ) ) {

--- a/api/segmentation/class-segmentation-client-data.php
+++ b/api/segmentation/class-segmentation-client-data.php
@@ -107,26 +107,6 @@ class Segmentation_Client_Data extends Lightweight_API {
 			];
 		}
 
-		// Get user ID if they have a user account.
-		$user_id = $this->get_request_param( 'user_id', $request );
-		if ( $user_id ) {
-			$existing_user_accounts = $this->get_reader_events( $client_id, 'user_account', $user_id );
-			$add_user_account       = true;
-
-			// Only add a new user account if it hasn't already been logged for this client.
-			if ( 0 < count( $existing_user_accounts ) ) {
-				$add_user_account = false;
-			}
-
-			if ( $add_user_account ) {
-				$reader_events[] = [
-					'date_created' => $timestamp,
-					'type'         => 'user_account',
-					'context'      => $user_id,
-				];
-			}
-		}
-
 		// Add donations data from past WC orders.
 		$orders = $this->get_request_param( 'orders', $request );
 		if ( $orders ) {

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -791,6 +791,13 @@ final class Newspack_Popups_Inserter {
 		$popups_access_provider['authorization'] .= '&popups=' . wp_json_encode( $popups_configs );
 		$popups_access_provider['authorization'] .= '&settings=' . wp_json_encode( $settings );
 		$popups_access_provider['authorization'] .= '&visit=' . wp_json_encode( $visit );
+
+		// Handle user accounts.
+		$user_id = get_current_user_id();
+		if ( ! empty( $user_id ) ) {
+			$popups_access_provider['authorization'] .= '&uid=' . absint( $user_id );
+		}
+
 		if ( isset( $_GET['newspack-campaigns-debug'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 			$popups_access_provider['authorization'] .= '&debug';
 		}

--- a/includes/class-newspack-popups-segmentation.php
+++ b/includes/class-newspack-popups-segmentation.php
@@ -245,15 +245,6 @@ final class Newspack_Popups_Segmentation {
 			$initial_client_report_url_params['mc_eid'] = sanitize_text_field( $_GET['mc_eid'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		}
 
-		// Handle user accounts and Newspack donations via WooCommerce.
-		if ( is_user_logged_in() && ! Newspack_Popups::is_preview_request() ) {
-			// If the user is logged in, store their user ID.
-			$user_id = get_current_user_id();
-			if ( $user_id ) {
-				$initial_client_report_url_params['user_id'] = $user_id;
-			}
-		}
-
 		// If visiting the donor landing page, mark the visitor as donor.
 		$donor_landing_page = intval( Newspack_Popups_Settings::donor_landing_page() );
 		if ( ! empty( $donor_landing_page ) && get_queried_object_id() === $donor_landing_page ) {

--- a/tests/test-api.php
+++ b/tests/test-api.php
@@ -826,10 +826,13 @@ class APITest extends WP_UnitTestCase {
 		);
 
 		// Report a login.
-		self::$report_client_data->report_client_data(
+		self::$maybe_show_campaign->save_reader_events(
+			self::$client_id,
 			[
-				'client_id' => self::$client_id,
-				'user_id'   => 123,
+				[
+					'type'    => 'user_account',
+					'context' => 123,
+				],
 			]
 		);
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes what seems to be a long-standing bug when evaluating whether a reader matches a prompt's segments, but none of the prompt's segments is the reader's highest-priority segment. In this case, the prompt's segmentation matching is evaluated as if it has no segments (same as "Everyone").

Closes #928.

### How to test the changes in this Pull Request:

1. On `master`, create an "Anonymous" segment targeted to readers with no account, and make it the highest-priority segment. Publish a prompt to the segment (only that segment) with "Every page" frequency. Then, create a second, lower-priority segment that will also easily match readers, such as "not subscribed" or "non-donors".
2. In a new incognito session, observe that you see the "Anonymous" prompt on every pageview before and after logging into a user account (**note:** must log in via the WP login screen, the WooCommerce My Account screen, or any page where the Campaigns plugin is disabled).
3. Check out this branch, and in a new incognito session, confirm that you only see the "Anonymous" prompt before you log in. If you add `?newspack-campaigns-debug` to your URL and inspect the `/api/campaigns/index.php` XHR request, you should be also be able to see in the `debug` response object that the prompt's segment does not match after logging in.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
