### PR TITLE
fix: utm_source suppression if segment also matches

### DIFF
--- a/api/campaigns/class-maybe-show-campaign.php
+++ b/api/campaigns/class-maybe-show-campaign.php
@@ -251,7 +251,7 @@ class Maybe_Show_Campaign extends Lightweight_API {
 					$should_display = true;
 				}
 			}
-		} elseif ( ! empty( $popup_segment_ids ) ) {
+		} elseif ( $should_display && ! empty( $popup_segment_ids ) ) {
 			// $settings->best_priority_segment_id should always be present, but in case it's not (e.g. in a unit test), we can fetch it here.
 			$best_priority_segment_id = isset( $settings->best_priority_segment_id ) ?
 				$settings->best_priority_segment_id :
@@ -281,6 +281,11 @@ class Maybe_Show_Campaign extends Lightweight_API {
 					self::add_suppression_reason( $popup->id, __( 'Segment does not match.', 'newspack-popups' ) );
 				}
 			}
+		}
+
+		// If the prompt is already suppressed, no need to proceed.
+		if ( ! $should_display ) {
+			return $should_display;
 		}
 
 		// Handle frequency.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes `utm_source` suppression logic. Currently, if the URL contains a `utm_source` value that matches the prompt's UTM Suppression setting, if the prompt also matches the reader's segment, the segmentation matching will override the UTM suppression. This fix skips evaluating the prompt's segments and frequency options if UTM suppression is triggered first.

### How to test the changes in this Pull Request:

1. Publish a prompt to a segment that will match a new reader (e.g. non-donors). Set the UTM Suppression value to something like "Suppress This".
2. On `master`, in a new incognito session, visit the site with a matching `utm_source=Suppress%20This` param. Observe that the prompt is still displayed even though the debug response says it should have been suppressed based on the `utm_source` value.
3. Check out this branch, repeat step 2 in a new session, confirm that the prompt is not displayed.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
