### PR TITLE
fix: category/tag exclusion fields in block editor

### DIFF
--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -918,22 +918,18 @@ final class Newspack_Popups_Inserter {
 		}
 
 		$post_terms     = get_the_terms( get_the_ID(), $taxonomy );
-		$post_terms_ids = array_column( $post_terms ? $post_terms : [], 'term_id' );
+		$post_terms_ids = $post_terms ? array_column( $post_terms, 'term_id' ) : [];
 
 		// Check if a post term is excluded on the popup options.
 		if ( 'category' === $taxonomy ) {
-			foreach ( $popup['options']['excluded_categories'] as $category_excluded_id ) {
-				if ( in_array( $category_excluded_id, $post_terms_ids ) ) {
-					return false;
-				}
+			if ( 0 < count( array_intersect( $popup['options']['excluded_categories'], $post_terms_ids ) ) ) {
+				return false;
 			}
 		}
 
 		if ( 'post_tag' === $taxonomy ) {
-			foreach ( $popup['options']['excluded_tags'] as $post_tag_excluded_id ) {
-				if ( in_array( $post_tag_excluded_id, $post_terms_ids ) ) {
-					return false;
-				}
+			if ( 0 < count( array_intersect( $popup['options']['excluded_tags'], $post_terms_ids ) ) ) {
+				return false;
 			}
 		}
 

--- a/src/editor/AdvancedSidebar.js
+++ b/src/editor/AdvancedSidebar.js
@@ -8,74 +8,34 @@
 import { __ } from '@wordpress/i18n';
 import { Fragment } from '@wordpress/element';
 import { BaseControl } from '@wordpress/components';
-import { decodeEntities } from '@wordpress/html-entities';
-import apiFetch from '@wordpress/api-fetch';
-import { addQueryArgs } from '@wordpress/url';
 
 /**
  * Internal dependencies
  */
-import { AutocompleteTokenField } from 'newspack-components';
+import { CategoryAutocomplete } from 'newspack-components';
 
 const AdvancedSidebar = ( { onMetaFieldChange, excluded_categories = [], excluded_tags = [] } ) => {
-	const getTaxonomyTitle = item =>
-		decodeEntities( item.name ) || __( '(no title)', 'newspack-blocks' );
-
-	const fetchTaxonomySuggestions = ( taxonomyRestRoute, search ) => {
-		return apiFetch( {
-			path: addQueryArgs( taxonomyRestRoute, {
-				search,
-				per_page: 20,
-				_fields: 'id,name,parent',
-				orderby: 'count',
-				order: 'desc',
-			} ),
-		} ).then( taxonomies =>
-			taxonomies.map( taxonomy => ( {
-				value: taxonomy.id,
-				label: getTaxonomyTitle( taxonomy ),
-			} ) )
-		);
-	};
-
-	const fetchSavedTaxonomies = ( taxonomyRestRoute, taxonomyIDs ) => {
-		return apiFetch( {
-			path: addQueryArgs( taxonomyRestRoute, {
-				per_page: 100,
-				_fields: 'id,name',
-				include: taxonomyIDs.join( ',' ),
-			} ),
-		} ).then( taxonomies =>
-			taxonomies.map( taxonomy => ( {
-				value: taxonomy.id,
-				label: getTaxonomyTitle( taxonomy ),
-			} ) )
-		);
-	};
-
 	return (
 		<Fragment>
 			<BaseControl className="newspack-popups__segmentation-sidebar">
-				<AutocompleteTokenField
-					key="categories"
-					tokens={ excluded_categories }
-					onChange={ _excluded_categories => {
-						onMetaFieldChange( { excluded_categories: _excluded_categories } );
-					} }
-					fetchSuggestions={ search => fetchTaxonomySuggestions( '/wp/v2/categories', search ) }
-					fetchSavedInfo={ taxonomyIDs => fetchSavedTaxonomies( '/wp/v2/categories', taxonomyIDs ) }
-					label={ __( 'Excluded Categories', 'newspack-blocks' ) }
+				<CategoryAutocomplete
+					label={ __( 'Post categories', 'newspack ' ) }
+					value={ excluded_categories }
+					onChange={ tokens =>
+						onMetaFieldChange( {
+							excluded_categories: tokens.map( token => parseInt( token.id ) ),
+						} )
+					}
 				/>
-
-				<AutocompleteTokenField
-					key="tags"
-					tokens={ excluded_tags }
-					onChange={ _excluded_tags => {
-						onMetaFieldChange( { excluded_tags: _excluded_tags } );
-					} }
-					fetchSuggestions={ search => fetchTaxonomySuggestions( '/wp/v2/tags', search ) }
-					fetchSavedInfo={ taxonomyIDs => fetchSavedTaxonomies( '/wp/v2/tags', taxonomyIDs ) }
-					label={ __( 'Excluded Tags', 'newspack-blocks' ) }
+				<CategoryAutocomplete
+					label={ __( 'Post tags', 'newspack ' ) }
+					taxonomy="tags"
+					value={ excluded_tags }
+					onChange={ tokens =>
+						onMetaFieldChange( {
+							excluded_tags: tokens.map( token => parseInt( token.id ) ),
+						} )
+					}
 				/>
 			</BaseControl>
 		</Fragment>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes the category/term exclusion fields in the single prompt editor so that multiple terms can be selected for a prompt.

Closes #932.

### How to test the changes in this Pull Request:

1. On `master`, create a prompt with a category and tag in the exclusion fields ("Advanced Settings" sidebar).
2. Check out this branch. Confirm that the previously selected category/tag are still shown for the prompt, and that #932 can't be replicated.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
