### PR TITLE
Clarify exclusion labels

### DIFF
--- a/src/editor/AdvancedSidebar.js
+++ b/src/editor/AdvancedSidebar.js
@@ -17,7 +17,7 @@ import { CategoryAutocomplete } from 'newspack-components';
 const AdvancedSidebar = ( { onMetaFieldChange, excluded_categories = [], excluded_tags = [] } ) => {
 	return (
 		<Fragment>
-			<BaseControl className="newspack-popups__advanced-sidebar">
+			<BaseControl>
 				<CategoryAutocomplete
 					label={ __( 'Excluded Categories', 'newspack-popups' ) }
 					description={ __(

--- a/src/editor/AdvancedSidebar.js
+++ b/src/editor/AdvancedSidebar.js
@@ -19,7 +19,7 @@ const AdvancedSidebar = ( { onMetaFieldChange, excluded_categories = [], exclude
 		<Fragment>
 			<BaseControl className="newspack-popups__segmentation-sidebar">
 				<CategoryAutocomplete
-					label={ __( 'Post categories', 'newspack ' ) }
+					label={ __( 'Exclude categories', 'newspack ' ) }
 					value={ excluded_categories }
 					onChange={ tokens =>
 						onMetaFieldChange( {
@@ -28,7 +28,7 @@ const AdvancedSidebar = ( { onMetaFieldChange, excluded_categories = [], exclude
 					}
 				/>
 				<CategoryAutocomplete
-					label={ __( 'Post tags', 'newspack ' ) }
+					label={ __( 'Exclude tags', 'newspack ' ) }
 					taxonomy="tags"
 					value={ excluded_tags }
 					onChange={ tokens =>

--- a/src/editor/AdvancedSidebar.js
+++ b/src/editor/AdvancedSidebar.js
@@ -17,9 +17,13 @@ import { CategoryAutocomplete } from 'newspack-components';
 const AdvancedSidebar = ( { onMetaFieldChange, excluded_categories = [], excluded_tags = [] } ) => {
 	return (
 		<Fragment>
-			<BaseControl className="newspack-popups__segmentation-sidebar">
+			<BaseControl className="newspack-popups__advanced-sidebar">
 				<CategoryAutocomplete
-					label={ __( 'Exclude categories', 'newspack ' ) }
+					label={ __( 'Excluded Categories', 'newspack-popups' ) }
+					description={ __(
+						'The prompt will not be shown on posts that have any these categories.',
+						'newspack-popups'
+					) }
 					value={ excluded_categories }
 					onChange={ tokens =>
 						onMetaFieldChange( {
@@ -27,8 +31,13 @@ const AdvancedSidebar = ( { onMetaFieldChange, excluded_categories = [], exclude
 						} )
 					}
 				/>
+				<hr />
 				<CategoryAutocomplete
-					label={ __( 'Exclude tags', 'newspack ' ) }
+					label={ __( 'Excluded Tags', 'newspack-popups' ) }
+					description={ __(
+						'The prompt will not be shown on posts that have any these tags.',
+						'newspack-popups'
+					) }
 					taxonomy="tags"
 					value={ excluded_tags }
 					onChange={ tokens =>


### PR DESCRIPTION
The "Advanced Settings" panel of the campaign editor lets users select categories and tags to exclude. However, this panel doesn't indicate that these are _exclusion_ settings, leading some users to mistakenly input their inclusion preferences into these fields, producing just the opposite results as intended.

### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Renames the labels for the category and tag exclusion fields, distinguishing them from the inclusion settings farther down the screen.

### How to test the changes in this Pull Request:

1. Observe the current behavior when editing a prompt:

<img src="https://user-images.githubusercontent.com/12199101/185234462-6916fca6-1e69-412e-b712-a39faaedcbe6.jpg" width="250">

2. Install this branch (complete with compiled JS files).
3. Open the prompt editor. The labels "Post categories" and "Post tags" should now read "Excluded categories" and "Excluded tags".

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
