### PR TITLE
fix: update frequency options disabled status when prompt type is changed

### DIFF
--- a/src/editor/FrequencySidebar.js
+++ b/src/editor/FrequencySidebar.js
@@ -40,10 +40,7 @@ const getFrequencyOptions = isOverlay => {
 	return frequencyOptions
 		.filter( item => 0 > experimentalKeys.indexOf( item.value ) )
 		.map( item => {
-			if ( 'always' === item.value && isOverlay ) {
-				item.disabled = true;
-			}
-
+			item.disabled = 'always' === item.value && isOverlay;
 			return item;
 		} );
 };


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a minor bug in the Frequency sidebar.

### How to test the changes in this Pull Request:

1. On `master`, with Reader Activation off (option in Engagement turned off, or no `NEWSPACK_EXPERIMENTAL_READER_ACTIVATION` flag) create a new overlay prompt.
2. In the Prompt Settings sidebar, change the Prompt Type to "inline".
3. In the Frequency Settings sidebar, observe that the "Every pageview" option remains disabled even after changing the prompt type to "inline", until you save draft + refresh.
4. Check out this branch, repeat steps 1–3, confirm that the "Every pageview" option becomes available whenever "Prompt Type" is set to "inline", without having to refresh the browser.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
