### PR TITLE
style: increase opacity of overlay close buttons

### DIFF
--- a/src/view/style.scss
+++ b/src/view/style.scss
@@ -156,7 +156,7 @@ $width__tablet: 782px;
 	&-featured-image {
 		@media only screen and ( min-width: $width__tablet ) {
 			.newspack-lightbox__close {
-				background-color: rgba( black, 0.25 );
+				background-color: rgba( black, 0.5 );
 				border-radius: 3px;
 				color: white;
 				height: 48px;
@@ -165,7 +165,7 @@ $width__tablet: 782px;
 
 				&:active,
 				&:hover {
-					background-color: rgba( black, 0.75 );
+					background-color: rgba( black, 0.95 );
 					opacity: 1;
 				}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Slightly increases the opacity of the close buttons for overlay prompts using featured images. This should help make them stand out more visually, for better accessibility.

Comparison:

#### Current styles

<img width="784" alt="Screen Shot 2022-08-24 at 4 14 11 PM" src="https://user-images.githubusercontent.com/2230142/186533148-23efa283-ea5b-4295-bd5a-b4cb352887f6.png">

Hover state:
<img width="780" alt="Screen Shot 2022-08-24 at 4 14 17 PM" src="https://user-images.githubusercontent.com/2230142/186533154-f7f88ff8-c827-4884-af56-f58842149f2f.png">

#### Proposed

<img width="786" alt="Screen Shot 2022-08-24 at 4 13 31 PM" src="https://user-images.githubusercontent.com/2230142/186533177-1da9d0ca-94e5-489d-b949-d4b18cac37d7.png">

Hover state:
<img width="783" alt="Screen Shot 2022-08-24 at 4 13 38 PM" src="https://user-images.githubusercontent.com/2230142/186533182-13d06415-a68a-4dba-9e6a-ec0afac5d2c0.png">


### How to test the changes in this Pull Request:

Check out this branch, publish an overlay prompt with a featured image, compare the close button styles.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
