### PR TITLE
feat: tapping on overlay background no longer dismisses prompt

### DIFF
--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -1191,12 +1191,7 @@ final class Newspack_Popups_Model {
 				</div>
 			</div>
 			<?php if ( ! $no_overlay_background ) : ?>
-				<form class="popup-dismiss-form <?php echo esc_attr( self::get_form_class( 'dismiss', $element_id ) ); ?> popup-action-form <?php echo esc_attr( self::get_form_class( 'action', $element_id ) ); ?>"
-					method="POST"
-					action-xhr="<?php echo esc_url( $endpoint ); ?>"
-					target="_top">
-					<?php echo $hidden_fields; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
-					<button style="opacity: <?php echo floatval( $overlay_opacity ); ?>;background-color:<?php echo esc_attr( $overlay_color ); ?>;" class="newspack-lightbox-shim" on="tap:<?php echo esc_attr( $element_id ); ?>.hide"></button>
+				<div style="opacity: <?php echo floatval( $overlay_opacity ); ?>;background-color:<?php echo esc_attr( $overlay_color ); ?>;" class="newspack-lightbox-shim"></div>
 				</form>
 			<?php endif; ?>
 		</amp-layout>

--- a/src/view/style.scss
+++ b/src/view/style.scss
@@ -59,6 +59,7 @@ $width__tablet: 782px;
 		padding: 0;
 		position: absolute;
 		top: 0;
+		user-select: none;
 		width: 100%;
 		z-index: 0;
 	}


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This makes it slightly harder to accidentally dismiss overlay prompts by removing the "dismiss" action from the overlay background. We've gotten feedback that it's very easy to accidentally dismiss overlays, especially on touchscreen devices where scrolling might be interpreted as a tap event that closes the overlay as soon as it appears.

@thomasguillot I wanted to tag you in case you think this warrants a redesign of the close button—we want to ensure that it's still easy enough to _intentionally_ dismiss the prompt, and not make readers hunt for the button. I think it's prominent-looking enough as-is, but it's something to consider.

### How to test the changes in this Pull Request:

1. Check out this branch, publish an overlay prompt.
2. On the front-end confirm that tapping or clicking the overlay background (the translucent part behind the prompt content) doesn't dismiss the prompt, but that tapping or clicking the X close button still does.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
