### PR TITLE
feat(analytics): prevent marking client as a subscriber if subscribing to master list

### DIFF
--- a/includes/class-newspack-popups-newsletters.php
+++ b/includes/class-newspack-popups-newsletters.php
@@ -83,6 +83,16 @@ final class Newspack_Popups_Newsletters {
 		if ( \is_wp_error( $result ) || ! $result || empty( $lists ) ) {
 			return;
 		}
+
+		// If adding to the master list only, don't add a new event. Adding to the master list is
+		// not an explicit action taken by the reader.
+		if ( method_exists( '\Newspack\Newspack_Newsletters', 'get_lists_without_active_campaign_master_list' ) ) {
+			$lists = \Newspack\Newspack_Newsletters::get_lists_without_active_campaign_master_list( $lists );
+			if ( empty( $lists ) ) {
+				return;
+			}
+		}
+
 		$subscription_event = [
 			'type'    => 'subscription',
 			'context' => $contact['email'],


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a segmentation bug. 

### How to test the changes in this Pull Request:

1. On `master`,
1. Switch Newspack Plugin to `fix/master-list-handling` branch (https://github.com/Automattic/newspack-plugin/pull/1946)
2. Configure a site w/ ActiveCampagin and set a "Master List" in the Engagement wizard
3. Register a new reader w/out subscribing to any newsletter 
4. Observe the reader will be identified as a subscriber for segmentation
5. Switch to this branch, repeat – observe the reader won't be identified as a subscriber 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->