### PR TITLE
feat: simplify overlay max-height

### DIFF
--- a/src/view/style.scss
+++ b/src/view/style.scss
@@ -213,7 +213,12 @@ $width__tablet: 782px;
 		}
 
 		.newspack-popup__content-wrapper {
+			max-height: 80vh;
 			max-width: 100%;
+
+			@media only screen and ( min-width: $width__tablet ) {
+				max-height: calc( 100vh - #{2 * $overlay__gap} );
+			}
 		}
 	}
 
@@ -224,9 +229,6 @@ $width__tablet: 782px;
 				width: $size__x-small;
 			}
 		}
-		.newspack-popup__content-wrapper {
-			max-height: 50vh;
-		}
 	}
 
 	&.newspack-lightbox-size-small {
@@ -236,9 +238,6 @@ $width__tablet: 782px;
 				width: $size__small;
 			}
 		}
-		.newspack-popup__content-wrapper {
-			max-height: 60vh;
-		}
 	}
 
 	&.newspack-lightbox-size-medium {
@@ -247,9 +246,6 @@ $width__tablet: 782px;
 				min-width: $size__medium;
 				width: $size__medium;
 			}
-		}
-		.newspack-popup__content-wrapper {
-			max-height: 80vh;
 		}
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Instead of having different max-height depending on the size of the overlay, this PR standardise it to `80vh` on small screens and `100vh - 32px` on larger screens.

This would avoid potential cases where some content gets cut when screen space is tight.

Pinging @dkoo since you originally implemented this max-height and I'd love your opinion. 

__After:__

![after](https://user-images.githubusercontent.com/177929/187493196-87f6341c-66a8-4cbf-8ef0-e52e197cdc60.png)

__Before:__

![before](https://user-images.githubusercontent.com/177929/187493170-941a2b66-9d2d-4c8c-a26b-16cdd462348a.png)

_Note: Both screenshots are meant to have a featured image at the top. Not quite sure why they're not appearing!_

### How to test the changes in this Pull Request:

1. Add tons of content to an overlay (play with different sizes as well)
2. Check front-end
3. Switch to this branch
4. Check again

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
