### PR TITLE
feat: log reg form info to analytics events

### DIFF
--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -971,7 +971,7 @@ final class Newspack_Popups_Model {
 
 		// If the form contains registration + list info, append that to the event label.
 		if ( $has_register_form ) {
-			$event_label .= __( ' | ${formId} - ${formFields[npe]} - ${formFields[lists[]]}' );
+			$event_label .= __( ' | ${formId} - ${formFields[lists[]]}' );
 		}
 
 		if ( $has_form ) {

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -938,6 +938,7 @@ final class Newspack_Popups_Model {
 		$has_link            = preg_match( '/<a\s/', $body ) !== 0;
 		$newspack_form_class = apply_filters( 'newspack_campaigns_form_class', '.newspack-subscribe-form' );
 		$newspack_form_class = '.' === substr( $newspack_form_class, 0, 1 ) ? substr( $newspack_form_class, 1 ) : $newspack_form_class; // Strip the "." class selector.
+		$has_register_form   = preg_match( '/id="newspack-(register|subscribe)-(.+)"/', $body ) !== 0;
 		$has_form            = preg_match( '/<form\s|mc4wp-form|\[gravityforms\s|' . $newspack_form_class . '/', $body ) !== 0;
 		$has_dismiss_form    = self::is_overlay( $popup );
 
@@ -966,6 +967,11 @@ final class Newspack_Popups_Model {
 				'amp_element' => '#' . esc_attr( $element_id ) . ' a',
 				'event_name'  => __( 'Link Click', 'newspack-popups' ),
 			];
+		}
+
+		// If the form contains registration + list info, append that to the event label.
+		if ( $has_register_form ) {
+			$event_label .= __( ' | ${formId} - ${formFields[npe]} - ${formFields[lists[]]}' );
 		}
 
 		if ( $has_form ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Captures form info to analytics events for forms submitted via prompts. This lets us distinguish between subscribe vs register forms, and tells us whether the reader subscribed to any newsletter lists (and which ones).

### How to test the changes in this Pull Request:

1. Check out this branch, as well as https://github.com/Automattic/newspack-plugin/pull/1953 and https://github.com/Automattic/newspack-newsletters/pull/943
2. Ensure that your site is connected to Google Analytics, and monitor the Realtime events dashboard for incoming events.
3. Publish a prompt containing a registration form.
4. On the front-end, register a new email address and optionally subscribe to one or more newsletter lists.
5. In Google Analytics, look for new events with the event category `Newspack Announcement` and event action `Form Submission`. Confirm that the event label for these events contains not just the prompt info, but also the registration info, in this format:

> Prompt position: Prompt Name (prompt ID) - Segment name | Form ID - signup email - list IDs

6. Publish a prompt containing a subscribe form and repeat steps 4–5.
7. Disable the AMP plugin and repeat steps 4-6.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
