### PR TITLE
style: ensure prompt featured images are always full-width

### DIFF
--- a/src/view/style.scss
+++ b/src/view/style.scss
@@ -96,6 +96,11 @@ $width__tablet: 782px;
 				display: flex;
 				justify-content: center;
 			}
+
+			img {
+				height: auto;
+				width: 100%;
+			}
 		}
 
 		&__content,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Ensures that prompts' featured images are always full-width.

### How to test the changes in this Pull Request:

1. On `master`, publish an overlay prompt with a featured image.
2. On the front-end, observe that the image doesn't quite reach the edges of the container: 

<img width="864" alt="Screen Shot 2022-08-31 at 11 51 25 AM" src="https://user-images.githubusercontent.com/2230142/187746049-d54ca5c1-4fd6-4e0b-9545-69877071cbd6.png">

  - If that didn't work, try a smaller image.
3. Check out this branch, confirm that the image always fills the whole width of the prompt, and is scaled appropriately (no horizontal or vertical distortion).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
