### PR TITLE
feat: allow custom frequencies as long as NEWSPACK_EXPERIMENTAL_READER_ACTIVATION is true

### DIFF
--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -653,7 +653,7 @@ final class Newspack_Popups {
 					)
 				),
 				'preview_query_keys'           => self::PREVIEW_QUERY_KEYS,
-				'experimental'                 => class_exists( '\Newspack\Reader_Activation' ) ? \Newspack\Reader_Activation::is_enabled() : false,
+				'experimental'                 => class_exists( '\Newspack\Reader_Activation' ) ? \Newspack\Reader_Activation::is_enabled( false ) : false,
 			]
 		);
 		\wp_enqueue_style(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Similarly to https://github.com/Automattic/newspack-plugin/pull/1962, allows custom prompt frequencies to be used if the `NEWSPACK_EXPERIMENTAL_READER_ACTIVATION` flag is set, even if Reader Activation isn't enabled in the Newspack dashboard. This will allow us to set up prompts with the proper frequency for beta testing sites without actually enabling RAS features.

### How to test the changes in this Pull Request:

1. Check out this branch and https://github.com/Automattic/newspack-plugin/pull/1962
2. Add `define( 'NEWSPACK_EXPERIMENTAL_READER_ACTIVATION', true );` to `wp-config.php`
3. In Newspack > Engagement > Reader Activation uncheck the "Enable Reader Activation" option and save
4. Create an overlay prompt
5. Confirm that you can still edit custom prompt frequency settings

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
