### PR TITLE
style: fix featured image wrapper style in AMP

### DIFF
--- a/src/view/style.scss
+++ b/src/view/style.scss
@@ -101,6 +101,10 @@ $width__tablet: 782px;
 				height: auto;
 				width: 100%;
 			}
+
+			amp-img.amp-wp-enforced-sizes {
+				object-fit: cover;
+			}
 		}
 
 		&__content,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

#952 fixed styles for prompt featured images to ensure they're always full-bleed, but the solution apparently didn't entirely fix the issue when AMP is active. This PR ensures that AMP images are also always full-width.

### How to test the changes in this Pull Request:

1. With AMP on, on `master` try to replicate the issue described in #952. You may need to try different combinations of featured images and prompt sizes to replicate.
2. Check out this branch and confirm that the issue is fixed with and without AMP on.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
