### PR TITLE
feat: remove wp-dom-ready, medialement dependencies for frontend script

### DIFF
--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -541,7 +541,7 @@ final class Newspack_Popups_Inserter {
 			wp_register_script(
 				'newspack-popups-view',
 				plugins_url( '../dist/view.js', __FILE__ ),
-				[ 'wp-dom-ready', 'wp-url', 'mediaelement-core' ],
+				[ 'wp-url' ],
 				filemtime( dirname( NEWSPACK_POPUPS_PLUGIN_FILE ) . '/dist/view.js' ),
 				true
 			);

--- a/src/view/index.js
+++ b/src/view/index.js
@@ -4,9 +4,26 @@
 import 'whatwg-fetch';
 
 /**
- * WordPress dependencies
+ * Specify a function to execute when the DOM is fully loaded.
+ *
+ * @see https://github.com/WordPress/gutenberg/blob/trunk/packages/dom-ready/
+ *
+ * @param {Function} callback A function to execute after the DOM is ready.
+ * @return {void}
  */
-import domReady from '@wordpress/dom-ready';
+function domReady( callback ) {
+	if ( typeof document === 'undefined' ) {
+		return;
+	}
+	if (
+		document.readyState === 'complete' || // DOMContentLoaded + Images/Styles/etc loaded, so we call directly.
+		document.readyState === 'interactive' // DOMContentLoaded fires at this point, so we call directly.
+	) {
+		return void callback();
+	}
+	// DOMContentLoaded has not fired yet, delay callback until then.
+	document.addEventListener( 'DOMContentLoaded', callback );
+}
 
 /**
  * Internal dependencies


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Removes enqueueing of `wp-dom-ready` and `mediaelement-core` dependencies: the first is replaced by an inline function, second simply removed. 

The `mediaelement-core` dependency was added in #771, but it's not clear how the fix there works. The podcast player block is broken for me with or without the `mediaelement-core` enqueued, so the fix seems not to work anymore. I've found that the podcast player block is also broken 

- whenever Newspack Newsletters' Subscribe block assets are loaded
- on one test site, when Newspack Plugin is active at all

Which makes me think that the code of the podcast player block is too brittle to function property with Newspack. 

### How to test the changes in this Pull Request:

View a page without AMP and confirm the prompts load as expected 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->