### PR TITLE
fix(analytics): only add form info to form submission events

### DIFF
--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -976,7 +976,7 @@ final class Newspack_Popups_Model {
 			$analytics_events[] = [
 				'amp_on'     => 'amp-form-submit',
 				'on'         => 'submit',
-				'element'    => '#' . esc_attr( $element_id ) . ' form:not(.' . self::get_form_class( 'action', $element_id ) . ')', // Not an 'action' (dismissal) form.
+				'element'    => '#' . esc_attr( $element_id ) . ' form:not(.popup-dismiss-form)', // Not a dismissal form.
 				'event_name' => __( 'Form Submission', 'newspack-popups' ),
 			];
 		}
@@ -984,7 +984,7 @@ final class Newspack_Popups_Model {
 			$analytics_events[] = [
 				'amp_on'          => 'amp-form-submit-success',
 				'on'              => 'submit',
-				'element'         => '.' . self::get_form_class( 'dismiss', $element_id ),
+				'element'         => '#' . esc_attr( $element_id ) . ' .popup-dismiss-form',
 				'event_name'      => __( 'Dismissal', 'newspack-popups' ),
 				'non_interaction' => true,
 			];
@@ -992,7 +992,7 @@ final class Newspack_Popups_Model {
 
 		foreach ( $analytics_events as &$event ) {
 			// If a form submission and the form contains registration + list info, append that to the event label.
-			if ( 'submit' === $event['on'] && $has_register_form ) {
+			if ( isset( $event['amp_on'] ) && 'amp-form-submit' === $event['amp_on'] && $has_register_form ) {
 				$event_label .= __( ' | ${formId} - ${formFields[lists[]]}' );
 			}
 

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -972,11 +972,6 @@ final class Newspack_Popups_Model {
 			];
 		}
 
-		// If the form contains registration + list info, append that to the event label.
-		if ( $has_register_form ) {
-			$event_label .= __( ' | ${formId} - ${formFields[lists[]]}' );
-		}
-
 		if ( $has_form ) {
 			$analytics_events[] = [
 				'amp_on'     => 'amp-form-submit',
@@ -996,6 +991,11 @@ final class Newspack_Popups_Model {
 		}
 
 		foreach ( $analytics_events as &$event ) {
+			// If a form submission and the form contains registration + list info, append that to the event label.
+			if ( 'submit' === $event['on'] && $has_register_form ) {
+				$event_label .= __( ' | ${formId} - ${formFields[lists[]]}' );
+			}
+
 			$event['id']             = self::get_uniqid();
 			$event['event_category'] = esc_attr( $event_category );
 			$event['event_label']    = esc_attr( $event_label );

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -942,6 +942,7 @@ final class Newspack_Popups_Model {
 		$newspack_form_class = apply_filters( 'newspack_campaigns_form_class', '.newspack-subscribe-form' );
 		$newspack_form_class = '.' === substr( $newspack_form_class, 0, 1 ) ? substr( $newspack_form_class, 1 ) : $newspack_form_class; // Strip the "." class selector.
 		$has_register_form   = preg_match( '/id="newspack-(register|subscribe)-(.+)"/', $body ) !== 0;
+		$has_lists_field     = preg_match( '/name="lists\[\]"/', $body ) !== 0;
 		$has_form            = preg_match( '/<form\s|mc4wp-form|\[gravityforms\s|' . $newspack_form_class . '/', $body ) !== 0;
 		$has_dismiss_form    = self::is_overlay( $popup );
 
@@ -993,7 +994,12 @@ final class Newspack_Popups_Model {
 		foreach ( $analytics_events as &$event ) {
 			// If a form submission and the form contains registration + list info, append that to the event label.
 			if ( isset( $event['amp_on'] ) && 'amp-form-submit' === $event['amp_on'] && $has_register_form ) {
-				$event_label .= __( ' | ${formId} - ${formFields[lists[]]}' );
+				$event_label .= ' | ${formId}';
+
+				// If the reg form has a lists[] field, append the value to the event label.
+				if ( $has_lists_field ) {
+					$event_label .= ' - ${formFields[lists[]]}';
+				}
 			}
 
 			$event['id']             = self::get_uniqid();

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -930,7 +930,7 @@ final class Newspack_Popups_Model {
 		);
 		$event_category      = __( 'Newspack Announcement', 'newspack-popups' );
 		$formatted_placement = ucwords( str_replace( '_', ' ', $popup['options']['placement'] ) );
-		$event_label         = sprintf(
+		$default_event_label = sprintf(
 			// Translators: Analytics label with prompt details (placement, title, ID, targeted segments).
 			__( '%1$s: %2$s (%3$s) - %4$s', 'newspack-popups' ),
 			$formatted_placement,
@@ -992,6 +992,8 @@ final class Newspack_Popups_Model {
 		}
 
 		foreach ( $analytics_events as &$event ) {
+			$event_label = $default_event_label;
+
 			// If a form submission and the form contains registration + list info, append that to the event label.
 			if ( isset( $event['amp_on'] ) && 'amp-form-submit' === $event['amp_on'] && $has_register_form ) {
 				$event_label .= ' | ${formId}';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

#951 added form info (form and list IDs) to analytics events that occur from inside a prompt. However, the placeholders for this info were added to _all_ events that are triggered by the prompt, even events that don't have anything to do with the form. This results in unprocessed placeholders being sent to GA. This PR only adds the form info to form submission events.

### How to test the changes in this Pull Request:

1. On `master`, on a site connected to Google Analytics, publish a prompt containing a registration or subscribe block.
2. On the front-end view the prompt and submit it.
3. On the Analytics side, in the Realtime Events report, observe that the `Form Submission` event has an Event Label with properly processed placeholders (e.g. `Prompt position: Prompt Name (prompt ID) - Segment name | Form ID - list IDs`), but that the `Seen` and `Load` events do not—they might appear with placeholders intact, like ``Prompt position: Prompt Name (prompt ID) - Segment name | ${formId} - ${formFields[lists[]]}`.
4. Check out this branch and repeat steps 2-3. Confirm that the `Form Submission` event still has the form ID and field IDs in the Event Label, but that all other events related to the prompt do not.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
