### PR TITLE
fix: fallback to AMP script polyfills if AMP scripts are blocked

### DIFF
--- a/src/view/utils/index.js
+++ b/src/view/utils/index.js
@@ -161,7 +161,10 @@ export const waitUntil = ( condition, callback, maxTries = 10 ) => {
 /**
  * If an AMP module was loaded, e.g. via another plugin or a custom header script, it should not be polyfilled.
  */
-export const shouldPolyfillAMPModule = name => undefined === customElements.get( `amp-${ name }` );
+export const shouldPolyfillAMPModule = name =>
+	undefined === customElements.get( `amp-${ name }` ) ||
+	( ! window.__AMP_SERVICES?.hasOwnProperty( `amp-${ name }` ) &&
+		! window.__AMP_SERVICES?.hasOwnProperty( name ) );
 
 export const parseOnHandlers = onAttributeValue =>
 	onAttributeValue


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

We've gotten a growing number of reports that prompts are being displayed more often than they should be. Most of these reports can likely be attributed to the AMP Analytics script being blocked by any means (browser extensions such as uBlock Origin or Ghostery, strict security settings, firewalls, etc.)—because we rely on AMP Analytics' visibility triggers to report `prompt_seen` events, if this script is blocked, the plugin will always assume that each prompt view is the reader's first. This only affects sites that are running on AMP or AMP Plus, as we have polyfills to handle the reporting for non-AMP.

This PR attempts to mitigate the issue by enqueuing the polyfill scripts in both non-AMP and AMP Plus settings, and falling back to the polyfills if the AMP scripts fail to load for any reason. This doesn't address the issue on non-AMP Plus sites because the polyfills rely on JS APIs that are not supported in `amp-script`'s [limited version of JS](https://amp.dev/documentation/components/amp-script/#supported-apis). But as most Newspack sites are moving toward AMP Plus or non-AMP, this should become less of an issue over time, and eventually when AMP is deprecated entirely, the current polyfill JS will become the de facto standard for all Newspack sites.

Closes #939 for non-AMP and AMP Plus sites.

### How to test the changes in this Pull Request:

1. Install uBlock Origin and/or Ghostery on your browser. Publish one or more prompts.
2. Enable AMP Plus with the `define( 'NEWSPACK_AMP_PLUS_ENABLED', true );` environmenet constant.
3. On `master`, view the prompts on the front-end. Observe that:
  a. In Dev Tools > Network, the `amp-analytics` script is blocked from loading.
  b. No `prompt_seen` events are logged to the `wp_newspack_campaigns_reader_events` table. (Note: if testing on a site with persistent caching enabled, change the value on [this line](https://github.com/Automattic/newspack-popups/blob/master/api/classes/class-lightweight-api.php#L39) to `true` in order to log events to the DB immediately, otherwise you'll have to wait ~15 minutes before the events move from the cache to the DB).
4. Check out this branch, repeat step 3, and confirm that even though the `amp-analytics` is still blocked, `prompt_seen` events are logged when the prompts are displayed in the viewport.
5. Turn off AMP and repeat step 4.
6. Turn off the browser extension blocking `amp-analytics` and repeat step 4, and confirm that only one `prompt_seen` event is logged per prompt view.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
