### PR TITLE
feat: improved frequency options no longer experimental; clearer UI (v2)

### DIFF
--- a/api/campaigns/class-maybe-show-campaign.php
+++ b/api/campaigns/class-maybe-show-campaign.php
@@ -324,12 +324,6 @@ class Maybe_Show_Campaign extends Lightweight_API {
 			$frequency_between = 0;
 			$frequency_reset   = 'month';
 		}
-		if ( 'preset_1' === $frequency ) {
-			$frequency_max     = 0;
-			$frequency_start   = 0;
-			$frequency_between = 3;
-			$frequency_reset   = 'day';
-		}
 
 		if ( false === $now ) {
 			$now = time();

--- a/api/campaigns/class-maybe-show-campaign.php
+++ b/api/campaigns/class-maybe-show-campaign.php
@@ -325,10 +325,10 @@ class Maybe_Show_Campaign extends Lightweight_API {
 			$frequency_reset   = 'month';
 		}
 		if ( 'preset_1' === $frequency ) {
-			$frequency_max     = 5;
-			$frequency_start   = 3;
+			$frequency_max     = 0;
+			$frequency_start   = 0;
 			$frequency_between = 3;
-			$frequency_reset   = 'month';
+			$frequency_reset   = 'day';
 		}
 
 		if ( false === $now ) {

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -121,7 +121,7 @@ final class Newspack_Popups_Model {
 		foreach ( $options as $key => $value ) {
 			switch ( $key ) {
 				case 'frequency':
-					if ( ! in_array( $value, [ 'once', 'daily', 'always', 'preset_1', 'custom' ] ) ) {
+					if ( ! in_array( $value, [ 'once', 'daily', 'always', 'custom' ] ) ) {
 						return new \WP_Error(
 							'newspack_popups_invalid_option_value',
 							esc_html__( 'Invalid frequency value.', 'newspack-popups' ),

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -653,7 +653,6 @@ final class Newspack_Popups {
 					)
 				),
 				'preview_query_keys'           => self::PREVIEW_QUERY_KEYS,
-				'experimental'                 => class_exists( '\Newspack\Reader_Activation' ) ? \Newspack\Reader_Activation::is_enabled( false ) : false,
 			]
 		);
 		\wp_enqueue_style(

--- a/src/editor/FrequencySidebar.js
+++ b/src/editor/FrequencySidebar.js
@@ -10,6 +10,7 @@ import { Fragment } from '@wordpress/element';
 import {
 	SelectControl,
 	TextControl,
+	ToggleControl,
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 	__experimentalNumberControl as NumberControl,
 } from '@wordpress/components';
@@ -19,31 +20,15 @@ const frequencyOptions = [
 	{ value: 'weekly', label: __( 'Once a week', 'newspack-popups' ) },
 	{ value: 'daily', label: __( 'Once a day', 'newspack-popups' ) },
 	{
-		value: 'preset_1',
-		label: __( 'Every 4th pageview, up to 5x per month', 'newspack-popups' ),
-	},
-	{
 		value: 'always',
 		label: __( 'Every pageview', 'newspack-popups' ),
 	},
+	{
+		value: 'preset_1',
+		label: __( 'Every 4 pageviews', 'newspack-popups' ),
+	},
 	{ value: 'custom', label: __( 'Custom', 'newspack-popups' ) },
 ];
-
-const getFrequencyOptions = isOverlay => {
-	const { experimental } = window.newspack_popups_data;
-	const experimentalKeys = [ 'weekly', 'preset_1', 'custom' ];
-
-	if ( experimental ) {
-		return frequencyOptions;
-	}
-
-	return frequencyOptions
-		.filter( item => 0 > experimentalKeys.indexOf( item.value ) )
-		.map( item => {
-			item.disabled = 'always' === item.value && isOverlay;
-			return item;
-		} );
-};
 
 const FrequencySidebar = ( {
 	frequency,
@@ -51,7 +36,6 @@ const FrequencySidebar = ( {
 	frequency_start,
 	frequency_between,
 	frequency_reset,
-	isOverlay,
 	onMetaFieldChange,
 	utm_suppression,
 } ) => {
@@ -94,38 +78,47 @@ const FrequencySidebar = ( {
 					}
 
 					if ( 'preset_1' === value ) {
-						metaToUpdate.frequency_max = 5;
-						metaToUpdate.frequency_start = 3;
+						metaToUpdate.frequency_max = 0;
+						metaToUpdate.frequency_start = 0;
 						metaToUpdate.frequency_between = 3;
-						metaToUpdate.frequency_reset = 'month';
+						metaToUpdate.frequency_reset = 'day';
 					}
 
 					onMetaFieldChange( metaToUpdate );
 				} }
-				options={ getFrequencyOptions( isOverlay ) }
+				options={ frequencyOptions }
 			/>
 			{ 'custom' === frequency && (
 				<>
-					<NumberControl
-						className="newspack-popups__frequency-number-control"
-						label={ __( 'Max number of displays', 'newspack-popups' ) }
-						value={ frequency_max }
-						min={ 0 }
-						onChange={ value => onMetaFieldChange( { frequency_max: value } ) }
+					<ToggleControl
+						className="newspack-popups__frequency-toggle-control"
+						label={ __( 'Limit number of displays', 'newspack-popups' ) }
+						checked={ 0 < frequency_max }
+						onChange={ value => onMetaFieldChange( { frequency_max: value ? 1 : 0 } ) }
 					/>
+					{ 0 < frequency_max && (
+						<NumberControl
+							className="newspack-popups__frequency-number-control"
+							disabled={ 0 === frequency_max }
+							label={ __( 'Max number of displays', 'newspack-popups' ) }
+							value={ frequency_max }
+							min={ 0 }
+							onChange={ value => onMetaFieldChange( { frequency_max: value } ) }
+						/>
+					) }
 					<NumberControl
 						className="newspack-popups__frequency-number-control"
-						label={ __( 'Start after pageview', 'newspack-popups' ) }
-						value={ frequency_start }
-						min={ 0 }
-						onChange={ value => onMetaFieldChange( { frequency_start: value } ) }
+						label={ __( 'Start at pageview', 'newspack-popups' ) }
+						value={ frequency_start + 1 }
+						min={ 1 }
+						onChange={ value => onMetaFieldChange( { frequency_start: value - 1 } ) }
 					/>
 					<NumberControl
 						className="newspack-popups__frequency-number-control"
 						label={ __( 'Pageviews between displays', 'newspack-popups' ) }
-						value={ frequency_between }
-						min={ 0 }
-						onChange={ value => onMetaFieldChange( { frequency_between: value } ) }
+						value={ frequency_between + 1 }
+						min={ 1 }
+						onChange={ value => onMetaFieldChange( { frequency_between: value - 1 } ) }
 					/>
 					<SelectControl
 						label={ __( 'Reset counter per:', 'newspack-popups' ) }

--- a/src/editor/FrequencySidebar.js
+++ b/src/editor/FrequencySidebar.js
@@ -23,10 +23,6 @@ const frequencyOptions = [
 		value: 'always',
 		label: __( 'Every pageview', 'newspack-popups' ),
 	},
-	{
-		value: 'preset_1',
-		label: __( 'Every 4 pageviews', 'newspack-popups' ),
-	},
 	{ value: 'custom', label: __( 'Custom', 'newspack-popups' ) },
 ];
 

--- a/src/editor/FrequencySidebar.js
+++ b/src/editor/FrequencySidebar.js
@@ -73,13 +73,6 @@ const FrequencySidebar = ( {
 						metaToUpdate.frequency_reset = 'month';
 					}
 
-					if ( 'preset_1' === value ) {
-						metaToUpdate.frequency_max = 0;
-						metaToUpdate.frequency_start = 0;
-						metaToUpdate.frequency_between = 3;
-						metaToUpdate.frequency_reset = 'day';
-					}
-
 					onMetaFieldChange( metaToUpdate );
 				} }
 				options={ frequencyOptions }

--- a/src/editor/FrequencySidebar.js
+++ b/src/editor/FrequencySidebar.js
@@ -79,6 +79,20 @@ const FrequencySidebar = ( {
 			/>
 			{ 'custom' === frequency && (
 				<>
+					<NumberControl
+						className="newspack-popups__frequency-number-control"
+						label={ __( 'Start at pageview', 'newspack-popups' ) }
+						value={ frequency_start + 1 }
+						min={ 1 }
+						onChange={ value => onMetaFieldChange( { frequency_start: value - 1 } ) }
+					/>
+					<NumberControl
+						className="newspack-popups__frequency-number-control"
+						label={ __( 'Display every n pageviews', 'newspack-popups' ) }
+						value={ frequency_between + 1 }
+						min={ 1 }
+						onChange={ value => onMetaFieldChange( { frequency_between: value - 1 } ) }
+					/>
 					<ToggleControl
 						className="newspack-popups__frequency-toggle-control"
 						label={ __( 'Limit number of displays', 'newspack-popups' ) }
@@ -95,20 +109,6 @@ const FrequencySidebar = ( {
 							onChange={ value => onMetaFieldChange( { frequency_max: value } ) }
 						/>
 					) }
-					<NumberControl
-						className="newspack-popups__frequency-number-control"
-						label={ __( 'Start at pageview', 'newspack-popups' ) }
-						value={ frequency_start + 1 }
-						min={ 1 }
-						onChange={ value => onMetaFieldChange( { frequency_start: value - 1 } ) }
-					/>
-					<NumberControl
-						className="newspack-popups__frequency-number-control"
-						label={ __( 'Display every n pageviews', 'newspack-popups' ) }
-						value={ frequency_between + 1 }
-						min={ 1 }
-						onChange={ value => onMetaFieldChange( { frequency_between: value - 1 } ) }
-					/>
 					<SelectControl
 						label={ __( 'Reset counter per:', 'newspack-popups' ) }
 						value={ frequency_reset }

--- a/src/editor/FrequencySidebar.js
+++ b/src/editor/FrequencySidebar.js
@@ -111,7 +111,7 @@ const FrequencySidebar = ( {
 					/>
 					<NumberControl
 						className="newspack-popups__frequency-number-control"
-						label={ __( 'Pageviews between displays', 'newspack-popups' ) }
+						label={ __( 'Display every n pageviews', 'newspack-popups' ) }
 						value={ frequency_between + 1 }
 						min={ 1 }
 						onChange={ value => onMetaFieldChange( { frequency_between: value - 1 } ) }

--- a/src/editor/style.scss
+++ b/src/editor/style.scss
@@ -66,6 +66,10 @@ $size__large: 1264px;
 		}
 	}
 
+	&__frequency-toggle-control.components-toggle-control {
+		margin-top: 16px;
+	}
+
 	&__frequency-number-control.components-number-control {
 		align-items: center;
 		display: flex;


### PR DESCRIPTION
Reopening #963 which was closed due to a conflict with an ongoing `release` build.

### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Moves the improved frequency options out from behind the `NEWSPACK_EXPERIMENTAL_READER_ACTIVATION` flag, replaces the preset with the one we actually went with for RAS sites, and makes the UI for custom frequency options a little bit more human-readable.

### How to test the changes in this Pull Request:

1. Check out this branch and https://github.com/Automattic/newspack-plugin/pull/2000.
2. Turn off the `NEWSPACK_EXPERIMENTAL_READER_ACTIVATION` flag in wp-config.
3. Create a new overlay prompt. In the Frequency Settings sidebar, confirm that you can select "every pageview" and "custom" options.
4. For "custom" options, confirm that there's a new toggle to enable or disable max displays. Disabling it forces the `frequency_max` meta value to `0`, or no limit, while enabling it forces the value to `1` and reveals a number control to change it.
5. Confirm that the "Start at pageview" and "Pageviews between displays" options are now no longer zero-indexed. These settings still work the same on the backend, but we simply add `1` to the value in the UI display so it's more human-readable. "Start at pageview 1" means the prompt will be displayed on the first pageview of a session (index `0`) and "Pageviews between displays 2" means the prompt will be displayed every other pageview.
6. Test the custom settings on the front-end and confirm that they work as expected.
7. Also test the new preset option "Every 4 pageviews" and confirm that it displays on the first pageview of a session, then every fourth pageview thereafter with no limit.
8. Also test the UI in the Campaigns wizard, single prompt card. The frequency options should match the ones in the single prompt editor sidebar:

<img width="362" alt="Screen Shot 2022-09-14 at 3 07 27 PM" src="https://user-images.githubusercontent.com/2230142/190262672-4e4a6b70-4d03-4d39-957b-82f8ac90e8f8.png">

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
