### PR TITLE
fix: lower visibility threshold for prompt_seen events

### DIFF
--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -834,9 +834,9 @@ final class Newspack_Popups_Model {
 					'request'        => 'event',
 					'visibilitySpec' => [
 						'selector'             => '#' . esc_attr( $element_id ),
-						'visiblePercentageMin' => 90,
-						'totalTimeMin'         => 500,
-						'continuousTimeMin'    => 200,
+						'visiblePercentageMin' => 50,
+						'totalTimeMin'         => 250,
+						'continuousTimeMin'    => 100,
 					],
 					'extraUrlParams' => [
 						'popup_id' => esc_attr( self::canonize_popup_id( $popup['id'] ) ),

--- a/src/view/analytics.js
+++ b/src/view/analytics.js
@@ -101,7 +101,7 @@ export const manageAnalyticsEvents = () => {
 						// The threshold should be the value of the visibilitySpec's visiblePercentageMin,
 						// but that would require a separate IntersectionObserver for each trigger.
 						// Since it's value the same for every popup, it can be hardcoded.
-						threshold: 0.9,
+						threshold: 0.5,
 					}
 				);
 			}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Lowers the threshold for a prompt being "visible" for purposes of logging `prompt_seen` events. Some people have really fast trigger fingers when it comes to closing modals!

* Before: At least 90% of a prompt element had to be visible within the viewport for at least half a second before it's considered seen.
* Proposed: At least 50% of a prompt element has to be visible within the viewport for at least a quarter of a second before it's considered seen.

### How to test the changes in this Pull Request:

Kind of hard to test, but may be easier with an inline prompt. Try to scroll it into view slowly, and note when the `POST` request to `newspack-popups/api/campaigns/index.php` happens—with this patch, it should happen more quickly than on `master`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
