### PR TITLE
feat: treat logged-in admins and editors as preview sessions

### DIFF
--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -704,7 +704,7 @@ final class Newspack_Popups_Inserter {
 
 		$popups_access_provider = [
 			'namespace'     => 'popups',
-			'authorization' => esc_url( Newspack_Popups_Model::get_reader_endpoint() ) . '?cid=CLIENT_ID(' . Newspack_Popups_Segmentation::NEWSPACK_SEGMENTATION_CID_NAME . ')',
+			'authorization' => esc_url( Newspack_Popups_Model::get_reader_endpoint() ) . '?cid=' . Newspack_Popups_Segmentation::get_cid_param(),
 			'noPingback'    => true,
 		];
 
@@ -811,7 +811,7 @@ final class Newspack_Popups_Inserter {
 		$popups_access_provider['authorization'] .= '&visit=' . wp_json_encode( $visit );
 
 		// Handle user accounts.
-		$user_id = get_current_user_id();
+		$user_id = Newspack_Popups::is_user_admin() ? 0 : get_current_user_id();
 		if ( ! empty( $user_id ) ) {
 			$popups_access_provider['authorization'] .= '&uid=' . absint( $user_id );
 		}

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -843,7 +843,7 @@ final class Newspack_Popups_Model {
 					],
 					'extraUrlParams' => [
 						'popup_id' => esc_attr( self::canonize_popup_id( $popup['id'] ) ),
-						'cid'      => 'CLIENT_ID(' . esc_attr( Newspack_Popups_Segmentation::NEWSPACK_SEGMENTATION_CID_NAME ) . ')',
+						'cid'      => Newspack_Popups_Segmentation::get_cid_param(),
 					],
 				],
 			],
@@ -851,7 +851,7 @@ final class Newspack_Popups_Model {
 		if ( $subscribe_form_selector && $email_form_field_name ) {
 			$extra_params = [
 				'popup_id'            => esc_attr( self::canonize_popup_id( $popup['id'] ) ),
-				'cid'                 => 'CLIENT_ID(' . esc_attr( Newspack_Popups_Segmentation::NEWSPACK_SEGMENTATION_CID_NAME ) . ')',
+				'cid'                 => Newspack_Popups_Segmentation::get_cid_param(),
 				'mailing_list_status' => 'subscribed',
 				'email'               => '${formFields[' . esc_attr( $email_form_field_name ) . ']}',
 			];
@@ -1348,7 +1348,7 @@ final class Newspack_Popups_Model {
 		<input
 			name="cid"
 			type="hidden"
-			value="CLIENT_ID(<?php echo esc_attr( Newspack_Popups_Segmentation::NEWSPACK_SEGMENTATION_CID_NAME ); ?>)"
+			value="<?php echo esc_attr( Newspack_Popups_Segmentation::get_cid_param() ); ?>"
 			data-amp-replace="CLIENT_ID"
 		/>
 		<input

--- a/includes/class-newspack-popups-segmentation.php
+++ b/includes/class-newspack-popups-segmentation.php
@@ -177,7 +177,7 @@ final class Newspack_Popups_Segmentation {
 
 		$remote_config_url = add_query_arg(
 			[
-				'client_id'                         => 'CLIENT_ID(' . esc_attr( self::NEWSPACK_SEGMENTATION_CID_NAME ) . ')',
+				'client_id'                         => self::get_cid_param(),
 				'post_id'                           => esc_attr( get_the_ID() ),
 				'custom_dimensions'                 => wp_json_encode( $custom_dimensions ),
 				'custom_dimensions_existing_values' => wp_json_encode( $custom_dimensions_existing_values ),
@@ -223,7 +223,7 @@ final class Newspack_Popups_Segmentation {
 				'enabled' => true,
 				self::NEWSPACK_SEGMENTATION_CID_LINKER_PARAM => [
 					'ids' => [
-						$linker_id => 'CLIENT_ID(' . self::NEWSPACK_SEGMENTATION_CID_NAME . ')',
+						$linker_id => self::get_cid_param(),
 					],
 				],
 			],
@@ -265,7 +265,7 @@ final class Newspack_Popups_Segmentation {
 				'extraUrlParams' => array_merge(
 					$initial_client_report_url_params,
 					[
-						'client_id' => 'CLIENT_ID(' . esc_attr( self::NEWSPACK_SEGMENTATION_CID_NAME ) . ')',
+						'client_id' => self::get_cid_param(),
 					]
 				),
 			];
@@ -474,9 +474,33 @@ final class Newspack_Popups_Segmentation {
 	}
 
 	/**
+	 * Mock a preview CID for logged-in admin and editor users.
+	 *
+	 * @return string Preview client ID.
+	 */
+	private static function get_preview_user_cid() {
+		return 'preview-user-' . \get_current_user_id();
+	}
+
+	/**
+	 * Get the client ID placeholder used in AMP Access requests.
+	 */
+	public static function get_cid_param() {
+		if ( Newspack_Popups::is_user_admin() ) {
+			return self::get_preview_user_cid();
+		}
+
+		return 'CLIENT_ID(' . esc_attr( self::NEWSPACK_SEGMENTATION_CID_NAME ) . ')';
+	}
+
+	/**
 	 * Get current client's id.
 	 */
 	public static function get_client_id() {
+		if ( Newspack_Popups::is_user_admin() ) {
+			return self::get_preview_user_cid();
+		}
+
 		return isset( $_COOKIE[ self::NEWSPACK_SEGMENTATION_CID_NAME ] ) ? esc_attr( $_COOKIE[ self::NEWSPACK_SEGMENTATION_CID_NAME ] ) : false; // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 	}
 

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -739,7 +739,7 @@ final class Newspack_Popups {
 		$is_customizer_preview = is_customize_preview();
 		// Used by the Newspack Plugin's Campaigns Wizard.
 		$is_view_as_preview = false != Newspack_Popups_View_As::viewing_as_spec();
-		return ! empty( self::previewed_popup_id() ) || $is_view_as_preview || $is_customizer_preview;
+		return ! empty( self::previewed_popup_id() ) || $is_view_as_preview || $is_customizer_preview || self::is_user_admin();
 	}
 
 	/**

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -739,7 +739,7 @@ final class Newspack_Popups {
 		$is_customizer_preview = is_customize_preview();
 		// Used by the Newspack Plugin's Campaigns Wizard.
 		$is_view_as_preview = false != Newspack_Popups_View_As::viewing_as_spec();
-		return ! empty( self::previewed_popup_id() ) || $is_view_as_preview || $is_customizer_preview || self::is_user_admin();
+		return ! empty( self::previewed_popup_id() ) || $is_view_as_preview || $is_customizer_preview;
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Currently, logged-in admins and editor users are treated the same as readers for segmentation purposes. That is, their browsing activity and logged-in state determine which segments they match and which prompts they see when browsing the site front-end. However, admins and editors often exhibit very different browsing behavior compared to real readers, so the prompts they see while browsing can feel unexpected or incongruous.

This PR proposes that logged-in admins and editors should be treated as preview users. That is, when browsing the site, their client IDs are mocked with a `preview-` prefix, and their logged-in status is forced to not logged in for purposes of showing prompts and RAS login states. Their browsing activity (post views, term views, prompt interactions, donations, subscriptions, etc.) will be purged hourly, just like in preview sessions started from the Campaigns wizard. For RAS purposes, they will be segmented as non-registered, non-subscribers and non-donors, and will see RAS registration prompts in a pre-logged-in state (however, if they try to register or log in using the RAS UI, they will get an error message). This does mean that logged-in admins and editors will never be segmented as registered users, but this should still hopefully make the prompts shown a bit less alarming and easier to comprehend.

### How to test the changes in this Pull Request:

1. Log into a site as an admin user.
2. Browse the site front-end while logged in. Confirm that you see prompts that a "new" unknown reader would see, but that otherwise your browsing activity will change your segmentation as expected (with the exception of registering—see note above about forcing the non-logged-in state for these users).
3. Come back to the session after at least one hour and confirm that your segmentation status has been "reset" due to your admin session data being purged along with other preview data.
4. Do a smoke test of segmentation and RAS functionality in an incognito session to ensure that behavior is unchanged for non-admin users.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
