### PR TITLE
fix: handle purged cache

### DIFF
--- a/api/campaigns/class-maybe-show-campaign.php
+++ b/api/campaigns/class-maybe-show-campaign.php
@@ -87,7 +87,10 @@ class Maybe_Show_Campaign extends Lightweight_API {
 
 		if ( $settings ) {
 			$settings->best_priority_segment_id = $this->get_best_priority_segment_id( $all_segments, $client_id, $referer_url, $page_referer_url, $view_as_spec );
-			$this->debug['matching_segment']    = $settings->best_priority_segment_id;
+
+			if ( $this->is_debug_enabled() ) {
+				$this->debug['matching_segment'] = $settings->best_priority_segment_id;
+			}
 		}
 
 		// Check each matching popup against other global factors.
@@ -214,10 +217,12 @@ class Maybe_Show_Campaign extends Lightweight_API {
 	 * @param string $reason The reason.
 	 */
 	private function add_suppression_reason( $id, $reason ) {
-		if ( isset( $this->debug['suppression'][ $id ] ) ) {
-			$this->debug['suppression'][ $id ][] = $reason;
+		if ( $this->is_debug_enabled() ) {
+			if ( isset( $this->debug['suppression'][ $id ] ) ) {
+				$this->debug['suppression'][ $id ][] = $reason;
+			}
+			$this->debug['suppression'][ $id ] = [ $reason ];
 		}
-		$this->debug['suppression'][ $id ] = [ $reason ];
 	}
 
 	/**

--- a/api/campaigns/class-maybe-show-campaign.php
+++ b/api/campaigns/class-maybe-show-campaign.php
@@ -163,6 +163,10 @@ class Maybe_Show_Campaign extends Lightweight_API {
 			$response[ $popup->id ] = $popup_should_be_shown;
 		}
 
+		if ( ! $this->ignore_cache ) {
+			wp_cache_set( 'reader_cache_version', $this->reader_cache_version, $client_id );
+		}
+
 		$this->response = $response;
 		$this->respond();
 	}

--- a/api/classes/class-lightweight-api.php
+++ b/api/classes/class-lightweight-api.php
@@ -891,11 +891,6 @@ class Lightweight_API {
 			array_filter(
 				$events_from_db,
 				function( $event ) use ( $existing_event_ids ) {
-					// If the event is coming from the persistent cache, fashion a faux-unique ID using the timestamp.
-					if ( ! isset( $event['id'] ) ) {
-						$event['id'] = $event['type'] . '_' . $event['context'] . '_' . $event['date_created'];
-					}
-
 					// Dedupe events from cache.
 					if ( in_array( $event['id'], $existing_event_ids, true ) ) {
 						return false;
@@ -1028,6 +1023,16 @@ class Lightweight_API {
 			// Rebuild cache.
 			$cached_events = $this->get_reader_events_from_cache( $client_id );
 			$all_events    = array_merge( $cached_events, $events );
+			$all_events    = array_map(
+				function( $event ) {
+					// If the event is coming from the persistent cache, fashion a faux-unique ID using the timestamp.
+					if ( ! isset( $event['id'] ) ) {
+						$event['id'] = $event['type'] . '_' . $event['context'] . '_' . $event['date_created'];
+					}
+					return $event;
+				},
+				$all_events
+			);
 
 			// Set a cache version for future validation.
 			wp_cache_set( 'reader_cache_version', $this->reader_cache_version, $client_id );

--- a/api/classes/class-lightweight-api.php
+++ b/api/classes/class-lightweight-api.php
@@ -18,6 +18,13 @@ use \DrewM\MailChimp\MailChimp;
  */
 class Lightweight_API {
 	/**
+	 * Cache version so we can force a cache rebuild for reader data.
+	 *
+	 * @var reader_cache_version
+	 */
+	private $reader_cache_version = '1.0';
+
+	/**
 	 * Response object.
 	 *
 	 * @var response
@@ -77,23 +84,35 @@ class Lightweight_API {
 		if ( ! $this->verify_referer( $nonce ) ) {
 			$this->error( 'invalid_referer' );
 		}
-		$this->debug = [
-			'read_query_count'   => 0,
-			'write_query_count'  => 0,
-			'delete_query_count' => 0,
-			'cache_count'        => 0,
-			'start_time'         => microtime( true ),
-			'end_time'           => null,
-			'duration'           => null,
-			'suppression'        => [],
-			'reader'             => null,
-			'reader_events'      => [],
-		];
+		if ( $this->is_debug_enabled() ) {
+			$this->debug = [
+				'read_query_count'   => 0,
+				'write_query_count'  => 0,
+				'delete_query_count' => 0,
+				'cache_count'        => 0,
+				'start_time'         => microtime( true ),
+				'end_time'           => null,
+				'duration'           => null,
+				'suppression'        => [],
+				'reader'             => null,
+				'reader_events'      => [],
+				'cache_is_valid'     => false,
+			];
+		}
 
 		// If we don't have a persistent object cache, we can't rely on it across page views.
 		if ( ! file_exists( WP_CONTENT_DIR . '/object-cache.php' ) || ( defined( 'IS_TEST_ENV' ) && IS_TEST_ENV ) ) {
 			$this->ignore_cache = true;
 		}
+	}
+
+	/**
+	 * Whether debug mode is enabled via newspack-popups-config.php or URL param.
+	 *
+	 * @return boolean
+	 */
+	public function is_debug_enabled() {
+		return isset( $_REQUEST['debug'] ) || ( defined( 'NEWSPACK_POPUPS_DEBUG' ) && NEWSPACK_POPUPS_DEBUG ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 	}
 
 	/**
@@ -156,9 +175,9 @@ class Lightweight_API {
 		if ( defined( 'IS_TEST_ENV' ) && IS_TEST_ENV ) {
 			return;
 		}
-		$this->debug['end_time'] = microtime( true );
-		$this->debug['duration'] = $this->debug['end_time'] - $this->debug['start_time'];
-		if ( isset( $_REQUEST['debug'] ) || ( defined( 'NEWSPACK_POPUPS_DEBUG' ) && NEWSPACK_POPUPS_DEBUG ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( $this->is_debug_enabled() ) {
+			$this->debug['end_time'] = microtime( true );
+			$this->debug['duration'] = $this->debug['end_time'] - $this->debug['start_time'];
 			$this->response['debug'] = $this->debug;
 		}
 		header( 'Access-Control-Allow-Origin: https://' . parse_url( $_SERVER['HTTP_REFERER'] )['host'], false ); // phpcs:ignore
@@ -201,7 +220,9 @@ class Lightweight_API {
 			return null;
 		}
 
-		$this->debug['read_query_count'] += 1;
+		if ( $this->is_debug_enabled() ) {
+			$this->debug['read_query_count'] += 1;
+		}
 
 		$value = $wpdb->get_var( $wpdb->prepare( "SELECT option_value FROM `$table_name` WHERE option_name = %s LIMIT 1", $name ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 
@@ -224,7 +245,9 @@ class Lightweight_API {
 			[ 'option_name' => $name ]
 		);
 
-		$this->debug['delete_query_count'] += 1;
+		if ( $this->is_debug_enabled() ) {
+			$this->debug['delete_query_count'] += 1;
+		}
 	}
 
 	/**
@@ -259,13 +282,87 @@ class Lightweight_API {
 		// Write to the DB.
 		$write_result = $wpdb->query( $query ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
 
-		$this->debug['write_query_count'] += 1;
+		if ( $this->is_debug_enabled() ) {
+			$this->debug['write_query_count'] += 1;
 
-		if ( ! $write_result ) {
-			$this->debug['write_error'] = "Error writing to $reader_events_table_name.";
+			if ( ! $write_result ) {
+				$this->debug['write_error'] = "Error writing to $reader_events_table_name.";
+			}
 		}
 
 		return $write_result;
+	}
+
+	/**
+	 * Parse event logs to the DB.
+	 */
+	public function parse_event_logs() {
+
+		global $wpdb;
+
+		if ( ! file_exists( Segmentation::get_log_file_path() ) ) {
+			return;
+		}
+
+		$log_file = fopen( Segmentation::get_log_file_path(), 'r+' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_fopen
+
+		if ( flock( $log_file, LOCK_EX ) ) { // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_flock
+			$lines = [];
+
+			while ( ! feof( $log_file ) ) {
+				$line = trim( fgets( $log_file ) );
+				if ( ! empty( $line ) ) {
+					$lines[] = $line;
+				}
+			}
+
+			$lines  = array_unique( $lines );
+			$events = [];
+
+			foreach ( $lines as $line ) {
+				$result = explode( '|', $line );
+				if ( isset( $result[1] ) ) {
+					$client_id    = $result[0];
+					$date_created = $result[1];
+					$type         = $result[2];
+					$context      = $result[3];
+					$value        = $result[4];
+				} else {
+					// Handle legacy format.
+					$result       = explode( ';', $line );
+					$client_id    = $result[1];
+					$date_created = $result[2];
+					$type         = 'view';
+					$context      = 'post';
+					$value        = wp_json_encode(
+						[
+							'post_id'    => (int) $result[3],
+							'categories' => $result[4],
+						]
+					);
+				}
+
+				$events[] = [
+					'client_id'    => $client_id,
+					'date_created' => $date_created,
+					'type'         => $type,
+					'context'      => $context,
+					'value'        => $value,
+				];
+			}
+
+			try {
+				$this->bulk_db_insert( $events );
+			} catch ( \Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
+				error_log( $e->getMessage() ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+			}
+
+			flock( $log_file, LOCK_UN ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_flock
+
+			// Clear the log file.
+			file_put_contents( Segmentation::get_log_file_path(), '' ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_file_put_contents
+			fclose( $log_file ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_fclose
+		}
 	}
 
 	/**
@@ -281,10 +378,12 @@ class Lightweight_API {
 		$reader_events       = [];
 
 		// Check the cache first.
-		if ( ! $this->ignore_cache ) {
+		if ( ! $this->ignore_cache || ! $this->validate_cache( $client_id ) ) {
 			$cached_reader = wp_cache_get( 'reader', $client_id );
 			if ( ! empty( $cached_reader ) ) {
-				$this->debug['reader'] = $cached_reader;
+				if ( $this->is_debug_enabled() ) {
+					$this->debug['reader'] = $cached_reader;
+				}
 				return $cached_reader;
 			}
 		}
@@ -299,7 +398,9 @@ class Lightweight_API {
 			)
 		);
 
-		$this->debug['read_query_count'] += 1;
+		if ( $this->is_debug_enabled() ) {
+			$this->debug['read_query_count'] += 1;
+		}
 
 		// If there's no reader for this client ID in the DB, create it.
 		if ( empty( $reader_from_db ) ) {
@@ -308,7 +409,9 @@ class Lightweight_API {
 
 			// If there's data for this reader in the legacy transients table, recreate it in the new table.
 			if ( ! empty( $legacy_reader ) ) {
-				$this->debug['legacy_reader'] = $legacy_reader;
+				if ( $this->is_debug_enabled() ) {
+					$this->debug['legacy_reader'] = $legacy_reader;
+				}
 
 				// Add posts_read data to views count.
 				if ( isset( $legacy_reader['posts_read'] ) && 0 < count( $legacy_reader['posts_read'] ) ) {
@@ -434,7 +537,9 @@ class Lightweight_API {
 		// Rebuild cache.
 		wp_cache_set( 'reader', $reader, $client_id );
 
-		$this->debug['reader'] = $reader;
+		if ( $this->is_debug_enabled() ) {
+			$this->debug['reader'] = $reader;
+		}
 		return $reader;
 	}
 
@@ -537,14 +642,18 @@ class Lightweight_API {
 		// Write to the DB.
 		$write_result = $wpdb->query( $query ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
 
-		$this->debug['write_query_count'] += 1;
+		if ( $this->is_debug_enabled() ) {
+			$this->debug['write_query_count'] += 1;
+		}
 
 		// If DB write was successful, rebuild cache.
 		if ( $write_result ) {
 			return wp_cache_set( 'reader', $reader, $client_id );
 		}
 
-		$this->debug['write_error'] = "Error writing to $readers_table_name.";
+		if ( $this->is_debug_enabled() ) {
+			$this->debug['write_error'] = "Error writing to $readers_table_name.";
+		}
 		return false;
 	}
 
@@ -654,7 +763,9 @@ class Lightweight_API {
 		$events_sql               = "SELECT id, client_id, date_created, type, context, value from $reader_events_table_name WHERE $client_filter $type_filter $context_filter ORDER BY date_created DESC LIMIT 1000";
 		$events                   = $wpdb->get_results( $events_sql ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
 
-		$this->debug['read_query_count'] += 1;
+		if ( $this->is_debug_enabled() ) {
+			$this->debug['read_query_count'] += 1;
+		}
 
 		if ( ! empty( $events ) ) {
 			$events = array_map(
@@ -675,6 +786,34 @@ class Lightweight_API {
 	}
 
 	/**
+	 * Checks whether cached data has a version number that matches the current.
+	 * If the version is missing or doesn't match the current version, the cache
+	 * should be rebuilt from the DB instead.
+	 *
+	 * @param string $client_id Single client ID associated with the current reader.
+	 *
+	 * @return boolean True if cached data is valid, false if we should rebuild from DB.
+	 */
+	public function validate_cache( $client_id ) {
+		$cache_version  = wp_cache_get( 'reader_cache_version', $client_id );
+		$cache_is_valid = false;
+
+		if ( ! empty( $cache_version ) && $cache_version === $this->reader_cache_version ) {
+			$cache_is_valid = true;
+		}
+
+		// If the cache has been purged, let's parse the cached events to the DB.
+		if ( ! $cache_is_valid ) {
+			$this->parse_event_logs();
+		}
+
+		$this->debug['cache_version']  = $cache_version;
+		$this->debug['cache_is_valid'] = $cache_is_valid;
+
+		return $cache_is_valid;
+	}
+
+	/**
 	 * Get reader events from the persistent cache, if available.
 	 *
 	 * @param string $client_id Single client ID associated with the current reader.
@@ -683,7 +822,9 @@ class Lightweight_API {
 	 */
 	public function get_reader_events_from_cache( $client_id ) {
 		$events = wp_cache_get( 'reader_events', $client_id );
-		if ( ! $events ) {
+
+		// If there are no cached events.
+		if ( empty( $events ) ) {
 			$events = [];
 		}
 
@@ -691,9 +832,31 @@ class Lightweight_API {
 	}
 
 	/**
+	 * Updates events logged in debug mode.
+	 *
+	 * @param array $events New events to log.
+	 */
+	public function update_debug_events( $events ) {
+		if ( $this->is_debug_enabled() ) {
+			$debug_event_ids              = array_column( $this->debug['reader_events'], 'id' );
+			$this->debug['reader_events'] = array_merge(
+				$this->debug['reader_events'],
+				array_values(
+					array_filter(
+						$events,
+						function( $event ) use ( $debug_event_ids ) {
+							return ! in_array( $event['id'], $debug_event_ids, true );
+						}
+					)
+				)
+			);
+		}
+	}
+
+	/**
 	 * Retrieve data for a specific reader from the cache or DB.
 	 *
-	 * @param string|array      $client_ids Client IDs of the reader.
+	 * @param string            $client_id Client ID of the current reader session.
 	 * @param string|array|null $type Type or types of data to retrieve.
 	 *                                If not given, only return temporary data types.
 	 * @param string|array|null $context Context or contexts of data to retrieve.
@@ -701,10 +864,7 @@ class Lightweight_API {
 	 *
 	 * @return array Array of reader data, optionally filtered by $type and $context.
 	 */
-	public function get_reader_events( $client_ids, $type = null, $context = null, $ignore_cache = false ) {
-		if ( ! is_array( $client_ids ) ) {
-			$client_ids = [ $client_ids ];
-		}
+	public function get_reader_events( $client_id, $type = null, $context = null, $ignore_cache = false ) {
 		if ( ! is_array( $type ) && null !== $type ) {
 			$type = [ $type ];
 		}
@@ -712,38 +872,46 @@ class Lightweight_API {
 			$context = [ $context ];
 		}
 
-		$events = [];
+		$cached_events = [];
 
 		// Check the cache first.
-		if ( ! $ignore_cache ) {
-			$events = $this->get_reader_events_from_cache( $client_ids[0] );
-			if ( ! empty( $events ) ) {
-				return $this->filter_events_by_type( $events, $type, $context );
+		if ( ! $this->ignore_cache && $this->validate_cache( $client_id ) ) {
+			$cached_events   = $this->get_reader_events_from_cache( $client_id );
+			$filtered_events = $this->filter_events_by_type( $cached_events, $type, $context );
+			if ( ! empty( $filtered_events ) ) {
+				$this->update_debug_events( $filtered_events );
+				return $filtered_events;
 			}
 		}
 
-		$events_from_db  = $this->get_reader_events_from_db( $client_ids, $type, $context );
-		$unique_ids      = [];
-		$filtered_events = array_values(
+		$events_from_db     = $this->get_reader_events_from_db( [ $client_id ], $type, $context );
+		$existing_event_ids = array_column( $cached_events, 'id' );
+		$unique_ids         = [];
+		$filtered_events    = array_values(
 			array_filter(
 				$events_from_db,
-				function( $event ) use ( $events ) {
+				function( $event ) use ( $existing_event_ids ) {
 					// If the event is coming from the persistent cache, fashion a faux-unique ID using the timestamp.
 					if ( ! isset( $event['id'] ) ) {
-						$event['id'] = $event['type'] . $event['context'] . $event['date_created'];
+						$event['id'] = $event['type'] . '_' . $event['context'] . '_' . $event['date_created'];
 					}
 
 					// Dedupe events from cache.
-					foreach ( $events as $existing_event ) {
-						if ( $event['id'] === $existing_event['id'] ) {
-							return false;
-						}
+					if ( in_array( $event['id'], $existing_event_ids, true ) ) {
+						return false;
 					}
 
 					return true;
 				}
 			)
 		);
+
+		// Rebuild cache.
+		if ( ! $this->ignore_cache ) {
+			wp_cache_set( 'reader_events', array_merge( $cached_events, $filtered_events ), $client_id );
+		}
+
+		$this->update_debug_events( $filtered_events );
 
 		return $filtered_events;
 	}
@@ -851,15 +1019,19 @@ class Lightweight_API {
 		if ( $this->ignore_cache ) {
 			$write_result = $this->bulk_db_insert( $events );
 
-			$this->debug['write_query_count'] += 1;
+			if ( $this->is_debug_enabled() ) {
+				$this->debug['write_query_count'] += 1;
+			}
 
 			return $write_result;
 		} else {
 			// Rebuild cache.
-			$cached_events                = $this->get_reader_events_from_cache( $client_id );
-			$all_events                   = array_merge( $cached_events, $events );
-			$write_result                 = wp_cache_set( 'reader_events', $all_events, $client_id );
-			$this->debug['reader_events'] = $all_events;
+			$cached_events = $this->get_reader_events_from_cache( $client_id );
+			$all_events    = array_merge( $cached_events, $events );
+
+			// Set a cache version for future validation.
+			wp_cache_set( 'reader_cache_version', $this->reader_cache_version, $client_id );
+			wp_cache_set( 'reader_events', $all_events, $client_id );
 
 			// Write items to the flat file to be parsed to the DB at a later point.
 			Segmentation_Report::log_reader_events( $events );

--- a/includes/class-newspack-popups-parse-logs.php
+++ b/includes/class-newspack-popups-parse-logs.php
@@ -64,72 +64,8 @@ final class Newspack_Popups_Parse_Logs {
 	 * Parse the log file, write data to the DB, and remove the file.
 	 */
 	public static function parse_events_logs() {
-		global $wpdb;
-
-		if ( ! file_exists( Segmentation::get_log_file_path() ) ) {
-			return;
-		}
-
-		$log_file = fopen( Segmentation::get_log_file_path(), 'r+' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_fopen
-
-		if ( flock( $log_file, LOCK_EX ) ) { // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_flock
-			$lines = [];
-
-			while ( ! feof( $log_file ) ) {
-				$line = trim( fgets( $log_file ) );
-				if ( ! empty( $line ) ) {
-					$lines[] = $line;
-				}
-			}
-
-			$lines  = array_unique( $lines );
-			$events = [];
-
-			foreach ( $lines as $line ) {
-				$result = explode( '|', $line );
-				if ( isset( $result[1] ) ) {
-					$client_id    = $result[0];
-					$date_created = $result[1];
-					$type         = $result[2];
-					$context      = $result[3];
-					$value        = $result[4];
-				} else {
-					// Handle legacy format.
-					$result       = explode( ';', $line );
-					$client_id    = $result[1];
-					$date_created = $result[2];
-					$type         = 'view';
-					$context      = 'post';
-					$value        = wp_json_encode(
-						[
-							'post_id'    => (int) $result[3],
-							'categories' => $result[4],
-						]
-					);
-				}
-
-				$events[] = [
-					'client_id'    => $client_id,
-					'date_created' => $date_created,
-					'type'         => $type,
-					'context'      => $context,
-					'value'        => $value,
-				];
-			}
-
-			try {
-				$api = new Lightweight_Api();
-				$api->bulk_db_insert( $events );
-			} catch ( \Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
-				error_log( $e->getMessage() ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
-			}
-
-			flock( $log_file, LOCK_UN ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_flock
-
-			// Clear the log file.
-			file_put_contents( Segmentation::get_log_file_path(), '' ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_file_put_contents
-			fclose( $log_file ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_fclose
-		}
+		$api = new Lightweight_Api();
+		$api->parse_event_logs();
 	}
 }
 Newspack_Popups_Parse_Logs::instance();

--- a/includes/class-newspack-popups-parse-logs.php
+++ b/includes/class-newspack-popups-parse-logs.php
@@ -9,6 +9,7 @@ defined( 'ABSPATH' ) || exit;
 
 require_once dirname( __FILE__ ) . '/../api/segmentation/class-segmentation.php';
 require_once dirname( __FILE__ ) . '/../api/classes/class-lightweight-api.php';
+require_once dirname( __FILE__ ) . '/../api/campaigns/class-campaign-data-utils.php';
 
 /**
  * Main Newspack Segmentation Plugin Class.
@@ -64,7 +65,8 @@ final class Newspack_Popups_Parse_Logs {
 	 * Parse the log file, write data to the DB, and remove the file.
 	 */
 	public static function parse_events_logs() {
-		$api = new Lightweight_Api();
+		$nonce = \wp_create_nonce( 'newspack_campaigns_lightweight_api' );
+		$api   = \Campaign_Data_Utils::get_api( $nonce );
 		$api->parse_event_logs();
 	}
 }

--- a/src/view/utils/index.js
+++ b/src/view/utils/index.js
@@ -172,8 +172,11 @@ export const waitUntil = ( condition, callback, maxTries = 10 ) => {
  * A common scenario is amp-analytics being blocked by ad blockers or privacy browser extensions like uBlock or Ghostery.
  * In this case the custom element will exist but the service's main class will not exist on the global __AMP_SERVICES object.
  * Extensions in this object may or may not be prefixed with `amp-`: e.g. `__AMP_SERVICES.access` vs. `__AMP_SERVICES.amp-analytics`.
+ *
+ * AMP Analytics should always be polyfilled, as non-AMP JS running in AMP Plus can break AMP Analytics features.
  */
 export const shouldPolyfillAMPModule = name =>
+	'analytics' === name ||
 	undefined === customElements.get( `amp-${ name }` ) ||
 	( ! window.__AMP_SERVICES?.hasOwnProperty( `amp-${ name }` ) &&
 		! window.__AMP_SERVICES?.hasOwnProperty( name ) );

--- a/src/view/utils/index.js
+++ b/src/view/utils/index.js
@@ -172,11 +172,8 @@ export const waitUntil = ( condition, callback, maxTries = 10 ) => {
  * A common scenario is amp-analytics being blocked by ad blockers or privacy browser extensions like uBlock or Ghostery.
  * In this case the custom element will exist but the service's main class will not exist on the global __AMP_SERVICES object.
  * Extensions in this object may or may not be prefixed with `amp-`: e.g. `__AMP_SERVICES.access` vs. `__AMP_SERVICES.amp-analytics`.
- *
- * AMP Analytics should always be polyfilled, as non-AMP JS running in AMP Plus can break AMP Analytics features.
  */
 export const shouldPolyfillAMPModule = name =>
-	'analytics' === name ||
 	undefined === customElements.get( `amp-${ name }` ) ||
 	( ! window.__AMP_SERVICES?.hasOwnProperty( `amp-${ name }` ) &&
 		! window.__AMP_SERVICES?.hasOwnProperty( name ) );

--- a/tests/test-api.php
+++ b/tests/test-api.php
@@ -472,24 +472,6 @@ class APITest extends WP_UnitTestCase {
 			$reader['reader_data']['category'],
 			'Returns category view count after a post view was reported.'
 		);
-
-		$api->save_reader(
-			self::$client_id,
-			[
-				'some_other_data' => 42,
-			]
-		);
-
-		$reader = $api->get_reader( self::$client_id );
-
-		self::assertArraySubset(
-			[
-				'client_id'  => self::$client_id,
-				'is_preview' => null,
-			],
-			$reader,
-			'Only valid keys are saved and returned.'
-		);
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a bug where reader data is not properly fetched from the DB if any reader data was previously cached but then purged. At the moment if a persistent cache is enabled, the plugin assumes that any data that exists in the cache is all that needs to be retrieved, but data in the cache is not guaranteed to persist indefinitely despite having no expiration.

Also implements a "cache version" constant so we can bust the cache for all readers by bumping the version number.

~Also adds a fix that closes #981 by polyfilling AMP Analytics whenever AMP Plus is enabled, not just if AMP Analytics isn't available. This should fix any conflicts between AMP and non-AMP JS in the AMP Plus context.~

### How to test the changes in this Pull Request:

1. On `master` using a site with a persistent cache configured, visit the front-end in a new session. Navigate around the site and take some reader actions like subscribing to a newsletter, dismissing overlay prompts, and making a donation.
2. Flush the cache using WP CLI: `wp cache flush`
3. In the same session from step 1, navigate through the site again. Turn on debug mode (`?newspack-campaigns-debug`) and observe that the reader events array only shows events that occurred after the cache flush, and that you're segmented only according to those newly cached events, rather than all past events.
4. Check out this branch and repeat step 3 in the same session. Confirm that segmentation takes into account all activity before and after the cache flush.
5. Refresh or navigate to a new page, and confirm that pre-cache-flush events* are logged to the debug object.
6. ~Also test that #981 can't be reproduced any longer ("Load" events in AMP Plus for each prompt should fire on page load if the prompt will be displayed, even if the layout shifts).~

* Note: `view` events will not persist after a cache flush, as these are temporary events. But the view counts in the `reader` object should be incremented accordingly.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
