### PR TITLE
chore: increase amp-access timeout limit to 10s in debug environments

### DIFF
--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -816,8 +816,9 @@ final class Newspack_Popups_Inserter {
 			$popups_access_provider['authorization'] .= '&uid=' . absint( $user_id );
 		}
 
-		if ( isset( $_GET['newspack-campaigns-debug'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		if ( isset( $_GET['newspack-campaigns-debug'] ) || ( \defined( 'NEWSPACK_POPUPS_DEBUG' ) && NEWSPACK_POPUPS_DEBUG ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 			$popups_access_provider['authorization'] .= '&debug';
+			$popups_access_provider['authorization'] .= '&authorizationTimeout=10000';
 		}
 
 		?>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

A small tweak to improve the dev experience. The [AMP Access component](https://amp.dev/documentation/components/amp-access/) automatically times out if the authorization request takes longer than 3 seconds. In dev/local environments this can often be the case, resulting in no prompts being shown. This tweak increases the timeout to 10 seconds if the debug flag is present in the Campaigns plugin config or as a URL parameter.

### How to test the changes in this Pull Request:

Might be hard to replicate the initial issue, but try throttling your network speed in dev tools. Confirm that the timeout error does not occur even if the auth request takes longer than 3 seconds.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
