### PR TITLE
hotfix: prompt visibility animation

### DIFF
--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -1237,7 +1237,7 @@ final class Newspack_Popups_Model {
 							"selector": "#<?php echo esc_attr( $element_id ); ?>",
 							"delay": "<?php echo esc_html( self::get_delay( $popup ) - 500 ); ?>",
 							"keyframes": {
-								"transform": ["translateY(100vh)", "translateY(0vh)"]
+								"transform": ["translateY(90vh)", "translateY(0vh)"]
 							}
 						},
 						{

--- a/src/view/style.scss
+++ b/src/view/style.scss
@@ -33,7 +33,7 @@ $width__tablet: 782px;
 	top: 0;
 	// Popup needs to be initially out of the viewport,
 	// so that analytics work when checking visibility.
-	transform: translateY( 100vh );
+	transform: translateY( 90vh );
 	visibility: hidden;
 	width: 100% !important;
 	z-index: 99999;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a hard-to-reproduce issue which causes a timer-triggered overlay prompt to not be animated into view.

Overlay prompts are inserted in the DOM, but pushed down visually with CSS. The "appearance" animation transitions them up, resulting in a from-below-the-viewport effect. This relies on an [`IntersectionObserver`](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API) which triggers the animation when the element is visible. 

For time-triggered prompts, the visibility should be immediate (and the animation delayed). There's a quirk in how the intersection is computed, though – if the prompt is pushed down by 100vh (100% of viewport height), the intersection still counts (the prompt only "touches" the viewport). Relying on that proved to be fragile on at least one live site, where the intersection does not happen, and so time-triggered overlay prompts are never displayed. 

The issue has been tough to reproduce locally, but seems to be related with accidental y-axis overflow of content, which possibly throws off the tenuous intersection calculation.  

This PR changes it so the overlay prompts are initially pushed by 90vh. This way 

_Previously submitted erroneously to `master` (not `release`)_

### How to test the changes in this Pull Request:

1. Ensure AMP plugin is off 
2. Visit a page with an overlay, time-triggered (set timer to 0) prompt
3. Observe the prompt appearing (if segmentation criteria are matching)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->