### PR TITLE
fix: remove async attribute from script

### DIFF
--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -563,7 +563,6 @@ final class Newspack_Popups_Inserter {
 			);
 			\wp_enqueue_script( 'newspack-popups-view' );
 			\wp_script_add_data( 'newspack-popups-view', 'amp-plus', true );
-			\wp_script_add_data( 'newspack-popups-view', 'async', true );
 		}
 
 		\wp_register_style(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

`document.DOMContentLoaded` event does not wait for `async` scripts to load so Campaigns' frontend library might not work as expected.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
