### PR TITLE
Invoke WP core polyfills for WP 6.1 compatibility

### DIFF
--- a/api/setup.php
+++ b/api/setup.php
@@ -49,6 +49,7 @@ function trailingslashit( $string ) {
 }
 
 if ( file_exists( ABSPATH . WPINC . '/wp-db.php' ) ) {
+	require_once ABSPATH . WPINC . '/compat.php';
 	require_once ABSPATH . WPINC . '/wp-db.php';
 	require_once ABSPATH . WPINC . '/functions.php';
 } else {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

A recent change to WordPress core added a call to `str_contains` in the `wpdb` class.

See https://github.com/WordPress/wordpress-develop/commit/fed98bd9ef9a232d102c41e74944d3c21cd6183e

This function is only available in PHP 8, and WordPress has a polyfill for it in `wp-includes/compat.php`.

Since our endpoint for segmentation loads `wpdb`, it now will fail when `wpdb` tries to call `str_contains`.

In order to fix it, we are now also including the core's polyfills.

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Invoke WP core polyfills for WP 6.1 compatibility

### How to test the changes in this Pull Request:

1. Upgrade your WP to the latest WP 6.1 RC release. You can use the Beta tester plugin for that
2. Set up some segmentations and prompts
3. Visit your site and inspect the response to the ajax call to `api/campaigns/index.php` or `api/segmentation/index.php`.
4. Confirm you see an error in the response `Call to undefined function str_contains`.
5. Checkout this branch and confirm the error is gone
6. Confirm Campaigns work as expected.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
