### PR TITLE
fix: clarify padding vs. border styles in overlay vs. inline

### DIFF
--- a/src/editor/StylesSidebar.js
+++ b/src/editor/StylesSidebar.js
@@ -5,11 +5,11 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
 
 const StylesSidebar = props => {
-	const { onMetaFieldChange, hide_border, large_border } = props;
+	const { onMetaFieldChange, hide_border, large_border, isOverlay } = props;
 
 	return (
 		<div className="newspack-popups-style-selector">
@@ -27,7 +27,11 @@ const StylesSidebar = props => {
 				onClick={ () => onMetaFieldChange( { hide_border: true, large_border: false } ) }
 				aria-current={ hide_border }
 			>
-				{ __( 'Hide Border', 'newspack-popups' ) }
+				{ sprintf(
+					// Translators: %s is "padding" if the prompt is inline, or "border" if not
+					__( 'Hide %s', 'newspack-popups' ),
+					isOverlay ? __( 'Padding', 'newspack-popups' ) : __( 'Border', 'newspack-popups' )
+				) }
 			</Button>
 			<Button
 				variant={ large_border ? 'primary' : 'secondary' }
@@ -35,7 +39,11 @@ const StylesSidebar = props => {
 				onClick={ () => onMetaFieldChange( { hide_border: false, large_border: true } ) }
 				aria-current={ large_border }
 			>
-				{ __( 'Large Border', 'newspack-popups' ) }
+				{ sprintf(
+					// Translators: %s is "padding" if the prompt is inline, or "border" if not
+					__( 'Large %s', 'newspack-popups' ),
+					isOverlay ? __( 'Padding', 'newspack-popups' ) : __( 'Border', 'newspack-popups' )
+				) }
 			</Button>
 		</div>
 	);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

As discussed, clarifies the names of the available prompt styles. For overlay prompts, these should be "hide padding" and "large padding" instead of "border".

### How to test the changes in this Pull Request:

Edit a prompt and look at the style names when switching between inline and overlay prompt settings.

<img width="268" alt="Screen Shot 2022-10-28 at 4 07 17 PM" src="https://user-images.githubusercontent.com/2230142/198740609-333f827f-9de2-4242-b2cd-404b06c6155d.png">

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
