### PR TITLE
Polyfill amp-access script

### DIFF
--- a/src/view/access.js
+++ b/src/view/access.js
@@ -1,0 +1,49 @@
+/* globals newspack_popups_view */
+
+/**
+ * Internal dependencies
+ */
+import { shouldPolyfillAMPModule, getCookies, setCookie, parseDynamicURL } from './utils';
+import './access.scss';
+
+const setClientIDCookieIfNotSet = () => {
+	const clientIDCookieName = newspack_popups_view.cid_cookie_name;
+	if ( ! getCookies()[ clientIDCookieName ] ) {
+		// If entropy is an issue, https://www.npmjs.com/package/nanoid can be used.
+		const getShortStringId = () => Math.floor( Math.random() * 999999999 ).toString( 36 );
+		setCookie( clientIDCookieName, `${ getShortStringId() }${ getShortStringId() }` );
+	}
+};
+
+export const manageAccess = () => {
+	if ( ! shouldPolyfillAMPModule( 'access' ) ) {
+		return;
+	}
+	setClientIDCookieIfNotSet();
+	const ampAccessScript = document.getElementById( 'amp-access' );
+	if ( ! ampAccessScript ) {
+		return;
+	}
+	let ampAccessConfig;
+	try {
+		ampAccessConfig = JSON.parse( ampAccessScript.innerText );
+	} catch ( error ) {}
+	if ( ! ampAccessConfig ) {
+		return;
+	}
+	const { authorization, namespace } = ampAccessConfig;
+
+	fetch( parseDynamicURL( authorization ) )
+		.then( response => response.json() )
+		.then( data => {
+			Object.keys( data ).forEach( key => {
+				const element = document.querySelectorAll( `[amp-access='${ namespace }.${ key }']` );
+				if ( element ) {
+					const shouldDisplay = data[ key ];
+					if ( shouldDisplay ) {
+						element.forEach( el => el.removeAttribute( 'amp-access-hide' ) );
+					}
+				}
+			} );
+		} );
+};

--- a/src/view/access.scss
+++ b/src/view/access.scss
@@ -1,0 +1,3 @@
+[amp-access][amp-access-hide] {
+	display: none;
+}

--- a/src/view/index.js
+++ b/src/view/index.js
@@ -36,6 +36,7 @@ import { manageForms } from './form';
 import { manageAnimations } from './animation';
 import { managePositionObservers } from './position-observer';
 import { manageBinds } from './bind';
+import { manageAccess } from './access';
 
 if ( typeof window !== 'undefined' ) {
 	domReady( () => {
@@ -49,5 +50,6 @@ if ( typeof window !== 'undefined' ) {
 		manageAnimations();
 		managePositionObservers();
 		manageBinds();
+		manageAccess();
 	} );
 }

--- a/src/view/utils/index.js
+++ b/src/view/utils/index.js
@@ -1,3 +1,5 @@
+/* globals newspack_popups_view */
+
 /**
  * WordPress dependencies
  */
@@ -23,14 +25,20 @@ export const performXHRequest = ( { url, data } ) => {
 	XHR.send( encodedData );
 };
 
-const getCookies = () =>
+export const getCookies = () =>
 	document.cookie.split( '; ' ).reduce( ( acc, cookieStr ) => {
 		const cookie = cookieStr.split( '=' );
 		acc[ cookie[ 0 ] ] = cookie[ 1 ];
 		return acc;
 	}, {} );
 
-export const getClientIDValue = () => getCookies()[ 'newspack-cid' ];
+export const getClientIDValue = () => getCookies()[ newspack_popups_view.cid_cookie_name ];
+
+export const setCookie = ( name, value, expirationDays = 365 ) => {
+	const date = new Date();
+	date.setTime( date.getTime() + expirationDays * 24 * 60 * 60 * 1000 );
+	document.cookie = `${ name }=${ value }; expires=${ date.toUTCString() }; path=/`;
+};
 
 /**
  * Replace a dynamic value, like a client ID, in a string.
@@ -39,8 +47,16 @@ export const getClientIDValue = () => getCookies()[ 'newspack-cid' ];
  * @return {string} String with the value replaced.
  */
 export const substituteDynamicValue = value => {
-	if ( value && String( value ).replace( /\s/g, '' ) === 'CLIENT_ID(newspack-cid)' ) {
-		value = getClientIDValue() || '';
+	if ( value ) {
+		const trimmedValue = String( value ).replace( /\s/g, '' );
+		switch ( trimmedValue ) {
+			case 'CLIENT_ID(newspack-cid)':
+				value = getClientIDValue() || '';
+				break;
+			case 'DOCUMENT_REFERRER':
+				value = document.referrer || '';
+				break;
+		}
 	}
 	return value;
 };

--- a/src/view/utils/index.test.js
+++ b/src/view/utils/index.test.js
@@ -1,6 +1,10 @@
 import { getCookieValueFromLinker, substituteDynamicValue } from '.';
 
 describe( 'amp-analytics linker handling', () => {
+	beforeEach( () => {
+		window.newspack_popups_view = { cid_cookie_name: 'newspack-cid' };
+	} );
+
 	const url =
 		'https://example.com/lorem/?test=42&ref_newspack_cid=1*ab3otu*cid*T2ptZDdJNU9EYndELWV0TlM1N0FwSGVwNHE3S240VkVVU0o3YlNsaFc2YVVPRXJhSWFhaVlsOTgtQXNsc21Eeg..';
 	const ampAnalyticsConfig = {
@@ -63,6 +67,10 @@ describe( 'amp-analytics linker handling', () => {
 } );
 
 describe( 'dynamic value substitution', () => {
+	beforeEach( () => {
+		window.newspack_popups_view = { cid_cookie_name: 'newspack-cid' };
+	} );
+
 	it( 'replaces client id from cookie', () => {
 		const clientId = 'id-42';
 		global.document.cookie = '';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Polyfills `amp-access` script. At this point what we called polyfills are not polyfills anymore, but a standalone JS solution for displaying prompts.

Some of the changes in this PR were originally introduced in #959, but then reverted in #995. The missing piece was setting the `newspack-cid` cookie, which resulting in some prompts being displayed on all pageviews. This was not caught in review because [Newspack Plugin's Reader Activation JS also sets this cookie](https://github.com/Automattic/newspack-plugin/blob/d6e072ccd18b2cff2e3dda97e371eedb1187afab/assets/reader-activation/index.js#L317-L321). With Reader Activation and AMP disabled, no JS code was setting this cookie. In this PR, there's the cookie-setting code on top of the original changes. 

Closes #193
Closes #880
Closes #749
Closes #170
Closes #569 

### How to test the changes in this Pull Request:

1. Follow same steps as in https://github.com/Automattic/newspack-popups/pull/959
2. Also test in a new session with Newspack Plugin disabled (to ensure its Reader Activation features are not at play)
3. On a non-AMP page, ensure there's only [one request made](https://github.com/Automattic/newspack-popups/pull/995#issuecomment-1286069218) to the segmentation endpoint (`/api/campaigns/index.php`) per page load
4. Verify that the bug described in "AMP Transitional fix" section in #995 is not reproducible 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->