### PR TITLE
fix: handle ESP exception on login fetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [2.8.1-hotfix.1](https://github.com/Automattic/newspack-popups/compare/v2.8.0...v2.8.1-hotfix.1) (2022-11-16)
+
+
+### Bug Fixes
+
+* handle ESP exception on login fetch ([e7018da](https://github.com/Automattic/newspack-popups/commit/e7018da39bc58b043c62715f25847f8be7a2b425))
+
 # [2.8.0](https://github.com/Automattic/newspack-popups/compare/v2.7.2...v2.8.0) (2022-11-14)
 
 

--- a/includes/class-newspack-popups-newsletters.php
+++ b/includes/class-newspack-popups-newsletters.php
@@ -62,7 +62,11 @@ final class Newspack_Popups_Newsletters {
 		if ( ! \Newspack\Reader_Activation::is_user_reader( $user ) ) {
 			return;
 		}
-		self::fetch_reader_data_from_esp( $user->user_email );
+		try {
+			self::fetch_reader_data_from_esp( $user->user_email );
+		} catch ( \Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
+			// Do nothing.
+		}
 	}
 
 	/**

--- a/newspack-popups.php
+++ b/newspack-popups.php
@@ -7,7 +7,7 @@
  * Author URI:      https://newspack.blog
  * Text Domain:     newspack-popups
  * Domain Path:     /languages
- * Version:         2.8.0
+ * Version:         2.8.1-hotfix.1
  *
  * @package         Newspack_Popups
  */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "newspack-popups",
-  "version": "2.8.0",
+  "version": "2.8.1-hotfix.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "newspack-popups",
-      "version": "2.8.0",
+      "version": "2.8.1-hotfix.1",
       "dependencies": {
         "classnames": "^2.3.2",
         "intersection-observer": "^0.12.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "newspack-popups",
-  "version": "2.8.0",
+  "version": "2.8.1-hotfix.1",
   "main": "Gruntfile.js",
   "author": "Automattic",
   "scripts": {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The `add_contact()` - or other ESP-related methods - might fail or error due to ESP misconfiguration. The fetch under `wp_login` shouldn't be susceptible to such errors.

### How to test the changes in this Pull Request:

1. While on the `release` branch, make sure you have Newspack Newsletters installed
3. Set your ESP to Constant Contact and save without setting any credentials
4. Log in as a reader/subscriber
5. Confirm the fatal error
6. Check out this branch, log out and log in again
7. Confirm you authenticate without errors

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
