### PR TITLE
fix: also limit query to fetch reconciled session client IDs

### DIFF
--- a/api/classes/class-lightweight-api.php
+++ b/api/classes/class-lightweight-api.php
@@ -370,6 +370,8 @@ class Lightweight_API {
 	 * Given an event type and value, find other client IDs with matching type and value
 	 * and reconcile all client IDs so they're considered a single reader.
 	 *
+	 * Limit the number of reconciled sessions to 10 for performance reasons.
+	 *
 	 * @param string $current_client_id The client ID of the current reader session.
 	 * @param string $type The type of event to look up.
 	 * @param mixed  $context The context of the event to look up.
@@ -381,7 +383,7 @@ class Lightweight_API {
 		$reader_events_table_name = Segmentation::get_reader_events_table_name();
 		$client_ids               = $wpdb->get_results( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 			$wpdb->prepare(
-				"SELECT DISTINCT client_id FROM $reader_events_table_name WHERE type = %s AND context = %s", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				"SELECT DISTINCT client_id FROM $reader_events_table_name WHERE type = %s AND context = %s ORDER BY date_created DESC LIMIT 10", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 				$type,
 				$context
 			)


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

#1010 fixed the issue of storing too many reconciled client IDs in the DB, but this fix is also needed to avoid querying too many in the first place.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
