### PR TITLE
feat: allow admins to toggle prompts

### DIFF
--- a/src/view/admin.js
+++ b/src/view/admin.js
@@ -1,0 +1,16 @@
+/**
+ * Internal dependencies
+ */
+import './admin.scss';
+
+const toggle = document.querySelectorAll( '.newspack-campaigns-preview-toggle' );
+
+const toggleHandler = e => {
+	e.preventDefault();
+	document.body.classList.toggle( 'newspack-popups-hide-prompts' );
+};
+
+for ( let i = 0; i < toggle.length; i++ ) {
+	const thisToggle = toggle[ i ];
+	thisToggle.addEventListener( 'click', toggleHandler );
+}

--- a/src/view/admin.js
+++ b/src/view/admin.js
@@ -4,10 +4,16 @@
 import './admin.scss';
 
 const toggle = document.querySelectorAll( '.newspack-campaigns-preview-toggle' );
+const isHidden = parseInt( localStorage.getItem( 'newspackPopupsHide' ) );
+
+if ( isHidden ) {
+	document.body.classList.add( 'newspack-popups-hide-prompts' );
+}
 
 const toggleHandler = e => {
 	e.preventDefault();
 	document.body.classList.toggle( 'newspack-popups-hide-prompts' );
+	localStorage.setItem( 'newspackPopupsHide', isHidden ? 0 : 1 );
 };
 
 for ( let i = 0; i < toggle.length; i++ ) {

--- a/src/view/admin.scss
+++ b/src/view/admin.scss
@@ -1,0 +1,17 @@
+body.admin-bar.logged-in {
+	.newspack-campaigns-preview-toggle a::before {
+		content: '\f177';
+		top: 1px;
+	}
+
+	&.newspack-popups-hide-prompts {
+		.newspack-campaigns-preview-toggle a::before {
+			content: '\f530';
+		}
+
+		.newspack-popup {
+			display: none !important;
+			visibility: hidden;
+		}
+	}
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,6 +14,7 @@ const path = require( 'path' );
  */
 const editor = path.join( __dirname, 'src', 'editor' );
 const view = path.join( __dirname, 'src', 'view' );
+const admin = path.join( __dirname, 'src', 'view', 'admin' );
 const documentSettings = path.join( __dirname, 'src', 'document-settings' );
 const settings = path.join( __dirname, 'src', 'settings' );
 const blocks = path.join( __dirname, 'src', 'blocks' );
@@ -25,6 +26,7 @@ const webpackConfig = getBaseWebpackConfig(
 		entry: {
 			editor,
 			view,
+			admin,
 			documentSettings,
 			settings,
 			blocks,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds a toggle button to the WP admin bar that lets logged-in admins and editors to toggle off all prompts.

Closes /0/1202719992789620/1203209198289631.

### How to test the changes in this Pull Request:

1. Publish some prompts that will show on every page.
2. While logged in as an admin or editor user, browse the site front-end. Confirm there's a new "Preview Campaigns" link in the WP admin bar:

<img width="1160" alt="Screen Shot 2022-11-17 at 5 18 37 PM" src="https://user-images.githubusercontent.com/2230142/202587742-94944990-1e8b-4afd-b2bb-8765952232f7.png">

4. Click on the button. Confirm that when clicked, the button changes state and all prompts are hidden.

<img width="174" alt="Screen Shot 2022-11-17 at 5 19 34 PM" src="https://user-images.githubusercontent.com/2230142/202587863-aaa598a6-3fef-429c-bb27-2435870d5000.png">

5. Continue navigating through the site. Confirm that the button state and prompt hidden state persists across pageviews.
6. Test with AMP, AMP Plus, and non-AMP.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
