### PR TITLE
feat: support custom class names on inline prompt blocks

### DIFF
--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -589,9 +589,15 @@ final class Newspack_Popups_Inserter {
 			return;
 		}
 
+		$class_names = '';
+
+		if ( isset( $atts['class'] ) && $atts['class'] ) {
+			$class_names .= ' class="' . $atts['class'] . '"';
+		}
+
 		// Wrapping the inline popup in an aside element prevents the markup from being mangled
 		// if the shortcode is the first block.
-		return '<aside>' . Newspack_Popups_Model::generate_popup( $found_popup ) . '</aside>';
+		return '<aside' . $class_names . '>' . Newspack_Popups_Model::generate_popup( $found_popup ) . '</aside>';
 	}
 
 	/**

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -590,8 +590,7 @@ final class Newspack_Popups_Inserter {
 		}
 
 		$class_names = '';
-
-		if ( isset( $atts['class'] ) && $atts['class'] ) {
+		if ( ! empty( $atts['class'] ) ) {
 			$class_names .= ' class="' . $atts['class'] . '"';
 		}
 

--- a/src/blocks/custom-placement/block.json
+++ b/src/blocks/custom-placement/block.json
@@ -5,6 +5,10 @@
 		"customPlacement": {
 			"type": "string",
 			"default": ""
+		},
+		"className": {
+			"type": "string",
+			"default": ""
 		}
 	}
 }

--- a/src/blocks/custom-placement/view.php
+++ b/src/blocks/custom-placement/view.php
@@ -34,7 +34,7 @@ function register_block() {
 function render_block( $attributes ) {
 	$content             = '';
 	$custom_placement_id = \Newspack_Popups_Custom_Placements::validate_custom_placement_id( $attributes['customPlacement'] );
-	$class_names         = $attributes['className'];
+	$class_names         = isset( $attributes['className'] ) ? $attributes['className'] : '';
 
 	if ( empty( $custom_placement_id ) ) {
 		return $content;

--- a/src/blocks/custom-placement/view.php
+++ b/src/blocks/custom-placement/view.php
@@ -34,7 +34,7 @@ function register_block() {
 function render_block( $attributes ) {
 	$content             = '';
 	$custom_placement_id = \Newspack_Popups_Custom_Placements::validate_custom_placement_id( $attributes['customPlacement'] );
-	$class_names         = isset( $attributes['className'] ) ? $attributes['className'] : '';
+	$class_names         = isset( $attributes['className'] ) ? ' class="' . $attributes['className'] . '"' : '';
 
 	if ( empty( $custom_placement_id ) ) {
 		return $content;
@@ -60,7 +60,7 @@ function render_block( $attributes ) {
 			$content .= '<!-- Newspack Campaigns: Start custom placement ' . $custom_placement_id . '-->';
 		}
 		foreach ( $prompts as $prompt_id ) {
-			$content .= '<!-- wp:shortcode -->[newspack-popup id="' . $prompt_id . '" class="' . $class_names . '"]<!-- /wp:shortcode -->';
+			$content .= '<!-- wp:shortcode -->[newspack-popup id="' . $prompt_id . '"' . $class_names . ']<!-- /wp:shortcode -->';
 		}
 		if ( defined( 'WP_NEWSPACK_DEBUG' ) && WP_NEWSPACK_DEBUG ) {
 			$content .= '<!-- Newspack Campaigns: End custom placement ' . $custom_placement_id . '-->';

--- a/src/blocks/custom-placement/view.php
+++ b/src/blocks/custom-placement/view.php
@@ -34,6 +34,7 @@ function register_block() {
 function render_block( $attributes ) {
 	$content             = '';
 	$custom_placement_id = \Newspack_Popups_Custom_Placements::validate_custom_placement_id( $attributes['customPlacement'] );
+	$class_names         = $attributes['className'];
 
 	if ( empty( $custom_placement_id ) ) {
 		return $content;
@@ -59,7 +60,7 @@ function render_block( $attributes ) {
 			$content .= '<!-- Newspack Campaigns: Start custom placement ' . $custom_placement_id . '-->';
 		}
 		foreach ( $prompts as $prompt_id ) {
-			$content .= '<!-- wp:shortcode -->[newspack-popup id="' . $prompt_id . '"]<!-- /wp:shortcode -->';
+			$content .= '<!-- wp:shortcode -->[newspack-popup id="' . $prompt_id . '" class="' . $class_names . '"]<!-- /wp:shortcode -->';
 		}
 		if ( defined( 'WP_NEWSPACK_DEBUG' ) && WP_NEWSPACK_DEBUG ) {
 			$content .= '<!-- Newspack Campaigns: End custom placement ' . $custom_placement_id . '-->';

--- a/src/blocks/single-prompt/block.json
+++ b/src/blocks/single-prompt/block.json
@@ -5,6 +5,10 @@
 		"promptId": {
 			"type": "number",
 			"default": 0
+		},
+		"className": {
+			"type": "string",
+			"default": ""
 		}
 	}
 }

--- a/src/blocks/single-prompt/view.php
+++ b/src/blocks/single-prompt/view.php
@@ -34,7 +34,7 @@ function register_block() {
 function render_block( $attributes ) {
 	$content     = '';
 	$prompt_id   = $attributes['promptId'];
-	$class_names = $attributes['className'];
+	$class_names = isset( $attributes['className'] ) ? $attributes['className'] : '';
 
 	if ( empty( $prompt_id ) ) {
 		return $content;

--- a/src/blocks/single-prompt/view.php
+++ b/src/blocks/single-prompt/view.php
@@ -32,8 +32,9 @@ function register_block() {
  * @param array $attributes Block attributes.
  */
 function render_block( $attributes ) {
-	$content   = '';
-	$prompt_id = $attributes['promptId'];
+	$content     = '';
+	$prompt_id   = $attributes['promptId'];
+	$class_names = $attributes['className'];
 
 	if ( empty( $prompt_id ) ) {
 		return $content;
@@ -48,7 +49,7 @@ function render_block( $attributes ) {
 			$content .= '<!-- Newspack Campaigns: Start Prompt ' . $prompt_id . '-->';
 		}
 
-		$content .= '<!-- wp:shortcode -->[newspack-popup id="' . $prompt_id . '"]<!-- /wp:shortcode -->';
+		$content .= '<!-- wp:shortcode -->[newspack-popup id="' . $prompt_id . '" class="' . $class_names . '"]<!-- /wp:shortcode -->';
 
 		if ( defined( 'WP_NEWSPACK_DEBUG' ) && WP_NEWSPACK_DEBUG ) {
 			$content .= '<!-- Newspack Campaigns: End Prompt ' . $prompt_id . '-->';

--- a/src/blocks/single-prompt/view.php
+++ b/src/blocks/single-prompt/view.php
@@ -34,7 +34,7 @@ function register_block() {
 function render_block( $attributes ) {
 	$content     = '';
 	$prompt_id   = $attributes['promptId'];
-	$class_names = isset( $attributes['className'] ) ? $attributes['className'] : '';
+	$class_names = isset( $attributes['className'] ) ? ' class="' . $attributes['className'] . '"' : '';
 
 	if ( empty( $prompt_id ) ) {
 		return $content;
@@ -49,7 +49,7 @@ function render_block( $attributes ) {
 			$content .= '<!-- Newspack Campaigns: Start Prompt ' . $prompt_id . '-->';
 		}
 
-		$content .= '<!-- wp:shortcode -->[newspack-popup id="' . $prompt_id . '" class="' . $class_names . '"]<!-- /wp:shortcode -->';
+		$content .= '<!-- wp:shortcode -->[newspack-popup id="' . $prompt_id . '"' . $class_names . ']<!-- /wp:shortcode -->';
 
 		if ( defined( 'WP_NEWSPACK_DEBUG' ) && WP_NEWSPACK_DEBUG ) {
 			$content .= '<!-- Newspack Campaigns: End Prompt ' . $prompt_id . '-->';

--- a/tests/test-blocks.php
+++ b/tests/test-blocks.php
@@ -53,6 +53,19 @@ class BlocksTest extends WP_UnitTestCase {
 			'',
 			'Overlay prompt not rendered by the Single Prompt block.'
 		);
+
+		$inline_block_content = Newspack_Popups\Prompt_Block\render_block(
+			[
+				'promptId'  => $inline_popup_id,
+				'className' => 'custom-class',
+			]
+		);
+
+		self::assertEquals(
+			$inline_block_content,
+			'<!-- wp:shortcode -->[newspack-popup id="' . $inline_popup_id . '" class="custom-class"]<!-- /wp:shortcode -->',
+			'Includes inline popup shortcode.'
+		);
 	}
 
 	/**
@@ -66,6 +79,19 @@ class BlocksTest extends WP_UnitTestCase {
 		self::assertEquals(
 			$block_content,
 			'<!-- wp:shortcode -->[newspack-popup id="' . $popup_id . '"]<!-- /wp:shortcode -->',
+			'Includes popup shortcode.'
+		);
+
+		$block_content = Newspack_Popups\Custom_Placement_Block\render_block(
+			[
+				'customPlacement' => $custom_placement_id,
+				'className'       => 'custom-class',
+			]
+		);
+
+		self::assertEquals(
+			$block_content,
+			'<!-- wp:shortcode -->[newspack-popup id="' . $popup_id . '" class="custom-class"]<!-- /wp:shortcode -->',
 			'Includes popup shortcode.'
 		);
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds support for the "Additional CSS Class(es)" field on Single Prompt and Custom Placement blocks.

Closes /0/1200550061930446/1203415265039373.

### How to test the changes in this Pull Request:

1. Add a Single Prompt and Custom Placement block to a post. Ensure that the latter has at least one prompt assigned to the selected placement.
2. Add class names to the Additional CSS Class(es) field:

<img width="277" alt="Screen Shot 2022-11-22 at 5 28 56 PM" src="https://user-images.githubusercontent.com/2230142/203447734-0182f708-d42e-487b-9358-fea838315991.png">

3. View on the front-end and inspect each element. Confirm in Dev Tools > Inspector that your class names are appended to the `aside` wrapper element for each prompt. Note that all prompts within the Custom Placement block will inherit the same class names.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
