### PR TITLE
Create Json schemas

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,12 @@
       ]
     }
   },
+  "autoload": {
+		"classmap": [
+			"includes",
+      "includes/schemas"
+		]
+	},
   "require": {
     "drewm/mailchimp-api": "^2.5"
   },

--- a/includes/schemas/class-campaigns.php
+++ b/includes/schemas/class-campaigns.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * The Campaigns Schema
+ *
+ * @package Newspack
+ */
+
+namespace Newspack\Campaigns\Schemas;
+
+use \Newspack\Campaigns\Schema;
+
+/**
+ * The Campaigns Schema
+ */
+class Campaigns extends Schema {
+
+	/**
+	 * Get the schema.
+	 *
+	 * @return array The schema.
+	 */
+	public function get_schema() {
+		return [
+			'type'                 => 'object',
+			'additionalProperties' => false,
+			'properties'           => [
+				'id'   => [
+					'name'     => 'id',
+					'type'     => 'integer',
+					'required' => true,
+				],
+				'name' => [
+					'name'     => 'name',
+					'type'     => 'string',
+					'required' => true,
+				],
+			],
+		];
+	}
+}

--- a/includes/schemas/class-prompts.php
+++ b/includes/schemas/class-prompts.php
@@ -250,7 +250,16 @@ class Prompts extends Schema {
 							'required' => false,
 							'default'  => [],
 							'items'    => [
-								'type' => 'integer',
+								'type'                 => 'object',
+								'additionalProperties' => false,
+								'properties'           => [
+									'id'   => [
+										'type' => 'integer',
+									],
+									'name' => [
+										'type' => 'string',
+									],
+								],
 							],
 						],
 						'excluded_tags'                  => [
@@ -259,7 +268,52 @@ class Prompts extends Schema {
 							'required' => false,
 							'default'  => [],
 							'items'    => [
-								'type' => 'integer',
+								'type'                 => 'object',
+								'additionalProperties' => false,
+								'properties'           => [
+									'id'   => [
+										'type' => 'integer',
+									],
+									'name' => [
+										'type' => 'string',
+									],
+								],
+							],
+						],
+						'categories'                     => [
+							'name'     => 'categories',
+							'type'     => 'array',
+							'required' => false,
+							'default'  => [],
+							'items'    => [
+								'type'                 => 'object',
+								'additionalProperties' => false,
+								'properties'           => [
+									'id'   => [
+										'type' => 'integer',
+									],
+									'name' => [
+										'type' => 'string',
+									],
+								],
+							],
+						],
+						'tags'                           => [
+							'name'     => 'tags',
+							'type'     => 'array',
+							'required' => false,
+							'default'  => [],
+							'items'    => [
+								'type'                 => 'object',
+								'additionalProperties' => false,
+								'properties'           => [
+									'id'   => [
+										'type' => 'integer',
+									],
+									'name' => [
+										'type' => 'string',
+									],
+								],
 							],
 						],
 						'duplicate_of'                   => [

--- a/includes/schemas/class-prompts.php
+++ b/includes/schemas/class-prompts.php
@@ -1,0 +1,283 @@
+<?php
+/**
+ * The Prompts Schema
+ *
+ * @package Newspack
+ */
+
+namespace Newspack\Campaigns\Schemas;
+
+use \Newspack\Campaigns\Schema;
+use Newspack_Popups_Model;
+
+/**
+ * The Prompts Schema
+ */
+class Prompts extends Schema {
+
+	/**
+	 * Get the schema.
+	 *
+	 * @return array The schema.
+	 */
+	public function get_schema() {
+		return [
+			'type'                 => 'object',
+			'additionalProperties' => false,
+			'properties'           => [
+				'title'           => [
+					'name'     => 'title',
+					'type'     => 'string',
+					'required' => true,
+				],
+				'content'         => [
+					'name'     => 'content',
+					'type'     => 'string',
+					'required' => true,
+				],
+				'campaign_groups' => [
+					'name'     => 'campaign_groups',
+					'type'     => 'array',
+					'required' => false,
+					'items'    => [
+						'type' => 'integer',
+					],
+					'default'  => [],
+				],
+				'meta'            => [
+					'type'                 => 'object',
+					'required'             => true,
+					'additionalProperties' => false,
+					'properties'           => [
+						'background_color'               => [
+							'name'     => 'background_color',
+							'type'     => 'string',
+							'format'   => 'hex-color',
+							'required' => false,
+							'default'  => '#FFFFFF',
+						],
+						'display_title'                  => [
+							'name'     => 'display_title',
+							'type'     => 'boolean',
+							'required' => false,
+							'default'  => false,
+						],
+						'hide_border'                    => [
+							'name'     => 'hide_border',
+							'type'     => 'boolean',
+							'required' => false,
+							'default'  => false,
+						],
+						'large_border'                   => [
+							'name'     => 'large_border',
+							'type'     => 'boolean',
+							'required' => false,
+							'default'  => false,
+						],
+						'frequency'                      => [
+							'name'     => 'frequency',
+							'type'     => 'string',
+							'required' => true,
+							'enum'     => [
+								'once',
+								'weekly',
+								'daily',
+								'always',
+								'custom',
+							],
+
+						],
+						'frequency_max'                  => [
+							'name'     => 'frequency_max',
+							'type'     => 'integer',
+							'required' => false,
+							'default'  => 0,
+						],
+						'frequency_start'                => [
+							'name'     => 'frequency_start',
+							'type'     => 'integer',
+							'required' => false,
+							'default'  => 0,
+						],
+						'frequency_between'              => [
+							'name'     => 'frequency_between',
+							'type'     => 'integer',
+							'required' => false,
+							'default'  => 0,
+						],
+						'frequency_reset'                => [
+							'name'     => 'frequency_reset',
+							'type'     => 'string',
+							'required' => false,
+							'default'  => 'month',
+							'enum'     => [
+								'month',
+								'week',
+								'day',
+							],
+						],
+						'overlay_color'                  => [
+							'name'     => 'overlay_color',
+							'type'     => 'string',
+							'required' => false,
+							'format'   => 'hex-color',
+							'default'  => '#000000',
+						],
+						'overlay_opacity'                => [
+							'name'     => 'overlay_opacity',
+							'type'     => 'integer',
+							'required' => false,
+							'default'  => 30,
+							'maximum'  => 100,
+						],
+						'overlay_size'                   => [
+							'name'     => 'overlay_size',
+							'type'     => 'string',
+							'required' => false,
+							'default'  => 'medium',
+							'enum'     => [
+								'x-small',
+								'small',
+								'medium',
+								'large',
+								'full-width',
+							],
+						],
+						'no_overlay_background'          => [
+							'name'     => 'no_overlay_background',
+							'type'     => 'boolean',
+							'required' => false,
+							'default'  => false,
+						],
+						'placement'                      => [
+							'name'     => 'placement',
+							'type'     => 'string',
+							'required' => true,
+							'enum'     => [
+								// overlay.
+								'top_left',
+								'top_right',
+								'top',
+								'bottom_left',
+								'bottom_right',
+								'bottom',
+								'center',
+								'center_left',
+								'center_right',
+
+								// inline.
+								'inline',
+								'archives',
+								'above_header',
+								'manual',
+								'custom1',
+								'custom2',
+								'custom3',
+							],
+						],
+						'trigger_type'                   => [
+							'name'     => 'trigger_type',
+							'type'     => 'string',
+							'required' => false,
+							'default'  => 'time',
+							'enum'     => [
+								'time',
+								'scroll',
+							],
+						],
+						'trigger_delay'                  => [
+							'name'     => 'trigger_delay',
+							'type'     => 'integer',
+							'required' => false,
+							'default'  => 0,
+						],
+						'trigger_scroll_progress'        => [
+							'name'     => 'trigger_scroll_progress',
+							'type'     => 'integer',
+							'required' => false,
+							'default'  => 0,
+						],
+						'trigger_blocks_count'           => [
+							'name'     => 'trigger_blocks_count',
+							'type'     => 'integer',
+							'required' => false,
+							'default'  => 0,
+						],
+						'archive_insertion_posts_count'  => [
+							'name'     => 'archive_insertion_posts_count',
+							'type'     => 'integer',
+							'required' => false,
+							'default'  => 1,
+						],
+						'archive_insertion_is_repeating' => [
+							'name'     => 'archive_insertion_is_repeating',
+							'type'     => 'boolean',
+							'required' => false,
+							'default'  => false,
+						],
+						'utm_suppression'                => [
+							'name'     => 'utm_suppression',
+							'type'     => 'string',
+							'required' => false,
+							'default'  => '',
+						],
+						'selected_segment_id'            => [
+							'name'     => 'selected_segment_id',
+							'type'     => 'string',
+							'required' => false,
+							'default'  => '',
+						],
+						'post_types'                     => [
+							'name'     => 'post_types',
+							'type'     => 'array',
+							'required' => false,
+							'default'  => Newspack_Popups_Model::get_default_popup_post_types(),
+							'items'    => [
+								'type' => 'string',
+							],
+						],
+						'archive_page_types'             => [
+							'name'     => 'archive_page_types',
+							'type'     => 'array',
+							'required' => false,
+							'default'  => Newspack_Popups_Model::get_supported_archive_page_types(),
+							'items'    => [
+								'type' => 'string',
+							],
+						],
+						'excluded_categories'            => [
+							'name'     => 'excluded_categories',
+							'type'     => 'array',
+							'required' => false,
+							'default'  => [],
+							'items'    => [
+								'type' => 'integer',
+							],
+						],
+						'excluded_tags'                  => [
+							'name'     => 'excluded_tags',
+							'type'     => 'array',
+							'required' => false,
+							'default'  => [],
+							'items'    => [
+								'type' => 'integer',
+							],
+						],
+						'duplicate_of'                   => [
+							'name'     => 'duplicate_of',
+							'type'     => 'integer',
+							'required' => false,
+							'default'  => 0,
+						],
+						'newspack_popups_has_disabled_popups' => [
+							'name'     => 'newspack_popups_has_disabled_popups',
+							'type'     => 'boolean',
+							'required' => false,
+							'default'  => false,
+						],
+					],
+				],
+			],
+		];
+	}
+}

--- a/includes/schemas/class-prompts.php
+++ b/includes/schemas/class-prompts.php
@@ -135,13 +135,12 @@ class Prompts extends Schema {
 							'type'     => 'string',
 							'required' => false,
 							'default'  => 'medium',
-							'enum'     => [
-								'x-small',
-								'small',
-								'medium',
-								'large',
-								'full-width',
-							],
+							'enum'     => array_map(
+								function( $item ) {
+									return $item['value'];
+								},
+								Newspack_Popups_Model::get_popup_size_options()
+							),
 						],
 						'no_overlay_background'          => [
 							'name'     => 'no_overlay_background',

--- a/includes/schemas/class-schema.php
+++ b/includes/schemas/class-schema.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Abstract Schema class
+ *
+ * @package Newspack
+ */
+
+namespace Newspack\Campaigns;
+
+/**
+ * Abstract Schema class
+ */
+abstract class Schema {
+
+	/**
+	 * The input value to be handled.
+	 *
+	 * @var mixed
+	 */
+	protected $value;
+
+	/**
+	 * The validation errors found
+	 *
+	 * @var array
+	 */
+	protected $errors = [];
+
+	/**
+	 * Constructor.
+	 *
+	 * @param mixed $value The value to be validated.
+	 */
+	public function __construct( $value ) {
+		$this->value  = $value;
+		$this->errors = array();
+		$this->schema = array(
+			'type' => 'string',
+			'enum' => array( 'foo', 'bar' ),
+		);
+	}
+
+	/**
+	 * Gets the Schema. This method must be overridden by the extending class.
+	 *
+	 * @return array The Schema.
+	 */
+	abstract public function get_schema();
+
+	/**
+	 * Validate the value against the schema.
+	 *
+	 * @return boolean
+	 */
+	public function is_valid() {
+		$result = rest_validate_value_from_schema( $this->value, $this->get_schema() );
+		if ( is_wp_error( $result ) ) {
+			$this->errors = $result->get_error_messages();
+			return false;
+		}
+		$this->errors = array();
+		return true;
+	}
+
+	/**
+	 * Get the validation errors.
+	 *
+	 * @return array
+	 */
+	public function get_errors() {
+		return $this->errors;
+	}
+}

--- a/includes/schemas/class-schema.php
+++ b/includes/schemas/class-schema.php
@@ -32,12 +32,7 @@ abstract class Schema {
 	 * @param mixed $value The value to be validated.
 	 */
 	public function __construct( $value ) {
-		$this->value  = $value;
-		$this->errors = array();
-		$this->schema = array(
-			'type' => 'string',
-			'enum' => array( 'foo', 'bar' ),
-		);
+		$this->value = $value;
 	}
 
 	/**

--- a/includes/schemas/class-segments.php
+++ b/includes/schemas/class-segments.php
@@ -1,0 +1,141 @@
+<?php
+/**
+ * The Segments Schema
+ *
+ * @package Newspack
+ */
+
+namespace Newspack\Campaigns\Schemas;
+
+use \Newspack\Campaigns\Schema;
+
+/**
+ * The Segments Schema
+ */
+class Segments extends Schema {
+
+	/**
+	 * Get the schema.
+	 *
+	 * @return array The schema.
+	 */
+	public function get_schema() {
+		return [
+			'type'                 => 'object',
+			'additionalProperties' => false,
+			'properties'           => [
+				'name'          => [
+					'name'     => 'name',
+					'type'     => 'string',
+					'required' => true,
+				],
+				'id'            => [
+					'name'     => 'id',
+					'type'     => 'string',
+					'required' => true,
+				],
+				'priority'      => [
+					'name'     => 'priority',
+					'type'     => 'integer',
+					'required' => false,
+					'default'  => PHP_INT_MAX,
+				],
+				'configuration' => [
+					'name'                 => 'configuration',
+					'type'                 => 'object',
+					'required'             => true,
+					'additionalProperties' => false,
+					'properties'           => [
+						'min_posts'           => [
+							'name'     => 'min_posts',
+							'type'     => 'integer',
+							'required' => false,
+							'default'  => 0,
+						],
+						'max_posts'           => [
+							'name'     => 'max_posts',
+							'type'     => 'integer',
+							'required' => false,
+							'default'  => 0,
+						],
+						'min_session_posts'   => [
+							'name'     => 'min_session_posts',
+							'type'     => 'integer',
+							'required' => false,
+							'default'  => 0,
+						],
+						'max_session_posts'   => [
+							'name'     => 'max_session_posts',
+							'type'     => 'integer',
+							'required' => false,
+							'default'  => 0,
+						],
+						'is_subscribed'       => [
+							'name'     => 'is_subscribed',
+							'type'     => 'boolean',
+							'required' => false,
+							'default'  => false,
+						],
+						'is_not_subscribed'   => [
+							'name'     => 'is_not_subscribed',
+							'type'     => 'boolean',
+							'required' => false,
+							'default'  => false,
+						],
+						'is_donor'            => [
+							'name'     => 'is_donor',
+							'type'     => 'boolean',
+							'required' => false,
+							'default'  => false,
+						],
+						'is_not_donor'        => [
+							'name'     => 'is_not_donor',
+							'type'     => 'boolean',
+							'required' => false,
+							'default'  => false,
+						],
+						'is_former_donor'     => [
+							'name'     => 'is_former_donor',
+							'type'     => 'boolean',
+							'required' => false,
+							'default'  => false,
+						],
+						'is_logged_in'        => [
+							'name'     => 'is_logged_in',
+							'type'     => 'boolean',
+							'required' => false,
+							'default'  => false,
+						],
+						'is_not_logged_in'    => [
+							'name'     => 'is_not_logged_in',
+							'type'     => 'boolean',
+							'required' => false,
+							'default'  => false,
+						],
+						'favorite_categories' => [
+							'name'     => 'favorite_categories',
+							'type'     => 'array',
+							'required' => false,
+							'default'  => [],
+							'items'    => [
+								'type' => 'integer',
+							],
+						],
+						'referrers'           => [
+							'name'     => 'referrers',
+							'type'     => 'string',
+							'required' => false,
+							'default'  => '',
+						],
+						'referrers_not'       => [
+							'name'     => 'referrers_not',
+							'type'     => 'string',
+							'required' => false,
+							'default'  => '',
+						],
+					],
+				],
+			],
+		];
+	}
+}

--- a/includes/schemas/class-segments.php
+++ b/includes/schemas/class-segments.php
@@ -118,7 +118,16 @@ class Segments extends Schema {
 							'required' => false,
 							'default'  => [],
 							'items'    => [
-								'type' => 'integer',
+								'type'                 => 'object',
+								'additionalProperties' => false,
+								'properties'           => [
+									'id'   => [
+										'type' => 'integer',
+									],
+									'name' => [
+										'type' => 'string',
+									],
+								],
 							],
 						],
 						'referrers'           => [

--- a/tests/test-schemas.php
+++ b/tests/test-schemas.php
@@ -48,6 +48,16 @@ class SchemasTest extends WP_UnitTestCase {
 						'archive_page_types'             => [],
 						'excluded_categories'            => [],
 						'excluded_tags'                  => [],
+						'categories'                     => [
+							[
+								'id'   => 1,
+								'name' => 'Category 1',
+							],
+							[
+								'id'   => 2,
+								'name' => 'Category 2',
+							],
+						],
 						'duplicate_of'                   => 0,
 						'newspack_popups_has_disabled_popups' => false,
 					],
@@ -233,7 +243,7 @@ class SchemasTest extends WP_UnitTestCase {
 						'is_former_donor'     => true,
 						'is_logged_in'        => true,
 						'is_not_logged_in'    => true,
-						'favorite_categories' => [ 1 ],
+						'favorite_categories' => [],
 						'referrers'           => '',
 						'referrers_not'       => '',
 					],
@@ -290,7 +300,12 @@ class SchemasTest extends WP_UnitTestCase {
 					'id'            => 'aasdqwe1234',
 					'priority'      => 10,
 					'configuration' => [
-						'favorite_categories' => [ 1 ],
+						'favorite_categories' => [
+							[
+								'id'   => 1,
+								'name' => 'Test Category',
+							],
+						],
 					],
 				],
 				true,

--- a/tests/test-schemas.php
+++ b/tests/test-schemas.php
@@ -1,0 +1,309 @@
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+/**
+ * Test Schemas
+ *
+ * @package Newspack_Popups
+ */
+
+/**
+ * Test Schemas
+ */
+class SchemasTest extends WP_UnitTestCase {
+
+	/**
+	 * Data provider to test prompts schema.
+	 *
+	 * @return array
+	 */
+	public function prompts_data() {
+		return [
+			'complete and valid' => [
+				[
+					'title'   => 'Test Campaign',
+					'content' => 'Test content',
+					'meta'    => [
+						'background_color'               => '#FFFFFF',
+						'display_title'                  => false,
+						'hide_border'                    => false,
+						'large_border'                   => false,
+						'frequency'                      => 'once',
+						'frequency_max'                  => 1,
+						'frequency_start'                => 1,
+						'frequency_between'              => 1,
+						'frequency_reset'                => 'day',
+						'overlay_color'                  => '#000000',
+						'overlay_opacity'                => 50,
+						'overlay_size'                   => 'medium',
+						'no_overlay_background'          => false,
+						'placement'                      => 'center',
+						'trigger_type'                   => 'scroll',
+						'trigger_scroll_progress'        => 50,
+						'trigger_delay'                  => 1,
+						'trigger_blocks_count'           => 1,
+						'archive_insertion_posts_count'  => 1,
+						'archive_insertion_is_repeating' => false,
+						'utm_suppression'                => '',
+						'selected_segment_id'            => 'asdasd',
+						'post_types'                     => [ 'post' ],
+						'archive_page_types'             => [],
+						'excluded_categories'            => [],
+						'excluded_tags'                  => [],
+						'duplicate_of'                   => 0,
+						'newspack_popups_has_disabled_popups' => false,
+					],
+				],
+				true,
+			],
+			'valid'              => [
+				[
+					'title'   => 'Test Campaign',
+					'content' => 'Test content',
+					'meta'    => [
+						'background_color' => '#FFFFFF',
+						'display_title'    => false,
+						'hide_border'      => false,
+						'large_border'     => false,
+						'frequency'        => 'once',
+						'placement'        => 'inline',
+					],
+				],
+				true,
+			],
+			'missing required'   => [
+				[
+					'title'   => 'Test Campaign',
+					'content' => 'Test content',
+					'meta'    => [
+						'background_color' => '#FFFFFF',
+						'display_title'    => false,
+						'hide_border'      => false,
+						'large_border'     => false,
+						'placement'        => 'inline',
+					],
+				],
+				false,
+			],
+			'invalid type'       => [
+				[
+					'title'   => 'Test Campaign',
+					'content' => 'Test content',
+					'meta'    => [
+						'background_color' => 33,
+						'display_title'    => false,
+						'hide_border'      => false,
+						'large_border'     => false,
+						'frequency'        => 'once',
+						'placement'        => 'inline',
+					],
+				],
+				false,
+			],
+			'invalid bool'       => [
+				[
+					'title'   => 'Test Campaign',
+					'content' => 'Test content',
+					'meta'    => [
+						'background_color' => '#FFFFFF',
+						'display_title'    => 'string',
+						'hide_border'      => false,
+						'large_border'     => false,
+						'frequency'        => 'once',
+						'placement'        => 'inline',
+					],
+				],
+				false,
+			],
+			'invalid format'     => [
+				[
+					'title'   => 'Test Campaign',
+					'content' => 'Test content',
+					'meta'    => [
+						'background_color' => 'not a color',
+						'display_title'    => false,
+						'hide_border'      => false,
+						'large_border'     => false,
+						'frequency'        => 'once',
+						'placement'        => 'inline',
+					],
+				],
+				false,
+			],
+			'invalid max'        => [
+				[
+					'title'   => 'Test Campaign',
+					'content' => 'Test content',
+					'meta'    => [
+						'background_color' => '#FFFFFF',
+						'display_title'    => false,
+						'hide_border'      => false,
+						'large_border'     => false,
+						'frequency'        => 'once',
+						'placement'        => 'inline',
+						'overlay_opacity'  => 200,
+					],
+				],
+				false,
+			],
+			'invalid enum'       => [
+				[
+					'title'   => 'Test Campaign',
+					'content' => 'Test content',
+					'meta'    => [
+						'background_color' => '#FFFFFF',
+						'display_title'    => false,
+						'hide_border'      => false,
+						'large_border'     => false,
+						'frequency'        => 'invalid',
+						'placement'        => 'inline',
+					],
+				],
+				false,
+			],
+			'additional prop'    => [
+				[
+					'title'   => 'Test Campaign',
+					'content' => 'Test content',
+					'meta'    => [
+						'background_color' => '#FFFFFF',
+						'display_title'    => false,
+						'hide_border'      => false,
+						'large_border'     => false,
+						'frequency'        => 'once',
+						'placement'        => 'inline',
+						'unknown'          => 'invalid',
+					],
+				],
+				false,
+			],
+
+		];
+	}
+
+	/**
+	 * Tests the Prompts Schema
+	 *
+	 * @param array $value The valie to be checked.
+	 * @param bool  $expected_result The expected result.
+	 * @return void
+	 * @dataProvider prompts_data
+	 */
+	public function test_prompts_schema( $value, $expected_result ) {
+		$schema = new Newspack\Campaigns\Schemas\Prompts( $value );
+		$this->assertSame( $expected_result, $schema->is_valid() );
+	}
+
+	/**
+	 * Data provider to test segment schema.
+	 *
+	 * @return array
+	 */
+	public function segments_data() {
+		// data provider to test Schemas\Segment.
+		return [
+			'complete and valid'     => [
+				[
+					'name'          => 'Test Segment',
+					'id'            => 'aasdqwe1234',
+					'priority'      => 10,
+					'configuration' => [
+						'max_posts'           => 1,
+						'min_posts'           => 1,
+						'min_session_posts'   => 1,
+						'max_session_posts'   => 1,
+						'is_subscribed'       => true,
+						'is_not_subscribed'   => true,
+						'is_donor'            => true,
+						'is_not_donor'        => true,
+						'is_former_donor'     => true,
+						'is_logged_in'        => true,
+						'is_not_logged_in'    => true,
+						'favorite_categories' => [ 1 ],
+						'referrers'           => '',
+						'referrers_not'       => '',
+					],
+				],
+				true,
+			],
+			'valid'                  => [
+				[
+					'name'          => 'Test Segment',
+					'id'            => 'aasdqwe1234',
+					'priority'      => 10,
+					'configuration' => [
+						'max_posts' => 1,
+					],
+				],
+				true,
+			],
+			'missing required'       => [
+				[
+					'name'          => 'Test Segment',
+					'priority'      => 10,
+					'configuration' => [
+						'max_posts' => 1,
+					],
+				],
+				false,
+			],
+			'additional propertu'    => [
+				[
+					'name'          => 'Test Segment',
+					'id'            => 'aasdqwe1234',
+					'priority'      => 10,
+					'configuration' => [
+						'max_posts' => 1,
+						'unknown'   => 'invalid',
+					],
+				],
+				false,
+			],
+			'invalid int'            => [
+				[
+					'name'          => 'Test Segment',
+					'id'            => 'aasdqwe1234',
+					'priority'      => 10,
+					'configuration' => [
+						'max_posts' => 'string',
+					],
+				],
+				false,
+			],
+			'fav categories valid'   => [
+				[
+					'name'          => 'Test Segment',
+					'id'            => 'aasdqwe1234',
+					'priority'      => 10,
+					'configuration' => [
+						'favorite_categories' => [ 1 ],
+					],
+				],
+				true,
+			],
+			'fav categories invalid' => [
+				[
+					'name'          => 'Test Segment',
+					'id'            => 'aasdqwe1234',
+					'priority'      => 10,
+					'configuration' => [
+						'favorite_categories' => [ 'string' ],
+					],
+				],
+				false,
+			],
+
+		];
+	}
+
+	/**
+	 * Tests the Segments Schema
+	 *
+	 * @param array $value The valie to be checked.
+	 * @param bool  $expected_result The expected result.
+	 * @return void
+	 * @dataProvider segments_data
+	 */
+	public function test_segments_schema( $value, $expected_result ) {
+		$schema = new Newspack\Campaigns\Schemas\Segments( $value );
+		$this->assertSame( $expected_result, $schema->is_valid() );
+	}
+}

--- a/tests/test-schemas.php
+++ b/tests/test-schemas.php
@@ -182,7 +182,7 @@ class SchemasTest extends WP_UnitTestCase {
 	/**
 	 * Tests the Prompts Schema
 	 *
-	 * @param array $value The valie to be checked.
+	 * @param array $value The value to be checked.
 	 * @param bool  $expected_result The expected result.
 	 * @return void
 	 * @dataProvider prompts_data

--- a/tests/test-schemas.php
+++ b/tests/test-schemas.php
@@ -297,7 +297,7 @@ class SchemasTest extends WP_UnitTestCase {
 	/**
 	 * Tests the Segments Schema
 	 *
-	 * @param array $value The valie to be checked.
+	 * @param array $value The value to be checked.
 	 * @param bool  $expected_result The expected result.
 	 * @return void
 	 * @dataProvider segments_data

--- a/tests/test-schemas.php
+++ b/tests/test-schemas.php
@@ -159,6 +159,22 @@ class SchemasTest extends WP_UnitTestCase {
 				],
 				false,
 			],
+			'invalid enum 2'     => [
+				[
+					'title'   => 'Test Campaign',
+					'content' => 'Test content',
+					'meta'    => [
+						'background_color' => '#FFFFFF',
+						'display_title'    => false,
+						'hide_border'      => false,
+						'large_border'     => false,
+						'frequency'        => 'once',
+						'placement'        => 'inline',
+						'overlay_size'     => 'super',
+					],
+				],
+				false,
+			],
 			'additional prop'    => [
 				[
 					'title'   => 'Test Campaign',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR creates a few JSON Schemas to describe the json format of the Prompts, Segments and Campaigns we will import and export.

This is a proposition based on what I could find, as the format of each entity is not formally described. The Schemas created here could also be used in the `schema` parameter of the REST api endpoints for documentation and validation if we want.

How I plan to use this:
* The importer/exporter will use these classes to validate the input json file
* Sanitize the input (with `rest_sanitize_value_from_schema`) and fill in default values when they are blank
* Santize the output json when exporting

Other notes:

* Note that the IDs (campaigns and segments IDs) that are used in the prompts will be replaced on importing. They will only have to be consistent within the json file being imported
* Not sure yet if we will import fields such as `favorite_categories` and `excluded_tags`, since they depend on terms to exist in the destination blog. We can discuss if we want to create them on the fly later...
* Question: Prompts can be assigned to Categories and Tags. Is this used? Does it define in which category/tag the prompt will be displayed? Should we add this to the schema? (considering that there is the issue of these terms having to exist in the destination blog)
* As much as possible, I made properties not required. I imagine a situation where we introduce a new property to one entity and if they were all required an old json would no longer be compatible.
* I added `additionalProperties` as `false` in all schemas. Is there any plugin adding additional properties we should consider? Is there a filter for that I should look into?

### How to test the changes in this Pull Request:

Nothing to test. Look at the Schemas and see if it has all we need, if the defaults are right, etc.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
