### PR TITLE
Addthe Importer

### DIFF
--- a/includes/class-newspack-popups-exporter.php
+++ b/includes/class-newspack-popups-exporter.php
@@ -5,9 +5,9 @@
  * @package Newspack
  */
 
-require_once dirname( __FILE__ ) . '/schemas/schemas-loader.php';
-
 defined( 'ABSPATH' ) || exit;
+
+require_once dirname( __FILE__ ) . '/schemas/schemas-loader.php';
 
 /**
  * Exporter

--- a/includes/class-newspack-popups-exporter.php
+++ b/includes/class-newspack-popups-exporter.php
@@ -85,7 +85,7 @@ class Newspack_Popups_Exporter {
 		$prompts        = [];
 		$stored_prompts = Newspack_Popups_Model::retrieve_popups( true );
 		foreach ( $stored_prompts as $stored_prompt ) {
-			$transformed = self::prepare_prompt_for_export( $stored_prompt );
+			$transformed = $this->prepare_prompt_for_export( $stored_prompt );
 			$val         = new Newspack\Campaigns\Schemas\Prompts( $transformed );
 			if ( $val->is_valid() ) {
 				$prompts[] = $transformed;
@@ -107,7 +107,7 @@ class Newspack_Popups_Exporter {
 	 */
 	private function get_campaigns() {
 		$campaigns        = [];
-		$stored_campaigns = self::sanitize_campaign_groups( Newspack_Popups::get_groups() );
+		$stored_campaigns = $this->sanitize_campaign_groups( Newspack_Popups::get_groups() );
 		foreach ( $stored_campaigns as $stored_campaign ) {
 			$val = new Newspack\Campaigns\Schemas\Campaigns( $stored_campaign );
 			if ( $val->is_valid() ) {
@@ -133,13 +133,26 @@ class Newspack_Popups_Exporter {
 		foreach ( $stored_segments as $stored_segment ) {
 			$val = new Newspack\Campaigns\Schemas\Segments( $stored_segment );
 			if ( $val->is_valid() ) {
-				$segments[] = $stored_segment;
+				$segments[] = $this->prepare_segment_for_export( $stored_segment );
 				$this->totals['segments']++;
 			} else {
 				$this->errors['segments'][ $stored_segment->term_id ] = $val->get_errors();
 			}
 		}
 		return $segments;
+	}
+
+	/**
+	 * Prepares the segment from the database for export.
+	 *
+	 * @param array $segment The segment as it is returned from Newspack_Popups_Segmentation::get_segments.
+	 * @return array The segment in the format expected by the exporter.
+	 */
+	private function prepare_segment_for_export( $segment ) {
+		if ( isset( $segment['configuration']['favorite_categories'] ) ) {
+			$segment['configuration']['favorite_categories'] = $this->sanitize_categories( $segment['configuration']['favorite_categories'] );
+		}
+		return $segment;
 	}
 
 	/**

--- a/includes/class-newspack-popups-exporter.php
+++ b/includes/class-newspack-popups-exporter.php
@@ -1,0 +1,236 @@
+<?php
+/**
+ * Newspack Popups Exporter
+ *
+ * @package Newspack
+ */
+
+require_once dirname( __FILE__ ) . '/schemas/schemas-loader.php';
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Exporter
+ */
+class Newspack_Popups_Exporter {
+
+	/**
+	 * Stores the total number of items exported.
+	 *
+	 * @var int[]
+	 */
+	protected $totals;
+
+	/**
+	 * Store the errors of items that could not be exported.
+	 *
+	 * @var int[]
+	 */
+	protected $errors;
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		$this->reset_results();
+	}
+
+	/**
+	 * Export prompts, segments and campaigns.
+	 *
+	 * @return array Exported data.
+	 */
+	public function export() {
+		$this->reset_results();
+		$exported_data = [
+			'prompts'   => $this->get_prompts(),
+			'segments'  => $this->get_segments(),
+			'campaigns' => $this->get_campaigns(),
+		];
+
+		return [
+			'totals' => $this->totals,
+			'errors' => $this->errors,
+			'data'   => $exported_data,
+		];
+	}
+
+	/**
+	 * Reset results for a new export
+	 *
+	 * @return void
+	 */
+	protected function reset_results() {
+		$this->totals = [
+			'prompts'   => 0,
+			'segments'  => 0,
+			'campaigns' => 0,
+		];
+		$this->errors = [
+			'prompts'   => [],
+			'segments'  => [],
+			'campaigns' => [],
+			'terms'     => [],
+		];
+	}
+
+	/**
+	 * Get the prompts to be exported.
+	 *
+	 * Return only items that pass validation and add errors for the ones that don't.
+	 *
+	 * @return array
+	 */
+	protected function get_prompts() {
+		$prompts        = [];
+		$stored_prompts = Newspack_Popups_Model::retrieve_popups( true );
+		foreach ( $stored_prompts as $stored_prompt ) {
+			$transformed = self::transform_prompt( $stored_prompt );
+			$val         = new Newspack\Campaigns\Schemas\Prompts( $transformed );
+			if ( $val->is_valid() ) {
+				$prompts[] = $transformed;
+				$this->totals['prompts']++;
+			} else {
+				$this->errors['prompts'][ $stored_prompt['id'] ] = $val->get_errors();
+			}
+		}
+
+		return $prompts;
+	}
+
+	/**
+	 * Get the Campaigns to be exported.
+	 *
+	 * Return only items that pass validation and add errors for the ones that don't.
+	 *
+	 * @return array
+	 */
+	protected function get_campaigns() {
+		$campaigns        = [];
+		$stored_campaigns = self::sanitize_campaign_groups( Newspack_Popups::get_groups() );
+		foreach ( $stored_campaigns as $stored_campaign ) {
+			$val = new Newspack\Campaigns\Schemas\Campaigns( $stored_campaign );
+			if ( $val->is_valid() ) {
+				$campaigns[] = $stored_campaign;
+				$this->totals['campaigns']++;
+			} else {
+				$this->errors['campaigns'][ $stored_campaign->term_id ] = $val->get_errors();
+			}
+		}
+		return $campaigns;
+	}
+
+	/**
+	 * Get the Segments to be exported.
+	 *
+	 * Return only items that pass validation and add errors for the ones that don't.
+	 *
+	 * @return array
+	 */
+	public function get_segments() {
+		$segments        = [];
+		$stored_segments = Newspack_Popups_Segmentation::get_segments();
+		foreach ( $stored_segments as $stored_segment ) {
+			$val = new Newspack\Campaigns\Schemas\Segments( $stored_segment );
+			if ( $val->is_valid() ) {
+				$segments[] = $stored_segment;
+				$this->totals['segments']++;
+			} else {
+				$this->errors['segments'][ $stored_segment->term_id ] = $val->get_errors();
+			}
+		}
+		return $segments;
+	}
+
+	/**
+	 * Prepares the prompt from the database for export.
+	 *
+	 * @param array $prompt The prompt as it is returned from Newspack_Popups_Model::retrieve_popups.
+	 * @return array The prompt in the format expected by the exporter.
+	 */
+	protected function transform_prompt( $prompt ) {
+		unset( $prompt['id'] );
+
+		$prompt['options']['excluded_categories'] = self::sanitize_categories( $prompt['options']['excluded_categories'] );
+		$prompt['options']['excluded_tags']       = self::sanitize_tags( $prompt['options']['excluded_tags'] );
+		$prompt['categories']                     = self::sanitize_categories( $prompt['categories'] );
+		$prompt['tags']                           = self::sanitize_tags( $prompt['tags'] );
+
+		$prompt['campaign_groups'] = self::sanitize_campaign_groups( $prompt['campaign_groups'] );
+
+		if ( empty( $prompt['options']['utm_suppression'] ) ) {
+			unset( $prompt['options']['utm_suppression'] );
+		}
+
+		return $prompt;
+
+	}
+
+	/**
+	 * Sanitizes an array of Categories
+	 *
+	 * @see self::sanitize_terms
+	 *
+	 * @param int[]|WP_Term[] $categories An array of categories IDs or WP_Term objects.
+	 * @return array
+	 */
+	public function sanitize_categories( $categories ) {
+		return $this->sanitize_terms( $categories, 'category' );
+	}
+
+	/**
+	 * Sanitizes an array of Tags
+	 *
+	 * @see self::sanitize_terms
+	 *
+	 * @param int[]|WP_Term[] $tags An array of tags IDs or WP_Term objects.
+	 * @return array
+	 */
+	public function sanitize_tags( $tags ) {
+		return $this->sanitize_terms( $tags, 'post_tag' );
+	}
+
+	/**
+	 * Sanitizes an array of Campaigns
+	 *
+	 * @see self::sanitize_terms
+	 *
+	 * @param int[]|WP_Term[] $campaign_groups An array of campaign_groups IDs or WP_Term objects.
+	 * @return array
+	 */
+	public function sanitize_campaign_groups( $campaign_groups ) {
+		return $this->sanitize_terms( $campaign_groups, Newspack_Popups::NEWSPACK_POPUPS_TAXONOMY );
+	}
+
+	/**
+	 * Sanitize terms.
+	 *
+	 * Transforms an array of terms in an array in the format expected by the Exporter, containing only the term ID and name.
+	 *
+	 * @param int[]|WP_Term[] $terms Array of terms. If term must be either an integer with the term ID, or a WP_Term object.
+	 * @param string          $taxonomy Taxonomy slug. Used to fetch the term name if only an ID is informed.
+	 * @return array
+	 */
+	public function sanitize_terms( $terms, $taxonomy ) {
+		$sanitized_terms = [];
+		foreach ( $terms as $term ) {
+			if ( is_int( $term ) ) {
+				$term = get_term( $term, $taxonomy );
+			}
+			if ( is_a( $term, 'WP_Term' ) ) {
+				$sanitized_terms[] = [
+					'id'   => $term->term_id,
+					'name' => $term->name,
+				];
+			} else {
+				if ( ! is_array( $this->errors['terms'][ $taxonomy ] ) ) {
+					$this->errors['terms'][ $taxonomy ] = [];
+					if ( is_wp_error( $term ) ) {
+						$this->errors['terms'][ $taxonomy ][] = $term->get_error_message();
+					}
+				}
+			}
+		}
+		return $sanitized_terms;
+	}
+}

--- a/includes/class-newspack-popups-importer.php
+++ b/includes/class-newspack-popups-importer.php
@@ -1,0 +1,269 @@
+<?php
+/**
+ * Newspack Popups Importer
+ *
+ * @package Newspack
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+require_once dirname( __FILE__ ) . '/schemas/schemas-loader.php';
+
+/**
+ * Importer
+ */
+class Newspack_Popups_Importer {
+
+	/**
+	 * Stores the total number of items exported.
+	 *
+	 * @var int[]
+	 */
+	private $totals;
+
+	/**
+	 * Store the errors of items that could not be exported.
+	 *
+	 * @var int[]
+	 */
+	private $errors;
+
+	/**
+	 * Store the mapping between the ID of the terms in the input data and the ID of the created terms.
+	 *
+	 * @var int[]
+	 */
+	private $terms_mapping;
+
+	/**
+	 * Store the mapping between the ID of the segments in the input data and the ID of the created segments.
+	 *
+	 * @var string[]
+	 */
+	private $segments_mapping;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param array $input_data Data to import.
+	 */
+	public function __construct( $input_data ) {
+		$this->reset_results();
+		$this->input = $input_data;
+	}
+
+	/**
+	 * Export prompts, segments and campaigns.
+	 *
+	 * @return array Exported data.
+	 */
+	public function import() {
+		$this->reset_results();
+
+		$validation = new Newspack\Campaigns\Schemas\Package( $this->input );
+		if ( ! $validation->is_valid() ) {
+			return [
+				'errors' => [
+					'validation' => $validation->get_errors(),
+				],
+			];
+		}
+
+		$this->process_campaigns();
+		$this->process_segments();
+		$this->process_prompts();
+
+		return [
+			'totals' => $this->totals,
+			'errors' => $this->errors,
+		];
+	}
+
+	/**
+	 * Reset results for a new export
+	 *
+	 * @return void
+	 */
+	private function reset_results() {
+		$this->totals           = [
+			'prompts'   => 0,
+			'segments'  => 0,
+			'campaigns' => 0,
+		];
+		$this->errors           = [
+			'prompts'    => [],
+			'segments'   => [],
+			'campaigns'  => [],
+			'terms'      => [],
+			'validation' => [],
+		];
+		$this->terms_mapping    = [];
+		$this->segments_mapping = [];
+	}
+
+	/**
+	 * Process campaigns
+	 *
+	 * Create the campaigns and store the mapping between the old and new IDs.
+	 *
+	 * @return void
+	 */
+	private function process_campaigns() {
+		$campaigns = $this->input['campaigns'];
+		foreach ( $campaigns as $campaign ) {
+			$created                                = Newspack_Popups::create_campaign( $campaign['name'] );
+			$this->terms_mapping[ $campaign['id'] ] = $created;
+			$this->totals['campaigns']++;
+		}
+	}
+
+	/**
+	 * Process segments
+	 *
+	 * Create the segments and store the mapping between the old and new IDs.
+	 *
+	 * @return void
+	 */
+	private function process_segments() {
+		$segments = $this->input['segments'];
+		$segments = $this->pre_process_segments_terms( $segments );
+		foreach ( $segments as $segment ) {
+			$stored_segments                          = Newspack_Popups_Segmentation::create_segment( $segment );
+			$created                                  = end( $stored_segments );
+			$this->segments_mapping[ $segment['id'] ] = $created['id'];
+			$this->totals['segments']++;
+		}
+	}
+
+	/**
+	 * Pre process terms in segments
+	 *
+	 * @param array $segments The segments from input.
+	 * @return array The segments with the terms pre processed.
+	 */
+	private function pre_process_segments_terms( $segments ) {
+		foreach ( $segments as $segment_index => $segment ) {
+			if ( ! empty( $segment['configuration']['favorite_categories'] ) ) {
+				$segments[ $segment_index ]['configuration']['favorite_categories'] = $this->pre_process_terms( $segment['configuration']['favorite_categories'] );
+			}
+		}
+		return $segments;
+	}
+
+	/**
+	 * Process prompts
+	 *
+	 * @return void
+	 */
+	private function process_prompts() {
+		$prompts = $this->input['prompts'];
+		$prompts = $this->pre_process_prompt_segments( $prompts );
+		$prompts = $this->pre_process_prompts_terms( $prompts );
+
+		foreach ( $prompts as $prompt ) {
+			$post_data = [
+				'post_title'   => $prompt['title'],
+				'post_content' => $prompt['content'],
+				'post_status'  => $prompt['status'],
+				'post_type'    => Newspack_Popups::NEWSPACK_POPUPS_CPT,
+			];
+			$new_post  = wp_insert_post( $post_data );
+			if ( is_wp_error( $new_post ) ) {
+				$this->errors['prompts'][] = $new_post->get_error_message();
+				continue;
+			}
+
+			$this->totals['prompts']++;
+
+			Newspack_Popups_Model::set_popup_options( $new_post, $prompt['options'] );
+
+			if ( ! empty( $prompt['campaign_groups'] ) ) {
+				Newspack_Popups_Model::set_popup_terms( $new_post, $prompt['campaign_groups'], Newspack_Popups::NEWSPACK_POPUPS_TAXONOMY );
+			}
+			if ( ! empty( $prompt['categories'] ) ) {
+				Newspack_Popups_Model::set_popup_terms( $new_post, $prompt['categories'], 'category' );
+			}
+			if ( ! empty( $prompt['tags'] ) ) {
+				Newspack_Popups_Model::set_popup_terms( $new_post, $prompt['tags'], 'post_tag' );
+			}
+		}
+	}
+
+	/**
+	 * Pre-process prompt segments
+	 *
+	 * If there are segments set, replace the IDs with the IDs from the segment mapping
+	 *
+	 * @param array $prompts The prompts to process.
+	 * @return array The processed prompts.
+	 */
+	private function pre_process_prompt_segments( $prompts ) {
+		foreach ( $prompts as $prompt_index => $prompt ) {
+			if ( ! empty( $prompt['options']['selected_segment_id'] ) ) {
+				$segments = explode( ',', $prompt['options']['selected_segment_id'] );
+				foreach ( $segments as $key => $segment ) {
+					if ( isset( $this->segments_mapping[ $segment ] ) ) {
+						$segments[ $key ] = $this->segments_mapping[ $segment ];
+					} else {
+						unset( $segments[ $key ] );
+					}
+				}
+				$prompts[ $prompt_index ]['options']['selected_segment_id'] = implode( ',', $segments );
+			}
+		}
+		return array_values( $prompts );
+	}
+
+	/**
+	 * Pre process terms in prompts
+	 *
+	 * @TODO: We are not handling tags and categories yet. They need to be handled beforehand and we need to decide what to do with them.
+	 * The best thing to do would be to let the user decide if they want to map them to an existing term or to create a new term.
+	 * For now, we are dropping them from the input and not importing them.
+	 *
+	 * @param array $prompts The prompts from input.
+	 * @return array The prompts with the terms pre processed.
+	 */
+	private function pre_process_prompts_terms( $prompts ) {
+		foreach ( $prompts as $prompt_index => $prompt ) {
+
+			if ( ! empty( $prompt['campaign_groups'] ) ) {
+				$prompts[ $prompt_index ]['campaign_groups'] = $this->pre_process_terms( $prompt['campaign_groups'] );
+			}
+			if ( ! empty( $prompt['categories'] ) ) {
+				$prompts[ $prompt_index ]['categories'] = $this->pre_process_terms( $prompt['categories'] );
+			}
+			if ( ! empty( $prompt['tags'] ) ) {
+				$prompts[ $prompt_index ]['tags'] = $this->pre_process_terms( $prompt['tags'] );
+			}
+			if ( ! empty( $prompt['options']['excluded_categories'] ) ) {
+				$prompts[ $prompt_index ]['options']['excluded_categories'] = $this->pre_process_terms( $prompt['options']['excluded_categories'] );
+			}
+			if ( ! empty( $prompt['options']['excluded_tags'] ) ) {
+				$prompts[ $prompt_index ]['options']['excluded_tags'] = $this->pre_process_terms( $prompt['options']['excluded_tags'] );
+			}
+		}
+		return array_values( $prompts );
+	}
+
+	/**
+	 * Pre process terms
+	 *
+	 * Check if terms mapping were defined and update their ids, otherwise remove them from the array.
+	 *
+	 * @param array $terms The terms array in which each item is and array with id and name.
+	 * @return array $terms The processed terms.
+	 */
+	private function pre_process_terms( $terms ) {
+		foreach ( $terms as $term_index => $term ) {
+			if ( isset( $this->terms_mapping[ $term['id'] ] ) ) {
+				$terms[ $term_index ]['id'] = $this->terms_mapping[ $term['id'] ];
+			} else {
+				unset( $terms[ $term_index ] );
+			}
+		}
+		return array_values( $terms );
+	}
+
+
+}

--- a/includes/schemas/class-campaigns.php
+++ b/includes/schemas/class-campaigns.php
@@ -19,7 +19,7 @@ class Campaigns extends Schema {
 	 *
 	 * @return array The schema.
 	 */
-	public function get_schema() {
+	public static function get_schema() {
 		return [
 			'type'                 => 'object',
 			'additionalProperties' => false,

--- a/includes/schemas/class-package.php
+++ b/includes/schemas/class-package.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * The Campaigns package Schema
+ *
+ * @package Newspack
+ */
+
+namespace Newspack\Campaigns\Schemas;
+
+use \Newspack\Campaigns\Schema;
+
+/**
+ * The Campaigns Schema
+ */
+class Package extends Schema {
+
+	/**
+	 * Get the schema.
+	 *
+	 * @return array The schema.
+	 */
+	public function get_schema() {
+		return [
+			'type'                 => 'object',
+			'additionalProperties' => false,
+			'properties'           => [
+				'prompts'   => [
+					'name'     => 'prompts',
+					'type'     => 'array',
+					'required' => true,
+					'items'    => Prompts::get_schema(),
+				],
+				'segments'  => [
+					'name'     => 'segments',
+					'type'     => 'array',
+					'required' => true,
+					'items'    => Segments::get_schema(),
+				],
+				'campaigns' => [
+					'name'     => 'campaigns',
+					'type'     => 'array',
+					'required' => true,
+					'items'    => Campaigns::get_schema(),
+				],
+
+			],
+		];
+	}
+}

--- a/includes/schemas/class-package.php
+++ b/includes/schemas/class-package.php
@@ -21,7 +21,7 @@ class Package extends Schema {
 	 *
 	 * @return array The schema.
 	 */
-	public function get_schema() {
+	public static function get_schema() {
 		return [
 			'type'                 => 'object',
 			'additionalProperties' => false,

--- a/includes/schemas/class-package.php
+++ b/includes/schemas/class-package.php
@@ -10,7 +10,9 @@ namespace Newspack\Campaigns\Schemas;
 use \Newspack\Campaigns\Schema;
 
 /**
- * The Campaigns Schema
+ * The Campaigns package Schema
+ *
+ * Defines the schema for the import/export package that includes Campaigns, Segments and Prompts.
  */
 class Package extends Schema {
 

--- a/includes/schemas/class-prompts.php
+++ b/includes/schemas/class-prompts.php
@@ -20,7 +20,7 @@ class Prompts extends Schema {
 	 *
 	 * @return array The schema.
 	 */
-	public function get_schema() {
+	public static function get_schema() {
 		return [
 			'type'                 => 'object',
 			'additionalProperties' => false,

--- a/includes/schemas/class-prompts.php
+++ b/includes/schemas/class-prompts.php
@@ -39,12 +39,66 @@ class Prompts extends Schema {
 					'name'     => 'campaign_groups',
 					'type'     => 'array',
 					'required' => false,
-					'items'    => [
-						'type' => 'integer',
-					],
 					'default'  => [],
+					'items'    => [
+						'type'                 => 'object',
+						'additionalProperties' => false,
+						'properties'           => [
+							'id'   => [
+								'type' => 'integer',
+							],
+							'name' => [
+								'type' => 'string',
+							],
+						],
+					],
 				],
-				'meta'            => [
+				'status'          => [
+					'name'     => 'status',
+					'type'     => 'string',
+					'required' => true,
+					'enum'     => [
+						'publish',
+						'draft',
+					],
+				],
+				'categories'      => [
+					'name'     => 'categories',
+					'type'     => 'array',
+					'required' => false,
+					'default'  => [],
+					'items'    => [
+						'type'                 => 'object',
+						'additionalProperties' => false,
+						'properties'           => [
+							'id'   => [
+								'type' => 'integer',
+							],
+							'name' => [
+								'type' => 'string',
+							],
+						],
+					],
+				],
+				'tags'            => [
+					'name'     => 'tags',
+					'type'     => 'array',
+					'required' => false,
+					'default'  => [],
+					'items'    => [
+						'type'                 => 'object',
+						'additionalProperties' => false,
+						'properties'           => [
+							'id'   => [
+								'type' => 'integer',
+							],
+							'name' => [
+								'type' => 'string',
+							],
+						],
+					],
+				],
+				'options'         => [
 					'type'                 => 'object',
 					'required'             => true,
 					'additionalProperties' => false,
@@ -264,42 +318,6 @@ class Prompts extends Schema {
 						],
 						'excluded_tags'                  => [
 							'name'     => 'excluded_tags',
-							'type'     => 'array',
-							'required' => false,
-							'default'  => [],
-							'items'    => [
-								'type'                 => 'object',
-								'additionalProperties' => false,
-								'properties'           => [
-									'id'   => [
-										'type' => 'integer',
-									],
-									'name' => [
-										'type' => 'string',
-									],
-								],
-							],
-						],
-						'categories'                     => [
-							'name'     => 'categories',
-							'type'     => 'array',
-							'required' => false,
-							'default'  => [],
-							'items'    => [
-								'type'                 => 'object',
-								'additionalProperties' => false,
-								'properties'           => [
-									'id'   => [
-										'type' => 'integer',
-									],
-									'name' => [
-										'type' => 'string',
-									],
-								],
-							],
-						],
-						'tags'                           => [
-							'name'     => 'tags',
 							'type'     => 'array',
 							'required' => false,
 							'default'  => [],

--- a/includes/schemas/class-schema.php
+++ b/includes/schemas/class-schema.php
@@ -40,7 +40,7 @@ abstract class Schema {
 	 *
 	 * @return array The Schema.
 	 */
-	abstract public function get_schema();
+	abstract public static function get_schema();
 
 	/**
 	 * Validate the value against the schema.

--- a/includes/schemas/class-segments.php
+++ b/includes/schemas/class-segments.php
@@ -19,7 +19,7 @@ class Segments extends Schema {
 	 *
 	 * @return array The schema.
 	 */
-	public function get_schema() {
+	public static function get_schema() {
 		return [
 			'type'                 => 'object',
 			'additionalProperties' => false,

--- a/includes/schemas/schemas-loader.php
+++ b/includes/schemas/schemas-loader.php
@@ -1,0 +1,7 @@
+<?php
+
+require_once dirname( __FILE__ ) . '/class-schema.php';
+require_once dirname( __FILE__ ) . '/class-prompts.php';
+require_once dirname( __FILE__ ) . '/class-campaigns.php';
+require_once dirname( __FILE__ ) . '/class-segments.php';
+require_once dirname( __FILE__ ) . '/class-package.php';

--- a/includes/schemas/schemas-loader.php
+++ b/includes/schemas/schemas-loader.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore Squiz.Commenting.FileComment.Missing
 /**
  * Loads all the Schema files
  *

--- a/includes/schemas/schemas-loader.php
+++ b/includes/schemas/schemas-loader.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * Loads all the Schema files
+ *
+ * @package Newspack
+ */
 
 require_once dirname( __FILE__ ) . '/class-schema.php';
 require_once dirname( __FILE__ ) . '/class-prompts.php';

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -37,6 +37,7 @@ function _manually_load_plugin() {
 	require dirname( dirname( __FILE__ ) ) . '/api/campaigns/class-report-campaign-data.php';
 	require dirname( dirname( __FILE__ ) ) . '/api/segmentation/class-segmentation-client-data.php';
 	require dirname( dirname( __FILE__ ) ) . '/includes/class-newspack-popups-exporter.php';
+	require dirname( dirname( __FILE__ ) ) . '/includes/class-newspack-popups-importer.php';
 }
 tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -36,6 +36,7 @@ function _manually_load_plugin() {
 	require dirname( dirname( __FILE__ ) ) . '/api/campaigns/class-maybe-show-campaign.php';
 	require dirname( dirname( __FILE__ ) ) . '/api/campaigns/class-report-campaign-data.php';
 	require dirname( dirname( __FILE__ ) ) . '/api/segmentation/class-segmentation-client-data.php';
+	require dirname( dirname( __FILE__ ) ) . '/includes/class-newspack-popups-exporter.php';
 }
 tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
 

--- a/tests/test-exporter.php
+++ b/tests/test-exporter.php
@@ -1,0 +1,180 @@
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+/**
+ * Class Exporter Test
+ *
+ * @package Newspack_Popups
+ */
+
+/**
+ * Exporter test case.
+ */
+class ExporterTest extends WP_UnitTestCase_PageWithPopups {
+
+	/**
+	 * Call protected/private method of a class.
+	 *
+	 * @param object $object    Instantiated object that we will run method on.
+	 * @param string $method_name Method name to call.
+	 * @param array  $parameters Array of parameters to pass into method.
+	 *
+	 * @return mixed Method return.
+	 */
+	public function invoke_method( &$object, $method_name, array $parameters = array() ) {
+		$reflection = new \ReflectionClass( get_class( $object ) );
+		$method     = $reflection->getMethod( $method_name );
+		$method->setAccessible( true );
+
+		return $method->invokeArgs( $object, $parameters );
+	}
+
+	/**
+	 * Data provider for test_prepare_prompt_for_export
+	 *
+	 * @return array
+	 */
+	public function prepare_prompt_for_export_data() {
+		return [
+			'id should be unset'             => [
+				[
+					'id'      => 123,
+					'title'   => 'Test Campaign',
+					'content' => 'Test content',
+					'status'  => 'publish',
+					'options' => [
+						'background_color' => '#FFFFFF',
+						'display_title'    => false,
+						'hide_border'      => false,
+						'large_border'     => false,
+						'frequency'        => 'once',
+						'placement'        => 'inline',
+					],
+				],
+				[
+					'title'   => 'Test Campaign',
+					'content' => 'Test content',
+					'status'  => 'publish',
+					'options' => [
+						'background_color' => '#FFFFFF',
+						'display_title'    => false,
+						'hide_border'      => false,
+						'large_border'     => false,
+						'frequency'        => 'once',
+						'placement'        => 'inline',
+					],
+				],
+
+			],
+			'fix overlay size'               => [
+				[
+					'id'      => 123,
+					'title'   => 'Test Campaign',
+					'content' => 'Test content',
+					'status'  => 'publish',
+					'options' => [
+						'overlay_size'  => 'full',
+						'display_title' => false,
+						'hide_border'   => false,
+						'large_border'  => false,
+						'frequency'     => 'once',
+						'placement'     => 'inline',
+					],
+				],
+				[
+					'title'   => 'Test Campaign',
+					'content' => 'Test content',
+					'status'  => 'publish',
+					'options' => [
+						'overlay_size'  => 'full-width',
+						'display_title' => false,
+						'hide_border'   => false,
+						'large_border'  => false,
+						'frequency'     => 'once',
+						'placement'     => 'inline',
+					],
+				],
+
+			],
+			'unset utm_suppression if empty' => [
+				[
+					'id'      => 123,
+					'title'   => 'Test Campaign',
+					'content' => 'Test content',
+					'status'  => 'publish',
+					'options' => [
+						'utm_suppression' => false,
+						'display_title'   => false,
+						'hide_border'     => false,
+						'large_border'    => false,
+						'frequency'       => 'once',
+						'placement'       => 'inline',
+					],
+				],
+				[
+					'title'   => 'Test Campaign',
+					'content' => 'Test content',
+					'status'  => 'publish',
+					'options' => [
+						'display_title' => false,
+						'hide_border'   => false,
+						'large_border'  => false,
+						'frequency'     => 'once',
+						'placement'     => 'inline',
+					],
+				],
+
+			],
+		];
+	}
+
+	/**
+	 * Test prepare_prompt_for_export.
+	 *
+	 * @param array $input The input for the prepare_prompt_for_export method.
+	 * @param array $expected The expected output.
+	 * @return void
+	 * @dataProvider prepare_prompt_for_export_data
+	 */
+	public function test_prepare_prompt_for_export( $input, $expected ) {
+		$exporter = new Newspack_Popups_Exporter();
+		$result   = $this->invoke_method( $exporter, 'prepare_prompt_for_export', [ $input ] );
+		$this->assertSame( $expected, $result );
+	}
+
+	/**
+	 * Test sanitize terms
+	 *
+	 * @return void
+	 */
+	public function test_sanitize_terms() {
+		$exporter        = new Newspack_Popups_Exporter();
+		$existing_term   = self::factory()->term->create(
+			[
+				'taxonomy' => 'category',
+				'name'     => 'Test cat',
+			]
+		);
+		$existing_term_2 = self::factory()->term->create(
+			[
+				'taxonomy' => 'category',
+				'name'     => 'Test cat 2',
+			]
+		);
+		$terms           = [
+			$existing_term, // Id of an existing term.
+			get_term( $existing_term_2, 'category' ), // a WP_Term object.
+			9999, // Id of a non-existing term.
+		];
+		$result          = $this->invoke_method( $exporter, 'sanitize_terms', [ $terms, 'category' ] );
+		$expected        = [
+			[
+				'id'   => $existing_term,
+				'name' => 'Test cat',
+			],
+			[
+				'id'   => $existing_term_2,
+				'name' => 'Test cat 2',
+			],
+		];
+		$this->assertSame( $expected, $result );
+	}
+}

--- a/tests/test-importer.php
+++ b/tests/test-importer.php
@@ -1,0 +1,305 @@
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+/**
+ * Class Importer Test
+ *
+ * @package Newspack_Popups
+ */
+
+/**
+ * Importer test case.
+ */
+class ImporterTest extends WP_UnitTestCase_PageWithPopups {
+
+	/**
+	 * Call protected/private method of a class.
+	 *
+	 * @param object $object    Instantiated object that we will run method on.
+	 * @param string $method_name Method name to call.
+	 * @param array  $parameters Array of parameters to pass into method.
+	 *
+	 * @return mixed Method return.
+	 */
+	public function invoke_method( &$object, $method_name, array $parameters = array() ) {
+		$reflection = new \ReflectionClass( get_class( $object ) );
+		$method     = $reflection->getMethod( $method_name );
+		$method->setAccessible( true );
+
+		return $method->invokeArgs( $object, $parameters );
+	}
+
+	public function process_terms_data() {
+		return [
+			'all mapped'     => [
+				[
+					[
+						'id'   => 10,
+						'name' => 'Test Term 1',
+					],
+					[
+						'id'   => 20,
+						'name' => 'Test Term 2',
+					],
+				],
+				[
+					[
+						'id'   => 11,
+						'name' => 'Test Term 1',
+					],
+					[
+						'id'   => 21,
+						'name' => 'Test Term 2',
+					],
+				],
+			],
+			'one not mapped' => [
+				[
+					[
+						'id'   => 10,
+						'name' => 'Test Term 1',
+					],
+					[
+						'id'   => 15,
+						'name' => 'Test Term 3',
+					],
+					[
+						'id'   => 20,
+						'name' => 'Test Term 2',
+					],
+				],
+				[
+					[
+						'id'   => 11,
+						'name' => 'Test Term 1',
+					],
+					[
+						'id'   => 21,
+						'name' => 'Test Term 2',
+					],
+				],
+			],
+			'none mapped'    => [
+				[
+					[
+						'id'   => 1,
+						'name' => 'Test Term 1',
+					],
+					[
+						'id'   => 2,
+						'name' => 'Test Term 3',
+					],
+					[
+						'id'   => 3,
+						'name' => 'Test Term 2',
+					],
+				],
+				[],
+			],
+		];
+	}
+
+	/**
+	 * Test the pre_process_terms method.
+	 *
+	 * @param array $input_data The array of terms to process.
+	 * @param array $expected The expected result.
+	 * @return void
+	 * @dataProvider process_terms_data
+	 */
+	public function test_process_terms( $input_data, $expected ) {
+		$importer      = new Newspack_Popups_Importer( [] );
+		$r_importer    = new \ReflectionClass( $importer );
+		$terms_mapping = [
+			10 => 11,
+			20 => 21,
+		];
+
+		$mapping = $r_importer->getProperty( 'terms_mapping' );
+		$mapping->setAccessible( true );
+		$mapping->setValue( $importer, $terms_mapping );
+
+		$method = $r_importer->getMethod( 'pre_process_terms' );
+		$method->setAccessible( true );
+		$result = $method->invokeArgs( $importer, [ $input_data ] );
+
+		$this->assertEquals( $expected, $result );
+
+	}
+
+	/**
+	 * Test the full functionality of the Importer class
+	 *
+	 * @return void
+	 */
+	public function test_integration() {
+
+		// Clear data created by other tests.
+		global $wpdb;
+		$wpdb->query( $wpdb->prepare( "DELETE FROM $wpdb->posts WHERE post_type = %s", Newspack_Popups::NEWSPACK_POPUPS_CPT ) );
+		delete_option( Newspack_Popups_Segmentation::SEGMENTS_OPTION_NAME );
+
+		$campaigns = [
+			[
+				'id'   => 10,
+				'name' => 'Campaign 1',
+			],
+			[
+				'id'   => 20,
+				'name' => 'Campaign 2',
+			],
+		];
+		$prompts   = [
+			[
+				'title'           => 'Test Prompt 1',
+				'content'         => 'Test content',
+				'status'          => 'publish',
+				'campaign_groups' => [
+					[
+						'id'   => 10,
+						'name' => 'Campaign 1',
+					],
+				],
+				'options'         => [
+					'background_color'    => '#FFFFFF',
+					'display_title'       => false,
+					'hide_border'         => false,
+					'large_border'        => false,
+					'frequency'           => 'once',
+					'placement'           => 'inline',
+					'selected_segment_id' => 'abc123,abc456',
+				],
+			],
+			[
+				'title'           => 'Test Prompt 2',
+				'content'         => 'Test content',
+				'status'          => 'publish',
+				'campaign_groups' => [
+					[
+						'id'   => 20,
+						'name' => 'Campaign 2',
+					],
+				],
+				'options'         => [
+					'background_color'    => '#FFFFFF',
+					'display_title'       => false,
+					'hide_border'         => false,
+					'large_border'        => false,
+					'frequency'           => 'once',
+					'placement'           => 'inline',
+					'selected_segment_id' => 'abc123',
+				],
+			],
+		];
+		$segments  = [
+			[
+				'name'          => 'Test Segment',
+				'id'            => 'abc123',
+				'priority'      => 10,
+				'configuration' => [
+					'max_posts' => 1,
+				],
+			],
+			[
+				'name'          => 'Test Segment 2',
+				'id'            => 'abc456',
+				'priority'      => 10,
+				'configuration' => [
+					'max_posts' => 1,
+				],
+			],
+		];
+
+		$package = [
+			'campaigns' => $campaigns,
+			'prompts'   => $prompts,
+			'segments'  => $segments,
+		];
+
+		$importer = new Newspack_Popups_Importer( $package );
+		$result   = $importer->import();
+
+		$this->assertSame( 2, $result['totals']['campaigns'] );
+		$this->assertSame( 2, $result['totals']['segments'] );
+		$this->assertSame( 2, $result['totals']['prompts'] );
+
+		// Test 2 groups were created.
+		$created_groups = Newspack_Popups::get_groups();
+		$this->assertSame( 2, count( $created_groups ) );
+
+		// Test if segmentes were properly created.
+		$created_segments = Newspack_Popups_Segmentation::get_segments();
+		$this->assertSame( 2, count( $created_segments ) );
+		$this->assertSame( 'Test Segment', $created_segments[0]['name'] );
+		$this->assertSame( 10, $created_segments[0]['priority'] );
+		$this->assertSame( 1, $created_segments[0]['configuration']['max_posts'] );
+		$this->assertSame( 'Test Segment 2', $created_segments[1]['name'] );
+
+		// Get the IDs of the created segments to see if they were properly mapped in the prompts.
+		$segment_1_id = $created_segments[0]['id'];
+		$segment_2_id = $created_segments[1]['id'];
+
+		// Check if 2 prompts were created.
+		$created_prompts = Newspack_Popups_Model::retrieve_popups( true );
+		$this->assertSame( 2, count( $created_prompts ) );
+
+		// Check if the prompts were properly mapped to the segments.
+		$this->assertStringContainsString( $segment_1_id, $created_prompts[0]['options']['selected_segment_id'] );
+		$this->assertStringContainsString( $segment_2_id, $created_prompts[0]['options']['selected_segment_id'] );
+		$this->assertStringContainsString( $segment_1_id, $created_prompts[1]['options']['selected_segment_id'] );
+
+		// Check if the campaign groups terms were properly applied to the prompts.
+		$this->assertSame( 1, count( $created_prompts[0]['campaign_groups'] ) );
+		$this->assertSame( 'Campaign 1', $created_prompts[0]['campaign_groups'][0]->name );
+		$this->assertSame( 1, count( $created_prompts[1]['campaign_groups'] ) );
+		$this->assertSame( 'Campaign 2', $created_prompts[1]['campaign_groups'][0]->name );
+
+	}
+
+	/**
+	 * Test the import method with invalid data.
+	 *
+	 * @return void
+	 */
+	public function test_integration_invalid_data() {
+
+		$campaigns = [
+			[
+				'id'   => 10,
+				'name' => 'Campaign 1',
+			],
+		];
+		// missing required filed in prompts.
+		$prompts = [
+			[
+				'title'   => 'Test Prompt 1',
+				'content' => 'Test content',
+				'status'  => 'publish',
+				'options' => [
+					'selected_segment_id' => 'abc123,abc456',
+					'frequency'           => 'once',
+				],
+			],
+		];
+		// missing required filed in segments.
+		$segments = [
+			[
+				'name'     => 'Test Segment',
+				'id'       => 'abc123',
+				'priority' => 10,
+			],
+		];
+
+		$package = [
+			'campaigns' => $campaigns,
+			'prompts'   => $prompts,
+			'segments'  => $segments,
+		];
+
+		$importer = new Newspack_Popups_Importer( $package );
+		$result   = $importer->import();
+
+		$this->assertNotEmpty( $result['errors'] );
+		$this->assertNotEmpty( $result['errors']['validation'] );
+
+	}
+
+}

--- a/tests/test-importer.php
+++ b/tests/test-importer.php
@@ -27,6 +27,11 @@ class ImporterTest extends WP_UnitTestCase_PageWithPopups {
 		return $method->invokeArgs( $object, $parameters );
 	}
 
+	/**
+	 * Data fortest_process_terms
+	 *
+	 * @return array
+	 */
 	public function process_terms_data() {
 		return [
 			'all mapped'     => [
@@ -134,7 +139,7 @@ class ImporterTest extends WP_UnitTestCase_PageWithPopups {
 
 		// Clear data created by other tests.
 		global $wpdb;
-		$wpdb->query( $wpdb->prepare( "DELETE FROM $wpdb->posts WHERE post_type = %s", Newspack_Popups::NEWSPACK_POPUPS_CPT ) );
+		$wpdb->query( $wpdb->prepare( "DELETE FROM $wpdb->posts WHERE post_type = %s", Newspack_Popups::NEWSPACK_POPUPS_CPT ) ); // phpcs:ignore
 		delete_option( Newspack_Popups_Segmentation::SEGMENTS_OPTION_NAME );
 
 		$campaigns = [

--- a/tests/test-schemas.php
+++ b/tests/test-schemas.php
@@ -19,9 +19,20 @@ class SchemasTest extends WP_UnitTestCase {
 		return [
 			'complete and valid' => [
 				[
-					'title'   => 'Test Campaign',
-					'content' => 'Test content',
-					'meta'    => [
+					'title'      => 'Test Campaign',
+					'content'    => 'Test content',
+					'status'     => 'publish',
+					'categories' => [
+						[
+							'id'   => 1,
+							'name' => 'Category 1',
+						],
+						[
+							'id'   => 2,
+							'name' => 'Category 2',
+						],
+					],
+					'options'    => [
 						'background_color'               => '#FFFFFF',
 						'display_title'                  => false,
 						'hide_border'                    => false,
@@ -48,16 +59,6 @@ class SchemasTest extends WP_UnitTestCase {
 						'archive_page_types'             => [],
 						'excluded_categories'            => [],
 						'excluded_tags'                  => [],
-						'categories'                     => [
-							[
-								'id'   => 1,
-								'name' => 'Category 1',
-							],
-							[
-								'id'   => 2,
-								'name' => 'Category 2',
-							],
-						],
 						'duplicate_of'                   => 0,
 						'newspack_popups_has_disabled_popups' => false,
 					],
@@ -68,7 +69,8 @@ class SchemasTest extends WP_UnitTestCase {
 				[
 					'title'   => 'Test Campaign',
 					'content' => 'Test content',
-					'meta'    => [
+					'status'  => 'publish',
+					'options' => [
 						'background_color' => '#FFFFFF',
 						'display_title'    => false,
 						'hide_border'      => false,
@@ -83,7 +85,8 @@ class SchemasTest extends WP_UnitTestCase {
 				[
 					'title'   => 'Test Campaign',
 					'content' => 'Test content',
-					'meta'    => [
+					'status'  => 'publish',
+					'options' => [
 						'background_color' => '#FFFFFF',
 						'display_title'    => false,
 						'hide_border'      => false,
@@ -97,7 +100,8 @@ class SchemasTest extends WP_UnitTestCase {
 				[
 					'title'   => 'Test Campaign',
 					'content' => 'Test content',
-					'meta'    => [
+					'status'  => 'publish',
+					'options' => [
 						'background_color' => 33,
 						'display_title'    => false,
 						'hide_border'      => false,
@@ -112,7 +116,8 @@ class SchemasTest extends WP_UnitTestCase {
 				[
 					'title'   => 'Test Campaign',
 					'content' => 'Test content',
-					'meta'    => [
+					'status'  => 'publish',
+					'options' => [
 						'background_color' => '#FFFFFF',
 						'display_title'    => 'string',
 						'hide_border'      => false,
@@ -127,7 +132,8 @@ class SchemasTest extends WP_UnitTestCase {
 				[
 					'title'   => 'Test Campaign',
 					'content' => 'Test content',
-					'meta'    => [
+					'status'  => 'publish',
+					'options' => [
 						'background_color' => 'not a color',
 						'display_title'    => false,
 						'hide_border'      => false,
@@ -142,7 +148,8 @@ class SchemasTest extends WP_UnitTestCase {
 				[
 					'title'   => 'Test Campaign',
 					'content' => 'Test content',
-					'meta'    => [
+					'status'  => 'publish',
+					'options' => [
 						'background_color' => '#FFFFFF',
 						'display_title'    => false,
 						'hide_border'      => false,
@@ -158,7 +165,8 @@ class SchemasTest extends WP_UnitTestCase {
 				[
 					'title'   => 'Test Campaign',
 					'content' => 'Test content',
-					'meta'    => [
+					'status'  => 'publish',
+					'options' => [
 						'background_color' => '#FFFFFF',
 						'display_title'    => false,
 						'hide_border'      => false,
@@ -173,7 +181,8 @@ class SchemasTest extends WP_UnitTestCase {
 				[
 					'title'   => 'Test Campaign',
 					'content' => 'Test content',
-					'meta'    => [
+					'status'  => 'publish',
+					'options' => [
 						'background_color' => '#FFFFFF',
 						'display_title'    => false,
 						'hide_border'      => false,
@@ -189,7 +198,8 @@ class SchemasTest extends WP_UnitTestCase {
 				[
 					'title'   => 'Test Campaign',
 					'content' => 'Test content',
-					'meta'    => [
+					'status'  => 'publish',
+					'options' => [
 						'background_color' => '#FFFFFF',
 						'display_title'    => false,
 						'hide_border'      => false,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Creates the Importer class

**This PR is depends on https://github.com/Automattic/newspack-popups/pull/1021**

Important: For now, we are not importing Categories and Tags. This will be handled in future PRs... The idea is to give the user the option to map tags and categories to existing terms or create them...

### How to test the changes in this Pull Request:

1. Tests are passing?

This will be easier to test once we implement the CLI commands for the exporter and the importer, but if you really want to test:

* Use the exporter to generate some data
* `json_encode` the data exported and save it to a file
* Delete all campaigns, prompts and segments from the site
* Load the contents of the file, `json_decode` it and import it using the Importer class
* Confirm that everything is created as expected


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
