### PR TITLE
feat: add new field for custom CSS classes

### DIFF
--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -372,6 +372,7 @@ final class Newspack_Popups_Model {
 			'selected_segment_id'            => get_post_meta( $id, 'selected_segment_id', true ),
 			'post_types'                     => get_post_meta( $id, 'post_types', true ),
 			'archive_page_types'             => get_post_meta( $id, 'archive_page_types', true ),
+			'additional_classes'             => get_post_meta( $id, 'additional_classes', true ),
 			'excluded_categories'            => get_post_meta( $id, 'excluded_categories', true ),
 			'excluded_tags'                  => get_post_meta( $id, 'excluded_tags', true ),
 		];
@@ -416,6 +417,7 @@ final class Newspack_Popups_Model {
 				'selected_segment_id'            => '',
 				'post_types'                     => self::get_default_popup_post_types(),
 				'archive_page_types'             => self::get_supported_archive_page_types(),
+				'additional_classes'             => '',
 				'excluded_categories'            => [],
 				'excluded_tags'                  => [],
 			]
@@ -1084,6 +1086,7 @@ final class Newspack_Popups_Model {
 		$classes[]            = $hide_border ? 'newspack-lightbox-no-border' : null;
 		$classes[]            = $large_border ? 'newspack-lightbox-large-border' : null;
 		$classes[]            = $is_newsletter_prompt ? 'newspack-newsletter-prompt-inline' : null;
+		$classes              = array_merge( $classes, explode( ' ', $popup['options']['additional_classes'] ) );
 
 		$analytics_events = self::get_analytics_events( $popup, $body, $element_id );
 		if ( ! empty( $analytics_events ) ) {
@@ -1164,6 +1167,7 @@ final class Newspack_Popups_Model {
 		$classes[]             = $is_newsletter_prompt ? 'newspack-newsletter-prompt-overlay' : null;
 		$classes[]             = $no_overlay_background ? 'newspack-lightbox-no-overlay' : null;
 		$classes[]             = $has_featured_image ? 'newspack-lightbox-featured-image' : null;
+		$classes               = array_merge( $classes, explode( ' ', $popup['options']['additional_classes'] ) );
 		$wrapper_classes       = [ 'newspack-popup-wrapper' ];
 		$wrapper_classes[]     = 'publish' !== $popup['status'] ? 'newspack-inactive-popup-status' : null;
 		$is_scroll_triggered   = 'scroll' === $popup['options']['trigger_type'];

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -462,6 +462,19 @@ final class Newspack_Popups {
 
 		\register_meta(
 			'post',
+			'additional_classes',
+			[
+				'object_subtype' => self::NEWSPACK_POPUPS_CPT,
+				'show_in_rest'   => true,
+				'type'           => 'string',
+				'default'        => '',
+				'single'         => true,
+				'auth_callback'  => '__return_true',
+			]
+		);
+
+		\register_meta(
+			'post',
 			'excluded_categories',
 			[
 				'object_subtype' => self::NEWSPACK_POPUPS_CPT,

--- a/includes/schemas/class-prompts.php
+++ b/includes/schemas/class-prompts.php
@@ -244,6 +244,12 @@ class Prompts extends Schema {
 								'type' => 'string',
 							],
 						],
+						'additional_classes'             => [
+							'name'     => 'additional_classes',
+							'type'     => 'string',
+							'required' => false,
+							'default'  => '',
+						],
 						'excluded_categories'            => [
 							'name'     => 'excluded_categories',
 							'type'     => 'array',

--- a/src/editor/AdvancedSidebar.js
+++ b/src/editor/AdvancedSidebar.js
@@ -12,12 +12,28 @@ import { BaseControl } from '@wordpress/components';
 /**
  * Internal dependencies
  */
-import { CategoryAutocomplete } from 'newspack-components';
+import { CategoryAutocomplete, TextControl } from 'newspack-components';
 
-const AdvancedSidebar = ( { onMetaFieldChange, excluded_categories = [], excluded_tags = [] } ) => {
+const AdvancedSidebar = ( {
+	onMetaFieldChange,
+	excluded_categories = [],
+	excluded_tags = [],
+	additional_classes = '',
+} ) => {
 	return (
 		<Fragment>
 			<BaseControl>
+				<TextControl
+					label={ __( 'Additional CSS class(es)', 'newspack-popups' ) }
+					help={ __( 'Separate multiple classes with spaces.', 'newspack-popups' ) }
+					value={ additional_classes }
+					onChange={ value =>
+						onMetaFieldChange( {
+							additional_classes: value,
+						} )
+					}
+				/>
+				<hr />
 				<CategoryAutocomplete
 					label={ __( 'Excluded Categories', 'newspack-popups' ) }
 					description={ __(

--- a/src/editor/utils.js
+++ b/src/editor/utils.js
@@ -33,6 +33,7 @@ export const optionsFieldsSelector = select => {
 		selected_segment_id,
 		post_types,
 		archive_page_types,
+		additional_classes,
 		excluded_categories,
 		excluded_tags,
 	} = meta || {};
@@ -65,6 +66,7 @@ export const optionsFieldsSelector = select => {
 		isOverlay,
 		post_types,
 		archive_page_types,
+		additional_classes,
 		excluded_categories,
 		excluded_tags,
 	};

--- a/tests/test-model.php
+++ b/tests/test-model.php
@@ -53,6 +53,7 @@ class ModelTest extends WP_UnitTestCase {
 				'selected_segment_id'            => '',
 				'post_types'                     => [ 'post', 'page' ],
 				'archive_page_types'             => [ 'category', 'tag', 'author', 'date', 'post-type', 'taxonomy' ],
+				'additional_classes'             => '',
 				'excluded_categories'            => [],
 				'excluded_tags'                  => [],
 			],

--- a/tests/test-schemas.php
+++ b/tests/test-schemas.php
@@ -46,6 +46,7 @@ class SchemasTest extends WP_UnitTestCase {
 						'selected_segment_id'            => 'asdasd',
 						'post_types'                     => [ 'post' ],
 						'archive_page_types'             => [],
+						'additional_classes'             => '',
 						'excluded_categories'            => [],
 						'excluded_tags'                  => [],
 						'categories'                     => [


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds a new field for prompts under Advanced Settings to add additional CSS classes. These classes, if set, are added to the outermost `amp-layout` container for the prompt.

### How to test the changes in this Pull Request:

1. Check out this branch.
2. Create or edit a prompt and expand the "Advanced Settings" sidebar. Confirm there's a new field here:

<img width="272" alt="Screen Shot 2022-12-06 at 5 46 35 PM" src="https://user-images.githubusercontent.com/2230142/206060006-5764ccca-6d33-4a64-ab55-4e6955932097.png">

3. Enter one or more class names to the field and save.
4. View the prompt on the front-end, confirm that the classes are added to the `<amp-layout>` element for the prompt.
5. Test with both inline and overlay prompts.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
