### PR TITLE
Add the Importer class and basic CLI command

### DIFF
--- a/includes/class-newspack-popups-importer.php
+++ b/includes/class-newspack-popups-importer.php
@@ -1,0 +1,269 @@
+<?php
+/**
+ * Newspack Popups Importer
+ *
+ * @package Newspack
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+require_once dirname( __FILE__ ) . '/schemas/schemas-loader.php';
+
+/**
+ * Importer
+ */
+class Newspack_Popups_Importer {
+
+	/**
+	 * Stores the total number of items exported.
+	 *
+	 * @var int[]
+	 */
+	private $totals;
+
+	/**
+	 * Store the errors of items that could not be exported.
+	 *
+	 * @var int[]
+	 */
+	private $errors;
+
+	/**
+	 * Store the mapping between the ID of the terms in the input data and the ID of the created terms.
+	 *
+	 * @var int[]
+	 */
+	private $terms_mapping;
+
+	/**
+	 * Store the mapping between the ID of the segments in the input data and the ID of the created segments.
+	 *
+	 * @var string[]
+	 */
+	private $segments_mapping;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param array $input_data Data to import.
+	 */
+	public function __construct( $input_data ) {
+		$this->reset_results();
+		$this->input = $input_data;
+	}
+
+	/**
+	 * Export prompts, segments and campaigns.
+	 *
+	 * @return array Exported data.
+	 */
+	public function import() {
+		$this->reset_results();
+
+		$validation = new Newspack\Campaigns\Schemas\Package( $this->input );
+		if ( ! $validation->is_valid() ) {
+			return [
+				'errors' => [
+					'validation' => $validation->get_errors(),
+				],
+			];
+		}
+
+		$this->process_campaigns();
+		$this->process_segments();
+		$this->process_prompts();
+
+		return [
+			'totals' => $this->totals,
+			'errors' => $this->errors,
+		];
+	}
+
+	/**
+	 * Reset results for a new export
+	 *
+	 * @return void
+	 */
+	private function reset_results() {
+		$this->totals           = [
+			'prompts'   => 0,
+			'segments'  => 0,
+			'campaigns' => 0,
+		];
+		$this->errors           = [
+			'prompts'    => [],
+			'segments'   => [],
+			'campaigns'  => [],
+			'terms'      => [],
+			'validation' => [],
+		];
+		$this->terms_mapping    = [];
+		$this->segments_mapping = [];
+	}
+
+	/**
+	 * Process campaigns
+	 *
+	 * Create the campaigns and store the mapping between the old and new IDs.
+	 *
+	 * @return void
+	 */
+	private function process_campaigns() {
+		$campaigns = $this->input['campaigns'];
+		foreach ( $campaigns as $campaign ) {
+			$created                                = Newspack_Popups::create_campaign( $campaign['name'] );
+			$this->terms_mapping[ $campaign['id'] ] = $created;
+			$this->totals['campaigns']++;
+		}
+	}
+
+	/**
+	 * Process segments
+	 *
+	 * Create the segments and store the mapping between the old and new IDs.
+	 *
+	 * @return void
+	 */
+	private function process_segments() {
+		$segments = $this->input['segments'];
+		$segments = $this->pre_process_segments_terms( $segments );
+		foreach ( $segments as $segment ) {
+			$stored_segments                          = Newspack_Popups_Segmentation::create_segment( $segment );
+			$created                                  = end( $stored_segments );
+			$this->segments_mapping[ $segment['id'] ] = $created['id'];
+			$this->totals['segments']++;
+		}
+	}
+
+	/**
+	 * Pre process terms in segments
+	 *
+	 * @param array $segments The segments from input.
+	 * @return array The segments with the terms pre processed.
+	 */
+	private function pre_process_segments_terms( $segments ) {
+		foreach ( $segments as $segment_index => $segment ) {
+			if ( ! empty( $segment['configuration']['favorite_categories'] ) ) {
+				$segments[ $segment_index ]['configuration']['favorite_categories'] = $this->pre_process_terms( $segment['configuration']['favorite_categories'] );
+			}
+		}
+		return $segments;
+	}
+
+	/**
+	 * Process prompts
+	 *
+	 * @return void
+	 */
+	private function process_prompts() {
+		$prompts = $this->input['prompts'];
+		$prompts = $this->pre_process_prompt_segments( $prompts );
+		$prompts = $this->pre_process_prompts_terms( $prompts );
+
+		foreach ( $prompts as $prompt ) {
+			$post_data = [
+				'post_title'   => $prompt['title'],
+				'post_content' => $prompt['content'],
+				'post_status'  => $prompt['status'],
+				'post_type'    => Newspack_Popups::NEWSPACK_POPUPS_CPT,
+			];
+			$new_post  = wp_insert_post( $post_data );
+			if ( is_wp_error( $new_post ) ) {
+				$this->errors['prompts'][] = $new_post->get_error_message();
+				continue;
+			}
+
+			$this->totals['prompts']++;
+
+			Newspack_Popups_Model::set_popup_options( $new_post, $prompt['options'] );
+
+			if ( ! empty( $prompt['campaign_groups'] ) ) {
+				Newspack_Popups_Model::set_popup_terms( $new_post, $prompt['campaign_groups'], Newspack_Popups::NEWSPACK_POPUPS_TAXONOMY );
+			}
+			if ( ! empty( $prompt['categories'] ) ) {
+				Newspack_Popups_Model::set_popup_terms( $new_post, $prompt['categories'], 'category' );
+			}
+			if ( ! empty( $prompt['tags'] ) ) {
+				Newspack_Popups_Model::set_popup_terms( $new_post, $prompt['tags'], 'post_tag' );
+			}
+		}
+	}
+
+	/**
+	 * Pre-process prompt segments
+	 *
+	 * If there are segments set, replace the IDs with the IDs from the segment mapping
+	 *
+	 * @param array $prompts The prompts to process.
+	 * @return array The processed prompts.
+	 */
+	private function pre_process_prompt_segments( $prompts ) {
+		foreach ( $prompts as $prompt_index => $prompt ) {
+			if ( ! empty( $prompt['options']['selected_segment_id'] ) ) {
+				$segments = explode( ',', $prompt['options']['selected_segment_id'] );
+				foreach ( $segments as $key => $segment ) {
+					if ( isset( $this->segments_mapping[ $segment ] ) ) {
+						$segments[ $key ] = $this->segments_mapping[ $segment ];
+					} else {
+						unset( $segments[ $key ] );
+					}
+				}
+				$prompts[ $prompt_index ]['options']['selected_segment_id'] = implode( ',', $segments );
+			}
+		}
+		return array_values( $prompts );
+	}
+
+	/**
+	 * Pre process terms in prompts
+	 *
+	 * @TODO: We are not handling tags and categories yet. They need to be handled beforehand and we need to decide what to do with them.
+	 * The best thing to do would be to let the user decide if they want to map them to an existing term or to create a new term.
+	 * For now, we are dropping them from the input and not importing them.
+	 *
+	 * @param array $prompts The prompts from input.
+	 * @return array The prompts with the terms pre processed.
+	 */
+	private function pre_process_prompts_terms( $prompts ) {
+		foreach ( $prompts as $prompt_index => $prompt ) {
+
+			if ( ! empty( $prompt['campaign_groups'] ) ) {
+				$prompts[ $prompt_index ]['campaign_groups'] = $this->pre_process_terms( $prompt['campaign_groups'] );
+			}
+			if ( ! empty( $prompt['categories'] ) ) {
+				$prompts[ $prompt_index ]['categories'] = $this->pre_process_terms( $prompt['categories'] );
+			}
+			if ( ! empty( $prompt['tags'] ) ) {
+				$prompts[ $prompt_index ]['tags'] = $this->pre_process_terms( $prompt['tags'] );
+			}
+			if ( ! empty( $prompt['options']['excluded_categories'] ) ) {
+				$prompts[ $prompt_index ]['options']['excluded_categories'] = $this->pre_process_terms( $prompt['options']['excluded_categories'] );
+			}
+			if ( ! empty( $prompt['options']['excluded_tags'] ) ) {
+				$prompts[ $prompt_index ]['options']['excluded_tags'] = $this->pre_process_terms( $prompt['options']['excluded_tags'] );
+			}
+		}
+		return array_values( $prompts );
+	}
+
+	/**
+	 * Pre process terms
+	 *
+	 * Check if terms mapping were defined and update their ids, otherwise remove them from the array.
+	 *
+	 * @param array $terms The terms array in which each item is and array with id and name.
+	 * @return array $terms The processed terms.
+	 */
+	private function pre_process_terms( $terms ) {
+		foreach ( $terms as $term_index => $term ) {
+			if ( isset( $this->terms_mapping[ $term['id'] ] ) ) {
+				$terms[ $term_index ]['id'] = $this->terms_mapping[ $term['id'] ];
+			} else {
+				unset( $terms[ $term_index ] );
+			}
+		}
+		return array_values( $terms );
+	}
+
+
+}

--- a/includes/class-newspack-popups-importer.php
+++ b/includes/class-newspack-popups-importer.php
@@ -7,8 +7,6 @@
 
 defined( 'ABSPATH' ) || exit;
 
-require_once dirname( __FILE__ ) . '/schemas/schemas-loader.php';
-
 /**
  * Importer
  */

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -106,6 +106,7 @@ final class Newspack_Popups {
 	 */
 	public static function register_cli_commands() {
 		WP_CLI::add_command( 'newspack-popups export', 'Newspack\Campaigns\CLI\Export' );
+		WP_CLI::add_command( 'newspack-popups import', 'Newspack\Campaigns\CLI\Import' );
 	}
 
 	/**

--- a/includes/cli/class-import.php
+++ b/includes/cli/class-import.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Campaigns Import CLI command.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack\Campaigns\CLI;
+
+use \WP_CLI;
+use \WP_CLI_Command;
+use Newspack_Popups_Importer;
+
+/**
+ * Campaigns Import CLI command.
+ */
+class Import extends WP_CLI_Command {
+
+	/**
+	 * Import Campaigns, Segments and Prompts.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <file>
+	 * : The name of the input file.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp newspack-popups import newspack-campaigns.json
+	 *
+	 * @param array $args Args.
+	 * @param array $assoc_args Assoc args.
+	 */
+	public function __invoke( $args, $assoc_args ) {
+
+		$file = $args[0];
+		if ( ! is_readable( $file ) ) {
+			WP_CLI::error( 'File not found or not readable.' );
+		}
+
+		$data = wp_json_file_decode( $file, [ 'associative' => true ] ); // phpcs:ignore
+		if ( empty( $data ) ) {
+			WP_CLI::error( 'File is not valid JSON.' );
+		}
+
+		$importer = new Newspack_Popups_Importer( $data );
+		$result   = $importer->import();
+
+		if ( ! empty( $result['errors'] ) && ! empty( $result['errors']['validation'] ) ) {
+			WP_CLI::warning( 'JSON could not be validated.' );
+			foreach ( $result['errors']['validation'] as $message ) {
+				WP_CLI::warning( $message );
+			}
+			WP_CLI::error( 'Could not import JSON file.' );
+		}
+
+		foreach ( $result['errors'] as $error_type => $error_group ) {
+			if ( empty( $error_group ) ) {
+				continue;
+			}
+			WP_CLI::warning( $error_type );
+			foreach ( $error_group as $error_id => $error ) {
+				WP_CLI::warning( '-- ' . $error_id );
+				foreach ( $error as $message ) {
+					WP_CLI::warning( '---- ' . $message );
+				}
+			}
+		}
+
+		WP_CLI::success( $result['totals']['campaigns'] . ' campaigns imported.' );
+		WP_CLI::success( $result['totals']['segments'] . ' segments imported.' );
+		WP_CLI::success( $result['totals']['prompts'] . ' prompts imported.' );
+		WP_CLI::success( 'Import complete!' );
+
+	}
+}

--- a/includes/schemas/class-campaigns.php
+++ b/includes/schemas/class-campaigns.php
@@ -19,7 +19,7 @@ class Campaigns extends Schema {
 	 *
 	 * @return array The schema.
 	 */
-	public function get_schema() {
+	public static function get_schema() {
 		return [
 			'type'                 => 'object',
 			'additionalProperties' => false,

--- a/includes/schemas/class-package.php
+++ b/includes/schemas/class-package.php
@@ -21,7 +21,7 @@ class Package extends Schema {
 	 *
 	 * @return array The schema.
 	 */
-	public function get_schema() {
+	public static function get_schema() {
 		return [
 			'type'                 => 'object',
 			'additionalProperties' => false,

--- a/includes/schemas/class-prompts.php
+++ b/includes/schemas/class-prompts.php
@@ -20,7 +20,7 @@ class Prompts extends Schema {
 	 *
 	 * @return array The schema.
 	 */
-	public function get_schema() {
+	public static function get_schema() {
 		return [
 			'type'                 => 'object',
 			'additionalProperties' => false,

--- a/includes/schemas/class-schema.php
+++ b/includes/schemas/class-schema.php
@@ -40,7 +40,7 @@ abstract class Schema {
 	 *
 	 * @return array The Schema.
 	 */
-	abstract public function get_schema();
+	abstract public static function get_schema();
 
 	/**
 	 * Validate the value against the schema.

--- a/includes/schemas/class-segments.php
+++ b/includes/schemas/class-segments.php
@@ -19,7 +19,7 @@ class Segments extends Schema {
 	 *
 	 * @return array The schema.
 	 */
-	public function get_schema() {
+	public static function get_schema() {
 		return [
 			'type'                 => 'object',
 			'additionalProperties' => false,

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -37,6 +37,7 @@ function _manually_load_plugin() {
 	require dirname( dirname( __FILE__ ) ) . '/api/campaigns/class-report-campaign-data.php';
 	require dirname( dirname( __FILE__ ) ) . '/api/segmentation/class-segmentation-client-data.php';
 	require dirname( dirname( __FILE__ ) ) . '/includes/class-newspack-popups-exporter.php';
+	require dirname( dirname( __FILE__ ) ) . '/includes/class-newspack-popups-importer.php';
 }
 tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
 

--- a/tests/test-importer.php
+++ b/tests/test-importer.php
@@ -1,0 +1,305 @@
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+/**
+ * Class Importer Test
+ *
+ * @package Newspack_Popups
+ */
+
+/**
+ * Importer test case.
+ */
+class ImporterTest extends WP_UnitTestCase_PageWithPopups {
+
+	/**
+	 * Call protected/private method of a class.
+	 *
+	 * @param object $object    Instantiated object that we will run method on.
+	 * @param string $method_name Method name to call.
+	 * @param array  $parameters Array of parameters to pass into method.
+	 *
+	 * @return mixed Method return.
+	 */
+	public function invoke_method( &$object, $method_name, array $parameters = array() ) {
+		$reflection = new \ReflectionClass( get_class( $object ) );
+		$method     = $reflection->getMethod( $method_name );
+		$method->setAccessible( true );
+
+		return $method->invokeArgs( $object, $parameters );
+	}
+
+	public function process_terms_data() {
+		return [
+			'all mapped'     => [
+				[
+					[
+						'id'   => 10,
+						'name' => 'Test Term 1',
+					],
+					[
+						'id'   => 20,
+						'name' => 'Test Term 2',
+					],
+				],
+				[
+					[
+						'id'   => 11,
+						'name' => 'Test Term 1',
+					],
+					[
+						'id'   => 21,
+						'name' => 'Test Term 2',
+					],
+				],
+			],
+			'one not mapped' => [
+				[
+					[
+						'id'   => 10,
+						'name' => 'Test Term 1',
+					],
+					[
+						'id'   => 15,
+						'name' => 'Test Term 3',
+					],
+					[
+						'id'   => 20,
+						'name' => 'Test Term 2',
+					],
+				],
+				[
+					[
+						'id'   => 11,
+						'name' => 'Test Term 1',
+					],
+					[
+						'id'   => 21,
+						'name' => 'Test Term 2',
+					],
+				],
+			],
+			'none mapped'    => [
+				[
+					[
+						'id'   => 1,
+						'name' => 'Test Term 1',
+					],
+					[
+						'id'   => 2,
+						'name' => 'Test Term 3',
+					],
+					[
+						'id'   => 3,
+						'name' => 'Test Term 2',
+					],
+				],
+				[],
+			],
+		];
+	}
+
+	/**
+	 * Test the pre_process_terms method.
+	 *
+	 * @param array $input_data The array of terms to process.
+	 * @param array $expected The expected result.
+	 * @return void
+	 * @dataProvider process_terms_data
+	 */
+	public function test_process_terms( $input_data, $expected ) {
+		$importer      = new Newspack_Popups_Importer( [] );
+		$r_importer    = new \ReflectionClass( $importer );
+		$terms_mapping = [
+			10 => 11,
+			20 => 21,
+		];
+
+		$mapping = $r_importer->getProperty( 'terms_mapping' );
+		$mapping->setAccessible( true );
+		$mapping->setValue( $importer, $terms_mapping );
+
+		$method = $r_importer->getMethod( 'pre_process_terms' );
+		$method->setAccessible( true );
+		$result = $method->invokeArgs( $importer, [ $input_data ] );
+
+		$this->assertEquals( $expected, $result );
+
+	}
+
+	/**
+	 * Test the full functionality of the Importer class
+	 *
+	 * @return void
+	 */
+	public function test_integration() {
+
+		// Clear data created by other tests.
+		global $wpdb;
+		$wpdb->query( $wpdb->prepare( "DELETE FROM $wpdb->posts WHERE post_type = %s", Newspack_Popups::NEWSPACK_POPUPS_CPT ) );
+		delete_option( Newspack_Popups_Segmentation::SEGMENTS_OPTION_NAME );
+
+		$campaigns = [
+			[
+				'id'   => 10,
+				'name' => 'Campaign 1',
+			],
+			[
+				'id'   => 20,
+				'name' => 'Campaign 2',
+			],
+		];
+		$prompts   = [
+			[
+				'title'           => 'Test Prompt 1',
+				'content'         => 'Test content',
+				'status'          => 'publish',
+				'campaign_groups' => [
+					[
+						'id'   => 10,
+						'name' => 'Campaign 1',
+					],
+				],
+				'options'         => [
+					'background_color'    => '#FFFFFF',
+					'display_title'       => false,
+					'hide_border'         => false,
+					'large_border'        => false,
+					'frequency'           => 'once',
+					'placement'           => 'inline',
+					'selected_segment_id' => 'abc123,abc456',
+				],
+			],
+			[
+				'title'           => 'Test Prompt 2',
+				'content'         => 'Test content',
+				'status'          => 'publish',
+				'campaign_groups' => [
+					[
+						'id'   => 20,
+						'name' => 'Campaign 2',
+					],
+				],
+				'options'         => [
+					'background_color'    => '#FFFFFF',
+					'display_title'       => false,
+					'hide_border'         => false,
+					'large_border'        => false,
+					'frequency'           => 'once',
+					'placement'           => 'inline',
+					'selected_segment_id' => 'abc123',
+				],
+			],
+		];
+		$segments  = [
+			[
+				'name'          => 'Test Segment',
+				'id'            => 'abc123',
+				'priority'      => 10,
+				'configuration' => [
+					'max_posts' => 1,
+				],
+			],
+			[
+				'name'          => 'Test Segment 2',
+				'id'            => 'abc456',
+				'priority'      => 10,
+				'configuration' => [
+					'max_posts' => 1,
+				],
+			],
+		];
+
+		$package = [
+			'campaigns' => $campaigns,
+			'prompts'   => $prompts,
+			'segments'  => $segments,
+		];
+
+		$importer = new Newspack_Popups_Importer( $package );
+		$result   = $importer->import();
+
+		$this->assertSame( 2, $result['totals']['campaigns'] );
+		$this->assertSame( 2, $result['totals']['segments'] );
+		$this->assertSame( 2, $result['totals']['prompts'] );
+
+		// Test 2 groups were created.
+		$created_groups = Newspack_Popups::get_groups();
+		$this->assertSame( 2, count( $created_groups ) );
+
+		// Test if segmentes were properly created.
+		$created_segments = Newspack_Popups_Segmentation::get_segments();
+		$this->assertSame( 2, count( $created_segments ) );
+		$this->assertSame( 'Test Segment', $created_segments[0]['name'] );
+		$this->assertSame( 10, $created_segments[0]['priority'] );
+		$this->assertSame( 1, $created_segments[0]['configuration']['max_posts'] );
+		$this->assertSame( 'Test Segment 2', $created_segments[1]['name'] );
+
+		// Get the IDs of the created segments to see if they were properly mapped in the prompts.
+		$segment_1_id = $created_segments[0]['id'];
+		$segment_2_id = $created_segments[1]['id'];
+
+		// Check if 2 prompts were created.
+		$created_prompts = Newspack_Popups_Model::retrieve_popups( true );
+		$this->assertSame( 2, count( $created_prompts ) );
+
+		// Check if the prompts were properly mapped to the segments.
+		$this->assertStringContainsString( $segment_1_id, $created_prompts[0]['options']['selected_segment_id'] );
+		$this->assertStringContainsString( $segment_2_id, $created_prompts[0]['options']['selected_segment_id'] );
+		$this->assertStringContainsString( $segment_1_id, $created_prompts[1]['options']['selected_segment_id'] );
+
+		// Check if the campaign groups terms were properly applied to the prompts.
+		$this->assertSame( 1, count( $created_prompts[0]['campaign_groups'] ) );
+		$this->assertSame( 'Campaign 1', $created_prompts[0]['campaign_groups'][0]->name );
+		$this->assertSame( 1, count( $created_prompts[1]['campaign_groups'] ) );
+		$this->assertSame( 'Campaign 2', $created_prompts[1]['campaign_groups'][0]->name );
+
+	}
+
+	/**
+	 * Test the import method with invalid data.
+	 *
+	 * @return void
+	 */
+	public function test_integration_invalid_data() {
+
+		$campaigns = [
+			[
+				'id'   => 10,
+				'name' => 'Campaign 1',
+			],
+		];
+		// missing required filed in prompts.
+		$prompts = [
+			[
+				'title'   => 'Test Prompt 1',
+				'content' => 'Test content',
+				'status'  => 'publish',
+				'options' => [
+					'selected_segment_id' => 'abc123,abc456',
+					'frequency'           => 'once',
+				],
+			],
+		];
+		// missing required filed in segments.
+		$segments = [
+			[
+				'name'     => 'Test Segment',
+				'id'       => 'abc123',
+				'priority' => 10,
+			],
+		];
+
+		$package = [
+			'campaigns' => $campaigns,
+			'prompts'   => $prompts,
+			'segments'  => $segments,
+		];
+
+		$importer = new Newspack_Popups_Importer( $package );
+		$result   = $importer->import();
+
+		$this->assertNotEmpty( $result['errors'] );
+		$this->assertNotEmpty( $result['errors']['validation'] );
+
+	}
+
+}

--- a/tests/test-importer.php
+++ b/tests/test-importer.php
@@ -27,6 +27,11 @@ class ImporterTest extends WP_UnitTestCase_PageWithPopups {
 		return $method->invokeArgs( $object, $parameters );
 	}
 
+	/**
+	 * Data fortest_process_terms
+	 *
+	 * @return array
+	 */
 	public function process_terms_data() {
 		return [
 			'all mapped'     => [
@@ -134,7 +139,7 @@ class ImporterTest extends WP_UnitTestCase_PageWithPopups {
 
 		// Clear data created by other tests.
 		global $wpdb;
-		$wpdb->query( $wpdb->prepare( "DELETE FROM $wpdb->posts WHERE post_type = %s", Newspack_Popups::NEWSPACK_POPUPS_CPT ) );
+		$wpdb->query( $wpdb->prepare( "DELETE FROM $wpdb->posts WHERE post_type = %s", Newspack_Popups::NEWSPACK_POPUPS_CPT ) ); // phpcs:ignore
 		delete_option( Newspack_Popups_Segmentation::SEGMENTS_OPTION_NAME );
 
 		$campaigns = [


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Creates the Importer class and bootstrap the CLI command

Important: For now, we are not importing Categories and Tags. This will be handled in future PRs... The idea is to give the user the option to map tags and categories to existing terms or create them...

### How to test the changes in this Pull Request:

1. Tests are passing?
2. Use the exporter to export all your data: `wp newspack-popups export campaigns.json`
3. Delete all your prompts and segments
4. Try to import a file that is not a json and confirm you see the correspondent error `wp newspack-popups import index.php`
5. Import the file you have just exported: `wp newspack-popups import campaigns.json`
6. Confirm everything was created back again (note that you will lose categories and tags for now)
7. Edit the json file and make it not pass validation (remove the `frequency` attribute from a prompt)
8. Try to import again and confirm you see the validation error

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
