### PR TITLE
feat: allow segments to contain undismissible prompts

### DIFF
--- a/api/campaigns/class-campaign-data-utils.php
+++ b/api/campaigns/class-campaign-data-utils.php
@@ -234,6 +234,7 @@ class Campaign_Data_Utils {
 				'referrers'           => '',
 				'favorite_categories' => [],
 				'priority'            => PHP_INT_MAX,
+				'undismissible'       => false,
 			],
 			(array) $segment
 		);

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -1171,6 +1171,7 @@ final class Newspack_Popups_Model {
 		$wrapper_classes       = [ 'newspack-popup-wrapper' ];
 		$wrapper_classes[]     = 'publish' !== $popup['status'] ? 'newspack-inactive-popup-status' : null;
 		$is_scroll_triggered   = 'scroll' === $popup['options']['trigger_type'];
+		$overlay_wall_enabled  = Newspack_Popups_Segmentation::is_overlay_wall_enabled( explode( ',', $popup['options']['selected_segment_id'] ) );
 
 		add_filter(
 			'newspack_analytics_events',
@@ -1204,15 +1205,17 @@ final class Newspack_Popups_Model {
 						<?php endif; ?>
 						<?php echo do_shortcode( $body ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 					</div>
-					<form class="popup-dismiss-form <?php echo esc_attr( self::get_form_class( 'dismiss', $element_id ) ); ?> popup-action-form <?php echo esc_attr( self::get_form_class( 'action', $element_id ) ); ?>"
-						method="POST"
-						action-xhr="<?php echo esc_url( $endpoint ); ?>"
-						target="_top">
-						<?php echo $hidden_fields; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
-						<button on="tap:<?php echo esc_attr( $element_id ); ?>.hide" class="newspack-lightbox__close" aria-label="<?php esc_html_e( 'Close Pop-up', 'newspack-popups' ); // phpcs:ignore WordPressVIPMinimum.Security.ProperEscapingFunction.htmlAttrNotByEscHTML ?>">
-							<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" role="img" aria-hidden="true" focusable="false"><path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12 19 6.41z"/></svg>
-						</button>
-					</form>
+					<?php if ( ! $overlay_wall_enabled ) : ?>
+						<form class="popup-dismiss-form <?php echo esc_attr( self::get_form_class( 'dismiss', $element_id ) ); ?> popup-action-form <?php echo esc_attr( self::get_form_class( 'action', $element_id ) ); ?>"
+							method="POST"
+							action-xhr="<?php echo esc_url( $endpoint ); ?>"
+							target="_top">
+							<?php echo $hidden_fields; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+							<button on="tap:<?php echo esc_attr( $element_id ); ?>.hide" class="newspack-lightbox__close" aria-label="<?php esc_html_e( 'Close Pop-up', 'newspack-popups' ); // phpcs:ignore WordPressVIPMinimum.Security.ProperEscapingFunction.htmlAttrNotByEscHTML ?>">
+								<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" role="img" aria-hidden="true" focusable="false"><path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12 19 6.41z"/></svg>
+							</button>
+						</form>
+					<?php endif; ?>
 				</div>
 			</div>
 			<?php if ( ! $no_overlay_background ) : ?>

--- a/includes/class-newspack-popups-segmentation.php
+++ b/includes/class-newspack-popups-segmentation.php
@@ -459,6 +459,34 @@ final class Newspack_Popups_Segmentation {
 	}
 
 	/**
+	 * Do the given segments allow for overlay walls?
+	 * An overlay can be a wall if assigned only to segments that allow it.
+	 *
+	 * @param array $segment_ids Array of segment IDs for the prompt to check.
+	 *
+	 * @return boolean True if enabled, otherwise false.
+	 */
+	public static function is_overlay_wall_enabled( $segment_ids = [] ) {
+		if ( empty( $segment_ids ) ) {
+			return false;
+		}
+
+		$is_enabled = true;
+		foreach ( $segment_ids as $segment_id ) {
+			$segment = self::get_segment( $segment_id );
+			if (
+				( empty( $segment['configuration']['undismissible'] ) ) ||
+				( empty( $segment['configuration']['min_posts'] ) && empty( $segment['configuration']['min_session_posts'] ) ) ||
+				( empty( $segment['configuration']['is_not_logged_in'] ) && empty( $segment['configuration']['no_user_account'] ) )
+			) {
+				$is_enabled = false;
+			}
+		}
+
+		return $is_enabled;
+	}
+
+	/**
 	 * Mock a preview CID for logged-in admin and editor users.
 	 *
 	 * @return string Preview client ID.

--- a/tests/test-api.php
+++ b/tests/test-api.php
@@ -82,6 +82,11 @@ class APITest extends WP_UnitTestCase {
 				'favorite_categories' => [ $category_1_id ],
 				'priority'            => 8,
 			],
+			'segmentWithOverlayWall'              => [
+				'min_posts'       => 3,
+				'no_user_account' => true,
+				'undismissible'   => true,
+			],
 		];
 
 		foreach ( $test_segments as $key => $value ) {
@@ -1615,6 +1620,23 @@ class APITest extends WP_UnitTestCase {
 		self::assertTrue(
 			count( Newspack_Popups_Model::retrieve_eligible_popups() ) === $number_of_prompts_to_display,
 			'Can retrieve up to 100 prompts at once.'
+		);
+	}
+
+	/**
+	 * Test overlay wall functionality.
+	 */
+	public function test_overlay_wall() {
+		$segments = [ self::$segment_ids['segmentBetween3And5'], self::$segment_ids['segmentSubscribers'] ];
+		self::assertFalse(
+			Newspack_Popups_Segmentation::is_overlay_wall_enabled( $segments ),
+			'Overlay wall not enabled without the required segmentation criteria.'
+		);
+
+		$segments = [ self::$segment_ids['segmentWithOverlayWall'] ];
+		self::assertTrue(
+			Newspack_Popups_Segmentation::is_overlay_wall_enabled( $segments ),
+			'Overlay wall enabled if the only segment contains the required segmentation criteria.'
 		);
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Requires: https://github.com/Automattic/newspack-plugin/pull/2191

Allows publishers to enable "overlay walls" for specific segments. The option is shown only if the segment contains the following criteria:

* Does not have user account
* Minimum number of articles read per session or for the past 30 days

It's purposefully a somewhat hidden feature to make it difficult to accidentally lock readers out of content. If an overlay prompt is assigned _only_ to segments that have this feature enabled, then the overlays will be displayed to readers matching the segments without a dismiss button, effectively making them a form of soft content gate. Adding a registration, newsletter signup, or donation block to these overlays can encourage readers who see them to take a specific action in order to access the content underneath.

TODO: add functionality to automatically dismiss the overlay once the required action is taken.

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
