### PR TITLE
fix: hide the 'Prompts Visible' button in the admin panel

### DIFF
--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -556,7 +556,7 @@ final class Newspack_Popups_Inserter {
 		$is_amp      = self::is_amp();
 		$is_amp_plus = $is_amp && self::is_amp_plus();
 
-		return Newspack_Popups_Segmentation::is_admin_user() && ( ! $is_amp || $is_amp_plus );
+		return Newspack_Popups_Segmentation::is_admin_user() && ( ! $is_amp || $is_amp_plus ) && ! is_admin();
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

#1012 has added a prompt visibility toggle for site admins. This toggle is not useful in the admin panel, though, so it should not be displayed there. 

### How to test the changes in this Pull Request:

1. On `master`
2. Visit any admin page, observe the "Prompts Visible" toggle in the admin bar
3. Switch to this branch, reload, observe the toggle gone 
4. Visit the front-end when logged-in as an admin, observe the toggle is there

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->