### PR TITLE
feat: add ras defaults preset

### DIFF
--- a/includes/cli/class-import.php
+++ b/includes/cli/class-import.php
@@ -51,12 +51,12 @@ class Import extends WP_CLI_Command {
 		$ras_defaults = WP_CLI\Utils\get_flag_value( $assoc_args, 'ras-defaults', false );
 		$file         = $args[0] ?? null;
 
-		if ( ! $file && ! $ras_defaults ) {
-			WP_CLI::error( __( 'You must either supply a json file path or use the --ras-defaults flag.', 'newspack-popups' ) );
-		}
-
 		if ( $ras_defaults ) {
 			$file = dirname( NEWSPACK_POPUPS_PLUGIN_FILE ) . '/presets/ras-defaults.json';
+		}
+
+		if ( ! $file && ! $ras_defaults ) {
+			WP_CLI::error( __( 'You must either supply a json file path or use the --ras-defaults flag.', 'newspack-popups' ) );
 		}
 
 		if ( ! is_readable( $file ) ) {

--- a/includes/cli/class-import.php
+++ b/includes/cli/class-import.php
@@ -55,7 +55,7 @@ class Import extends WP_CLI_Command {
 			$file = dirname( NEWSPACK_POPUPS_PLUGIN_FILE ) . '/presets/ras-defaults.json';
 		}
 
-		if ( ! $file && ! $ras_defaults ) {
+		if ( ! $file ) {
 			WP_CLI::error( __( 'You must either supply a json file path or use the --ras-defaults flag.', 'newspack-popups' ) );
 		}
 

--- a/includes/cli/class-import.php
+++ b/includes/cli/class-import.php
@@ -26,7 +26,7 @@ class Import extends WP_CLI_Command {
 	 *
 	 * ## OPTIONS
 	 *
-	 * <file>
+	 * [<file>]
 	 * : The name of the input file.
 	 *
 	 * [--ignore-terms]
@@ -34,6 +34,9 @@ class Import extends WP_CLI_Command {
 	 *
 	 * [--create-terms]
 	 * : Create categories and tags that are not present in the site.
+	 *
+	 * [--ras-defaults]
+	 * : Import from the RAS defaults preset located at presets/ras-defaults.json. This will ignore the <file> argument.
 	 *
 	 * ## EXAMPLES
 	 *
@@ -45,7 +48,16 @@ class Import extends WP_CLI_Command {
 	public function __invoke( $args, $assoc_args ) {
 		$ignore_terms = WP_CLI\Utils\get_flag_value( $assoc_args, 'ignore-terms', false );
 		$create_terms = WP_CLI\Utils\get_flag_value( $assoc_args, 'create-terms', false );
-		$file         = $args[0];
+		$ras_defaults = WP_CLI\Utils\get_flag_value( $assoc_args, 'ras-defaults', false );
+		$file         = $args[0] ?? null;
+
+		if ( ! $file && ! $ras_defaults ) {
+			WP_CLI::error( __( 'You must either inform a json file name or use the --ras-defaults flag.', 'newspack-popups' ) );
+		}
+
+		if ( $ras_defaults ) {
+			$file = dirname( NEWSPACK_POPUPS_PLUGIN_FILE ) . '/presets/ras-defaults.json';
+		}
 
 		if ( ! is_readable( $file ) ) {
 			WP_CLI::error( __( 'File not found or not readable.', 'newspack-popups' ) );

--- a/includes/cli/class-import.php
+++ b/includes/cli/class-import.php
@@ -52,7 +52,7 @@ class Import extends WP_CLI_Command {
 		$file         = $args[0] ?? null;
 
 		if ( ! $file && ! $ras_defaults ) {
-			WP_CLI::error( __( 'You must either inform a json file name or use the --ras-defaults flag.', 'newspack-popups' ) );
+			WP_CLI::error( __( 'You must either supply a json file path or use the --ras-defaults flag.', 'newspack-popups' ) );
 		}
 
 		if ( $ras_defaults ) {

--- a/presets/ras-defaults.json
+++ b/presets/ras-defaults.json
@@ -1,0 +1,334 @@
+{
+    "prompts": [
+        {
+            "status": "draft",
+            "title": "Inline Donation (secondary)",
+            "content": "<!-- wp:separator -->\n<hr class=\"wp-block-separator has-alpha-channel-opacity\"\/>\n<!-- \/wp:separator -->\n\n<!-- wp:heading -->\n<h2>Support our work<\/h2>\n<!-- \/wp:heading -->\n\n<!-- wp:paragraph -->\n<p>As an independent publication, we rely on donations to fund our journalism<\/p>\n<!-- \/wp:paragraph -->\n\n<!-- wp:newspack-blocks\/donate {\"className\":\"is-style-alternate\",\"amounts\":{\"once\":[9,20,90,20],\"month\":[7,15,30,15],\"year\":[84,180,360,180]},\"disabledFrequencies\":{\"once\":false,\"month\":false,\"year\":false},\"minimumDonation\":5} \/-->",
+            "options": {
+                "background_color": "#FFFFFF",
+                "display_title": false,
+                "hide_border": false,
+                "large_border": false,
+                "frequency": "always",
+                "frequency_max": 0,
+                "frequency_start": 0,
+                "frequency_between": 0,
+                "frequency_reset": "month",
+                "overlay_color": "#000000",
+                "overlay_opacity": "30",
+                "overlay_size": "medium",
+                "no_overlay_background": false,
+                "placement": "inline",
+                "trigger_type": "scroll",
+                "trigger_delay": "3",
+                "trigger_scroll_progress": "100",
+                "trigger_blocks_count": 0,
+                "archive_insertion_posts_count": 1,
+                "archive_insertion_is_repeating": false,
+                "selected_segment_id": "",
+                "post_types": [
+                    "post"
+                ],
+                "archive_page_types": [
+                    "category",
+                    "tag",
+                    "author",
+                    "date",
+                    "post-type",
+                    "taxonomy"
+                ],
+                "additional_classes": "",
+                "excluded_categories": [],
+                "excluded_tags": []
+            },
+            "categories": [],
+            "tags": false,
+            "campaign_groups": [
+                {
+                    "id": 30,
+                    "name": "Reader Activation Defaults"
+                }
+            ]
+        },
+        {
+            "status": "draft",
+            "title": "Registration Overlay",
+            "content": "<!-- wp:newspack\/reader-registration {\"title\":\"Sign Up\",\"description\":\"Sign up for our free newsletters to receive the latest news.\"} -->\n<div class=\"wp-block-newspack-reader-registration\"><\/div>\n<!-- \/wp:newspack\/reader-registration -->",
+            "options": {
+                "background_color": "#FFFFFF",
+                "display_title": false,
+                "hide_border": false,
+                "large_border": false,
+                "frequency": "custom",
+                "frequency_max": 0,
+                "frequency_start": 0,
+                "frequency_between": "3",
+                "frequency_reset": "day",
+                "overlay_color": "#000000",
+                "overlay_opacity": "30",
+                "overlay_size": "medium",
+                "no_overlay_background": false,
+                "placement": "center",
+                "trigger_type": "time",
+                "trigger_delay": "2",
+                "trigger_scroll_progress": 0,
+                "trigger_blocks_count": "3",
+                "archive_insertion_posts_count": 1,
+                "archive_insertion_is_repeating": false,
+                "selected_segment_id": "639b337fdbf33",
+                "post_types": [
+                    "post",
+                    "page",
+                    "product",
+                    "newspack_nl_cpt"
+                ],
+                "archive_page_types": [
+                    "category",
+                    "tag",
+                    "author",
+                    "date",
+                    "post-type",
+                    "taxonomy"
+                ],
+                "additional_classes": "",
+                "excluded_categories": [],
+                "excluded_tags": []
+            },
+            "categories": [],
+            "tags": false,
+            "campaign_groups": [
+                {
+                    "id": 30,
+                    "name": "Reader Activation Defaults"
+                }
+            ]
+        },
+        {
+            "status": "draft",
+            "title": "Inline Newsletter Signup (secondary)",
+            "content": "<!-- wp:paragraph -->\n<p>Signup for our free newsletter to receive the latest news<\/p>\n<!-- \/wp:paragraph -->\n\n<!-- wp:newspack-newsletters\/subscribe \/-->\n\n<!-- wp:separator -->\n<hr class=\"wp-block-separator has-alpha-channel-opacity\"\/>\n<!-- \/wp:separator -->",
+            "options": {
+                "background_color": "#FFFFFF",
+                "display_title": false,
+                "hide_border": "1",
+                "large_border": false,
+                "frequency": "always",
+                "frequency_max": 0,
+                "frequency_start": 0,
+                "frequency_between": 0,
+                "frequency_reset": "month",
+                "overlay_color": "#000000",
+                "overlay_opacity": "30",
+                "overlay_size": "medium",
+                "no_overlay_background": false,
+                "placement": "inline",
+                "trigger_type": "scroll",
+                "trigger_delay": "3",
+                "trigger_scroll_progress": 0,
+                "trigger_blocks_count": 0,
+                "archive_insertion_posts_count": 1,
+                "archive_insertion_is_repeating": false,
+                "selected_segment_id": "639b333b41025,639b337fdbf33",
+                "post_types": [
+                    "post"
+                ],
+                "archive_page_types": [
+                    "category",
+                    "tag",
+                    "author",
+                    "date",
+                    "post-type",
+                    "taxonomy"
+                ],
+                "additional_classes": "",
+                "excluded_categories": [],
+                "excluded_tags": []
+            },
+            "categories": [],
+            "tags": false,
+            "campaign_groups": [
+                {
+                    "id": 30,
+                    "name": "Reader Activation Defaults"
+                }
+            ]
+        },
+        {
+            "status": "draft",
+            "title": "Newsletter Sign-up Overlay",
+            "content": "<!-- wp:heading -->\n<h2>Stay in the know<\/h2>\n<!-- \/wp:heading -->\n\n<!-- wp:paragraph -->\n<p>Sign up for our free newsletters to receive the latest news directly in your inbox.<\/p>\n<!-- \/wp:paragraph -->\n\n<!-- wp:newspack-newsletters\/subscribe \/-->",
+            "options": {
+                "background_color": "#FFFFFF",
+                "display_title": false,
+                "hide_border": false,
+                "large_border": false,
+                "frequency": "custom",
+                "frequency_max": 0,
+                "frequency_start": 0,
+                "frequency_between": "3",
+                "frequency_reset": "day",
+                "overlay_color": "#000000",
+                "overlay_opacity": "30",
+                "overlay_size": "medium",
+                "no_overlay_background": false,
+                "placement": "center",
+                "trigger_type": "time",
+                "trigger_delay": "2",
+                "trigger_scroll_progress": 0,
+                "trigger_blocks_count": "3",
+                "archive_insertion_posts_count": 1,
+                "archive_insertion_is_repeating": false,
+                "selected_segment_id": "639b333b41025",
+                "post_types": [
+                    "post",
+                    "page",
+                    "product",
+                    "newspack_nl_cpt"
+                ],
+                "archive_page_types": [
+                    "category",
+                    "tag",
+                    "author",
+                    "date",
+                    "post-type",
+                    "taxonomy"
+                ],
+                "additional_classes": "",
+                "excluded_categories": [],
+                "excluded_tags": []
+            },
+            "categories": [],
+            "tags": false,
+            "campaign_groups": [
+                {
+                    "id": 30,
+                    "name": "Reader Activation Defaults"
+                }
+            ]
+        },
+        {
+            "status": "draft",
+            "title": "Donation Overlay",
+            "content": "<!-- wp:heading -->\n<h2>Support our work<\/h2>\n<!-- \/wp:heading -->\n\n<!-- wp:paragraph -->\n<p>As an independent publication, we rely on donations to fund our journalism<\/p>\n<!-- \/wp:paragraph -->\n\n<!-- wp:newspack-blocks\/donate {\"className\":\"is-style-alternate\",\"amounts\":{\"once\":[9,20,90,20],\"month\":[7,15,30,15],\"year\":[84,180,360,180]},\"disabledFrequencies\":{\"once\":false,\"month\":false,\"year\":false},\"minimumDonation\":5} \/-->",
+            "options": {
+                "background_color": "#FFFFFF",
+                "display_title": false,
+                "hide_border": false,
+                "large_border": false,
+                "frequency": "custom",
+                "frequency_max": 0,
+                "frequency_start": 0,
+                "frequency_between": "3",
+                "frequency_reset": "day",
+                "overlay_color": "#000000",
+                "overlay_opacity": "30",
+                "overlay_size": "medium",
+                "no_overlay_background": false,
+                "placement": "center",
+                "trigger_type": "time",
+                "trigger_delay": "2",
+                "trigger_scroll_progress": 0,
+                "trigger_blocks_count": "3",
+                "archive_insertion_posts_count": 1,
+                "archive_insertion_is_repeating": false,
+                "selected_segment_id": "639b3315239f0",
+                "post_types": [
+                    "post",
+                    "page",
+                    "product",
+                    "newspack_nl_cpt"
+                ],
+                "archive_page_types": [
+                    "category",
+                    "tag",
+                    "author",
+                    "date",
+                    "post-type",
+                    "taxonomy"
+                ],
+                "additional_classes": "",
+                "excluded_categories": [],
+                "excluded_tags": []
+            },
+            "categories": [],
+            "tags": false,
+            "campaign_groups": [
+                {
+                    "id": 30,
+                    "name": "Reader Activation Defaults"
+                }
+            ]
+        }
+    ],
+    "segments": [
+        {
+            "name": "Registered, signed up for at least one newsletter, but has not donated",
+            "configuration": {
+                "min_posts": 0,
+                "max_posts": 0,
+                "min_session_posts": 0,
+                "max_session_posts": 0,
+                "is_subscribed": true,
+                "is_not_subscribed": false,
+                "is_donor": false,
+                "is_not_donor": true,
+                "is_former_donor": false,
+                "is_logged_in": true,
+                "is_not_logged_in": false,
+                "favorite_categories": [],
+                "referrers": "",
+                "referrers_not": ""
+            },
+            "id": "639b3315239f0",
+            "priority": 0
+        },
+        {
+            "name": "Registered but not signed up for a newsletter",
+            "configuration": {
+                "min_posts": 0,
+                "max_posts": 0,
+                "min_session_posts": 0,
+                "max_session_posts": 0,
+                "is_subscribed": false,
+                "is_not_subscribed": true,
+                "is_donor": false,
+                "is_not_donor": false,
+                "is_former_donor": false,
+                "is_logged_in": true,
+                "is_not_logged_in": false,
+                "favorite_categories": [],
+                "referrers": "",
+                "referrers_not": ""
+            },
+            "id": "639b333b41025",
+            "priority": 1
+        },
+        {
+            "name": "Not registered and not signed up for a newsletter",
+            "configuration": {
+                "min_posts": 0,
+                "max_posts": 0,
+                "min_session_posts": 0,
+                "max_session_posts": 0,
+                "is_subscribed": false,
+                "is_not_subscribed": true,
+                "is_donor": false,
+                "is_not_donor": false,
+                "is_former_donor": false,
+                "is_logged_in": false,
+                "is_not_logged_in": true,
+                "favorite_categories": [],
+                "referrers": "",
+                "referrers_not": ""
+            },
+            "id": "639b337fdbf33",
+            "priority": 2
+        }
+    ],
+    "campaigns": [
+        {
+            "id": 30,
+            "name": "Reader Activation Defaults"
+        }
+    ]
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1. Checkout this branch, make sure to run `composer install`
2. Run `wp newspack-popups import --ras-defaults`
3. Confirm that a Campaign named "Reader Activation Defaults" was created with a set of prompts and Segments
4. Check pemhSX-2m-p2 and verify everything was created as expected

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
