### PR TITLE
fix: temporarily remove cd filter

### DIFF
--- a/includes/class-newspack-popups-segmentation.php
+++ b/includes/class-newspack-popups-segmentation.php
@@ -67,7 +67,9 @@ final class Newspack_Popups_Segmentation {
 		add_action( 'wp_footer', [ __CLASS__, 'insert_amp_analytics' ], 20 );
 
 		add_filter( 'newspack_custom_dimensions', [ __CLASS__, 'register_custom_dimensions' ] );
-		add_filter( 'newspack_custom_dimensions_values', [ __CLASS__, 'report_custom_dimensions' ] );
+		// Temporarily removed this filter on 2022-12-20. It's causing blank pages to get cached intermittently on production sites.
+		// phpcs:ignore Squiz.Commenting.InlineComment.InvalidEndChar
+		// add_filter( 'newspack_custom_dimensions_values', [ __CLASS__, 'report_custom_dimensions' ] );
 
 		// Data pruning CRON job.
 		register_deactivation_hook( NEWSPACK_POPUPS_PLUGIN_FILE, [ __CLASS__, 'cron_deactivate' ] );

--- a/includes/class-newspack-popups-segmentation.php
+++ b/includes/class-newspack-popups-segmentation.php
@@ -137,6 +137,25 @@ final class Newspack_Popups_Segmentation {
 			return $custom_dimensions_values;
 		}
 
+		$campaigns_custom_dimensions = [
+			Segmentation::CUSTOM_DIMENSIONS_OPTION_NAME_READER_FREQUENCY,
+			Segmentation::CUSTOM_DIMENSIONS_OPTION_NAME_IS_SUBSCRIBER,
+			Segmentation::CUSTOM_DIMENSIONS_OPTION_NAME_IS_DONOR,
+		];
+		$all_campaign_dimensions     = array_values(
+			array_map(
+				function( $custom_dimension ) {
+					return $custom_dimension['role'];
+				},
+				$custom_dimensions
+			)
+		);
+
+		// No need to proceed if the configured custom dimensions do not include any Campaigns data.
+		if ( 0 === count( array_intersect( $campaigns_custom_dimensions, $all_campaign_dimensions ) ) ) {
+			return $custom_dimensions_values;
+		}
+
 		$client_id           = self::get_client_id();
 		$api                 = self::load_lightweight_api();
 		$subscription_events = $api->get_reader_events( $client_id, 'subscription' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Optimizes performance of, and also temporarily disables, a filter related to reporting custom dimensions which has proven to cause issues with edge caching.

### How to test the changes in this Pull Request:

No reader-facing changes, but custom dimensions related to Campaigns segmentation data will not be reported in the meantime. The following custom dimension roles are affected:

* `newspack_popups_cd_reader_frequency`
* `newspack_popups_cd_is_subscriber`
* `newspack_popups_cd_is_donor`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
