### PR TITLE
fix: prevent API bot exit without referer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [2.9.2-hotfix.1](https://github.com/Automattic/newspack-popups/compare/v2.9.1...v2.9.2-hotfix.1) (2022-12-20)
+
+
+### Bug Fixes
+
+* prevent API bot exit without referer ([b9f5c56](https://github.com/Automattic/newspack-popups/commit/b9f5c5646580f7f354dac1279a33a7398bc6491c))
+
 ## [2.9.1](https://github.com/Automattic/newspack-popups/compare/v2.9.0...v2.9.1) (2022-12-20)
 
 

--- a/api/classes/class-lightweight-api.php
+++ b/api/classes/class-lightweight-api.php
@@ -78,7 +78,7 @@ class Lightweight_API {
 	 * @codeCoverageIgnore
 	 */
 	public function __construct( $nonce = null, $ignore_referer_validation = false ) {
-		if ( $this->is_a_web_crawler() ) {
+		if ( $this->is_a_web_crawler() && ! $ignore_referer_validation ) {
 			header( 'X-Robots-Tag: noindex' );
 			exit;
 		}

--- a/includes/class-newspack-popups-segmentation.php
+++ b/includes/class-newspack-popups-segmentation.php
@@ -67,9 +67,7 @@ final class Newspack_Popups_Segmentation {
 		add_action( 'wp_footer', [ __CLASS__, 'insert_amp_analytics' ], 20 );
 
 		add_filter( 'newspack_custom_dimensions', [ __CLASS__, 'register_custom_dimensions' ] );
-		// Temporarily removed this filter on 2022-12-20. It's causing blank pages to get cached intermittently on production sites.
-		// phpcs:ignore Squiz.Commenting.InlineComment.InvalidEndChar
-		// add_filter( 'newspack_custom_dimensions_values', [ __CLASS__, 'report_custom_dimensions' ] );
+		add_filter( 'newspack_custom_dimensions_values', [ __CLASS__, 'report_custom_dimensions' ] );
 
 		// Data pruning CRON job.
 		register_deactivation_hook( NEWSPACK_POPUPS_PLUGIN_FILE, [ __CLASS__, 'cron_deactivate' ] );

--- a/newspack-popups.php
+++ b/newspack-popups.php
@@ -7,7 +7,7 @@
  * Author URI:      https://newspack.blog
  * Text Domain:     newspack-popups
  * Domain Path:     /languages
- * Version:         2.9.1
+ * Version:         2.9.2-hotfix.1
  *
  * @package         Newspack_Popups
  */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "newspack-popups",
-  "version": "2.9.1",
+  "version": "2.9.2-hotfix.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "newspack-popups",
-      "version": "2.9.1",
+      "version": "2.9.2-hotfix.1",
       "dependencies": {
         "classnames": "^2.3.2",
         "intersection-observer": "^0.12.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "newspack-popups",
-  "version": "2.9.1",
+  "version": "2.9.2-hotfix.1",
   "main": "Gruntfile.js",
   "author": "Automattic",
   "scripts": {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

#1014 introduced a strategy that requires the `Lightweight_API` to be instantiated on every page load. The web crawler check under the API constructor should consider the new argument to not exit the page on every crawler render.

4516503a981bb18bc8f4eb7099bd807fdb98955f restores the filter hook commented-out on #1034

### How to test the changes in this Pull Request:

1. While on `release`, change your user agent to `Googlebot`, visit the page and confirm it renders blank
2. Check out this branch, refresh, and confirm the page renders without issues

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
