### PR TITLE
fix: allow every pageview frequency for overlays in editor

### DIFF
--- a/src/editor/Sidebar.js
+++ b/src/editor/Sidebar.js
@@ -44,9 +44,6 @@ const Sidebar = props => {
 	} = props;
 	const updatePlacement = value => {
 		onMetaFieldChange( { placement: value } );
-		if ( isOverlayPlacement( value ) && frequency === 'always' ) {
-			onMetaFieldChange( { frequency: 'once' } );
-		}
 	};
 	const updatePlacementWhenPopupIsFullWidth = () => {
 		switch ( placement ) {

--- a/src/editor/Sidebar.js
+++ b/src/editor/Sidebar.js
@@ -23,13 +23,12 @@ import { without } from 'lodash';
 /**
  * Internal dependencies
  */
-import { isOverlayPlacement, getPlacementHelpMessage } from './utils';
+import { getPlacementHelpMessage } from './utils';
 import PositionPlacementControl from './PositionPlacementControl';
 
 const Sidebar = props => {
 	const {
 		display_title,
-		frequency,
 		onMetaFieldChange,
 		placement,
 		overlay_size,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Removes some editor behavior which was a holdover from when we didn't allow "every pageview" frequency for overlays.

### How to test the changes in this Pull Request:

1. On `master`, create an inline prompt. Set the frequency to "every pageview".
2. Under Prompt Settings, change the prompt type to "overlay". Observe that the frequency reverts to "once a month".
3. Check out this branch, repeat steps 1–2, confirm that the frequency remains "every pageview".

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
