### PR TITLE
Add CLI command to run data pruning

### DIFF
--- a/includes/class-newspack-popups-segmentation.php
+++ b/includes/class-newspack-popups-segmentation.php
@@ -781,23 +781,25 @@ final class Newspack_Popups_Segmentation {
 			return;
 		}
 
+		$logger_function = defined( 'WP_CLI' ) ? '\WP_CLI::log' : 'error_log';
+
 		if ( $removed_preview_readers ) {
-			error_log( 'Newspack Campaigns: Data pruning – removed ' . $removed_preview_readers . ' preview session rows from ' . $readers_table_name . ' table.' ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+			$logger_function( 'Newspack Campaigns: Data pruning – removed ' . $removed_preview_readers . ' preview session rows from ' . $readers_table_name . ' table.' ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 		}
 		if ( $removed_preview_events ) {
-			error_log( 'Newspack Campaigns: Data pruning – removed ' . $removed_preview_events . ' preview session rows from ' . $reader_events_table_name . ' table.' ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+			$logger_function( 'Newspack Campaigns: Data pruning – removed ' . $removed_preview_events . ' preview session rows from ' . $reader_events_table_name . ' table.' ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 		}
 		if ( $removed_old_readers ) {
-			error_log( 'Newspack Campaigns: Data pruning – removed ' . $removed_old_readers . ' old rows from ' . $readers_table_name . ' table.' ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+			$logger_function( 'Newspack Campaigns: Data pruning – removed ' . $removed_old_readers . ' old rows from ' . $readers_table_name . ' table.' ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 		}
 		if ( $removed_old_events ) {
-			error_log( 'Newspack Campaigns: Data pruning – removed ' . $removed_old_events . ' old rows from ' . $reader_events_table_name . ' table.' ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+			$logger_function( 'Newspack Campaigns: Data pruning – removed ' . $removed_old_events . ' old rows from ' . $reader_events_table_name . ' table.' ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 		}
 		if ( $removed_rows_count_page_view_events ) {
-			error_log( 'Newspack Campaigns: Data pruning – removed ' . $removed_rows_count_page_view_events . ' article/page view events from ' . $reader_events_table_name . ' table.' ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+			$logger_function( 'Newspack Campaigns: Data pruning – removed ' . $removed_rows_count_page_view_events . ' article/page view events from ' . $reader_events_table_name . ' table.' ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 		}
 		if ( $removed_row_counts_prompt_seen_events ) {
-			error_log( 'Newspack Campaigns: Data pruning – removed ' . $removed_row_counts_prompt_seen_events . ' prompt seen events from ' . $reader_events_table_name . ' table.' ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+			$logger_function( 'Newspack Campaigns: Data pruning – removed ' . $removed_row_counts_prompt_seen_events . ' prompt seen events from ' . $reader_events_table_name . ' table.' ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 		}
 	}
 

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -107,6 +107,7 @@ final class Newspack_Popups {
 	public static function register_cli_commands() {
 		WP_CLI::add_command( 'newspack-popups export', 'Newspack\Campaigns\CLI\Export' );
 		WP_CLI::add_command( 'newspack-popups import', 'Newspack\Campaigns\CLI\Import' );
+		WP_CLI::add_command( 'newspack-popups prune-data', 'Newspack\Campaigns\CLI\Prune_Data' );
 	}
 
 	/**

--- a/includes/cli/class-prune-data.php
+++ b/includes/cli/class-prune-data.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Campaigns Prune Data CLI command.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack\Campaigns\CLI;
+
+use \WP_CLI;
+use \WP_CLI_Command;
+use Newspack_Popups_Segmentation;
+
+/**
+ * Campaigns Export CLI command.
+ */
+class Prune_Data extends WP_CLI_Command {
+
+	/**
+	 * Run the data prune job.
+	 */
+	public function __invoke() {
+		WP_CLI::log( __( 'Starting data pruning', 'newspack-popups' ) );
+		Newspack_Popups_Segmentation::prune_data();
+		WP_CLI::success( __( 'Completed data pruning.', 'newspack-popups' ) );
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR adds ability to run the data prune from the CLI. We occasionally have to go into a site and do some manual cleanup of the Campaigns tables if they get so large that they crash the cron job, and this would make that much simpler.

### How to test the changes in this Pull Request:

1. `composer install`
2. At the CLI, run `wp newspack-popups prune-data`. If there is data to prune you should see something like this:
```
Starting data pruning
Newspack Campaigns: Data pruning – removed X preview session rows from wp_newspack_campaigns_readers table.
Newspack Campaigns: Data pruning – removed X preview session rows from wp_newspack_campaigns_reader_events table.
Newspack Campaigns: Data pruning – removed X old rows from wp_newspack_campaigns_readers table.
Newspack Campaigns: Data pruning – removed X old rows from wp_newspack_campaigns_reader_events table.
Newspack Campaigns: Data pruning – removed X article/page view events from wp_newspack_campaigns_reader_events table.
Newspack Campaigns: Data pruning – removed X prompt seen events from wp_newspack_campaigns_reader_events table.
Success: Completed data pruning.
```
4. Verify the cron-based data pruning still works using WP Control or similar. You should still see logging output in the error log when Campaigns does the cron-based data pruning:
```
[02-Jan-2023 16:59:42 UTC] Newspack Campaigns: Data pruning – removed X preview session rows from wp_newspack_campaigns_readers table.
[02-Jan-2023 16:59:42 UTC] Newspack Campaigns: Data pruning – removed X preview session rows from wp_newspack_campaigns_reader_events table.
[02-Jan-2023 16:59:42 UTC] Newspack Campaigns: Data pruning – removed X old rows from wp_newspack_campaigns_readers table.
[02-Jan-2023 16:59:42 UTC] Newspack Campaigns: Data pruning – removed X old rows from wp_newspack_campaigns_reader_events table.
[02-Jan-2023 16:59:42 UTC] Newspack Campaigns: Data pruning – removed X article/page view events from wp_newspack_campaigns_reader_events table.
[02-Jan-2023 16:59:42 UTC] Newspack Campaigns: Data pruning – removed X prompt seen events from wp_newspack_campaigns_reader_events table.
```

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
