### PR TITLE
feat: new option to show close button only on form submit

### DIFF
--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -1191,9 +1191,10 @@ final class Newspack_Popups_Model {
 
 		// If the dismiss action is by form submission, dismiss the prompt when the form is submitted.
 		if ( 'form_submission' === $dismiss_action ) {
+			$site_is_amp         = Newspack_Popups_Inserter::is_amp() && ! Newspack_Popups_Inserter::is_amp_plus();
 			$newspack_form_class = apply_filters( 'newspack_campaigns_form_class', 'newspack-subscribe-form' );
 			$has_form            = preg_match( '/<form\s|mc4wp-form|\[gravityforms\s|' . $newspack_form_class . '/', $body ) !== 0;
-			if ( $has_form ) {
+			if ( $has_form && ! $site_is_amp ) {
 				$body = str_replace(
 					'<form',
 					'<form data-submit-success on="submit-success:' . esc_attr( $element_id ) . '-close.show"',

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -522,6 +522,19 @@ final class Newspack_Popups {
 			]
 		);
 
+		\register_meta(
+			'post',
+			'dismiss_action',
+			[
+				'object_subtype' => self::NEWSPACK_POPUPS_CPT,
+				'show_in_rest'   => true,
+				'type'           => 'string',
+				'default'        => 'close_button',
+				'single'         => true,
+				'auth_callback'  => '__return_true',
+			]
+		);
+
 		// Meta field for all post types.
 		\register_meta(
 			'post',

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -703,6 +703,7 @@ final class Newspack_Popups {
 					)
 				),
 				'preview_query_keys'           => self::PREVIEW_QUERY_KEYS,
+				'site_is_amp'                  => Newspack_Popups_Inserter::is_amp() && ! Newspack_Popups_Inserter::is_amp_plus(),
 			]
 		);
 		\wp_enqueue_style(

--- a/includes/schemas/class-prompts.php
+++ b/includes/schemas/class-prompts.php
@@ -340,6 +340,12 @@ class Prompts extends Schema {
 								],
 							],
 						],
+						'dismiss_action'                 => [
+							'name'     => 'dismiss_action',
+							'type'     => 'string',
+							'required' => false,
+							'default'  => 'close_button',
+						],
 						'duplicate_of'                   => [
 							'name'     => 'duplicate_of',
 							'type'     => 'integer',

--- a/src/editor/AdvancedSidebar.js
+++ b/src/editor/AdvancedSidebar.js
@@ -22,6 +22,7 @@ const AdvancedSidebar = ( {
 	dismiss_action,
 	isOverlay,
 } ) => {
+	const siteIsAMP = window.newspack_popups_data?.site_is_amp;
 	return (
 		<Fragment>
 			<BaseControl>
@@ -64,7 +65,7 @@ const AdvancedSidebar = ( {
 						} )
 					}
 				/>
-				{ isOverlay && (
+				{ isOverlay && ! siteIsAMP && (
 					<>
 						<hr />
 						<SelectControl

--- a/src/editor/AdvancedSidebar.js
+++ b/src/editor/AdvancedSidebar.js
@@ -12,13 +12,15 @@ import { BaseControl } from '@wordpress/components';
 /**
  * Internal dependencies
  */
-import { CategoryAutocomplete, TextControl } from 'newspack-components';
+import { CategoryAutocomplete, SelectControl, TextControl } from 'newspack-components';
 
 const AdvancedSidebar = ( {
 	onMetaFieldChange,
 	excluded_categories = [],
 	excluded_tags = [],
 	additional_classes = '',
+	dismiss_action,
+	isOverlay,
 } ) => {
 	return (
 		<Fragment>
@@ -62,6 +64,20 @@ const AdvancedSidebar = ( {
 						} )
 					}
 				/>
+				{ isOverlay && (
+					<>
+						<hr />
+						<SelectControl
+							label={ __( 'Dismiss action', 'newspack-popups' ) }
+							value={ dismiss_action }
+							options={ [
+								{ value: 'close_button', label: __( 'Close Button', 'newspack-popups' ) },
+								{ value: 'form_submission', label: __( 'Form Submission', 'newspack-popups' ) },
+							] }
+							onChange={ value => onMetaFieldChange( { dismiss_action: value } ) }
+						/>
+					</>
+				) }
 			</BaseControl>
 		</Fragment>
 	);

--- a/src/editor/utils.js
+++ b/src/editor/utils.js
@@ -36,6 +36,7 @@ export const optionsFieldsSelector = select => {
 		additional_classes,
 		excluded_categories,
 		excluded_tags,
+		dismiss_action,
 	} = meta || {};
 
 	const isOverlay = isOverlayPlacement( placement );
@@ -69,6 +70,7 @@ export const optionsFieldsSelector = select => {
 		additional_classes,
 		excluded_categories,
 		excluded_tags,
+		dismiss_action,
 	};
 };
 

--- a/tests/test-model.php
+++ b/tests/test-model.php
@@ -56,6 +56,7 @@ class ModelTest extends WP_UnitTestCase {
 				'additional_classes'             => '',
 				'excluded_categories'            => [],
 				'excluded_tags'                  => [],
+				'dismiss_action'                 => 'close_button',
 			],
 			'Default options are as expected.'
 		);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This implements a highly-requested feature for some advanced publishers who want to start soft-gating content behind email collection or registration actions. It introduces a new option in the Advanced Settings sidebar for overlay prompts which lets publishers specify that the prompt can't be dismissed until a form inside the prompt is submitted.

<img width="269" alt="Screen Shot 2023-01-11 at 11 51 01 AM" src="https://user-images.githubusercontent.com/2230142/211892857-969539ed-ca64-4732-a767-0c59d5d8bf5a.png">

The intended use case is for an overlay prompt targeted to unregistered or unsubscribed readers who have read a minimum number of articles. Once they've viewed the requisite number of articles, we can show an "undismissible" prompt to encourage registration or newsletter signup in order to continue viewing article content. Once the reader takes the required action, the prompt becomes dismissible again.

This is a fairly rudimentary and soft registration wall, as it's intentionally easy to defeat. If an overlay prompt contains a form element and is set to "Dismiss Action: Form Submission", its close button will be hidden upon initial render until the reader submits the form. Because we don't know what form could be inside the prompt or the behavior of the form after initial submit, we only listen for the `submit` action, not the successful async response to the submission, which would greatly increase the complexity of the feature. Tech-savvy readers can also use dev tools to defeat the prompt, as the article content is still rendered in the HTML underneath the overlay.

Other caveats:

* The feature is somewhat hidden in the Advanced Settings sidebar as it's an advanced feature that should be used with caution.
* Form submission is the only alternative dismiss action supported at this time. We may choose to add others in the future.
* The close button can only be hidden if the prompt contains a form. If a prompt is set to "Dismiss Action: Form Submission" but doesn't contain a form, the close button behavior will revert to the regular behavior (close button is shown on initial render).
* The feature depends on JavaScript and is therefore only available on for AMP Plus and non-AMP pages. On pages rendered with full AMP standard mode, the close button behavior will revert to regular behavior.

### How to test the changes in this Pull Request:

1. On an AMP Plus or non-AMP site, create an overlay prompt and observe a new "Dismiss Action" field under Advanced Settings, set to "Close button" by default (status quo).
2. Set the Dismiss Action to "Form Submission" and add a block that will render a `form` element in the prompt content (such as a Registration or Newsletter Subscription Form block). Publish the prompt.
3. View the prompt on the front-end and confirm that the prompt renders with its close button hidden.
4. Submit the form and confirm that the close button becomes available upon form submission.
5. Remove the form block from the prompt content and repeat step 3, but this time confirm that the close button is shown on initial render (because there's no form to submit, which would make the prompt impossible to dismiss)
6. Add the form block again but configure your site to use AMP (not AMP Plus). Repeat step 3 again, and confirm that the close button is shown on initial render (front-end JS isn't supported in AMP).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
