### PR TITLE
fix: force invalid "full" size value to correct "full-width" value

### DIFF
--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -1160,7 +1160,7 @@ final class Newspack_Popups_Model {
 		$large_border          = $popup['options']['large_border'];
 		$overlay_opacity       = absint( $popup['options']['overlay_opacity'] ) / 100;
 		$overlay_color         = $popup['options']['overlay_color'];
-		$overlay_size          = $popup['options']['overlay_size'];
+		$overlay_size          = 'full' === $popup['options']['overlay_size'] ? 'full-width' : $popup['options']['overlay_size'];
 		$no_overlay_background = $popup['options']['no_overlay_background'];
 		$hidden_fields         = self::get_hidden_fields( $popup );
 		$is_newsletter_prompt  = self::has_newsletter_prompt( $popup );

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -804,11 +804,11 @@ final class Newspack_Popups {
 				break;
 			case 'overlay-top':
 				$placement    = 'top';
-				$overlay_size = 'full';
+				$overlay_size = 'full-width';
 				break;
 			case 'overlay-bottom':
 				$placement    = 'bottom';
-				$overlay_size = 'full';
+				$overlay_size = 'full-width';
 				break;
 			case 'archives':
 				$placement = 'archives';

--- a/src/editor/utils.js
+++ b/src/editor/utils.js
@@ -52,7 +52,7 @@ export const optionsFieldsSelector = select => {
 		frequency_reset,
 		overlay_color,
 		overlay_opacity,
-		overlay_size,
+		overlay_size: 'full' === overlay_size ? 'full-width' : overlay_size,
 		no_overlay_background,
 		placement,
 		trigger_type,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a bug that sometimes results in an invalid `full` size value, when the correct value should be `full-width`. Also accounts for the invalid size value so that it renders the same as `full-size`.

Closes 1203536997639429/1203494575662740.

### How to test the changes in this Pull Request:

1. On `master`, go to Newspack > Campaigns and use the wizard to create a new prompt. Select the "Top Overlay" placement.
2. In the editor for the prompt, in the Prompt Settings sidebar, observe that the "size" dropdown shows "extra small" (this is because the size value is forced to `full`, which is not a valid value, resulting in the first option being shown). Add a small amount of content which won't fill the full viewport width, like a few words.
3. View the prompt on the front-end and observe that it renders at the minimum width required for the content.
4. Check out this branch and refresh the prompt in the editor—confirm that the "size" dropdown now shows "Full width" and that the prompt is shown at a wider width in the editor preview.
5. View on the front-end again and confirm that the prompt now shows at full viewport width.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
