### PR TITLE
feat: add feature to disable reader data caching via flag

### DIFF
--- a/api/classes/class-lightweight-api.php
+++ b/api/classes/class-lightweight-api.php
@@ -105,6 +105,11 @@ class Lightweight_API {
 		if ( ! file_exists( WP_CONTENT_DIR . '/object-cache.php' ) || ( defined( 'IS_TEST_ENV' ) && IS_TEST_ENV ) ) {
 			$this->ignore_cache = true;
 		}
+
+		if ( $this->is_cache_disabled() ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$this->ignore_cache     = true;
+			$this->debug['nocache'] = true;
+		}
 	}
 
 	/**
@@ -114,6 +119,15 @@ class Lightweight_API {
 	 */
 	public function is_debug_enabled() {
 		return isset( $_REQUEST['debug'] ) || ( defined( 'NEWSPACK_POPUPS_DEBUG' ) && NEWSPACK_POPUPS_DEBUG ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+	}
+
+	/**
+	 * Whether caching is disabled via newspack-popups-config.php or URL param.
+	 *
+	 * @return boolean
+	 */
+	public function is_cache_disabled() {
+		return isset( $_REQUEST['nocache'] ) || ( defined( 'NEWSPACK_POPUPS_NOCACHE' ) && NEWSPACK_POPUPS_NOCACHE ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 	}
 
 	/**
@@ -1009,9 +1023,7 @@ class Lightweight_API {
 		);
 
 		// Rebuild cache.
-		if ( ! $this->ignore_cache ) {
-			wp_cache_set( 'reader_events', array_merge( $cached_events, $filtered_events ), $client_id );
-		}
+		wp_cache_set( 'reader_events', array_merge( $cached_events, $filtered_events ), $client_id );
 
 		$this->update_debug_events( $filtered_events );
 
@@ -1151,7 +1163,7 @@ class Lightweight_API {
 				$all_events
 			);
 
-			// Set a cache version for future validation.
+			// Rebuild cache.
 			wp_cache_set( 'reader_events', $all_events, $client_id );
 
 			$this->update_debug_events( $all_events );

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -880,6 +880,10 @@ final class Newspack_Popups_Inserter {
 			$popups_access_provider['authorization'] .= '&authorizationTimeout=10000';
 		}
 
+		if ( isset( $_GET['nocache'] ) || ( defined( 'NEWSPACK_POPUPS_NOCACHE' ) && NEWSPACK_POPUPS_NOCACHE ) ) {// phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+			$popups_access_provider['authorization'] .= '&nocache';
+		}
+
 		?>
 		<script id="amp-access" type="application/json">
 			<?php echo wp_json_encode( $popups_access_provider ); ?>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds a feature to bypass reader and reader event data caching via a URL param or environment flag. Cached data can sometimes become unreliable as a reader amasses many client IDs, and this offers us a way to bypass the cache.

### How to test the changes in this Pull Request:

1. On a site with memcache setup, check out this branch and browse around the site as a reader.
2. Observe that after the first pageview, on subsequent pageviews your reader data and events are fetched from and written to the persistent object cache instead of directly to the DB.
3. Add a `?nocache` param to the URL and refresh. Confirm that reader data and events are fetched directly from the DB when this param is prseent.
4. Add `define( 'NEWSPACK_POPUPS_NOCACHE', true );` to your `newspack-popups-config.php` file and repeat step 3 without the param. Confirm that the cache is bypassed in the same way for every pageview when this environment variable is set.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
