### PR TITLE
Add type to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
   "name": "automattic/newspack-popups",
   "description": "AMP-compatible popup notifications.",
+  "type": "wordpress-plugin",
   "require-dev": {
     "automattic/vipwpcs": "^2.0",
     "wp-coding-standards/wpcs": "^2.1",


### PR DESCRIPTION
Updates the composer.json to add the "type" parameter with "wordpress-plugin" to allow for inclusion in Composer-based WordPress projects. This matches the [composer.json for the Newspack Plugin](https://github.com/Automattic/newspack-plugin/blob/master/composer.json)