### PR TITLE
fix: avoid notice on php 8

### DIFF
--- a/api/campaigns/class-maybe-show-campaign.php
+++ b/api/campaigns/class-maybe-show-campaign.php
@@ -182,7 +182,7 @@ class Maybe_Show_Campaign extends Lightweight_API {
 	 *
 	 * @return string|null ID of the best matching segment, or null if the client matches no segment.
 	 */
-	public function get_best_priority_segment_id( $all_segments = [], $client_id, $referer_url = '', $page_referer_url = '', $view_as_spec = false ) {
+	public function get_best_priority_segment_id( $all_segments, $client_id, $referer_url = '', $page_referer_url = '', $view_as_spec = false ) {
 		// If using "view as" feature, automatically make that the matching segment. Otherwise, find the matching segment with the best priority.
 		if ( $view_as_spec && isset( $view_as_spec['segment'] ) ) {
 			return $view_as_spec['segment'];

--- a/api/campaigns/class-maybe-show-campaign.php
+++ b/api/campaigns/class-maybe-show-campaign.php
@@ -272,7 +272,7 @@ class Maybe_Show_Campaign extends Lightweight_API {
 					$should_display = true;
 				}
 			}
-		} elseif ( $should_display && ! empty( $popup_segment_ids ) ) {
+		} elseif ( $should_display && ! empty( $popup_segment_ids ) && ! empty( $settings ) ) {
 			// $settings->best_priority_segment_id should always be present, but in case it's not (e.g. in a unit test), we can fetch it here.
 			$best_priority_segment_id = isset( $settings->best_priority_segment_id ) ?
 				$settings->best_priority_segment_id :


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fixes the method signature so it won't throw notices on PHP 8+

### How to test the changes in this Pull Request:

1. Spin up a site with php 8 and Campaigns
2. Visit the site and inspect the ajax requests to `.../wp-content/plugins/newspack-popups/api/campaigns/index.php?cid=...`
3. Check the response and confirm you see the following warning:
```
<br />
<b>Deprecated</b>:  Required parameter $client_id follows optional parameter $all_segments in <b>/newspack-repos/newspack-popups/api/campaigns/class-maybe-show-campaign.php</b> on line <b>185</b><br />
```
4. Checkout this branch and confirm the warning is gone.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
