### PR TITLE
feat: allow overlays to be dismissed on background tap

### DIFF
--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -1284,8 +1284,17 @@ final class Newspack_Popups_Model {
 				</div>
 			</div>
 			<?php if ( ! $no_overlay_background ) : ?>
+				<?php if ( Newspack_Popups_Settings::enable_dismiss_overlays_on_background_tap() ) : ?>
+					<form class="popup-dismiss-form <?php echo esc_attr( self::get_form_class( 'dismiss', $element_id ) ); ?> popup-action-form <?php echo esc_attr( self::get_form_class( 'action', $element_id ) ); ?>"
+					method="POST"
+					action-xhr="<?php echo esc_url( $endpoint ); ?>"
+					target="_top">
+						<?php echo $hidden_fields; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+						<button style="opacity: <?php echo floatval( $overlay_opacity ); ?>;background-color:<?php echo esc_attr( $overlay_color ); ?>;" class="newspack-lightbox-shim" on="tap:<?php echo esc_attr( $element_id ); ?>.hide"></button>
+					</form>
+				<?php else : ?>
 				<div style="opacity: <?php echo floatval( $overlay_opacity ); ?>;background-color:<?php echo esc_attr( $overlay_color ); ?>;" class="newspack-lightbox-shim"></div>
-				</form>
+				<?php endif; ?>
 			<?php endif; ?>
 		</amp-layout>
 		<?php if ( $is_scroll_triggered ) : ?>

--- a/includes/class-newspack-popups-settings.php
+++ b/includes/class-newspack-popups-settings.php
@@ -283,6 +283,16 @@ class Newspack_Popups_Settings {
 				'help'        => __( 'Use this setting in high traffic scenarios. No API requests will be made, reducing server load. Inline prompts will be shown to all users, and overlay prompts will be suppressed.', 'newspack-popups' ),
 				'public'      => false,
 			],
+			[
+				'section'     => 'general_settings',
+				'key'         => 'newspack_popups_dismiss_overlays_on_tap',
+				'type'        => 'boolean',
+				'value'       => self::enable_dismiss_overlays_on_background_tap(),
+				'default'     => false,
+				'description' => __( 'Dismiss overlays on background tap', 'newspack-popups' ),
+				'help'        => __( 'If enabled, readers can dismiss overlay prompts by tapping on the colored overlay background underneath the prompt content. This will make it easier for readers to dismiss prompts, but potentially result in less reader engagement.', 'newspack-popups' ),
+				'public'      => false,
+			],
 		];
 
 		$default_setting = array(
@@ -362,6 +372,15 @@ class Newspack_Popups_Settings {
 	 */
 	public static function donor_landing_page() {
 		return get_option( 'newspack_popups_donor_landing_page', '' );
+	}
+
+	/**
+	 * Enable overlay dismiss on background tap.
+	 *
+	 * @return boolean
+	 */
+	public static function enable_dismiss_overlays_on_background_tap() {
+		return get_option( 'newspack_popups_dismiss_overlays_on_tap', false );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

#948 changed overlay behavior so that tapping on the overlay background no longer dismissed overlay prompts. This largely resulted in increased prompt engagement from readers, but also some greater degree of reader frustration. We've received feedback from some publishers that this is highly undesired because of the frustration, so we're introducing a global option to restore the prior behavior for publishers who want it.

### How to test the changes in this Pull Request:

1. Check out this branch. Go to **Newspack > Campaigns > Settings** and confirm there's a new option (disabled by default) under General Settings:

<img width="1058" alt="Screen Shot 2023-02-28 at 12 15 43 PM" src="https://user-images.githubusercontent.com/2230142/221956590-ce08951e-8dfd-4a39-89cf-c02592c62b67.png">

2. Without enabling the new option, publish an overlay prompt with a visible overlay background. (Prompts without overlay backgrounds will not be affected as there's no overlay background to tap.)
3. View the overlay on the front-end and confirm that tapping on the overlay background does not dismiss the prompt (default behavior is status quo).
4. Enable the new option and save.
5. View the overlay on the front-end again and confirm that tapping on the overlay background dismisses the prompt and also results in a `prompt_dismissed` event being recorded (in the `wp_newspack_campaigns_reader_events` table, or in the `/tmp/wp_newspack-popups-events.log` file if memcache is enabled).
6. Temporarily disable the `newspack-plugin` plugin and confirm that the setting still works in the **Prompts > Settings** standalone settings page.

<img width="537" alt="Screen Shot 2023-02-28 at 12 09 01 PM" src="https://user-images.githubusercontent.com/2230142/221957640-623b6425-aa70-4eb7-b189-e4c30dc340e6.png">

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
