### PR TITLE
fix: ensure the plugin works when performance-lab plugin is active

### DIFF
--- a/api/setup.php
+++ b/api/setup.php
@@ -40,6 +40,10 @@ function __( $in ) { return $in; }
 function wp_load_translations_early() {return null;}
 function add_filter() {}
 function do_action() {}
+function add_action() {}
+function wp_cache_init() {}
+function wp_cache_get() {}
+function wp_cache_set() {}
 function has_filter() { return false;}
 function apply_filters( $f, $in ) { return $in; }
 function is_multisite() { return false; }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

It may happen that a plugin will load code when this plugin's API is running. This plugin's API is not WordPress, so some functions assumed to be present in a WP environment have to be provided.

### How to test the changes in this Pull Request:

1. On `master`, activate the `performance-lab` plugin an visit a page with prompts 
2. Observe the request made to the API (`/wp-content/plugins/newspack-popups/api/campaigns/index.php`) – it will fail with a WP HTML error message as response 
3. Switch to this branch, observe the request succeeds as expected 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->