### PR TITLE
feat: remove handling of unsupported Stripe event

### DIFF
--- a/includes/class-newspack-popups-donations.php
+++ b/includes/class-newspack-popups-donations.php
@@ -41,8 +41,6 @@ final class Newspack_Popups_Donations {
 		\add_action( 'admin_init', [ __CLASS__, 'delete_legacy_wc_webhook' ] );
 		\add_action( 'woocommerce_checkout_order_created', [ __CLASS__, 'create_donation_event_woocommerce' ] );
 		\add_action( 'newspack_new_donation_woocommerce', [ __CLASS__, 'create_donation_event_woocommerce' ], 10, 2 );
-		\add_action( 'newspack_stripe_new_donation', [ __CLASS__, 'create_donation_event_stripe' ], 10, 3 );
-		\add_action( 'newspack_stripe_donation_cancellation', [ __CLASS__, 'create_donation_cancellation_event_stripe' ], 10, 2 );
 	}
 
 	/**
@@ -169,56 +167,6 @@ final class Newspack_Popups_Donations {
 
 			$api->save_reader_events( $client_id, $donation_events );
 		}
-	}
-
-	/**
-	 * Add a new reader events for the segmentation API.
-	 *
-	 * @param string $client_id Client ID.
-	 * @param array  $event Event payload.
-	 * @param string $context Event context.
-	 */
-	private static function add_reader_event( $client_id, $event, $context = 'stripe' ) {
-		$event['context'] = $context;
-		$api              = \Campaign_Data_Utils::get_api( \wp_create_nonce( 'newspack_campaigns_lightweight_api' ) );
-		if ( ! $api ) {
-			return;
-		}
-		$api->save_reader_events( $client_id, [ $event ] );
-	}
-
-	/**
-	 * Add Stripe donation data.
-	 *
-	 * @param string      $client_id Client ID.
-	 * @param array       $donation_data Info about the transaction.
-	 * @param string|null $newsletter_email If the user signed up for a newsletter as part of the transaction, the subscribed email address. Otherwise, null.
-	 */
-	public static function create_donation_event_stripe( $client_id, $donation_data, $newsletter_email ) {
-		self::add_reader_event(
-			$client_id,
-			[
-				'type'  => 'donation',
-				'value' => $donation_data,
-			]
-		);
-
-	}
-
-	/**
-	 * Cancellation of a recurring donation.
-	 *
-	 * @param string $client_id Client ID.
-	 * @param array  $donation_cancellation_data Info about the transaction.
-	 */
-	public static function create_donation_cancellation_event_stripe( $client_id, $donation_cancellation_data ) {
-		self::add_reader_event(
-			$client_id,
-			[
-				'type'  => 'donation_cancelled',
-				'value' => $donation_cancellation_data,
-			]
-		);
 	}
 }
 Newspack_Popups_Donations::instance();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Removes handling of the event which is removed in https://github.com/Automattic/newspack-plugin/pull/2315.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->