### PR TITLE
fix: fatal error if wp_cache_* functions do exist

### DIFF
--- a/api/setup.php
+++ b/api/setup.php
@@ -41,9 +41,6 @@ function wp_load_translations_early() {return null;}
 function add_filter() {}
 function do_action() {}
 function add_action() {}
-function wp_cache_init() {}
-function wp_cache_get() {}
-function wp_cache_set() {}
 function has_filter() { return false;}
 function apply_filters( $f, $in ) { return $in; }
 function is_multisite() { return false; }
@@ -76,7 +73,13 @@ $wpdb->set_prefix( $db_prefix );
 global $table_prefix;
 $table_prefix = $db_prefix;
 
-wp_cache_init();
+if ( function_exists( 'wp_cache_init' ) ) {
+	wp_cache_init();
+} else {
+	function wp_cache_init() {}
+	function wp_cache_get() {}
+	function wp_cache_set() {}
+}
 
 // phpcs:enable
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Avoids a fatal error in the Campaigns API without the `performance-lab` plugin.

### How to test the changes in this Pull Request:

1. Deactivate the Performance Lab plugin, if active.
2. On `master`, inspect the network request for the API (`/wp-content/plugins/newspack-popups/api/campaigns/index.php`): it will fail with an error:

```
Fatal error: Cannot redeclare wp_cache_get() (previously declared in ./newspack-popups/api/setup.php:45) in /var/www/html/wp-content/object-cache.php on line 55
```

3. Also observe that no prompts are displayed because of the API failure.
4. Check out this branch; confirm that the fatal is fixed and the prompts display as expected.
5. Install/activate the Performance Lab plugin and confirm that the API still succeeds and the prompts are displayed.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
