### PR TITLE
feat: Update default newsletter prompt

### DIFF
--- a/includes/schemas/class-prompts.php
+++ b/includes/schemas/class-prompts.php
@@ -236,6 +236,7 @@ class Prompts extends Schema {
 							'enum'     => [
 								'time',
 								'scroll',
+								'blocks_count',
 							],
 						],
 						'trigger_delay'                  => [

--- a/presets/ras-defaults.json
+++ b/presets/ras-defaults.json
@@ -106,7 +106,7 @@
         {
             "status": "draft",
             "title": "Inline Newsletter Signup (secondary)",
-            "content": "<!-- wp:paragraph -->\n<p>Signup for our free newsletter to receive the latest news</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:newspack-newsletters/subscribe /-->",
+            "content": "<!-- wp:paragraph -->\n<p>Sign up for our free newsletter to receive the latest news</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:newspack-newsletters/subscribe /-->",
             "options": {
                 "background_color": "#FFFFFF",
                 "display_title": false,

--- a/presets/ras-defaults.json
+++ b/presets/ras-defaults.json
@@ -106,11 +106,11 @@
         {
             "status": "draft",
             "title": "Inline Newsletter Signup (secondary)",
-            "content": "<!-- wp:group {\"className\":\"is-style-border\",\"layout\":{\"type\":\"constrained\"}} -->\n<div class=\"wp-block-group is-style-border\"><!-- wp:paragraph -->\n<p>Signup for our free newsletter to receive the latest news<\/p>\n<!-- \/wp:paragraph -->\n\n<!-- wp:newspack-newsletters\/subscribe \/--><\/div>\n<!-- \/wp:group -->",
+            "content": "<!-- wp:paragraph -->\n<p>Signup for our free newsletter to receive the latest news</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:newspack-newsletters/subscribe /-->",
             "options": {
                 "background_color": "#FFFFFF",
                 "display_title": false,
-                "hide_border": "1",
+                "hide_border": false,
                 "large_border": false,
                 "frequency": "always",
                 "frequency_max": 0,

--- a/presets/ras-defaults.json
+++ b/presets/ras-defaults.json
@@ -106,7 +106,7 @@
         {
             "status": "draft",
             "title": "Inline Newsletter Signup (secondary)",
-            "content": "<!-- wp:paragraph -->\n<p>Signup for our free newsletter to receive the latest news<\/p>\n<!-- \/wp:paragraph -->\n\n<!-- wp:newspack-newsletters\/subscribe \/-->\n\n<!-- wp:separator -->\n<hr class=\"wp-block-separator has-alpha-channel-opacity\"\/>\n<!-- \/wp:separator -->",
+            "content": "<!-- wp:group {\"className\":\"is-style-border\",\"layout\":{\"type\":\"constrained\"}} -->\n<div class=\"wp-block-group is-style-border\"><!-- wp:paragraph -->\n<p>Signup for our free newsletter to receive the latest news<\/p>\n<!-- \/wp:paragraph -->\n\n<!-- wp:newspack-newsletters\/subscribe \/--><\/div>\n<!-- \/wp:group -->",
             "options": {
                 "background_color": "#FFFFFF",
                 "display_title": false,
@@ -122,10 +122,10 @@
                 "overlay_size": "medium",
                 "no_overlay_background": false,
                 "placement": "inline",
-                "trigger_type": "scroll",
+                "trigger_type": "blocks_count",
                 "trigger_delay": "3",
                 "trigger_scroll_progress": 0,
-                "trigger_blocks_count": 0,
+                "trigger_blocks_count": 2,
                 "archive_insertion_posts_count": 1,
                 "archive_insertion_is_repeating": false,
                 "selected_segment_id": "639b333b41025,639b337fdbf33",


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Changes the default RAS newsletter signup prompt

See 1204068745367915-as-1204158608390449

### How to test the changes in this Pull Request:

1. Set up a new site
2. Activate Campaigns
3. Import defaults with `wp newspack-popups import --ras-defaults`
4. See all prompts
5. Open the Newsletters Inline signup (secondary)
6. Confirm the paragraph and the form are grouped and the group has a border
7. Confirm the separator at the bottom was removed
8. Confirm "Insert position" is set to "block count"
9. Confirm "Number of blocks" is set to 2

![Captura de tela de 2023-03-24 10-47-14](https://user-images.githubusercontent.com/971483/227539328-40fb1196-5208-48e8-b23a-e1f4aa379d84.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
