### PR TITLE
fix: hide lightbox when modal checkout

### DIFF
--- a/src/view/style.scss
+++ b/src/view/style.scss
@@ -484,3 +484,9 @@ $width__tablet: 782px;
 .hide {
 	display: none;
 }
+
+.newspack-modal-checkout-open {
+	.newspack-lightbox {
+		display: none !important;
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Hide overlay prompts when in the modal checkout.

### How to test the changes in this Pull Request:

Instructions at https://github.com/Automattic/newspack-blocks/pull/1411

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
