### PR TITLE
feat: add user_input fields to prompt schema

### DIFF
--- a/includes/class-newspack-popups-importer.php
+++ b/includes/class-newspack-popups-importer.php
@@ -228,9 +228,17 @@ class Newspack_Popups_Importer {
 		$prompts = $this->pre_process_prompts_terms( $prompts );
 
 		foreach ( $prompts as $prompt ) {
+			$prompt_content = $prompt['content'];
+			$user_inputs    = isset( $prompt['user_inputs'] ) ? $prompt['user_inputs'] : [];
+
+			foreach ( $user_inputs as $user_input ) {
+				$value          = ! empty( $user_input['value'] ) ? $user_input['value'] : $user_input['default'];
+				$prompt_content = str_replace( '{{' . $user_input['name'] . '}}', $value, $prompt_content );
+			}
+
 			$post_data = [
 				'post_title'   => $prompt['title'],
-				'post_content' => $prompt['content'],
+				'post_content' => $prompt_content,
 				'post_status'  => $prompt['status'],
 				'post_type'    => Newspack_Popups::NEWSPACK_POPUPS_CPT,
 			];
@@ -252,6 +260,11 @@ class Newspack_Popups_Importer {
 			}
 			if ( ! empty( $prompt['tags'] ) ) {
 				Newspack_Popups_Model::set_popup_terms( $new_post, $prompt['tags'], 'post_tag' );
+			}
+
+			// If there's a featured image.
+			if ( ! empty( $prompt['featured_image_id'] ) && false !== wp_get_attachment_url( (int) $prompt['featured_image_id'] ) ) {
+				set_post_thumbnail( $new_post, (int) $prompt['featured_image_id'] );
 			}
 		}
 	}

--- a/includes/schemas/class-prompts.php
+++ b/includes/schemas/class-prompts.php
@@ -25,17 +25,22 @@ class Prompts extends Schema {
 			'type'                 => 'object',
 			'additionalProperties' => false,
 			'properties'           => [
-				'title'           => [
+				'title'             => [
 					'name'     => 'title',
 					'type'     => 'string',
 					'required' => true,
 				],
-				'content'         => [
+				'content'           => [
 					'name'     => 'content',
 					'type'     => 'string',
 					'required' => true,
 				],
-				'campaign_groups' => [
+				'featured_image_id' => [
+					'name'     => 'featured_image_id',
+					'type'     => 'integer', // Attachment ID to be used as the featured image.
+					'required' => false,
+				],
+				'campaign_groups'   => [
 					'name'     => 'campaign_groups',
 					'type'     => 'array',
 					'required' => false,
@@ -53,7 +58,7 @@ class Prompts extends Schema {
 						],
 					],
 				],
-				'status'          => [
+				'status'            => [
 					'name'     => 'status',
 					'type'     => 'string',
 					'required' => true,
@@ -62,7 +67,7 @@ class Prompts extends Schema {
 						'draft',
 					],
 				],
-				'categories'      => [
+				'categories'        => [
 					'name'     => 'categories',
 					'type'     => 'array',
 					'required' => false,
@@ -80,7 +85,7 @@ class Prompts extends Schema {
 						],
 					],
 				],
-				'tags'            => [
+				'tags'              => [
 					'name'     => 'tags',
 					'type'     => 'array',
 					'required' => false,
@@ -98,7 +103,7 @@ class Prompts extends Schema {
 						],
 					],
 				],
-				'options'         => [
+				'options'           => [
 					'type'                 => 'object',
 					'required'             => true,
 					'additionalProperties' => false,
@@ -352,6 +357,61 @@ class Prompts extends Schema {
 							'type'     => 'boolean',
 							'required' => false,
 							'default'  => false,
+						],
+					],
+				],
+				// Required user inputs when auto-generating a prompt. These will be shown as fields in the UI.
+				'user_inputs'       => [
+					'name'     => 'user_inputs',
+					'type'     => 'array',
+					'required' => false,
+					'default'  => [],
+					'items'    => [
+						'type'                 => 'object',
+						'additionalProperties' => false,
+						'properties'           => [
+							// Slug for the input. Must be unique per prompt.
+							'name'        => [
+								'type' => 'string',
+							],
+							// Data type for the input.
+							'type'        => [
+								'type' => 'string',
+							],
+							// Label for the input.
+							'label'       => [
+								'type' => 'string',
+							],
+							// Help text describing the input.
+							'description' => [
+								'type' => 'string',
+							],
+							// Whether the input is required to generate the prompt or if it can be generated with an empty value. If true, the default value will be used when the input is empty.
+							'required'    => [
+								'type' => 'boolean',
+							],
+							// Default value of the input. This will be populated by default in the UI.
+							'default'     => [
+								'type' => [
+									'string',
+									'integer',
+									'boolean',
+								],
+							],
+							// Value of the input as inputted by the user.
+							'value'       => [
+								'type'     => [
+									'string',
+									'integer',
+									'boolean',
+								],
+								'required' => false,
+							],
+							// If a string, maximum length for the input value. This will be used to validate the input in the UI.
+							'max_length'  => [
+								'type'     => 'integer',
+								'required' => false,
+							],
 						],
 					],
 				],

--- a/presets/ras-defaults.json
+++ b/presets/ras-defaults.json
@@ -3,7 +3,7 @@
         {
             "status": "draft",
             "title": "Inline Donation (secondary)",
-            "content": "<!-- wp:separator -->\n<hr class=\"wp-block-separator has-alpha-channel-opacity\"\/>\n<!-- \/wp:separator -->\n\n<!-- wp:heading -->\n<h2>Support our work<\/h2>\n<!-- \/wp:heading -->\n\n<!-- wp:paragraph -->\n<p>As an independent publication, we rely on donations to fund our journalism<\/p>\n<!-- \/wp:paragraph -->\n\n<!-- wp:newspack-blocks\/donate {\"className\":\"is-style-alternate\",\"amounts\":{\"once\":[9,20,90,20],\"month\":[7,15,30,15],\"year\":[84,180,360,180]},\"disabledFrequencies\":{\"once\":false,\"month\":false,\"year\":false},\"minimumDonation\":5} \/-->",
+            "content": "<!-- wp:separator -->\n<hr class=\"wp-block-separator has-alpha-channel-opacity\"\/>\n<!-- \/wp:separator -->\n\n<!-- wp:heading -->\n<h2>{{heading}}<\/h2>\n<!-- \/wp:heading -->\n\n<!-- wp:paragraph -->\n<p>{{body}}<\/p>\n<!-- \/wp:paragraph -->\n\n<!-- wp:newspack-blocks\/donate {\"className\":\"is-style-alternate\",\"amounts\":{\"once\":[9,20,90,20],\"month\":[7,15,30,15],\"year\":[84,180,360,180]},\"disabledFrequencies\":{\"once\":false,\"month\":false,\"year\":false},\"thanksText\":\"{{thanks_message}}\",\"buttonText\": \"{{button_label}}\",\"minimumDonation\":5} \/-->",
             "options": {
                 "background_color": "#FFFFFF",
                 "display_title": false,
@@ -48,12 +48,50 @@
                     "id": 30,
                     "name": "Reader Activation Defaults"
                 }
+            ],
+            "user_inputs": [
+                {
+                    "name": "heading",
+                    "type": "string",
+                    "label": "Heading",
+                    "description": "A heading to describe the prompt.",
+                    "required": true,
+                    "default": "Support Our Work",
+                    "max_length": 40
+                },
+                {
+                    "name": "body",
+                    "type": "string",
+                    "label": "Body",
+                    "description": "The primary call to action for the prompt.",
+                    "required": true,
+                    "default": "As an independent publication, we rely on donations to fund our journalism.",
+                    "max_length": 300
+                },
+                {
+                    "name": "thanks_message",
+                    "type": "string",
+                    "label": "Thanks Message",
+                    "description": "A message to thank the reader for their contribution.",
+                    "required": true,
+                    "default": "Thanks for your contribution!",
+                    "max_length": 300
+                },
+                {
+                    "name": "button_label",
+                    "type": "string",
+                    "label": "Button Label",
+                    "description": "The label for the primary CTA button.",
+                    "required": true,
+                    "default": "Donate Now",
+                    "max_length": 20
+                }
             ]
         },
         {
             "status": "draft",
             "title": "Registration Overlay",
-            "content": "<!-- wp:newspack\/reader-registration {\"title\":\"Sign Up\",\"description\":\"Sign up for our free newsletters to receive the latest news.\"} -->\n<div class=\"wp-block-newspack-reader-registration\"><\/div>\n<!-- \/wp:newspack\/reader-registration -->",
+            "content": "<!-- wp:newspack\/reader-registration {\"title\":\"{{heading}}\",\"description\":\"{{body}}\",\"label\":\"{{button_label}}\"} -->\n<div class=\"wp-block-newspack-reader-registration\"><!-- wp:paragraph {\"align\":\"center\"} --><p class=\"has-text-align-center\">{{success_message}}</p><!-- /wp:paragraph --><\/div>\n<!-- \/wp:newspack\/reader-registration -->",
             "options": {
                 "background_color": "#FFFFFF",
                 "display_title": false,
@@ -101,12 +139,50 @@
                     "id": 30,
                     "name": "Reader Activation Defaults"
                 }
+            ],
+            "user_inputs": [
+                {
+                    "name": "heading",
+                    "type": "string",
+                    "label": "Heading",
+                    "description": "A heading to describe the prompt.",
+                    "required": true,
+                    "default": "Sign Up",
+                    "max_length": 40
+                },
+                {
+                    "name": "body",
+                    "type": "string",
+                    "label": "Body",
+                    "description": "The primary call to action for the prompt.",
+                    "required": true,
+                    "default": "Sign up for our free newsletter to receive the latest news.",
+                    "max_length": 300
+                },
+                {
+                    "name": "button_label",
+                    "type": "string",
+                    "label": "Button Label",
+                    "description": "The label for the primary CTA button.",
+                    "required": true,
+                    "default": "Sign up",
+                    "max_length": 20
+                },
+                {
+                    "name": "success_message",
+                    "type": "string",
+                    "label": "Success Message",
+                    "description": "The message shown to readers after completing the signup.",
+                    "required": true,
+                    "default": "Thank you for registering!",
+                    "max_length": 300
+                }
             ]
         },
         {
             "status": "draft",
             "title": "Inline Newsletter Signup (secondary)",
-            "content": "<!-- wp:paragraph -->\n<p>Sign up for our free newsletter to receive the latest news</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:newspack-newsletters/subscribe /-->",
+            "content": "<!-- wp:paragraph -->\n<p>{{body}}</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:newspack-newsletters/subscribe {\"label\":\"{{button_label}}\",\"successMessage\":\"{{success_message}}\"} /-->",
             "options": {
                 "background_color": "#FFFFFF",
                 "display_title": false,
@@ -151,12 +227,41 @@
                     "id": 30,
                     "name": "Reader Activation Defaults"
                 }
+            ],
+            "user_inputs": [
+                {
+                    "name": "body",
+                    "type": "string",
+                    "label": "Body",
+                    "description": "The primary call to action for the prompt.",
+                    "required": true,
+                    "default": "Sign up for our free newsletter to receive the latest news.",
+                    "max_length": 300
+                },
+                {
+                    "name": "button_label",
+                    "type": "string",
+                    "label": "Button Label",
+                    "description": "The label for the primary CTA button.",
+                    "required": true,
+                    "default": "Sign up",
+                    "max_length": 20
+                },
+                {
+                    "name": "success_message",
+                    "type": "string",
+                    "label": "Success Message",
+                    "description": "The message shown to readers after completing the signup.",
+                    "required": true,
+                    "default": "Thank you for signing up!",
+                    "max_length": 300
+                }
             ]
         },
         {
             "status": "draft",
             "title": "Newsletter Sign-up Overlay",
-            "content": "<!-- wp:heading -->\n<h2>Stay in the know<\/h2>\n<!-- \/wp:heading -->\n\n<!-- wp:paragraph -->\n<p>Sign up for our free newsletters to receive the latest news directly in your inbox.<\/p>\n<!-- \/wp:paragraph -->\n\n<!-- wp:newspack-newsletters\/subscribe \/-->",
+            "content": "<!-- wp:heading -->\n<h2>{{heading}}<\/h2>\n<!-- \/wp:heading -->\n\n<!-- wp:paragraph -->\n<p>{{body}}<\/p>\n<!-- \/wp:paragraph -->\n\n<!-- wp:newspack-newsletters/subscribe {\"label\":\"{{button_label}}\",\"successMessage\":\"{{success_message}}\"} /-->",
             "options": {
                 "background_color": "#FFFFFF",
                 "display_title": false,
@@ -204,12 +309,50 @@
                     "id": 30,
                     "name": "Reader Activation Defaults"
                 }
+            ],
+            "user_inputs": [
+                {
+                    "name": "heading",
+                    "type": "string",
+                    "label": "Heading",
+                    "description": "A heading to describe the prompt.",
+                    "required": true,
+                    "default": "Stay in the know",
+                    "max_length": 40
+                },
+                {
+                    "name": "body",
+                    "type": "string",
+                    "label": "Body",
+                    "description": "The primary call to action for the prompt.",
+                    "required": true,
+                    "default": "Sign up for our free newsletters to receive the latest news directly in your inbox.",
+                    "max_length": 300
+                },
+                {
+                    "name": "button_label",
+                    "type": "string",
+                    "label": "Button Label",
+                    "description": "The label for the primary CTA button.",
+                    "required": true,
+                    "default": "Sign up",
+                    "max_length": 20
+                },
+                {
+                    "name": "success_message",
+                    "type": "string",
+                    "label": "Success Message",
+                    "description": "The message shown to readers after completing the signup.",
+                    "required": true,
+                    "default": "Thank you for signing up!",
+                    "max_length": 300
+                }
             ]
         },
         {
             "status": "draft",
             "title": "Donation Overlay",
-            "content": "<!-- wp:heading -->\n<h2>Support our work<\/h2>\n<!-- \/wp:heading -->\n\n<!-- wp:paragraph -->\n<p>As an independent publication, we rely on donations to fund our journalism<\/p>\n<!-- \/wp:paragraph -->\n\n<!-- wp:newspack-blocks\/donate {\"className\":\"is-style-alternate\",\"amounts\":{\"once\":[9,20,90,20],\"month\":[7,15,30,15],\"year\":[84,180,360,180]},\"disabledFrequencies\":{\"once\":false,\"month\":false,\"year\":false},\"minimumDonation\":5} \/-->",
+            "content": "<!-- wp:heading -->\n<h2>{{heading}}<\/h2>\n<!-- \/wp:heading -->\n\n<!-- wp:paragraph -->\n<p>{{body}}<\/p>\n<!-- \/wp:paragraph -->\n\n<!-- wp:newspack-blocks\/donate {\"className\":\"is-style-alternate\",\"amounts\":{\"once\":[9,20,90,20],\"month\":[7,15,30,15],\"year\":[84,180,360,180]},\"disabledFrequencies\":{\"once\":false,\"month\":false,\"year\":false},\"thanksText\":\"{{thanks_message}}\",\"buttonText\": \"{{button_label}}\",\"minimumDonation\":5} \/-->",
             "options": {
                 "background_color": "#FFFFFF",
                 "display_title": false,
@@ -256,6 +399,44 @@
                 {
                     "id": 30,
                     "name": "Reader Activation Defaults"
+                }
+            ],
+            "user_inputs": [
+                {
+                    "name": "heading",
+                    "type": "string",
+                    "label": "Heading",
+                    "description": "A heading to describe the prompt.",
+                    "required": true,
+                    "default": "Support Our Work",
+                    "max_length": 40
+                },
+                {
+                    "name": "body",
+                    "type": "string",
+                    "label": "Body",
+                    "description": "The primary call to action for the prompt.",
+                    "required": true,
+                    "default": "As an independent publication, we rely on donations to fund our journalism.",
+                    "max_length": 300
+                },
+                {
+                    "name": "thanks_message",
+                    "type": "string",
+                    "label": "Thanks Message",
+                    "description": "A message to thank the reader for their contribution.",
+                    "required": true,
+                    "default": "Thanks for your contribution!",
+                    "max_length": 300
+                },
+                {
+                    "name": "button_label",
+                    "type": "string",
+                    "label": "Button Label",
+                    "description": "The label for the primary CTA button.",
+                    "required": true,
+                    "default": "Donate Now",
+                    "max_length": 20
                 }
             ]
         }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds an optional `user_inputs` array to the prompts schema. If these are populated in a prompt's config JSON, they can be used to populate placeholders by field name in the prompt's content. In the future, the array of fields can be used to create actual input fields in the default prompts UI, the values of which can be used to create prompt config JSON to generate the prompts with user input.

Also adds `featured_image_id` to the schema so that the importer can generate a prompt with a given attachment ID, which will be another feature of the default prompts UI.

### How to test the changes in this Pull Request:

1. On a fresh site, run `wp newspack-popups import --ras-defaults`.
2. Compare the generated prompts with the config JSON in `./presets/ras-defaults.json`. The `{{placeholder}}` values in the prompts' content should be populated by the default values of the corresponding user input fields. In the future, an optional `value` property can store the user's real input.
3. You can play around with the config or create your own JSON config with other placeholders and user inputs, and different `default` or `value` properties, to ensure that the placeholders are always populated by the corresponding `user_input` field values.
4. Also test the featured image functionality by hard-coding a `featured_image_id` property for a prompt to import, and confirm that the prompt is created with the given attachment ID as featured image.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
