### PR TITLE
fix(memberships): restriction check for inline prompt insertion

### DIFF
--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -418,6 +418,24 @@ final class Newspack_Popups_Inserter {
 	}
 
 	/**
+	 * Whether the given post is being restricted by Woo Memberships.
+	 *
+	 * @param int $post_id The post ID.
+	 */
+	private static function is_memberships_restricted( $post_id = null ) {
+		if ( ! function_exists( 'wc_memberships_is_post_content_restricted' ) ) {
+			return false;
+		}
+		if ( ! $post_id ) {
+			$post_id = get_the_ID();
+		}
+		if ( ! \wc_memberships_is_post_content_restricted( $post_id ) ) {
+			return false;
+		}
+		return ! is_user_logged_in() || ! current_user_can( 'wc_memberships_view_restricted_post_content', $post_id );
+	}
+
+	/**
 	 * Process popups and insert into post and page content if needed.
 	 *
 	 * @param string $content The content of the post.
@@ -436,7 +454,7 @@ final class Newspack_Popups_Inserter {
 			|| ! in_the_loop()
 			// Don't inject inline popups on paywalled posts.
 			// It doesn't make sense with a paywall message and also causes an infinite loop.
-			|| function_exists( 'wc_memberships_is_post_content_restricted' ) && wc_memberships_is_post_content_restricted()
+			|| self::is_memberships_restricted()
 		) {
 			return $content;
 		}

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -421,6 +421,8 @@ final class Newspack_Popups_Inserter {
 	 * Whether the given post is being restricted by Woo Memberships.
 	 *
 	 * @param int $post_id The post ID.
+	 *
+	 * @return bool
 	 */
 	private static function is_memberships_restricted( $post_id = null ) {
 		if ( ! function_exists( 'wc_memberships_is_post_content_restricted' ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The paywalled post check is using the `wc_memberships_is_post_content_restricted()` function incorrectly. This will always be true if the post is restricted to any user and does not take the current user into account. 

This bug was found while working [the same fix for another feature](https://github.com/Automattic/newspack-plugin/pull/2366#issuecomment-1489119379).

This PR improves the check with the `wc_memberships_view_restricted_post_content` capability check.

### How to test the changes in this Pull Request:

1. Install and configure Woo Memberships while in the master branch
2. Setup an always visible inline prompt set to position 0
3. Login with an account that has a plan (can be the admin account)
4. Confirm the inline prompt does not render
5. Checkout this branch and confirm the prompt renders
6. Log out, visit the page and confirm the prompt does not render

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
