### PR TITLE
feat: support RAS default prompts wizard UI

### DIFF
--- a/includes/class-newspack-popups-api.php
+++ b/includes/class-newspack-popups-api.php
@@ -100,6 +100,26 @@ final class Newspack_Popups_API {
 				],
 			]
 		);
+
+		// API endpoints for RAS presets.
+		register_rest_route(
+			'newspack-popups/v1',
+			'/reader-activation/campaign',
+			[
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => [ $this, 'api_get_reader_activation_campaign_settings' ],
+				'permission_callback' => [ $this, 'permission_callback' ],
+			]
+		);
+		register_rest_route(
+			'newspack-popups/v1',
+			'/reader-activation/campaign',
+			[
+				'methods'             => \WP_REST_Server::EDITABLE,
+				'callback'            => [ $this, 'api_update_reader_activation_campaign_settings' ],
+				'permission_callback' => [ $this, 'permission_callback' ],
+			]
+		);
 	}
 
 	/**
@@ -281,6 +301,42 @@ final class Newspack_Popups_API {
 	public function api_duplicate_popup( $request ) {
 		$response = Newspack_Popups::duplicate_popup( $request['id'], $request['title'] );
 		return rest_ensure_response( $response );
+	}
+
+	/**
+	 * Get reader activation campaign settings.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 *
+	 * @return WP_REST_Response
+	 */
+	public function api_get_reader_activation_campaign_settings( $request ) {
+		$response = Newspack_Popups_Model::get_ras_presets();
+
+		if ( \is_wp_error( $response ) ) {
+			return new \WP_REST_Response( [ 'message' => $response->get_error_message() ], 400 );
+		}
+
+		return rest_ensure_response( $response['prompts'] );
+	}
+
+	/**
+	 * Update reader activation campaign settings.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+	 */
+	public function api_update_reader_activation_campaign_settings( $request ) {
+		$slug = $request['slug'];
+		$data = $request['data'];
+
+		$response = Newspack_Popups_Model::update_preset_prompt( $slug, $data );
+
+		if ( \is_wp_error( $response ) ) {
+			return new \WP_REST_Response( [ 'message' => $response->get_error_message() ], 400 );
+		}
+
+		return rest_ensure_response( $response['prompts'] );
 	}
 }
 $newspack_popups_api = new Newspack_Popups_API();

--- a/includes/class-newspack-popups-importer.php
+++ b/includes/class-newspack-popups-importer.php
@@ -223,26 +223,17 @@ class Newspack_Popups_Importer {
 	 * @return void
 	 */
 	private function process_prompts() {
-		$prompts    = $this->input['prompts'];
-		$prompts    = $this->pre_process_prompt_segments( $prompts );
-		$prompts    = $this->pre_process_prompts_terms( $prompts );
-		$user_input = isset( $this->input['user_input'] ) ? $this->input['user_input'] : [];
+		$prompts = $this->input['prompts'];
+		$prompts = $this->pre_process_prompt_segments( $prompts );
+		$prompts = $this->pre_process_prompts_terms( $prompts );
 
 		foreach ( $prompts as $prompt ) {
 			$prompt_slug       = isset( $prompt['slug'] ) ? $prompt['slug'] : null;
 			$prompt_content    = $prompt['content'];
 			$user_input_fields = isset( $prompt['user_input_fields'] ) ? $prompt['user_input_fields'] : [];
 
-			foreach ( $user_input_fields as $user_input_field ) {
-				$field_name = $user_input_field['name'];
-				$value      = $prompt_slug && isset( $user_input[ $prompt_slug ][ $field_name ] ) ? $user_input[ $prompt_slug ][ $field_name ] : $user_input_field['default'];
-
-				// Crop the value if max_length is set.
-				if ( isset( $user_input_field['max_length'] ) ) {
-					$value = substr( $value, 0, $user_input_field['max_length'] );
-				}
-
-				$prompt_content = str_replace( '{{' . $field_name . '}}', $value, $prompt_content );
+			foreach ( $user_input_fields as $field ) {
+				$prompt_content = Newspack_Popups_Model::process_user_inputs( $prompt_content, $field );
 			}
 
 			$post_data = [

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -395,7 +395,7 @@ final class Newspack_Popups_Inserter {
 				$insert_for_blocks = 'blocks_count' === $trigger_type && $block_index >= $position;
 
 				if ( $insert_at_zero || $insert_for_scroll || $insert_for_blocks ) {
-					$output                     .= '<!-- wp:html --><aside>' . Newspack_Popups_Model::generate_popup( $inline_popup ) . '</aside><!-- /wp:html -->';
+					$output                     .= '<!-- wp:shortcode -->[newspack-popup id="' . $inline_popup['id'] . '"]<!-- /wp:shortcode -->';
 					$inline_popup['is_inserted'] = true;
 				}
 			}
@@ -409,7 +409,7 @@ final class Newspack_Popups_Inserter {
 		// 3. Insert any remaining inline prompts at the end.
 		foreach ( $inline_popups as &$inline_popup ) {
 			if ( ! $inline_popup['is_inserted'] ) {
-				$output                     .= '<!-- wp:html --><aside>' . Newspack_Popups_Model::generate_popup( $inline_popup ) . '</aside><!-- /wp:html -->';
+				$output                     .= '<!-- wp:shortcode -->[newspack-popup id="' . $inline_popup['id'] . '"]<!-- /wp:shortcode -->';
 				$inline_popup['is_inserted'] = true;
 			}
 		}

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -98,7 +98,7 @@ final class Newspack_Popups_Model {
 				if ( ! empty( $saved_inputs[ $prompt['slug'] ] ) ) {
 					$fields                      = array_map(
 						function ( $field ) use ( $saved_inputs, $prompt ) {
-							if ( isset( $saved_inputs[ $prompt['slug'] ][ $field['name'] ] ) ) {
+							if ( ! empty( $saved_inputs[ $prompt['slug'] ][ $field['name'] ] ) ) {
 								$field['value'] = $saved_inputs[ $prompt['slug'] ][ $field['name'] ];
 							}
 							return $field;

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -259,6 +259,10 @@ final class Newspack_Popups_Model {
 
 		\update_option( Newspack_Popups::NEWSPACK_POPUPS_RAS_PROMPTS_OPTION, $saved_inputs );
 
+		if ( ! $ready ) {
+			return new \WP_Error( 'newspack_popups_update_ras_prompt_required_missing', __( 'Prompt saved. All required fields must be filled out to complete setup.', 'newspack-popups' ) );
+		}
+
 		return self::get_ras_presets();
 	}
 

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -56,7 +56,7 @@ final class Newspack_Popups_Model {
 		}
 
 		$lists = array_reduce(
-			method_exists( '\Newspack_Newsletters_Subscription', 'get_lists' ) ? \Newspack_Newsletters_Subscription::get_lists() : [],
+			$provider_lists,
 			function( $acc, $list ) {
 				if ( ! empty( $list['active'] ) ) {
 					$acc[] = [

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -540,7 +540,7 @@ final class Newspack_Popups_Model {
 			'utm_suppression'                => filter_input( INPUT_GET, Newspack_Popups::PREVIEW_QUERY_KEYS['utm_suppression'], FILTER_SANITIZE_FULL_SPECIAL_CHARS ),
 		];
 
-		if ( $preset['featured_image_id'] ) {
+		if ( ! empty( $preset['featured_image_id'] ) ) {
 			$options['featured_image_id'] = $preset['featured_image_id'];
 		}
 
@@ -1552,7 +1552,7 @@ final class Newspack_Popups_Model {
 				<div class="newspack-popup__content-wrapper" style="<?php echo $hide_border ? esc_attr( self::container_style( $popup ) ) : ''; ?>">
 					<?php if ( $has_featured_image ) : ?>
 						<div class="newspack-popup__featured-image">
-							<?php echo ! empty( $popup['options']['featured_image_id'] ) ? wp_get_attachment_image( $popup['options']['featured_image_id'] ) : get_the_post_thumbnail( $popup['id'], 'large' ); ?>
+							<?php echo ! empty( $popup['options']['featured_image_id'] ) ? wp_get_attachment_image( $popup['options']['featured_image_id'], 'large' ) : get_the_post_thumbnail( $popup['id'], 'large' ); ?>
 						</div>
 					<?php endif; ?>
 					<div class="newspack-popup__content">

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -462,6 +462,44 @@ final class Newspack_Popups_Model {
 	}
 
 	/**
+	 * Get an array of options from abbreviated query parameters.
+	 *
+	 * @return array Array of options.
+	 */
+	public static function get_preview_query_keys() {
+		$options_filters = [
+			'background_color'               => FILTER_SANITIZE_FULL_SPECIAL_CHARS,
+			'display_title'                  => FILTER_VALIDATE_BOOLEAN,
+			'hide_border'                    => FILTER_VALIDATE_BOOLEAN,
+			'large_border'                   => FILTER_VALIDATE_BOOLEAN,
+			'frequency'                      => FILTER_SANITIZE_FULL_SPECIAL_CHARS,
+			'frequency_max'                  => FILTER_SANITIZE_FULL_SPECIAL_CHARS,
+			'frequency_start'                => FILTER_SANITIZE_FULL_SPECIAL_CHARS,
+			'frequency_between'              => FILTER_SANITIZE_FULL_SPECIAL_CHARS,
+			'frequency_reset'                => FILTER_SANITIZE_FULL_SPECIAL_CHARS,
+			'overlay_color'                  => FILTER_SANITIZE_FULL_SPECIAL_CHARS,
+			'overlay_opacity'                => FILTER_SANITIZE_FULL_SPECIAL_CHARS,
+			'overlay_size'                   => FILTER_SANITIZE_FULL_SPECIAL_CHARS,
+			'no_overlay_background'          => FILTER_VALIDATE_BOOLEAN,
+			'placement'                      => FILTER_SANITIZE_FULL_SPECIAL_CHARS,
+			'trigger_type'                   => FILTER_SANITIZE_FULL_SPECIAL_CHARS,
+			'trigger_delay'                  => FILTER_SANITIZE_FULL_SPECIAL_CHARS,
+			'trigger_scroll_progress'        => FILTER_SANITIZE_FULL_SPECIAL_CHARS,
+			'trigger_blocks_count'           => FILTER_SANITIZE_FULL_SPECIAL_CHARS,
+			'archive_insertion_posts_count'  => FILTER_SANITIZE_FULL_SPECIAL_CHARS,
+			'archive_insertion_is_repeating' => FILTER_VALIDATE_BOOLEAN,
+			'utm_suppression'                => FILTER_SANITIZE_FULL_SPECIAL_CHARS,
+		];
+
+		$options = [];
+		foreach ( $options_filters as $option => $filter ) {
+			$options[ $option ] = filter_input( INPUT_GET, Newspack_Popups::PREVIEW_QUERY_KEYS[ $option ], $filter );
+		}
+
+		return $options;
+	}
+
+	/**
 	 * Retrieve popup preview CPT post.
 	 *
 	 * @param string $post_id Post id.
@@ -474,33 +512,7 @@ final class Newspack_Popups_Model {
 		// Setting proper id for correct API calls.
 		$post_object->ID = $post_id;
 
-		return self::create_popup_object(
-			$post_object,
-			false,
-			[
-				'background_color'               => filter_input( INPUT_GET, Newspack_Popups::PREVIEW_QUERY_KEYS['background_color'], FILTER_SANITIZE_FULL_SPECIAL_CHARS ),
-				'display_title'                  => filter_input( INPUT_GET, Newspack_Popups::PREVIEW_QUERY_KEYS['display_title'], FILTER_VALIDATE_BOOLEAN ),
-				'hide_border'                    => filter_input( INPUT_GET, Newspack_Popups::PREVIEW_QUERY_KEYS['hide_border'], FILTER_VALIDATE_BOOLEAN ),
-				'large_border'                   => filter_input( INPUT_GET, Newspack_Popups::PREVIEW_QUERY_KEYS['large_border'], FILTER_VALIDATE_BOOLEAN ),
-				'frequency'                      => filter_input( INPUT_GET, Newspack_Popups::PREVIEW_QUERY_KEYS['frequency'], FILTER_SANITIZE_FULL_SPECIAL_CHARS ),
-				'frequency_max'                  => filter_input( INPUT_GET, Newspack_Popups::PREVIEW_QUERY_KEYS['frequency_max'], FILTER_SANITIZE_FULL_SPECIAL_CHARS ),
-				'frequency_start'                => filter_input( INPUT_GET, Newspack_Popups::PREVIEW_QUERY_KEYS['frequency_start'], FILTER_SANITIZE_FULL_SPECIAL_CHARS ),
-				'frequency_between'              => filter_input( INPUT_GET, Newspack_Popups::PREVIEW_QUERY_KEYS['frequency_between'], FILTER_SANITIZE_FULL_SPECIAL_CHARS ),
-				'frequency_reset'                => filter_input( INPUT_GET, Newspack_Popups::PREVIEW_QUERY_KEYS['frequency_reset'], FILTER_SANITIZE_FULL_SPECIAL_CHARS ),
-				'overlay_color'                  => filter_input( INPUT_GET, Newspack_Popups::PREVIEW_QUERY_KEYS['overlay_color'], FILTER_SANITIZE_FULL_SPECIAL_CHARS ),
-				'overlay_opacity'                => filter_input( INPUT_GET, Newspack_Popups::PREVIEW_QUERY_KEYS['overlay_opacity'], FILTER_SANITIZE_FULL_SPECIAL_CHARS ),
-				'overlay_size'                   => filter_input( INPUT_GET, Newspack_Popups::PREVIEW_QUERY_KEYS['overlay_size'], FILTER_SANITIZE_FULL_SPECIAL_CHARS ),
-				'no_overlay_background'          => filter_input( INPUT_GET, Newspack_Popups::PREVIEW_QUERY_KEYS['no_overlay_background'], FILTER_VALIDATE_BOOLEAN ),
-				'placement'                      => filter_input( INPUT_GET, Newspack_Popups::PREVIEW_QUERY_KEYS['placement'], FILTER_SANITIZE_FULL_SPECIAL_CHARS ),
-				'trigger_type'                   => filter_input( INPUT_GET, Newspack_Popups::PREVIEW_QUERY_KEYS['trigger_type'], FILTER_SANITIZE_FULL_SPECIAL_CHARS ),
-				'trigger_delay'                  => filter_input( INPUT_GET, Newspack_Popups::PREVIEW_QUERY_KEYS['trigger_delay'], FILTER_SANITIZE_FULL_SPECIAL_CHARS ),
-				'trigger_scroll_progress'        => filter_input( INPUT_GET, Newspack_Popups::PREVIEW_QUERY_KEYS['trigger_scroll_progress'], FILTER_SANITIZE_FULL_SPECIAL_CHARS ),
-				'trigger_blocks_count'           => filter_input( INPUT_GET, Newspack_Popups::PREVIEW_QUERY_KEYS['trigger_blocks_count'], FILTER_SANITIZE_FULL_SPECIAL_CHARS ),
-				'archive_insertion_posts_count'  => filter_input( INPUT_GET, Newspack_Popups::PREVIEW_QUERY_KEYS['archive_insertion_posts_count'], FILTER_SANITIZE_FULL_SPECIAL_CHARS ),
-				'archive_insertion_is_repeating' => filter_input( INPUT_GET, Newspack_Popups::PREVIEW_QUERY_KEYS['archive_insertion_is_repeating'], FILTER_VALIDATE_BOOLEAN ),
-				'utm_suppression'                => filter_input( INPUT_GET, Newspack_Popups::PREVIEW_QUERY_KEYS['utm_suppression'], FILTER_SANITIZE_FULL_SPECIAL_CHARS ),
-			]
-		);
+		return self::create_popup_object( $post_object, false, self::get_preview_query_keys() );
 	}
 
 	/**
@@ -545,39 +557,11 @@ final class Newspack_Popups_Model {
 		$post_object->filter         = 'raw'; // Don't try to fetch from the wp_posts table.
 		$post_object                 = new \WP_Post( $post_object );
 
-		$options = [
-			'background_color'               => filter_input( INPUT_GET, Newspack_Popups::PREVIEW_QUERY_KEYS['background_color'], FILTER_SANITIZE_FULL_SPECIAL_CHARS ),
-			'display_title'                  => filter_input( INPUT_GET, Newspack_Popups::PREVIEW_QUERY_KEYS['display_title'], FILTER_VALIDATE_BOOLEAN ),
-			'hide_border'                    => filter_input( INPUT_GET, Newspack_Popups::PREVIEW_QUERY_KEYS['hide_border'], FILTER_VALIDATE_BOOLEAN ),
-			'large_border'                   => filter_input( INPUT_GET, Newspack_Popups::PREVIEW_QUERY_KEYS['large_border'], FILTER_VALIDATE_BOOLEAN ),
-			'frequency'                      => filter_input( INPUT_GET, Newspack_Popups::PREVIEW_QUERY_KEYS['frequency'], FILTER_SANITIZE_FULL_SPECIAL_CHARS ),
-			'frequency_max'                  => filter_input( INPUT_GET, Newspack_Popups::PREVIEW_QUERY_KEYS['frequency_max'], FILTER_SANITIZE_FULL_SPECIAL_CHARS ),
-			'frequency_start'                => filter_input( INPUT_GET, Newspack_Popups::PREVIEW_QUERY_KEYS['frequency_start'], FILTER_SANITIZE_FULL_SPECIAL_CHARS ),
-			'frequency_between'              => filter_input( INPUT_GET, Newspack_Popups::PREVIEW_QUERY_KEYS['frequency_between'], FILTER_SANITIZE_FULL_SPECIAL_CHARS ),
-			'frequency_reset'                => filter_input( INPUT_GET, Newspack_Popups::PREVIEW_QUERY_KEYS['frequency_reset'], FILTER_SANITIZE_FULL_SPECIAL_CHARS ),
-			'overlay_color'                  => filter_input( INPUT_GET, Newspack_Popups::PREVIEW_QUERY_KEYS['overlay_color'], FILTER_SANITIZE_FULL_SPECIAL_CHARS ),
-			'overlay_opacity'                => filter_input( INPUT_GET, Newspack_Popups::PREVIEW_QUERY_KEYS['overlay_opacity'], FILTER_SANITIZE_FULL_SPECIAL_CHARS ),
-			'overlay_size'                   => filter_input( INPUT_GET, Newspack_Popups::PREVIEW_QUERY_KEYS['overlay_size'], FILTER_SANITIZE_FULL_SPECIAL_CHARS ),
-			'no_overlay_background'          => filter_input( INPUT_GET, Newspack_Popups::PREVIEW_QUERY_KEYS['no_overlay_background'], FILTER_VALIDATE_BOOLEAN ),
-			'placement'                      => filter_input( INPUT_GET, Newspack_Popups::PREVIEW_QUERY_KEYS['placement'], FILTER_SANITIZE_FULL_SPECIAL_CHARS ),
-			'trigger_type'                   => filter_input( INPUT_GET, Newspack_Popups::PREVIEW_QUERY_KEYS['trigger_type'], FILTER_SANITIZE_FULL_SPECIAL_CHARS ),
-			'trigger_delay'                  => filter_input( INPUT_GET, Newspack_Popups::PREVIEW_QUERY_KEYS['trigger_delay'], FILTER_SANITIZE_FULL_SPECIAL_CHARS ),
-			'trigger_scroll_progress'        => filter_input( INPUT_GET, Newspack_Popups::PREVIEW_QUERY_KEYS['trigger_scroll_progress'], FILTER_SANITIZE_FULL_SPECIAL_CHARS ),
-			'trigger_blocks_count'           => filter_input( INPUT_GET, Newspack_Popups::PREVIEW_QUERY_KEYS['trigger_blocks_count'], FILTER_SANITIZE_FULL_SPECIAL_CHARS ),
-			'archive_insertion_posts_count'  => filter_input( INPUT_GET, Newspack_Popups::PREVIEW_QUERY_KEYS['archive_insertion_posts_count'], FILTER_SANITIZE_FULL_SPECIAL_CHARS ),
-			'archive_insertion_is_repeating' => filter_input( INPUT_GET, Newspack_Popups::PREVIEW_QUERY_KEYS['archive_insertion_is_repeating'], FILTER_VALIDATE_BOOLEAN ),
-			'utm_suppression'                => filter_input( INPUT_GET, Newspack_Popups::PREVIEW_QUERY_KEYS['utm_suppression'], FILTER_SANITIZE_FULL_SPECIAL_CHARS ),
-		];
-
 		if ( ! empty( $preset['featured_image_id'] ) ) {
 			$options['featured_image_id'] = $preset['featured_image_id'];
 		}
 
-		return self::create_popup_object(
-			$post_object,
-			false,
-			$options
-		);
+		return self::create_popup_object( $post_object, false, self::get_preview_query_keys() );
 	}
 
 	/**

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -477,9 +477,10 @@ final class Newspack_Popups_Model {
 
 	/**
 	 * Retrieve popup preview preset prompt.
+	 * Because presets don't exist yet as real WP posts, we need to mock a post object using the preset config.
 	 *
 	 * @param string $slug Preset slug.
-	 * @return object Popup object.
+	 * @return object|null Popup object, or null if no preset is found for the given slug.
 	 */
 	public static function retrieve_preset_popup( $slug ) {
 		$presets = self::get_ras_presets();
@@ -499,7 +500,7 @@ final class Newspack_Popups_Model {
 			return null;
 		}
 
-		// Create a fake post object from the preset data.
+		// Create a fake post object from the preset config.
 		$preset                      = reset( $preset );
 		$post_object                 = new stdClass();
 		$post_object->ID             = \wp_rand( 10000000, 10001000 ); // Make the ID really high to avoid collision with real post IDs.

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -466,7 +466,7 @@ final class Newspack_Popups_Model {
 	 *
 	 * @return array Array of options.
 	 */
-	public static function get_preview_query_keys() {
+	public static function get_preview_query_options() {
 		$options_filters = [
 			'background_color'               => FILTER_SANITIZE_FULL_SPECIAL_CHARS,
 			'display_title'                  => FILTER_VALIDATE_BOOLEAN,
@@ -512,7 +512,7 @@ final class Newspack_Popups_Model {
 		// Setting proper id for correct API calls.
 		$post_object->ID = $post_id;
 
-		return self::create_popup_object( $post_object, false, self::get_preview_query_keys() );
+		return self::create_popup_object( $post_object, false, self::get_preview_query_options() );
 	}
 
 	/**
@@ -561,7 +561,7 @@ final class Newspack_Popups_Model {
 			$options['featured_image_id'] = $preset['featured_image_id'];
 		}
 
-		return self::create_popup_object( $post_object, false, self::get_preview_query_keys() );
+		return self::create_popup_object( $post_object, false, self::get_preview_query_options() );
 	}
 
 	/**

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -44,6 +44,216 @@ final class Newspack_Popups_Model {
 	protected static $form_hooks_popup_id;
 
 	/**
+	 * Get subscribable lists from the Newspack Newsletters plugin.
+	 *
+	 * @return array Array of lists.
+	 */
+	private static function get_newsletter_lists() {
+		// TODO: There's a race condition here.
+		$lists = array_reduce(
+			method_exists( '\Newspack_Newsletters_Subscription', 'get_lists' ) ? \Newspack_Newsletters_Subscription::get_lists() : [],
+			function( $acc, $list ) {
+				if ( ! empty( $list['active'] ) ) {
+					$acc[] = [
+						'id'          => $list['id'] ?? 0,
+						'label'       => $list['title'] ?? '',
+						'description' => $list['description'] ?? '',
+						'checked'     => false,
+					];
+				}
+
+				return $acc;
+			},
+			[]
+		);
+
+		return $lists;
+	}
+
+	/**
+	 * Retrieve default prompts + segments.
+	 *
+	 * @return array Array of prompt and segment default configs.
+	 */
+	public static function get_ras_presets() {
+		$file = dirname( NEWSPACK_POPUPS_PLUGIN_FILE ) . '/presets/ras-defaults.json';
+
+		if ( ! is_readable( $file ) ) {
+			return new \WP_Error( 'newspack_popups_file_read_error', __( 'File not found or not readable.', 'newspack-popups' ) );
+		}
+
+		$data = wp_json_file_decode( $file, [ 'associative' => true ] );
+
+		if ( empty( $data ) || empty( $data['prompts'] ) || empty( $data['segments'] ) ) {
+			return new \WP_Error( 'newspack_popups_file_read_error', __( 'File is empty or invalid JSON.', 'newspack-popups' ) );
+		}
+
+		$saved_inputs = \get_option( Newspack_Popups::NEWSPACK_POPUPS_RAS_PROMPTS_OPTION, [] );
+		$lists        = self::get_newsletter_lists();
+
+		// Populate prompt configs with saved inputs.
+		$data['prompts'] = array_map(
+			function( $prompt ) use ( $lists, $saved_inputs ) {
+				// Check for saved inputs.
+				if ( ! empty( $saved_inputs[ $prompt['slug'] ] ) ) {
+					$fields                      = array_map(
+						function ( $field ) use ( $saved_inputs, $prompt ) {
+							if ( isset( $saved_inputs[ $prompt['slug'] ][ $field['name'] ] ) ) {
+								$field['value'] = $saved_inputs[ $prompt['slug'] ][ $field['name'] ];
+							}
+							return $field;
+						},
+						$prompt['user_input_fields']
+					);
+					$prompt['user_input_fields'] = $fields;
+
+					// Mark as ready if all required inputs are filled.
+					if ( ! empty( $saved_inputs[ $prompt['slug'] ]['ready'] ) ) {
+						$prompt['ready'] = true;
+					}
+				}
+
+				// Populate placeholder content with saved inputs or default values.
+				foreach ( $prompt['user_input_fields'] as $field ) {
+					if ( 'array' === $field['type'] || 'string' === $field['type'] ) {
+						$prompt['content'] = self::process_user_inputs( $prompt['content'], $field );
+					}
+					if ( 'int' === $field['type'] && 'featured_image_id' === $field['name'] && isset( $field['value'] ) ) {
+						$prompt['featured_image_id'] = $field['value'];
+					}
+				}
+
+				// Append newsletter list IDs as a selectable field.
+				if ( false !== strpos( $prompt['slug'], '_registration_' ) || false !== strpos( $prompt['slug'], '_newsletter_' ) ) {
+					$fields                      = array_map(
+						function( $field ) use ( $lists ) {
+							if ( 'lists' === $field['name'] ) {
+								$field['options'] = $lists;
+							}
+
+							return $field;
+						},
+						$prompt['user_input_fields']
+					);
+					$prompt['user_input_fields'] = $fields;
+				}
+
+				return $prompt;
+			},
+			$data['prompts']
+		);
+
+		return $data;
+	}
+
+	/**
+	 * Replace placeholders in a prompt's content with user input or default values.
+	 *
+	 * @param string $prompt_content Prompt content.
+	 * @param array  $field Field config.
+	 *               $field['name'] string Field name. Required.
+	 *               $field['type'] string Field value type: array or string. Required.
+	 *               $field['default'] string Field default value. Required.
+	 *               $field['value'] string Field user input value.
+	 *               $field['max_length'] int Max length of string-type user input value.
+	 *
+	 * @return string Prompt content with placeholders replaced.
+	 */
+	public static function process_user_inputs( $prompt_content, $field ) {
+		if ( ! isset( $field['name'] ) || ! isset( $field['type'] ) || ! isset( $field['default'] ) ) {
+			return $prompt_content;
+		}
+
+		$field_name = $field['name'];
+		$value      = isset( $field['value'] ) ? $field['value'] : $field['default'];
+
+		// If a string, crop to max_length if set.
+		if ( 'string' === $field['type'] && isset( $field['max_length'] ) ) {
+			$value = substr( trim( $value ), 0, $field['max_length'] );
+		}
+		// If an array, stringify with field name.
+		if ( 'array' === $field['type'] ) {
+			$value = '"' . $field_name . '": ' . \wp_json_encode( $value );
+		}
+
+		$prompt_content = str_replace( '{{' . $field_name . '}}', $value, $prompt_content );
+
+		return $prompt_content;
+	}
+
+	/**
+	 * Update saved inputs for a prompt preset.
+	 *
+	 * @param string $slug Slug name of the preset.
+	 * @param array  $inputs Array of user inputs, keyed by field name.
+	 * @return boolean True if updated, false if not.
+	 */
+	public static function update_preset_prompt( $slug, $inputs ) {
+		$defaults       = self::get_ras_presets();
+		$saved_inputs   = \get_option( Newspack_Popups::NEWSPACK_POPUPS_RAS_PROMPTS_OPTION, [] );
+		$updated        = false;
+		$ready          = true;
+		$default_slugs  = array_map(
+			function( $default_prompt ) {
+				return $default_prompt['slug'];
+			},
+			$defaults['prompts']
+		);
+		$default_fields = array_reduce(
+			$defaults['prompts'],
+			function( $acc, $prompt ) use ( $slug ) {
+				if ( $prompt['slug'] === $slug ) {
+					$acc = $prompt['user_input_fields'];
+				}
+				return $acc;
+			},
+			[]
+		);
+
+		// Validate prompt slug.
+		if ( ! in_array( $slug, $default_slugs, true ) ) {
+			return new \WP_Error( 'newspack_popups_update_ras_prompt_error', __( 'Invalid prompt slug.', 'newspack-popups' ) );
+		}
+
+		foreach ( $inputs as $field_name => $input ) {
+			$field_info = array_values(
+				array_filter(
+					$default_fields,
+					function( $field ) use ( $field_name ) {
+						return $field['name'] === $field_name;
+					}
+				)
+			);
+
+			// Validate prompt fields.
+			if ( empty( $field_info ) ) {
+				return new \WP_Error( 'newspack_popups_update_ras_prompt_error', __( 'Invalid field name.', 'newspack-popups' ) );
+			}
+			$field_info = $field_info[0];
+
+			// Save input value.
+			if ( isset( $input ) ) {
+				$saved_inputs[ $slug ][ $field_name ] = $input;
+			}
+
+			// Determine ready state.
+			if ( $field_info['required'] && empty( $input ) ) {
+				$ready = false;
+			}
+		}
+
+		if ( $ready ) {
+			$saved_inputs[ $slug ]['ready'] = true;
+		} else {
+			unset( $saved_inputs[ $slug ]['ready'] );
+		}
+
+		\update_option( Newspack_Popups::NEWSPACK_POPUPS_RAS_PROMPTS_OPTION, $saved_inputs );
+
+		return self::get_ras_presets();
+	}
+
+	/**
 	 * Retrieve all Popups (first 100).
 	 *
 	 * @param  boolean $include_unpublished Whether to include unpublished posts.
@@ -240,28 +450,104 @@ final class Newspack_Popups_Model {
 			$post_object,
 			false,
 			[
-				'background_color'               => filter_input( INPUT_GET, 'n_bc', FILTER_SANITIZE_FULL_SPECIAL_CHARS ),
-				'display_title'                  => filter_input( INPUT_GET, 'n_ti', FILTER_VALIDATE_BOOLEAN ),
-				'hide_border'                    => filter_input( INPUT_GET, 'n_hb', FILTER_VALIDATE_BOOLEAN ),
-				'large_border'                   => filter_input( INPUT_GET, 'n_lb', FILTER_VALIDATE_BOOLEAN ),
-				'frequency'                      => filter_input( INPUT_GET, 'n_fr', FILTER_SANITIZE_FULL_SPECIAL_CHARS ),
-				'frequency_max'                  => filter_input( INPUT_GET, 'n_fm', FILTER_SANITIZE_FULL_SPECIAL_CHARS ),
-				'frequency_start'                => filter_input( INPUT_GET, 'n_fs', FILTER_SANITIZE_FULL_SPECIAL_CHARS ),
-				'frequency_between'              => filter_input( INPUT_GET, 'n_fb', FILTER_SANITIZE_FULL_SPECIAL_CHARS ),
-				'frequency_reset'                => filter_input( INPUT_GET, 'n_ft', FILTER_SANITIZE_FULL_SPECIAL_CHARS ),
-				'overlay_color'                  => filter_input( INPUT_GET, 'n_oc', FILTER_SANITIZE_FULL_SPECIAL_CHARS ),
-				'overlay_opacity'                => filter_input( INPUT_GET, 'n_oo', FILTER_SANITIZE_FULL_SPECIAL_CHARS ),
-				'overlay_size'                   => filter_input( INPUT_GET, 'n_os', FILTER_SANITIZE_FULL_SPECIAL_CHARS ),
-				'no_overlay_background'          => filter_input( INPUT_GET, 'n_bg', FILTER_VALIDATE_BOOLEAN ),
-				'placement'                      => filter_input( INPUT_GET, 'n_pl', FILTER_SANITIZE_FULL_SPECIAL_CHARS ),
-				'trigger_type'                   => filter_input( INPUT_GET, 'n_tt', FILTER_SANITIZE_FULL_SPECIAL_CHARS ),
-				'trigger_delay'                  => filter_input( INPUT_GET, 'n_td', FILTER_SANITIZE_FULL_SPECIAL_CHARS ),
-				'trigger_scroll_progress'        => filter_input( INPUT_GET, 'n_ts', FILTER_SANITIZE_FULL_SPECIAL_CHARS ),
-				'trigger_blocks_count'           => filter_input( INPUT_GET, 'n_tb', FILTER_SANITIZE_FULL_SPECIAL_CHARS ),
-				'archive_insertion_posts_count'  => filter_input( INPUT_GET, 'n_ac', FILTER_SANITIZE_FULL_SPECIAL_CHARS ),
-				'archive_insertion_is_repeating' => filter_input( INPUT_GET, 'n_ar', FILTER_VALIDATE_BOOLEAN ),
-				'utm_suppression'                => filter_input( INPUT_GET, 'n_ut', FILTER_SANITIZE_FULL_SPECIAL_CHARS ),
+				'background_color'               => filter_input( INPUT_GET, Newspack_Popups::PREVIEW_QUERY_KEYS['background_color'], FILTER_SANITIZE_FULL_SPECIAL_CHARS ),
+				'display_title'                  => filter_input( INPUT_GET, Newspack_Popups::PREVIEW_QUERY_KEYS['display_title'], FILTER_VALIDATE_BOOLEAN ),
+				'hide_border'                    => filter_input( INPUT_GET, Newspack_Popups::PREVIEW_QUERY_KEYS['hide_border'], FILTER_VALIDATE_BOOLEAN ),
+				'large_border'                   => filter_input( INPUT_GET, Newspack_Popups::PREVIEW_QUERY_KEYS['large_border'], FILTER_VALIDATE_BOOLEAN ),
+				'frequency'                      => filter_input( INPUT_GET, Newspack_Popups::PREVIEW_QUERY_KEYS['frequency'], FILTER_SANITIZE_FULL_SPECIAL_CHARS ),
+				'frequency_max'                  => filter_input( INPUT_GET, Newspack_Popups::PREVIEW_QUERY_KEYS['frequency_max'], FILTER_SANITIZE_FULL_SPECIAL_CHARS ),
+				'frequency_start'                => filter_input( INPUT_GET, Newspack_Popups::PREVIEW_QUERY_KEYS['frequency_start'], FILTER_SANITIZE_FULL_SPECIAL_CHARS ),
+				'frequency_between'              => filter_input( INPUT_GET, Newspack_Popups::PREVIEW_QUERY_KEYS['frequency_between'], FILTER_SANITIZE_FULL_SPECIAL_CHARS ),
+				'frequency_reset'                => filter_input( INPUT_GET, Newspack_Popups::PREVIEW_QUERY_KEYS['frequency_reset'], FILTER_SANITIZE_FULL_SPECIAL_CHARS ),
+				'overlay_color'                  => filter_input( INPUT_GET, Newspack_Popups::PREVIEW_QUERY_KEYS['overlay_color'], FILTER_SANITIZE_FULL_SPECIAL_CHARS ),
+				'overlay_opacity'                => filter_input( INPUT_GET, Newspack_Popups::PREVIEW_QUERY_KEYS['overlay_opacity'], FILTER_SANITIZE_FULL_SPECIAL_CHARS ),
+				'overlay_size'                   => filter_input( INPUT_GET, Newspack_Popups::PREVIEW_QUERY_KEYS['overlay_size'], FILTER_SANITIZE_FULL_SPECIAL_CHARS ),
+				'no_overlay_background'          => filter_input( INPUT_GET, Newspack_Popups::PREVIEW_QUERY_KEYS['no_overlay_background'], FILTER_VALIDATE_BOOLEAN ),
+				'placement'                      => filter_input( INPUT_GET, Newspack_Popups::PREVIEW_QUERY_KEYS['placement'], FILTER_SANITIZE_FULL_SPECIAL_CHARS ),
+				'trigger_type'                   => filter_input( INPUT_GET, Newspack_Popups::PREVIEW_QUERY_KEYS['trigger_type'], FILTER_SANITIZE_FULL_SPECIAL_CHARS ),
+				'trigger_delay'                  => filter_input( INPUT_GET, Newspack_Popups::PREVIEW_QUERY_KEYS['trigger_delay'], FILTER_SANITIZE_FULL_SPECIAL_CHARS ),
+				'trigger_scroll_progress'        => filter_input( INPUT_GET, Newspack_Popups::PREVIEW_QUERY_KEYS['trigger_scroll_progress'], FILTER_SANITIZE_FULL_SPECIAL_CHARS ),
+				'trigger_blocks_count'           => filter_input( INPUT_GET, Newspack_Popups::PREVIEW_QUERY_KEYS['trigger_blocks_count'], FILTER_SANITIZE_FULL_SPECIAL_CHARS ),
+				'archive_insertion_posts_count'  => filter_input( INPUT_GET, Newspack_Popups::PREVIEW_QUERY_KEYS['archive_insertion_posts_count'], FILTER_SANITIZE_FULL_SPECIAL_CHARS ),
+				'archive_insertion_is_repeating' => filter_input( INPUT_GET, Newspack_Popups::PREVIEW_QUERY_KEYS['archive_insertion_is_repeating'], FILTER_VALIDATE_BOOLEAN ),
+				'utm_suppression'                => filter_input( INPUT_GET, Newspack_Popups::PREVIEW_QUERY_KEYS['utm_suppression'], FILTER_SANITIZE_FULL_SPECIAL_CHARS ),
 			]
+		);
+	}
+
+	/**
+	 * Retrieve popup preview preset prompt.
+	 *
+	 * @param string $slug Preset slug.
+	 * @return object Popup object.
+	 */
+	public static function retrieve_preset_popup( $slug ) {
+		$presets = self::get_ras_presets();
+
+		if ( \is_wp_error( $presets ) || ! $presets || ! isset( $presets['prompts'] ) ) {
+			return null;
+		}
+
+		$preset = array_filter(
+			$presets['prompts'],
+			function( $preset ) use ( $slug ) {
+				return $preset['slug'] === $slug;
+			}
+		);
+
+		if ( empty( $preset ) ) {
+			return null;
+		}
+
+		// Create a fake post object from the preset data.
+		$preset                      = reset( $preset );
+		$post_object                 = new stdClass();
+		$post_object->ID             = \wp_rand( 10000000, 10001000 ); // Make the ID really high to avoid collision with real post IDs.
+		$post_object->post_title     = $preset['title'];
+		$post_object->post_author    = 1;
+		$post_object->post_date      = current_time( 'mysql' );
+		$post_object->post_date_gmt  = current_time( 'mysql', 1 );
+		$post_object->post_content   = $preset['content'];
+		$post_object->post_status    = 'publish';
+		$post_object->comment_status = 'closed';
+		$post_object->ping_status    = 'closed';
+		$post_object->post_name      = $slug;
+		$post_object->post_type      = Newspack_Popups::NEWSPACK_POPUPS_CPT;
+		$post_object->filter         = 'raw'; // Don't try to fetch from the wp_posts table.
+		$post_object                 = new \WP_Post( $post_object );
+
+		$options = [
+			'background_color'               => filter_input( INPUT_GET, Newspack_Popups::PREVIEW_QUERY_KEYS['background_color'], FILTER_SANITIZE_FULL_SPECIAL_CHARS ),
+			'display_title'                  => filter_input( INPUT_GET, Newspack_Popups::PREVIEW_QUERY_KEYS['display_title'], FILTER_VALIDATE_BOOLEAN ),
+			'hide_border'                    => filter_input( INPUT_GET, Newspack_Popups::PREVIEW_QUERY_KEYS['hide_border'], FILTER_VALIDATE_BOOLEAN ),
+			'large_border'                   => filter_input( INPUT_GET, Newspack_Popups::PREVIEW_QUERY_KEYS['large_border'], FILTER_VALIDATE_BOOLEAN ),
+			'frequency'                      => filter_input( INPUT_GET, Newspack_Popups::PREVIEW_QUERY_KEYS['frequency'], FILTER_SANITIZE_FULL_SPECIAL_CHARS ),
+			'frequency_max'                  => filter_input( INPUT_GET, Newspack_Popups::PREVIEW_QUERY_KEYS['frequency_max'], FILTER_SANITIZE_FULL_SPECIAL_CHARS ),
+			'frequency_start'                => filter_input( INPUT_GET, Newspack_Popups::PREVIEW_QUERY_KEYS['frequency_start'], FILTER_SANITIZE_FULL_SPECIAL_CHARS ),
+			'frequency_between'              => filter_input( INPUT_GET, Newspack_Popups::PREVIEW_QUERY_KEYS['frequency_between'], FILTER_SANITIZE_FULL_SPECIAL_CHARS ),
+			'frequency_reset'                => filter_input( INPUT_GET, Newspack_Popups::PREVIEW_QUERY_KEYS['frequency_reset'], FILTER_SANITIZE_FULL_SPECIAL_CHARS ),
+			'overlay_color'                  => filter_input( INPUT_GET, Newspack_Popups::PREVIEW_QUERY_KEYS['overlay_color'], FILTER_SANITIZE_FULL_SPECIAL_CHARS ),
+			'overlay_opacity'                => filter_input( INPUT_GET, Newspack_Popups::PREVIEW_QUERY_KEYS['overlay_opacity'], FILTER_SANITIZE_FULL_SPECIAL_CHARS ),
+			'overlay_size'                   => filter_input( INPUT_GET, Newspack_Popups::PREVIEW_QUERY_KEYS['overlay_size'], FILTER_SANITIZE_FULL_SPECIAL_CHARS ),
+			'no_overlay_background'          => filter_input( INPUT_GET, Newspack_Popups::PREVIEW_QUERY_KEYS['no_overlay_background'], FILTER_VALIDATE_BOOLEAN ),
+			'placement'                      => filter_input( INPUT_GET, Newspack_Popups::PREVIEW_QUERY_KEYS['placement'], FILTER_SANITIZE_FULL_SPECIAL_CHARS ),
+			'trigger_type'                   => filter_input( INPUT_GET, Newspack_Popups::PREVIEW_QUERY_KEYS['trigger_type'], FILTER_SANITIZE_FULL_SPECIAL_CHARS ),
+			'trigger_delay'                  => filter_input( INPUT_GET, Newspack_Popups::PREVIEW_QUERY_KEYS['trigger_delay'], FILTER_SANITIZE_FULL_SPECIAL_CHARS ),
+			'trigger_scroll_progress'        => filter_input( INPUT_GET, Newspack_Popups::PREVIEW_QUERY_KEYS['trigger_scroll_progress'], FILTER_SANITIZE_FULL_SPECIAL_CHARS ),
+			'trigger_blocks_count'           => filter_input( INPUT_GET, Newspack_Popups::PREVIEW_QUERY_KEYS['trigger_blocks_count'], FILTER_SANITIZE_FULL_SPECIAL_CHARS ),
+			'archive_insertion_posts_count'  => filter_input( INPUT_GET, Newspack_Popups::PREVIEW_QUERY_KEYS['archive_insertion_posts_count'], FILTER_SANITIZE_FULL_SPECIAL_CHARS ),
+			'archive_insertion_is_repeating' => filter_input( INPUT_GET, Newspack_Popups::PREVIEW_QUERY_KEYS['archive_insertion_is_repeating'], FILTER_VALIDATE_BOOLEAN ),
+			'utm_suppression'                => filter_input( INPUT_GET, Newspack_Popups::PREVIEW_QUERY_KEYS['utm_suppression'], FILTER_SANITIZE_FULL_SPECIAL_CHARS ),
+		];
+
+		if ( $preset['featured_image_id'] ) {
+			$options['featured_image_id'] = $preset['featured_image_id'];
+		}
+
+		return self::create_popup_object(
+			$post_object,
+			false,
+			$options
 		);
 	}
 
@@ -1055,7 +1341,7 @@ final class Newspack_Popups_Model {
 		if ( Newspack_Popups_Settings::is_non_interactive() ) {
 			return '';
 		}
-		if ( Newspack_Popups::previewed_popup_id() ) {
+		if ( Newspack_Popups::previewed_popup_id() || Newspack_Popups::preset_popup_id() ) {
 			return '';
 		}
 		// The amp-access endpoint is queried only once (on page load), but after changing block settings,
@@ -1196,6 +1482,9 @@ final class Newspack_Popups_Model {
 		if ( Newspack_Popups::previewed_popup_id() ) {
 			$popup = self::retrieve_preview_popup( Newspack_Popups::previewed_popup_id() );
 		}
+		if ( Newspack_Popups::preset_popup_id() ) {
+			$popup = self::retrieve_preset_popup( Newspack_Popups::preset_popup_id() );
+		}
 
 		if ( self::is_overlay( $popup ) && self::is_overlay( $popup ) && has_block( 'newspack-blocks/homepage-articles', $popup['content'] ) ) {
 			add_filter( 'newspack_blocks_homepage_enable_duplication', '__return_true' );
@@ -1227,7 +1516,7 @@ final class Newspack_Popups_Model {
 		$no_overlay_background = $popup['options']['no_overlay_background'];
 		$hidden_fields         = self::get_hidden_fields( $popup );
 		$is_newsletter_prompt  = self::has_newsletter_prompt( $popup );
-		$has_featured_image    = has_post_thumbnail( $popup['id'] );
+		$has_featured_image    = has_post_thumbnail( $popup['id'] ) || ! empty( $popup['options']['featured_image_id'] );
 		$classes               = array( 'newspack-lightbox', 'newspack-popup', 'newspack-lightbox-placement-' . $popup['options']['placement'], 'newspack-lightbox-size-' . $overlay_size );
 		$classes[]             = ( ! empty( $popup['title'] ) && $display_title ) ? 'newspack-lightbox-has-title' : null;
 		$classes[]             = $hide_border ? 'newspack-lightbox-no-border' : null;
@@ -1263,7 +1552,7 @@ final class Newspack_Popups_Model {
 				<div class="newspack-popup__content-wrapper" style="<?php echo $hide_border ? esc_attr( self::container_style( $popup ) ) : ''; ?>">
 					<?php if ( $has_featured_image ) : ?>
 						<div class="newspack-popup__featured-image">
-							<?php echo get_the_post_thumbnail( $popup['id'], 'large' ); ?>
+							<?php echo ! empty( $popup['options']['featured_image_id'] ) ? wp_get_attachment_image( $popup['options']['featured_image_id'] ) : get_the_post_thumbnail( $popup['id'], 'large' ); ?>
 						</div>
 					<?php endif; ?>
 					<div class="newspack-popup__content">

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -46,10 +46,15 @@ final class Newspack_Popups_Model {
 	/**
 	 * Get subscribable lists from the Newspack Newsletters plugin.
 	 *
-	 * @return array Array of lists.
+	 * @return array|WP_Error Array of lists.
 	 */
 	private static function get_newsletter_lists() {
-		// TODO: There's a race condition here.
+		$provider_lists = method_exists( '\Newspack_Newsletters_Subscription', 'get_lists' ) ? \Newspack_Newsletters_Subscription::get_lists() : [];
+
+		if ( \is_wp_error( $provider_lists ) ) {
+			return $provider_lists;
+		}
+
 		$lists = array_reduce(
 			method_exists( '\Newspack_Newsletters_Subscription', 'get_lists' ) ? \Newspack_Newsletters_Subscription::get_lists() : [],
 			function( $acc, $list ) {
@@ -73,7 +78,7 @@ final class Newspack_Popups_Model {
 	/**
 	 * Retrieve default prompts + segments.
 	 *
-	 * @return array Array of prompt and segment default configs.
+	 * @return array|WP_Error Array of prompt and segment default configs.
 	 */
 	public static function get_ras_presets() {
 		$file = dirname( NEWSPACK_POPUPS_PLUGIN_FILE ) . '/presets/ras-defaults.json';
@@ -90,6 +95,10 @@ final class Newspack_Popups_Model {
 
 		$saved_inputs = \get_option( Newspack_Popups::NEWSPACK_POPUPS_RAS_PROMPTS_OPTION, [] );
 		$lists        = self::get_newsletter_lists();
+
+		if ( \is_wp_error( $lists ) ) {
+			return $lists;
+		}
 
 		// Populate prompt configs with saved inputs.
 		$data['prompts'] = array_map(

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -16,7 +16,9 @@ final class Newspack_Popups {
 	const NEWSPACK_POPUPS_TAXONOMY              = 'newspack_popups_taxonomy';
 	const NEWSPACK_POPUPS_ACTIVE_CAMPAIGN_GROUP = 'newspack_popups_active_campaign_group';
 	const NEWSPACK_POPUP_PREVIEW_QUERY_PARAM    = 'pid';
+	const NEWSPACK_POPUP_PRESET_QUERY_PARAM     = 'preset';
 	const NEWSPACK_POPUPS_TAXONOMY_STATUS       = 'newspack_popups_taxonomy_status';
+	const NEWSPACK_POPUPS_RAS_PROMPTS_OPTION    = 'newspack_popups_ras_prompts';
 
 	const LIGHTWEIGHT_API_CONFIG_FILE_PATH_LEGACY = WP_CONTENT_DIR . '/../newspack-popups-config.php';
 	const LIGHTWEIGHT_API_CONFIG_FILE_PATH        = WP_CONTENT_DIR . '/newspack-popups-config.php';
@@ -764,7 +766,7 @@ final class Newspack_Popups {
 		$is_customizer_preview = is_customize_preview();
 		// Used by the Newspack Plugin's Campaigns Wizard.
 		$is_view_as_preview = false != Newspack_Popups_View_As::viewing_as_spec();
-		return ! empty( self::previewed_popup_id() ) || $is_view_as_preview || $is_customizer_preview;
+		return ! empty( self::previewed_popup_id() ) || ! empty( self::preset_popup_id() ) || $is_view_as_preview || $is_customizer_preview;
 	}
 
 	/**
@@ -776,6 +778,19 @@ final class Newspack_Popups {
 		// Not using filter_input since it's not playing well with phpunit.
 		if ( isset( $_GET[ self::NEWSPACK_POPUP_PREVIEW_QUERY_PARAM ] ) && $_GET[ self::NEWSPACK_POPUP_PREVIEW_QUERY_PARAM ] ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 			return sanitize_text_field( $_GET[ self::NEWSPACK_POPUP_PREVIEW_QUERY_PARAM ] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		}
+		return null;
+	}
+
+	/**
+	 * Get preset popup slug from the URL.
+	 *
+	 * @return string|null Popup slug, if found in the URL
+	 */
+	public static function preset_popup_id() {
+		// Not using filter_input since it's not playing well with phpunit.
+		if ( isset( $_GET[ self::NEWSPACK_POPUP_PRESET_QUERY_PARAM ] ) && $_GET[ self::NEWSPACK_POPUP_PRESET_QUERY_PARAM ] ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+			return sanitize_text_field( $_GET[ self::NEWSPACK_POPUP_PRESET_QUERY_PARAM ] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		}
 		return null;
 	}

--- a/includes/schemas/class-prompts.php
+++ b/includes/schemas/class-prompts.php
@@ -381,7 +381,7 @@ class Prompts extends Schema {
 							],
 							// Data type for the input.
 							'type'        => [
-								'type' => 'string',
+								'type' => [ 'array', 'int', 'string' ],
 							],
 							// Label for the input.
 							'label'       => [
@@ -402,6 +402,11 @@ class Prompts extends Schema {
 							// If a string, maximum length for the input value. This will be used to validate the input in the UI.
 							'max_length'  => [
 								'type'     => 'integer',
+								'required' => false,
+							],
+							// If an array, selectable options.
+							'options'     => [
+								'type'     => 'array',
 								'required' => false,
 							],
 						],

--- a/includes/schemas/class-prompts.php
+++ b/includes/schemas/class-prompts.php
@@ -381,7 +381,7 @@ class Prompts extends Schema {
 							],
 							// Data type for the input.
 							'type'        => [
-								'type' => [ 'array', 'int', 'string' ],
+								'type' => [ 'array', 'integer', 'string' ],
 							],
 							// Label for the input.
 							'label'       => [

--- a/includes/schemas/class-prompts.php
+++ b/includes/schemas/class-prompts.php
@@ -381,7 +381,7 @@ class Prompts extends Schema {
 							],
 							// Data type for the input.
 							'type'        => [
-								'type' => [ 'array', 'integer', 'string' ],
+								'type' => 'string',
 							],
 							// Label for the input.
 							'label'       => [
@@ -397,7 +397,11 @@ class Prompts extends Schema {
 							],
 							// Default value of the input. This will be populated by default in the UI.
 							'default'     => [
-								'type' => 'string',
+								'type' => [ 'array', 'integer', 'string' ],
+							],
+							// User-inputted value of the input, if available.
+							'value'       => [
+								'type' => [ 'array', 'integer', 'string' ],
 							],
 							// If a string, maximum length for the input value. This will be used to validate the input in the UI.
 							'max_length'  => [

--- a/presets/ras-defaults.json
+++ b/presets/ras-defaults.json
@@ -2,98 +2,9 @@
     "prompts": [
         {
             "status": "draft",
-            "slug": "ras_donation_inline",
-            "title": "Inline Donation (secondary)",
-            "content": "<!-- wp:separator -->\n<hr class=\"wp-block-separator has-alpha-channel-opacity\"\/>\n<!-- \/wp:separator -->\n\n<!-- wp:heading -->\n<h2>{{heading}}<\/h2>\n<!-- \/wp:heading -->\n\n<!-- wp:paragraph -->\n<p>{{body}}<\/p>\n<!-- \/wp:paragraph -->\n\n<!-- wp:newspack-blocks\/donate {\"className\":\"is-style-alternate\",\"amounts\":{\"once\":[9,20,90,20],\"month\":[7,15,30,15],\"year\":[84,180,360,180]},\"disabledFrequencies\":{\"once\":false,\"month\":false,\"year\":false},\"thanksText\":\"{{thanks_message}}\",\"buttonText\": \"{{button_label}}\",\"minimumDonation\":5} \/-->",
-            "options": {
-                "background_color": "#FFFFFF",
-                "display_title": false,
-                "hide_border": false,
-                "large_border": false,
-                "frequency": "always",
-                "frequency_max": 0,
-                "frequency_start": 0,
-                "frequency_between": 0,
-                "frequency_reset": "month",
-                "overlay_color": "#000000",
-                "overlay_opacity": "30",
-                "overlay_size": "medium",
-                "no_overlay_background": false,
-                "placement": "inline",
-                "trigger_type": "scroll",
-                "trigger_delay": "3",
-                "trigger_scroll_progress": "100",
-                "trigger_blocks_count": 0,
-                "archive_insertion_posts_count": 1,
-                "archive_insertion_is_repeating": false,
-                "selected_segment_id": "",
-                "post_types": [
-                    "post"
-                ],
-                "archive_page_types": [
-                    "category",
-                    "tag",
-                    "author",
-                    "date",
-                    "post-type",
-                    "taxonomy"
-                ],
-                "additional_classes": "",
-                "excluded_categories": [],
-                "excluded_tags": []
-            },
-            "categories": [],
-            "tags": false,
-            "campaign_groups": [
-                {
-                    "id": 30,
-                    "name": "Reader Activation Defaults"
-                }
-            ],
-            "user_input_fields": [
-                {
-                    "name": "heading",
-                    "type": "string",
-                    "label": "Heading",
-                    "description": "A heading to describe the prompt.",
-                    "required": true,
-                    "default": "Support Our Work",
-                    "max_length": 40
-                },
-                {
-                    "name": "body",
-                    "type": "string",
-                    "label": "Body",
-                    "description": "The primary call to action for the prompt.",
-                    "required": true,
-                    "default": "As an independent publication, we rely on donations to fund our journalism.",
-                    "max_length": 300
-                },
-                {
-                    "name": "thanks_message",
-                    "type": "string",
-                    "label": "Thanks Message",
-                    "description": "A message to thank the reader for their contribution.",
-                    "required": true,
-                    "default": "Thanks for your contribution!",
-                    "max_length": 300
-                },
-                {
-                    "name": "button_label",
-                    "type": "string",
-                    "label": "Button Label",
-                    "description": "The label for the primary CTA button.",
-                    "required": true,
-                    "default": "Donate Now",
-                    "max_length": 20
-                }
-            ]
-        },
-        {
-            "status": "draft",
             "slug": "ras_registration_overlay",
             "title": "Registration Overlay",
-            "content": "<!-- wp:newspack\/reader-registration {\"title\":\"{{heading}}\",\"description\":\"{{body}}\",\"label\":\"{{button_label}}\"} -->\n<div class=\"wp-block-newspack-reader-registration\"><!-- wp:paragraph {\"align\":\"center\"} --><p class=\"has-text-align-center\">{{success_message}}</p><!-- /wp:paragraph --><\/div>\n<!-- \/wp:newspack\/reader-registration -->",
+            "content": "<!-- wp:newspack\/reader-registration {\"title\":\"{{heading}}\",\"description\":\"{{body}}\",\"label\":\"{{button_label}}\",{{lists}}} -->\n<div class=\"wp-block-newspack-reader-registration\"><!-- wp:paragraph {\"align\":\"center\"} --><p class=\"has-text-align-center\">{{success_message}}</p><!-- /wp:paragraph --><\/div>\n<!-- \/wp:newspack\/reader-registration -->",
             "options": {
                 "background_color": "#FFFFFF",
                 "display_title": false,
@@ -178,94 +89,29 @@
                     "required": true,
                     "default": "Thank you for registering!",
                     "max_length": 300
-                }
-            ]
-        },
-        {
-            "status": "draft",
-            "slug": "ras_newsletter_inline",
-            "title": "Inline Newsletter Signup (secondary)",
-            "content": "<!-- wp:paragraph -->\n<p>{{body}}</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:newspack-newsletters/subscribe {\"label\":\"{{button_label}}\",\"successMessage\":\"{{success_message}}\"} /-->",
-            "options": {
-                "background_color": "#FFFFFF",
-                "display_title": false,
-                "hide_border": false,
-                "large_border": false,
-                "frequency": "always",
-                "frequency_max": 0,
-                "frequency_start": 0,
-                "frequency_between": 0,
-                "frequency_reset": "month",
-                "overlay_color": "#000000",
-                "overlay_opacity": "30",
-                "overlay_size": "medium",
-                "no_overlay_background": false,
-                "placement": "inline",
-                "trigger_type": "blocks_count",
-                "trigger_delay": "3",
-                "trigger_scroll_progress": 0,
-                "trigger_blocks_count": 2,
-                "archive_insertion_posts_count": 1,
-                "archive_insertion_is_repeating": false,
-                "selected_segment_id": "639b333b41025,639b337fdbf33",
-                "post_types": [
-                    "post"
-                ],
-                "archive_page_types": [
-                    "category",
-                    "tag",
-                    "author",
-                    "date",
-                    "post-type",
-                    "taxonomy"
-                ],
-                "additional_classes": "",
-                "excluded_categories": [],
-                "excluded_tags": []
-            },
-            "categories": [],
-            "tags": false,
-            "campaign_groups": [
-                {
-                    "id": 30,
-                    "name": "Reader Activation Defaults"
-                }
-            ],
-            "user_input_fields": [
-                {
-                    "name": "body",
-                    "type": "string",
-                    "label": "Body",
-                    "description": "The primary call to action for the prompt.",
-                    "required": true,
-                    "default": "Sign up for our free newsletter to receive the latest news.",
-                    "max_length": 300
                 },
                 {
-                    "name": "button_label",
-                    "type": "string",
-                    "label": "Button Label",
-                    "description": "The label for the primary CTA button.",
-                    "required": true,
-                    "default": "Sign up",
-                    "max_length": 20
+                    "name": "featured_image_id",
+                    "type": "int",
+                    "label": "Header Image (optional)",
+                    "description": "Banner image to show at the top of the prompt.",
+                    "default": 0
                 },
                 {
-                    "name": "success_message",
-                    "type": "string",
-                    "label": "Success Message",
-                    "description": "The message shown to readers after completing the signup.",
+                    "name": "lists",
+                    "type": "array",
+                    "label": "Select Newsletters",
+                    "description": "Newsletter lists the reader can subscribe to.",
                     "required": true,
-                    "default": "Thank you for signing up!",
-                    "max_length": 300
+                    "default": []
                 }
             ]
         },
         {
             "status": "draft",
             "slug": "ras_newsletter_overlay",
-            "title": "Newsletter Sign-up Overlay",
-            "content": "<!-- wp:heading -->\n<h2>{{heading}}<\/h2>\n<!-- \/wp:heading -->\n\n<!-- wp:paragraph -->\n<p>{{body}}<\/p>\n<!-- \/wp:paragraph -->\n\n<!-- wp:newspack-newsletters/subscribe {\"label\":\"{{button_label}}\",\"successMessage\":\"{{success_message}}\"} /-->",
+            "title": "Newsletter Signup Overlay",
+            "content": "<!-- wp:heading -->\n<h2>{{heading}}<\/h2>\n<!-- \/wp:heading -->\n\n<!-- wp:paragraph -->\n<p>{{body}}<\/p>\n<!-- \/wp:paragraph -->\n\n<!-- wp:newspack-newsletters/subscribe {\"label\":\"{{button_label}}\",\"successMessage\":\"{{success_message}}\",{{lists}}} /-->",
             "options": {
                 "background_color": "#FFFFFF",
                 "display_title": false,
@@ -350,6 +196,21 @@
                     "required": true,
                     "default": "Thank you for signing up!",
                     "max_length": 300
+                },
+                {
+                    "name": "featured_image_id",
+                    "type": "int",
+                    "label": "Header Image (optional)",
+                    "description": "Banner image to show at the top of the prompt.",
+                    "default": 0
+                },
+                {
+                    "name": "lists",
+                    "type": "array",
+                    "label": "Select Newsletters",
+                    "description": "Newsletter lists the reader can subscribe to.",
+                    "required": true,
+                    "default": []
                 }
             ]
         },
@@ -442,6 +303,190 @@
                     "required": true,
                     "default": "Donate Now",
                     "max_length": 20
+                },
+                {
+                    "name": "featured_image_id",
+                    "type": "int",
+                    "label": "Header Image (optional)",
+                    "description": "Banner image to show at the top of the prompt.",
+                    "default": 0
+                }
+            ]
+        },
+        {
+            "status": "draft",
+            "slug": "ras_donation_inline",
+            "title": "Inline Donation (secondary)",
+            "content": "<!-- wp:separator -->\n<hr class=\"wp-block-separator has-alpha-channel-opacity\"\/>\n<!-- \/wp:separator -->\n\n<!-- wp:heading -->\n<h2>{{heading}}<\/h2>\n<!-- \/wp:heading -->\n\n<!-- wp:paragraph -->\n<p>{{body}}<\/p>\n<!-- \/wp:paragraph -->\n\n<!-- wp:newspack-blocks\/donate {\"className\":\"is-style-alternate\",\"amounts\":{\"once\":[9,20,90,20],\"month\":[7,15,30,15],\"year\":[84,180,360,180]},\"disabledFrequencies\":{\"once\":false,\"month\":false,\"year\":false},\"thanksText\":\"{{thanks_message}}\",\"buttonText\": \"{{button_label}}\",\"minimumDonation\":5} \/-->",
+            "options": {
+                "background_color": "#FFFFFF",
+                "display_title": false,
+                "hide_border": false,
+                "large_border": false,
+                "frequency": "always",
+                "frequency_max": 0,
+                "frequency_start": 0,
+                "frequency_between": 0,
+                "frequency_reset": "month",
+                "overlay_color": "#000000",
+                "overlay_opacity": "30",
+                "overlay_size": "medium",
+                "no_overlay_background": false,
+                "placement": "inline",
+                "trigger_type": "scroll",
+                "trigger_delay": "3",
+                "trigger_scroll_progress": "100",
+                "trigger_blocks_count": 0,
+                "archive_insertion_posts_count": 1,
+                "archive_insertion_is_repeating": false,
+                "selected_segment_id": "",
+                "post_types": [
+                    "post"
+                ],
+                "archive_page_types": [
+                    "category",
+                    "tag",
+                    "author",
+                    "date",
+                    "post-type",
+                    "taxonomy"
+                ],
+                "additional_classes": "",
+                "excluded_categories": [],
+                "excluded_tags": []
+            },
+            "categories": [],
+            "tags": false,
+            "campaign_groups": [
+                {
+                    "id": 30,
+                    "name": "Reader Activation Defaults"
+                }
+            ],
+            "user_input_fields": [
+                {
+                    "name": "heading",
+                    "type": "string",
+                    "label": "Heading",
+                    "description": "A heading to describe the prompt.",
+                    "required": true,
+                    "default": "Support Our Work",
+                    "max_length": 40
+                },
+                {
+                    "name": "body",
+                    "type": "string",
+                    "label": "Body",
+                    "description": "The primary call to action for the prompt.",
+                    "required": true,
+                    "default": "As an independent publication, we rely on donations to fund our journalism.",
+                    "max_length": 300
+                },
+                {
+                    "name": "thanks_message",
+                    "type": "string",
+                    "label": "Thanks Message",
+                    "description": "A message to thank the reader for their contribution.",
+                    "required": true,
+                    "default": "Thanks for your contribution!",
+                    "max_length": 300
+                },
+                {
+                    "name": "button_label",
+                    "type": "string",
+                    "label": "Button Label",
+                    "description": "The label for the primary CTA button.",
+                    "required": true,
+                    "default": "Donate Now",
+                    "max_length": 20
+                }
+            ]
+        },
+        {
+            "status": "draft",
+            "slug": "ras_newsletter_inline",
+            "title": "Inline Newsletter Signup (secondary)",
+            "content": "<!-- wp:paragraph -->\n<p>{{body}}</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:newspack-newsletters/subscribe {\"label\":\"{{button_label}}\",\"successMessage\":\"{{success_message}}\",{{lists}}} /-->",
+            "options": {
+                "background_color": "#FFFFFF",
+                "display_title": false,
+                "hide_border": false,
+                "large_border": false,
+                "frequency": "always",
+                "frequency_max": 0,
+                "frequency_start": 0,
+                "frequency_between": 0,
+                "frequency_reset": "month",
+                "overlay_color": "#000000",
+                "overlay_opacity": "30",
+                "overlay_size": "medium",
+                "no_overlay_background": false,
+                "placement": "inline",
+                "trigger_type": "blocks_count",
+                "trigger_delay": "3",
+                "trigger_scroll_progress": 0,
+                "trigger_blocks_count": 2,
+                "archive_insertion_posts_count": 1,
+                "archive_insertion_is_repeating": false,
+                "selected_segment_id": "639b333b41025,639b337fdbf33",
+                "post_types": [
+                    "post"
+                ],
+                "archive_page_types": [
+                    "category",
+                    "tag",
+                    "author",
+                    "date",
+                    "post-type",
+                    "taxonomy"
+                ],
+                "additional_classes": "",
+                "excluded_categories": [],
+                "excluded_tags": []
+            },
+            "categories": [],
+            "tags": false,
+            "campaign_groups": [
+                {
+                    "id": 30,
+                    "name": "Reader Activation Defaults"
+                }
+            ],
+            "user_input_fields": [
+                {
+                    "name": "body",
+                    "type": "string",
+                    "label": "Body",
+                    "description": "The primary call to action for the prompt.",
+                    "required": true,
+                    "default": "Sign up for our free newsletter to receive the latest news.",
+                    "max_length": 300
+                },
+                {
+                    "name": "button_label",
+                    "type": "string",
+                    "label": "Button Label",
+                    "description": "The label for the primary CTA button.",
+                    "required": true,
+                    "default": "Sign up",
+                    "max_length": 20
+                },
+                {
+                    "name": "success_message",
+                    "type": "string",
+                    "label": "Success Message",
+                    "description": "The message shown to readers after completing the signup.",
+                    "required": true,
+                    "default": "Thank you for signing up!",
+                    "max_length": 300
+                },
+                {
+                    "name": "lists",
+                    "type": "array",
+                    "label": "Select Newsletters",
+                    "description": "Newsletter lists the reader can subscribe to.",
+                    "required": true,
+                    "default": []
                 }
             ]
         }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Supports new RAS-related setup UI in https://github.com/Automattic/newspack-plugin/pull/2399. The main changes:

- Updates the prompt schema to support additional user input field data types (array and integer in addition to string)
- Implements logic to store user inputs by field name and populate preset config placeholders with matching stored inputs when fetching the preset configs
- Implements logic to build dynamic prompt previews from preset config + user input, without having to create prompt posts

### How to test the changes in this Pull Request:

Follow testing instructions in https://github.com/Automattic/newspack-plugin/pull/2399. The plugin should function as usual and all tests should continue passing even without the changes in https://github.com/Automattic/newspack-plugin/pull/2399.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
