### PR TITLE
feat: add filter to maybe display prompt check

### DIFF
--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -1057,20 +1057,17 @@ final class Newspack_Popups_Inserter {
 		}
 		$is_post_context_matching = $is_taxonomy_matching && in_array( $post_type, $supported_post_types );
 
-		if ( $is_post_context_matching ) {
-			/**
-			 * Allow additional checks to be performed before displaying a prompt.
-			 *
-			 * Additional checks will be checked alongside regular checks for taxonomies and post types, but will not override them. All checks must pass for the prompt to be displayed.
-			 *
-			 * @param bool   $addidional_checks_result Whether the popup should be displayed.
-			 * @param object $popup The popup to assess.
-			 * @param bool   $check_if_is_post Should the post type of post be taken into account.
-			 */
-			$is_post_context_matching = apply_filters( 'newspack_popups_should_display_prompt_additional_checks', true, $popup, $check_if_is_post );
-		}
-
-		return $is_post_context_matching;
+		/**
+		 * Filters the result of the should_display check for each prompt.
+		 *
+		 * If $check_result is false, it means it failed the previous checks. Changing this to true will make the prompt appear.
+		 * Use it with caution as this might result in unexpected behavior.
+		 *
+		 * @param bool   $check_result Whether the popup should be displayed.
+		 * @param object $popup The popup to assess.
+		 * @param bool   $check_if_is_post Should the post type of post be taken into account.
+		 */
+		return apply_filters( 'newspack_popups_should_display_prompt', $is_post_context_matching, $popup, $check_if_is_post );
 	}
 
 	/**

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -1057,6 +1057,19 @@ final class Newspack_Popups_Inserter {
 		}
 		$is_post_context_matching = $is_taxonomy_matching && in_array( $post_type, $supported_post_types );
 
+		if ( $is_post_context_matching ) {
+			/**
+			 * Allow additional checks to be performed before displaying a prompt.
+			 *
+			 * Additional checks will be checked alongside regular checks for taxonomies and post types, but will not override them. All checks must pass for the prompt to be displayed.
+			 *
+			 * @param bool   $addidional_checks Whether additional checks should be performed.
+			 * @param object $popup The popup to assess.
+			 * @param bool   $check_if_is_post Should the post type of post be taken into account.
+			 */
+			$is_post_context_matching = apply_filters( 'newspack_popups_should_display_prompt_additional_checks', true, $popup, $check_if_is_post );
+		}
+
 		return $is_post_context_matching;
 	}
 

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -1063,7 +1063,7 @@ final class Newspack_Popups_Inserter {
 			 *
 			 * Additional checks will be checked alongside regular checks for taxonomies and post types, but will not override them. All checks must pass for the prompt to be displayed.
 			 *
-			 * @param bool   $addidional_checks Whether additional checks should be performed.
+			 * @param bool   $addidional_checks_result Whether the popup should be displayed.
 			 * @param object $popup The popup to assess.
 			 * @param bool   $check_if_is_post Should the post type of post be taken into account.
 			 */


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds a filter so plugins can add additional rules for prompt visibility

### How to test the changes in this Pull Request:

1. Check the code and read the docs to see if it's all clear

I preferred to not allow filters to completely override the checks, meaning that a plugin could make a prompt be displayed when the rules set by the user would not.

In practice, plugins will only be able to not display prompts that match all native conditions.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
