### PR TITLE
feat: add custom prompt taxonomies

### DIFF
--- a/includes/class-newspack-popups-exporter.php
+++ b/includes/class-newspack-popups-exporter.php
@@ -194,6 +194,14 @@ class Newspack_Popups_Exporter {
 			unset( $prompt['options']['utm_suppression'] );
 		}
 
+		// We do not export custom taxonomies added to the popup.
+		$custom_taxonomies = Newspack_Popups_Model::get_custom_taxonomies();
+		foreach ( $custom_taxonomies as $custom_tax ) {
+			if ( isset( $prompt[ $custom_tax ] ) ) {
+				unset( $prompt[ $custom_tax ] );
+			}
+		}
+
 		return $prompt;
 
 	}

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -613,6 +613,12 @@ final class Newspack_Popups_Model {
 			$popup['categories']      = get_the_category( $id );
 			$popup['tags']            = get_the_tags( $id );
 			$popup['campaign_groups'] = get_the_terms( $id, Newspack_Popups::NEWSPACK_POPUPS_TAXONOMY );
+
+			$all_taxonomies = self::get_custom_taxonomies();
+
+			foreach ( $all_taxonomies as $custom_taxonomy ) {
+				$popup[ $custom_taxonomy ] = get_the_terms( $id, $custom_taxonomy );
+			}
 		}
 
 		$duplicate_of = get_post_meta( $id, 'duplicate_of', true );
@@ -652,6 +658,16 @@ final class Newspack_Popups_Model {
 		}
 
 		return $popup;
+	}
+
+	/**
+	 * Gets custom taxonomies that are assigned to the popup post type.
+	 *
+	 * @return array
+	 */
+	public static function get_custom_taxonomies() {
+		$all_taxonomies = get_object_taxonomies( Newspack_Popups::NEWSPACK_POPUPS_CPT );
+		return array_diff( $all_taxonomies, [ Newspack_Popups::NEWSPACK_POPUPS_TAXONOMY, 'category', 'post_tag' ] );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds custom taxonomies information to the prompt object.

Remove it from the exporter since we are not changing the prompt schema for now.

### How to test the changes in this Pull Request:

See https://github.com/Automattic/newspack-multibranded-site/pull/19

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
