### PR TITLE
feat(ras-defaults): increase max length of default prompt input fields

### DIFF
--- a/presets/ras-defaults.json
+++ b/presets/ras-defaults.json
@@ -61,7 +61,7 @@
                     "description": "A heading to describe the prompt.",
                     "required": true,
                     "default": "Join our community for free. Sign up now.",
-                    "max_length": 40
+                    "max_length": 120
                 },
                 {
                     "name": "body",
@@ -79,7 +79,7 @@
                     "description": "The label for the primary CTA button.",
                     "required": true,
                     "default": "Sign up",
-                    "max_length": 20
+                    "max_length": 40
                 },
                 {
                     "name": "success_message",
@@ -179,7 +179,7 @@
                     "description": "A heading to describe the prompt.",
                     "required": true,
                     "default": "Stay in the know",
-                    "max_length": 40
+                    "max_length": 120
                 },
                 {
                     "name": "body",
@@ -197,7 +197,7 @@
                     "description": "The label for the primary CTA button.",
                     "required": true,
                     "default": "Sign up",
-                    "max_length": 20
+                    "max_length": 40
                 },
                 {
                     "name": "success_message",
@@ -297,7 +297,7 @@
                     "description": "A heading to describe the prompt.",
                     "required": true,
                     "default": "Support our work",
-                    "max_length": 40
+                    "max_length": 120
                 },
                 {
                     "name": "body",
@@ -324,7 +324,7 @@
                     "description": "The label for the primary CTA button.",
                     "required": true,
                     "default": "Contribute Now",
-                    "max_length": 20
+                    "max_length": 40
                 },
                 {
                     "name": "featured_image_id",
@@ -413,7 +413,7 @@
                     "description": "The label for the primary CTA button.",
                     "required": true,
                     "default": "Sign up",
-                    "max_length": 20
+                    "max_length": 40
                 },
                 {
                     "name": "success_message",
@@ -503,7 +503,7 @@
                     "description": "A heading to describe the prompt.",
                     "required": true,
                     "default": "Support our work",
-                    "max_length": 40
+                    "max_length": 120
                 },
                 {
                     "name": "body",
@@ -530,7 +530,7 @@
                     "description": "The label for the primary CTA button.",
                     "required": true,
                     "default": "Contribute Now",
-                    "max_length": 20
+                    "max_length": 40
                 }
             ],
             "help_info": {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Increases the max length of input fields for RAS default prompts.

### How to test the changes in this Pull Request:

See

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
