### PR TITLE
fix(ras-defaults): turn on feature to always subscribe to newsletters by default

### DIFF
--- a/presets/ras-defaults.json
+++ b/presets/ras-defaults.json
@@ -4,7 +4,7 @@
             "status": "draft",
             "slug": "ras_registration_overlay",
             "title": "Registration Overlay",
-            "content": "<!-- wp:newspack\/reader-registration {\"title\":\"{{heading}}\",\"description\":\"{{body}}\",\"label\":\"{{button_label}}\",{{lists}}} -->\n<div class=\"wp-block-newspack-reader-registration\"><!-- wp:paragraph {\"align\":\"center\"} --><p class=\"has-text-align-center\">{{success_message}}</p><!-- /wp:paragraph --><\/div>\n<!-- \/wp:newspack\/reader-registration -->",
+            "content": "<!-- wp:newspack\/reader-registration {\"title\":\"{{heading}}\",\"description\":\"{{body}}\",\"label\":\"{{button_label}}\",\"hideSubscriptionInput\":true,{{lists}}} -->\n<div class=\"wp-block-newspack-reader-registration\"><!-- wp:paragraph {\"align\":\"center\"} --><p class=\"has-text-align-center\">{{success_message}}</p><!-- /wp:paragraph --><\/div>\n<!-- \/wp:newspack\/reader-registration -->",
             "options": {
                 "background_color": "#FFFFFF",
                 "display_title": false,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

The Registration block has an attribute to always sign up the reader to a newsletter upon registration, if there's only one newsletter. This attribute's default value is `false`, but we want the behavior in the RAS presets to be `true`, so this updates the preset config accordingly.

### How to test the changes in this Pull Request:

1. Start with a fresh site or delete all prompts + segments and the `newspack_reader_activation_enabled` option.
2. Run through the entire RAS setup wizard again and create default prompts and segments. Make sure at least one newsletter list is selected for the Registration Overlay prompt.
3. After completing setup, go to the Campaigns dashboard and edit the Registration Overlay prompt. Confirm that the "Hide newsletter selection and always subscribe" option is enabled. Note that it will be greyed out if there's more than one list available, as it only applies if there's exactly one (but the attribute can still be enabled by default in either case, it just won't do anything if it's greyed out).

<img width="244" alt="Screen Shot 2023-05-04 at 4 54 47 PM" src="https://user-images.githubusercontent.com/2230142/236347289-78d4dd9a-8ca1-4607-b3fb-1d10849fb4d9.png">


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
