### PR TITLE
feat: record timestamp when RAS setup wizard is completed

### DIFF
--- a/includes/class-newspack-popups-presets.php
+++ b/includes/class-newspack-popups-presets.php
@@ -12,6 +12,7 @@ defined( 'ABSPATH' ) || exit;
  */
 final class Newspack_Popups_Presets {
 	const NEWSPACK_POPUPS_RAS_PROMPTS_OPTION = 'newspack_popups_ras_prompts';
+	const NEWSPACK_POPUPS_RAS_TIMESTAMP      = 'newspack_popups_ras_prompts_last_updated';
 
 	/**
 	 * Retrieve popup preview preset prompt.
@@ -383,6 +384,9 @@ final class Newspack_Popups_Presets {
 			}
 			return new \WP_Error( 'newspack_popups_activate_ras_prompts_error', __( 'Error creating preset prompts and segments. Please try again.', 'newspack-popups' ) );
 		}
+
+		// Set the last updated timestamp.
+		\update_option( self::NEWSPACK_POPUPS_RAS_TIMESTAMP, time() );
 
 		return true;
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds a timestamp when the RAS setup wizard is complete.

### How to test the changes in this Pull Request:

1. Reset your site to a pre-RAS state by running `n wp option delete newspack_popups_segments && n wp post delete --force $(n wp post list --post_type=newspack_popups_cpt --fields=ID --format=csv)`
2. Run through the RAS wizard again
3. After the wizard completes, check that the timestamp is recorded: `n wp option get newspack_popups_ras_prompts_last_updated`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
