### PR TITLE
fix: attempt to create config file on every host

### DIFF
--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -874,23 +874,54 @@ final class Newspack_Popups {
 	 * Create the config file for the API, unless it exists.
 	 */
 	public static function create_lightweight_api_config() {
-		// Don't create a config file if not on Newspack's Atomic platform, or if there is a file already.
+		// Don't create a config file if it's already there.
 		if (
-			! ( defined( 'ATOMIC_SITE_ID' ) && ATOMIC_SITE_ID ) ||
 			( file_exists( self::LIGHTWEIGHT_API_CONFIG_FILE_PATH_LEGACY ) || file_exists( self::LIGHTWEIGHT_API_CONFIG_FILE_PATH ) )
 		) {
 			return;
 		}
+		// Don't create a config file if the directory is not writeable.
+		if ( ! is_writable( dirname( self::LIGHTWEIGHT_API_CONFIG_FILE_PATH ) ) ) { // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_is_writable
+			return;
+		}
 		global $wpdb;
+		$config_vars = [
+			'DB_NAME',
+			'DB_USER',
+			'DB_PASSWORD',
+			'DB_HOST',
+			'DB_CHARSET',
+			'DB_COLLATE',
+			'DB_PREFIX',
+			'WP_CACHE_KEY_SALT',
+			'NEWSPACK_POPUPS_DEBUG',
+		];
+
 		$new_config_file = file_put_contents( // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_file_put_contents -- VIP will have to create a config manually
 			self::LIGHTWEIGHT_API_CONFIG_FILE_PATH,
-			'<?php' .
-			// Insert these only if they are defined, but not in the as environment variables.
-			// This way only variables which are already declared in wp-config.php should be inserted in this config file.
-			( ! getenv( 'DB_CHARSET' ) && defined( 'DB_CHARSET' ) ? "\ndefine( 'DB_CHARSET', '" . DB_CHARSET . "' );" : '' ) .
-			( ! getenv( 'WP_CACHE_KEY_SALT' ) && defined( 'WP_CACHE_KEY_SALT' ) ? "\ndefine( 'WP_CACHE_KEY_SALT', '" . WP_CACHE_KEY_SALT . "' );" : '' ) .
-			"\ndefine( 'DB_PREFIX', '" . $wpdb->prefix . "' );" .
-			"\n"
+			"<?php\n" .
+			implode(
+				"\n",
+				array_map(
+					function( $config_var ) use ( $wpdb ) {
+						// Skip if it's set through an env var.
+						if ( getenv( $config_var ) ) {
+							return '';
+						}
+						if ( defined( $config_var ) ) {
+							$value = constant( $config_var );
+						}
+						if ( 'DB_PREFIX' === $config_var ) {
+							$value = $wpdb->prefix;
+						}
+						if ( ! isset( $value ) ) {
+							return '';
+						}
+						return "define( '" . $config_var . "', '" . $value . "' );";
+					},
+					$config_vars
+				)
+			)
 		);
 		if ( $new_config_file ) {
 			error_log( 'Created the config file: ' . self::LIGHTWEIGHT_API_CONFIG_FILE_PATH ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -880,7 +880,7 @@ final class Newspack_Popups {
 		) {
 			return;
 		}
-		// Don't create a config file if the directory is not writeable.
+		// Don't create a config file if the directory is not writable.
 		if ( ! is_writable( dirname( self::LIGHTWEIGHT_API_CONFIG_FILE_PATH ) ) ) { // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_is_writable
 			return;
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Tweaks the lightweight API config file creation to attempt on every host. The logic to skip if set as env var is preserved but all config variables will be checked, instead of just `DB_CHARSET`, `WP_CACHE_KEY_SALT`, and `DB_PREFIX`.

### How to test the changes in this Pull Request:

1. On a fresh instance, install the plugin and confirm the file is created
2. Remove the created file and set your database credentials as env vars, if not possible through runtime configuration, [`putenv()`](https://www.php.net/manual/en/function.putenv.php) is convenient
3. Refresh wp-admin and confirm the file is created but the env vars were skipped

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
