### PR TITLE
fix: escape value when creating config file

### DIFF
--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -917,6 +917,7 @@ final class Newspack_Popups {
 						if ( ! isset( $value ) ) {
 							return '';
 						}
+						$value = addslashes( $value );
 						return "define( '" . $config_var . "', '" . $value . "' );";
 					},
 					$config_vars


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fixes an oversight in #1121, values should be escaped.

### How to test the changes in this Pull Request:

1. While in master, change your wp-config file to have a `'` character as part of the db password
2. Delete the `newspack-popups-config.php` so it's created again
3. Confirm the broken php
4. Check out this branch and delete the file
5. Confirm it's properly escaped and works

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
