### PR TITLE
feat(ras): add segmentation support for NRH donations

### DIFF
--- a/includes/class-newspack-popups-segmentation.php
+++ b/includes/class-newspack-popups-segmentation.php
@@ -257,6 +257,23 @@ final class Newspack_Popups_Segmentation {
 					'offsite_has_donated' => true,
 				]
 			);
+
+			// Log a donation event for the reader.
+			try {
+				$api = \Campaign_Data_Utils::get_api( \wp_create_nonce( 'newspack_campaigns_lightweight_api' ) );
+				if ( ! $api ) {
+					return;
+				}
+				$reader_events = [
+					[
+						'type'    => 'donation',
+						'context' => method_exists( '\Newspack\Donations', 'get_platform_slug' ) ? \Newspack\Donations::get_platform_slug() : 'offsite',
+					],
+				];
+				$api->save_reader_events( self::get_client_id(), $reader_events );
+			} catch ( \Throwable $th ) {
+				\Newspack\Logger::log( 'Error when saving reader data on offsite donation: ' . $th->getMessage() );
+			}
 		}
 
 		if ( ! empty( $initial_client_report_url_params ) ) {

--- a/includes/class-newspack-popups-settings.php
+++ b/includes/class-newspack-popups-settings.php
@@ -117,7 +117,7 @@ class Newspack_Popups_Settings {
 	 *
 	 * @return bool|WP_Error Whether the value was updated or error if key does not match settings configuration.
 	 */
-	private static function update_setting( $section, $key, $value ) {
+	public static function update_setting( $section, $key, $value ) {
 		$config = self::get_setting_config( $section, $key );
 		if ( ! $config ) {
 			return new WP_Error( 'newspack_ads_invalid_setting_update', __( 'Invalid setting.', 'newspack-ads' ) );

--- a/includes/class-newspack-popups-settings.php
+++ b/includes/class-newspack-popups-settings.php
@@ -120,7 +120,7 @@ class Newspack_Popups_Settings {
 	public static function update_setting( $section, $key, $value ) {
 		$config = self::get_setting_config( $section, $key );
 		if ( ! $config ) {
-			return new WP_Error( 'newspack_ads_invalid_setting_update', __( 'Invalid setting.', 'newspack-ads' ) );
+			return new WP_Error( 'newspack_popups_invalid_setting_update', __( 'Invalid setting.', 'newspack-popups' ) );
 		}
 		if ( isset( $config['options'] ) && is_array( $config['options'] ) ) {
 			$accepted_values = array_map(
@@ -129,9 +129,9 @@ class Newspack_Popups_Settings {
 				},
 				$config['options']
 			);
-			if ( ! in_array( $value, $accepted_values, true ) ) {
+			if ( ! empty( $value ) && ! in_array( $value, $accepted_values, true ) ) {
 				// translators: %s is the description of the option.
-				return new WP_Error( 'newspack_ads_invalid_setting_update', sprintf( __( 'Invalid setting value for "%s".', 'newspack-ads' ), $config['description'] ) );
+				return new WP_Error( 'newspack_popups_invalid_setting_update', sprintf( __( 'Invalid setting value for "%s".', 'newspack-popups' ), $config['description'] ) );
 			}
 		}
 		$updated = update_option( $config['key'], self::sanitize_setting_option( $config['type'], $value ) );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Exposes a previously private method so that https://github.com/Automattic/newspack-plugin/pull/2484 can update the donor landing page from Reader Revenue settings. Also adds a missing feature to segment readers who hit the donor landing page as donors.

### How to test the changes in this Pull Request:

See testing instructions in https://github.com/Automattic/newspack-plugin/pull/2484.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
