### PR TITLE
fix: don’t include inactive segments in API request payload

### DIFF
--- a/includes/class-newspack-popups-segmentation.php
+++ b/includes/class-newspack-popups-segmentation.php
@@ -357,9 +357,11 @@ final class Newspack_Popups_Segmentation {
 	/**
 	 * Get all configured segments.
 	 *
+	 * @param boolean $include_inactive If true, fetch both inactive and active segments. If false, only fetch active segments.
+	 *
 	 * @return array Array of segments.
 	 */
-	public static function get_segments() {
+	public static function get_segments( $include_inactive = true ) {
 		$segments                  = get_option( self::SEGMENTS_OPTION_NAME, [] );
 		$segments_without_priority = array_filter(
 			$segments,
@@ -371,6 +373,16 @@ final class Newspack_Popups_Segmentation {
 		// Failsafe to ensure that all segments have an assigned priority.
 		if ( 0 < count( $segments_without_priority ) ) {
 			$segments = self::reindex_segments( $segments );
+		}
+
+		// Filter out inactive segments, if needed.
+		if ( ! $include_inactive ) {
+			$segments = array_filter(
+				$segments,
+				function( $segment ) {
+					return empty( $segment['configuration']['is_disabled'] );
+				}
+			);
 		}
 
 		// Filter out non-existing categories.

--- a/includes/class-newspack-popups-settings.php
+++ b/includes/class-newspack-popups-settings.php
@@ -328,7 +328,7 @@ class Newspack_Popups_Settings {
 					[
 						'key'   => 'all_segments',
 						'value' => array_reduce(
-							Newspack_Popups_Segmentation::get_segments(),
+							Newspack_Popups_Segmentation::get_segments( false ),
 							function( $acc, $item ) {
 								$acc[ $item['id'] ]             = $item['configuration'];
 								$acc[ $item['id'] ]['priority'] = $item['priority'];

--- a/tests/test-segments.php
+++ b/tests/test-segments.php
@@ -90,6 +90,20 @@ class SegmentsTest extends WP_UnitTestCase {
 	];
 
 	/**
+	 * An inactive segment.
+	 *
+	 * @var array
+	 */
+	public $inactive = [
+		'name'          => 'Inactive Segment',
+		'priority'      => 50,
+		'configuration' => [
+			'max_posts'   => 'string',
+			'is_disabled' => true,
+		],
+	];
+
+	/**
 	 * Make sure we have a clear environment
 	 */
 	public static function set_up_before_class() {
@@ -111,6 +125,7 @@ class SegmentsTest extends WP_UnitTestCase {
 			'missing_required'      => [ $this->missing_required ],
 			'additional_properties' => [ $this->additional_properties ],
 			'invalid_int'           => [ $this->invalid_int ],
+			'inactive'              => [ $this->inactive ],
 		];
 	}
 
@@ -151,8 +166,15 @@ class SegmentsTest extends WP_UnitTestCase {
 		$this->assertSame( [], Newspack_Popups_Segmentation::get_segments() );
 		Newspack_Popups_Segmentation::create_segment( $this->complete_and_valid );
 		Newspack_Popups_Segmentation::create_segment( $this->valid );
+		Newspack_Popups_Segmentation::create_segment( $this->inactive );
 
 		$segments = Newspack_Popups_Segmentation::get_segments();
+		$this->assertSame( 3, count( $segments ) );
+		$this->assertSame( $this->complete_and_valid['name'], $segments[0]['name'] );
+		$this->assertSame( $this->valid['name'], $segments[1]['name'] );
+		$this->assertSame( $this->inactive['name'], $segments[2]['name'] );
+
+		$segments = Newspack_Popups_Segmentation::get_segments( false );
 
 		$this->assertSame( 2, count( $segments ) );
 		$this->assertSame( $this->complete_and_valid['name'], $segments[0]['name'] );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a bug in which inactive segments are included in the payload for the segmentation API request. This doesn't resolve, but helps avoid, an issue where including too many segments in the payload results in a "Request URI too long" error response.

This is fairly unlikely to happen in a production environment, so it's an edge case.

### How to test the changes in this Pull Request:

1. Generate a lot of segments, but make most of them inactive. The easiest way to do this is to repeatedly navigate to `domain/wp-admin/admin.php?page=newspack-engagement-wizard#/reader-activation/complete` and click the button to "Enable Reader Activation". Each time you do this it will generate a new set of default segments + prompts, and deactivate the old ones. Do this at least 4 times to replicate the bug.
2. View the front-end and observe that no prompts are shown. If you open Dev Tools > Network and inspect the response from the `newspack-popups/api/campaigns/index.php` GET request, you should see the "Request URI too long" error response.
3. Check out this branch and repeat step 2. Confirm that the prompts matching your reader segment are shown as expected, and that the payload for the GET request is now much shorter.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
