### PR TITLE
feat: scaffold GA4 modules and implement `loaded` event

### DIFF
--- a/src/view/analytics/ga4.js
+++ b/src/view/analytics/ga4.js
@@ -1,0 +1,14 @@
+/* global gtag */
+
+import { manageLoadEvents } from './load';
+import { getPrompts } from '../utils';
+
+export const manageAnalytics = () => {
+	// Must have a gtag instance to proceed.
+	if ( 'function' === typeof gtag ) {
+		// Fetch all prompts on the page just once.
+		const prompts = getPrompts();
+
+		manageLoadEvents( prompts );
+	}
+};

--- a/src/view/analytics/load.js
+++ b/src/view/analytics/load.js
@@ -1,0 +1,15 @@
+import { getEventPayload } from '../utils';
+
+/**
+ * Event fired as soon as a prompt is loaded in the DOM.
+ *
+ * @param {Array} prompts Array of prompts loaded in the DOM.
+ */
+export const manageLoadEvents = prompts => {
+	prompts.forEach( prompt => {
+		const payload = getEventPayload( 'loaded', 'passive', prompt );
+
+		console.log( 'event name', 'prompt_interaction' );
+		console.log( 'event payload', payload );
+	} );
+};

--- a/src/view/index.js
+++ b/src/view/index.js
@@ -37,6 +37,7 @@ import { manageAnimations } from './animation';
 import { managePositionObservers } from './position-observer';
 import { manageBinds } from './bind';
 import { manageAccess } from './access';
+import { manageAnalytics } from './analytics/ga4';
 
 if ( typeof window !== 'undefined' ) {
 	domReady( () => {
@@ -51,5 +52,7 @@ if ( typeof window !== 'undefined' ) {
 		managePositionObservers();
 		manageBinds();
 		manageAccess();
+
+		manageAnalytics();
 	} );
 }

--- a/src/view/utils/index.js
+++ b/src/view/utils/index.js
@@ -184,3 +184,61 @@ export const parseOnHandlers = onAttributeValue =>
 		.split( ';' )
 		.filter( Boolean )
 		.map( onHandler => /(?<action>\w*):(?<id>(\w|-)*)\.(?<method>.*)/.exec( onHandler ).groups );
+
+/**
+ * Get all prompts on the page.
+ *
+ * @return {Array} Array of prompt elements.
+ */
+export const getPrompts = () => {
+	return [ ...document.querySelectorAll( '.newspack-popup' ) ];
+};
+
+/**
+ * Get raw prompt ID number from element ID name.
+ *
+ * @param {string} id Element ID of the prompt.
+ *
+ * @return {number} Raw ID number from the element ID.
+ */
+export const getRawId = id => {
+	const parts = id.split( '_' );
+	return parseInt( parts[ parts.length - 1 ] );
+};
+
+/**
+ * Get a GA4 event payload for a given prompt element.
+ *
+ * @param {string}      action     Action name for the event.
+ * @param {string}      actionType Action type for the event.
+ * @param {HTMLElement} prompt     HTML element for a prompt.
+ *
+ * @return {Object} Event payload.
+ */
+export const getEventPayload = ( action, actionType, prompt ) => {
+	const blocksToTrack = {
+		donation: '.wp-block-newspack-blocks-donate',
+		newsletter_subscription: '.newspack-newsletters-subscribe',
+		registration: '.newspack-registration',
+	};
+	const promptBlocks = Object.keys( blocksToTrack ).reduce( ( acc, blockType ) => {
+		const selector = blocksToTrack[ blockType ];
+
+		if ( prompt.querySelector( selector ) ) {
+			acc.push( blockType );
+		}
+
+		return acc;
+	}, [] );
+
+	return {
+		action,
+		action_type: actionType,
+		prompt_id: getRawId( prompt.getAttribute( 'id' ) ),
+		prompt_title: prompt.getAttribute( 'data-title' ),
+		prompt_frequency: prompt.getAttribute( 'data-frequency' ),
+		prompt_placement: prompt.getAttribute( 'data-placement' ),
+		prompt_blocks: promptBlocks,
+		interaction_data: {}, // TK
+	};
+};


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Scaffolds JS modules for setting up and firing GA4 custom events for prompt interactions. Also scaffolds a `loaded` event, which fires as soon as a prompt is loaded in the DOM (so no event handler needed for this trigger).

Because UA/GA3 events are being deprecated in July, this PR implements the GA4 events separately and in parallel with the existing analytics events, which can be removed after the official UA deprecation.

Closes `1204616440912018/1204751246643877`.

### How to test the changes in this Pull Request:

1. Ensure that you have Google Analytics and a GA4 property set up in Site Kit (otherwise the JS won't init).
2. Check out this branch.
3. Visit a post or page that has prompts (doesn't matter whether or not they're displayed for the `loaded` event).
4. In your JS console, confirm that each prompt logs a `prompt_interaction` event name and an accompanying payload with info about the specific prompt for the `loaded` action.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
