### PR TITLE
feat: first pass at dismiss event tracking

### DIFF
--- a/src/view/analytics/dismissed.js
+++ b/src/view/analytics/dismissed.js
@@ -1,0 +1,28 @@
+import { getEventPayload, getRawId, parseOnHandlers } from '../utils';
+
+/**
+ * Execute a callback function to send a GA event when a prompt is dismissed.
+ *
+ * @param {Function} handleEvent Callback function to execute when the prompt is dismissed.
+ * @return
+ */
+
+const manageBind = bindElement => {
+	const onHandlers = parseOnHandlers( bindElement.getAttribute( 'on' ) );
+	onHandlers.forEach( onHandler => {
+		if ( onHandler.action === 'tap' ) {
+			const handleClick = () => {
+				if ( onHandler.method === 'hide' ) {
+					const payload = getEventPayload( 'dismissed', getRawId( onHandler.id ) );
+					console.log( 'From dismiss: event name', 'prompt_interaction' );
+					console.log( 'From dismiss: event payload', payload );
+				}
+			};
+			bindElement.addEventListener( 'click', handleClick );
+		}
+	} );
+};
+
+export const manageDismissals = () => {
+	[ ...document.querySelectorAll( '.newspack-popup button[on]' ) ].map( manageBind );
+};

--- a/src/view/analytics/dismissed.js
+++ b/src/view/analytics/dismissed.js
@@ -1,4 +1,4 @@
-import { getEventPayload, getRawId } from '../utils';
+import { getEventPayload, getRawId, sendEvent } from '../utils';
 
 /**
  * Execute a callback function to send a GA event when a prompt is dismissed.
@@ -9,9 +9,9 @@ import { getEventPayload, getRawId } from '../utils';
 export const manageDismissals = prompts => {
 	prompts.forEach( prompt => {
 		const closeButton = prompt.querySelector( '.newspack-lightbox__close' );
-		const payload = getEventPayload( 'dismiss', getRawId( prompt.getAttribute( 'id' ) ) );
 		const handleEvent = () => {
-			console.log( payload );
+			const payload = getEventPayload( 'dismissed', getRawId( prompt.getAttribute( 'id' ) ) );
+			sendEvent( payload );
 		};
 
 		closeButton.addEventListener( 'click', handleEvent );

--- a/src/view/analytics/dismissed.js
+++ b/src/view/analytics/dismissed.js
@@ -1,28 +1,19 @@
-import { getEventPayload, getRawId, parseOnHandlers } from '../utils';
+import { getEventPayload, getRawId } from '../utils';
 
 /**
  * Execute a callback function to send a GA event when a prompt is dismissed.
  *
- * @param {Function} handleEvent Callback function to execute when the prompt is dismissed.
- * @return
+ * @param {Array} prompts Array of prompts loaded in the DOM.
  */
 
-const manageBind = bindElement => {
-	const onHandlers = parseOnHandlers( bindElement.getAttribute( 'on' ) );
-	onHandlers.forEach( onHandler => {
-		if ( onHandler.action === 'tap' ) {
-			const handleClick = () => {
-				if ( onHandler.method === 'hide' ) {
-					const payload = getEventPayload( 'dismissed', getRawId( onHandler.id ) );
-					console.log( 'From dismiss: event name', 'prompt_interaction' );
-					console.log( 'From dismiss: event payload', payload );
-				}
-			};
-			bindElement.addEventListener( 'click', handleClick );
-		}
-	} );
-};
+export const manageDismissals = prompts => {
+	prompts.forEach( prompt => {
+		const closeButton = prompt.querySelector( '.newspack-lightbox__close' );
+		const payload = getEventPayload( 'dismiss', getRawId( prompt.getAttribute( 'id' ) ) );
+		const handleEvent = () => {
+			console.log( payload );
+		};
 
-export const manageDismissals = () => {
-	[ ...document.querySelectorAll( '.newspack-popup button[on]' ) ].map( manageBind );
+		closeButton.addEventListener( 'click', handleEvent );
+	} );
 };

--- a/src/view/analytics/ga4.js
+++ b/src/view/analytics/ga4.js
@@ -2,6 +2,7 @@
 
 import { manageLoadedEvents } from './loaded';
 import { manageSeenEvents } from './seen';
+import { manageDismissals } from './dismissed';
 import { getPrompts } from '../utils';
 
 export const manageAnalytics = () => {
@@ -12,5 +13,6 @@ export const manageAnalytics = () => {
 
 		manageLoadedEvents( prompts );
 		manageSeenEvents( prompts );
+		manageDismissals( prompts );
 	}
 };


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds tracking for a `dismissed` event.

See 1204238302518911-as-1204668686462485

### How to test the changes in this Pull Request:

1. Ensure that you have Google Analytics and a GA4 property set up in Site Kit (otherwise the JS won't init).
2. Check out this branch.
3. Visit a post or page that will display overlay prompts. 
4. Click the 'close' button on the overlap prompt. 
5. Check the realtime tracking in your GA account and confirm that `dismissed` was tracked as an action for the `np_prompt_interaction` event.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
