### PR TITLE
feat: add tracking for click events

### DIFF
--- a/src/view/analytics/clicked.js
+++ b/src/view/analytics/clicked.js
@@ -1,0 +1,23 @@
+import { getEventPayload, getRawId, sendEvent } from '../utils';
+
+/**
+ * Execute a callback function to send a GA event when a prompt is dismissed.
+ *
+ * @param {Array} prompts Array of prompts loaded in the DOM.
+ */
+
+export const manageClickedEvents = prompts => {
+	prompts.forEach( prompt => {
+		const anchorLinks = [
+			...prompt.querySelectorAll( '.newspack-inline-popup a, .newspack-popup__content a' ),
+		];
+		const handleEvent = () => {
+			const payload = getEventPayload( 'clicked', getRawId( prompt.getAttribute( 'id' ) ) );
+			sendEvent( payload );
+		};
+
+		anchorLinks.forEach( function ( link ) {
+			link.addEventListener( 'click', handleEvent );
+		} );
+	} );
+};

--- a/src/view/analytics/clicked.js
+++ b/src/view/analytics/clicked.js
@@ -11,8 +11,18 @@ export const manageClickedEvents = prompts => {
 		const anchorLinks = [
 			...prompt.querySelectorAll( '.newspack-inline-popup a, .newspack-popup__content a' ),
 		];
-		const handleEvent = () => {
-			const payload = getEventPayload( 'clicked', getRawId( prompt.getAttribute( 'id' ) ) );
+		const handleEvent = e => {
+			const extraParams = {};
+
+			if ( e.currentTarget?.href && '#' !== e.currentTarget?.href ) {
+				extraParams.action_value = e.currentTarget.getAttribute( 'href' );
+			}
+
+			const payload = getEventPayload(
+				'clicked',
+				getRawId( prompt.getAttribute( 'id' ) ),
+				extraParams
+			);
 			sendEvent( payload );
 		};
 

--- a/src/view/analytics/clicked.js
+++ b/src/view/analytics/clicked.js
@@ -16,8 +16,6 @@ export const manageClickedEvents = prompts => {
 			sendEvent( payload );
 		};
 
-		anchorLinks.forEach( function ( link ) {
-			link.addEventListener( 'click', handleEvent );
-		} );
+		anchorLinks.forEach( link => link.addEventListener( 'click', handleEvent ) );
 	} );
 };

--- a/src/view/analytics/dismissed.js
+++ b/src/view/analytics/dismissed.js
@@ -9,11 +9,13 @@ import { getEventPayload, getRawId, sendEvent } from '../utils';
 export const manageDismissals = prompts => {
 	prompts.forEach( prompt => {
 		const closeButton = prompt.querySelector( '.newspack-lightbox__close' );
-		const handleEvent = () => {
-			const payload = getEventPayload( 'dismissed', getRawId( prompt.getAttribute( 'id' ) ) );
-			sendEvent( payload );
-		};
+		if ( closeButton ) {
+			const handleEvent = () => {
+				const payload = getEventPayload( 'dismissed', getRawId( prompt.getAttribute( 'id' ) ) );
+				sendEvent( payload );
+			};
 
-		closeButton.addEventListener( 'click', handleEvent );
+			closeButton.addEventListener( 'click', handleEvent );
+		}
 	} );
 };

--- a/src/view/analytics/ga4.js
+++ b/src/view/analytics/ga4.js
@@ -3,6 +3,8 @@
 import { manageLoadedEvents } from './loaded';
 import { manageSeenEvents } from './seen';
 import { manageDismissals } from './dismissed';
+import { manageClickedEvents } from './clicked';
+
 import { getPrompts } from '../utils';
 
 export const manageAnalytics = () => {
@@ -14,5 +16,6 @@ export const manageAnalytics = () => {
 		manageLoadedEvents( prompts );
 		manageSeenEvents( prompts );
 		manageDismissals( prompts );
+		manageClickedEvents( prompts );
 	}
 };

--- a/src/view/utils/index.js
+++ b/src/view/utils/index.js
@@ -209,17 +209,18 @@ export const getRawId = id => {
 /**
  * Get a GA4 event payload for a given prompt.
  *
- * @param {string} action   Action name for the event.
- * @param {number} promptId ID of the prompt
+ * @param {string} action      Action name for the event.
+ * @param {number} promptId    ID of the prompt
+ * @param {Object} extraParams Additional key/value pairs to add as params to the event payload.
  *
  * @return {Object} Event payload.
  */
-export const getEventPayload = ( action, promptId ) => {
+export const getEventPayload = ( action, promptId, extraParams = {} ) => {
 	if ( ! newspackPopupsData || ! newspackPopupsData[ promptId ] ) {
 		return false;
 	}
 
-	return { ...newspackPopupsData[ promptId ], action };
+	return { ...newspackPopupsData[ promptId ], ...extraParams, action };
 };
 
 /**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds tracking for links inside of prompts.

### How to test the changes in this Pull Request:

1. Ensure that you have Google Analytics and a GA4 property set up in Site Kit (otherwise the JS won't init).
2. Check out this branch.
3. Set up a few different prompts with and without links; confirm that clicking those links is getting tracked correctly in GA. 

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
