### PR TITLE
fix: add check for close button before adding action

### DIFF
--- a/src/view/analytics/dismissed.js
+++ b/src/view/analytics/dismissed.js
@@ -9,11 +9,13 @@ import { getEventPayload, getRawId, sendEvent } from '../utils';
 export const manageDismissals = prompts => {
 	prompts.forEach( prompt => {
 		const closeButton = prompt.querySelector( '.newspack-lightbox__close' );
-		const handleEvent = () => {
-			const payload = getEventPayload( 'dismissed', getRawId( prompt.getAttribute( 'id' ) ) );
-			sendEvent( payload );
-		};
+		if ( closeButton ) {
+			const handleEvent = () => {
+				const payload = getEventPayload( 'dismissed', getRawId( prompt.getAttribute( 'id' ) ) );
+				sendEvent( payload );
+			};
 
-		closeButton.addEventListener( 'click', handleEvent );
+			closeButton.addEventListener( 'click', handleEvent );
+		}
 	} );
 };


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds a check for the close button before trying to add events to it, just in case it's not actually there 😅 

### How to test the changes in this Pull Request:

Repeat the testing steps from https://github.com/Automattic/newspack-popups/pull/1131, and make sure everything still works as expected!

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
