### PR TITLE
feat: GA4 `form_submission` events for prompts

### DIFF
--- a/includes/class-newspack-popups-data-api.php
+++ b/includes/class-newspack-popups-data-api.php
@@ -124,10 +124,10 @@ final class Newspack_Popups_Data_Api {
 						// The tiers block layout doesn't allow for one-time donations.
 						if ( $is_layout_tiers ) {
 							// So we can differentiate between standard and tiers layouts.
-							$suggested_summary['layout'] = __( 'tiers', 'newspack-popup' );
-							$disabled_tiers['once']      = true;
+							$suggested_summary['l'] = __( 'tiers', 'newspack-popup' );
+							$disabled_tiers['once'] = true;
 						} else {
-							$suggested_summary['layout'] = __( 'standard', 'newspack-popup' );
+							$suggested_summary['l'] = __( 'default', 'newspack-popup' );
 						}
 
 						foreach ( $suggested_amounts as $frequency => $amounts ) {
@@ -139,7 +139,7 @@ final class Newspack_Popups_Data_Api {
 									// If standard layout + untiered, only show the suggested amount for "other".
 									$amounts = [ end( $amounts ) ];
 								}
-								$suggested_summary[ $frequency ] = $amounts;
+								$suggested_summary[ substr( $frequency, 0, 1 ) ] = $amounts;
 							}
 						}
 

--- a/includes/class-newspack-popups-data-api.php
+++ b/includes/class-newspack-popups-data-api.php
@@ -124,10 +124,10 @@ final class Newspack_Popups_Data_Api {
 						// The tiers block layout doesn't allow for one-time donations.
 						if ( $is_layout_tiers ) {
 							// So we can differentiate between standard and tiers layouts.
-							$suggested_summary[]    = __( 'tiers layout', 'newspack-popup' );
-							$disabled_tiers['once'] = true;
+							$suggested_summary['layout'] = __( 'tiers', 'newspack-popup' );
+							$disabled_tiers['once']      = true;
 						} else {
-							$suggested_summary[] = __( 'standard layout', 'newspack-popup' );
+							$suggested_summary['layout'] = __( 'standard', 'newspack-popup' );
 						}
 
 						foreach ( $suggested_amounts as $frequency => $amounts ) {
@@ -139,12 +139,12 @@ final class Newspack_Popups_Data_Api {
 									// If standard layout + untiered, only show the suggested amount for "other".
 									$amounts = [ end( $amounts ) ];
 								}
-								$suggested_summary[] = $frequency . ': ' . implode( ',', $amounts );
+								$suggested_summary[ $frequency ] = $amounts;
 							}
 						}
 
 						if ( ! empty( $suggested_summary ) ) {
-							$data['action_value'] = implode( ' | ', $suggested_summary );
+							$data['action_value'] = \wp_json_encode( $suggested_summary );
 						}
 					}
 				}

--- a/src/view/analytics/dismissed.js
+++ b/src/view/analytics/dismissed.js
@@ -9,11 +9,14 @@ import { getEventPayload, getRawId, sendEvent } from '../utils';
 export const manageDismissals = prompts => {
 	prompts.forEach( prompt => {
 		const closeButton = prompt.querySelector( '.newspack-lightbox__close' );
-		const handleEvent = () => {
-			const payload = getEventPayload( 'dismissed', getRawId( prompt.getAttribute( 'id' ) ) );
-			sendEvent( payload );
-		};
 
-		closeButton.addEventListener( 'click', handleEvent );
+		if ( closeButton ) {
+			const handleEvent = () => {
+				const payload = getEventPayload( 'dismissed', getRawId( prompt.getAttribute( 'id' ) ) );
+				sendEvent( payload );
+			};
+
+			closeButton.addEventListener( 'click', handleEvent );
+		}
 	} );
 };

--- a/src/view/analytics/ga4.js
+++ b/src/view/analytics/ga4.js
@@ -3,6 +3,7 @@
 import { manageLoadedEvents } from './loaded';
 import { manageSeenEvents } from './seen';
 import { manageDismissals } from './dismissed';
+import { manageFormSubmissions } from './submitted';
 import { getPrompts } from '../utils';
 
 export const manageAnalytics = () => {
@@ -14,5 +15,6 @@ export const manageAnalytics = () => {
 		manageLoadedEvents( prompts );
 		manageSeenEvents( prompts );
 		manageDismissals( prompts );
+		manageFormSubmissions( prompts );
 	}
 };

--- a/src/view/analytics/submitted.js
+++ b/src/view/analytics/submitted.js
@@ -12,7 +12,7 @@ export const manageFormSubmissions = prompts => {
 			...prompt.querySelectorAll( '.newspack-popup__content form, .newspack-inline-popup form' ),
 		];
 		const handleEvent = () => {
-			const payload = getEventPayload( 'submitted', getRawId( prompt.getAttribute( 'id' ) ) );
+			const payload = getEventPayload( 'form_submission', getRawId( prompt.getAttribute( 'id' ) ) );
 			sendEvent( payload );
 		};
 

--- a/src/view/analytics/submitted.js
+++ b/src/view/analytics/submitted.js
@@ -8,7 +8,9 @@ import { getEventPayload, getRawId, sendEvent } from '../utils';
 
 export const manageFormSubmissions = prompts => {
 	prompts.forEach( prompt => {
-		const forms = [ ...prompt.querySelectorAll( '.newspack-popup__content form' ) ];
+		const forms = [
+			...prompt.querySelectorAll( '.newspack-popup__content form, .newspack-inline-popup form' ),
+		];
 		const handleEvent = () => {
 			const payload = getEventPayload( 'submitted', getRawId( prompt.getAttribute( 'id' ) ) );
 			sendEvent( payload );

--- a/src/view/analytics/submitted.js
+++ b/src/view/analytics/submitted.js
@@ -1,0 +1,19 @@
+import { getEventPayload, getRawId, sendEvent } from '../utils';
+
+/**
+ * Execute a callback function to send a GA event when a prompt is dismissed.
+ *
+ * @param {Array} prompts Array of prompts loaded in the DOM.
+ */
+
+export const manageFormSubmissions = prompts => {
+	prompts.forEach( prompt => {
+		const forms = [ ...prompt.querySelectorAll( '.newspack-popup__content form' ) ];
+		const handleEvent = () => {
+			const payload = getEventPayload( 'submitted', getRawId( prompt.getAttribute( 'id' ) ) );
+			sendEvent( payload );
+		};
+
+		forms.forEach( form => form.addEventListener( 'submit', handleEvent ) );
+	} );
+};


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Implements `form_submission` GA4 events when a form inside prompt content is submitted.

Also implements an `action_value` for all donation-related events, which lists the suggested donations for that form (if manually configured in the block, from the block's attributes, if not, from the sitewide donation settings).

### How to test the changes in this Pull Request:

#### `form_submission` events

1. On a site connected to a GA4 property via Site Kit, publish prompts containing registration, newsletter signup, and donation forms.
2. On the front-end, submit each form. Confirm in your GA dashboard > Reports > Realtime that a `form_submission` event with relevant event params gets fired upon form submission for each form.

#### `clicked` event `action_value`

1. Publish a prompt containing an link pointing to a URL anywhere in the content.
2. View the prompt on the front-end and click on the prompt.
3. In your GA dashboard, confirm that the corresponding `clicked` event has an `action_value` param with the link's URL. Note that we won't pass `#` values if the link triggers HTML, but we will pass `#id` values if it links to another element on the same page.

#### Suggested donation `action_value`

1. Publish several prompts containing Donation blocks. Make sure you have at least the following variations (in all cases make sure the suggested donation values for manually configured blocks differ from default Donation settings in Reader Revenue):
  - Not manually configured, standard layout
  - Manually configured, standard layout, tiered
  - Manually configured, standard layout, not tiered
  - Manually configured with at least one disabled frequency (different from the default Donation settings in Reader Revenue, if any are disabled there)
  - Not manually configured, tiers layout
  - Manually configured, tiers layout
4. View the prompts on the front-end. In your GA dashboard, confirm that any event fired by a prompt containing a donation block has an `action_value` param with a value showing the donate block layout plus the suggested donations for every enabled tier, like so:
  - `standard layout | once: 9,20,90,20 | month: 7,15,30,15 | year: 84,180,360,180`
  - `tiers layout | month: 20,40,60 | year: 84,180,360`
5. Confirm that each `action_value` matches the suggested donation amounts displayed in each block variation. You can also more easily debug this by changing the `gtag` to `console.log` at [this line](https://github.com/Automattic/newspack-popups/blob/epic/ga4/src/view/utils/index.js#L233).

Notes on the format of the summary:
  - If a block is set to "manually configured", the values come from block attributes. If not, they come from Reader Revenue > Donation settings.
  - Disabled frequencies won't be shown.
  - If standard layout + not tiered, the Donate block only shows the "other" input field, so each frequency should show only a single suggested value.
  - If tiered layout, the Donate block doesn't allow for one-time frequency or "other" inputs, so these should be omitted from the summary.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
