### PR TITLE
fix: ensure inline posts are inserted into main post content only

### DIFF
--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -461,6 +461,8 @@ final class Newspack_Popups_Inserter {
 			// Don't inject inline popups on paywalled posts.
 			// It doesn't make sense with a paywall message and also causes an infinite loop.
 			|| self::is_memberships_restricted()
+			// At filter priority 1, $content should be the same as the unfiltered post_content. This guards against inserting in other content such as featured image captions/descriptions.
+			|| get_post()->post_content !== $content
 		) {
 			return $content;
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

There's a weakness in the [`the_content`](https://developer.wordpress.org/reference/hooks/the_content/) filter hook in that it doesn't tell you what post object the filtered content is coming from. For this reason, the callback to insert inline prompts in article content sometimes gets called on the wrong content, as was discovered in https://github.com/Automattic/newspack-theme/pull/2127.

This PR attempts to mitigate that situation by comparing the `post_content` property on the post in the global `$wp_query` and comparing it to the `$content` string being filtered, before executing the prompt insertion logic. Since this filter callback is being called with priority `1`, before most or all other content filters would be run to transform this content string, the strings should match. I haven't done an exhaustive test of this, though.

### How to test the changes in this Pull Request:

There shouldn't be any major changes in functionality. Inline prompts should be inserted in article post content only.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
