### PR TITLE
fix: remove dismissed event after form is submitted

### DIFF
--- a/src/view/analytics/dismissed.js
+++ b/src/view/analytics/dismissed.js
@@ -9,6 +9,7 @@ import { getEventPayload, getRawId, sendEvent } from '../utils';
 export const manageDismissals = prompts => {
 	prompts.forEach( prompt => {
 		const closeButton = prompt.querySelector( '.newspack-lightbox__close' );
+		const forms = [ ...prompt.querySelectorAll( '.newspack-popup__content form' ) ];
 		if ( closeButton ) {
 			const handleEvent = () => {
 				const payload = getEventPayload( 'dismissed', getRawId( prompt.getAttribute( 'id' ) ) );
@@ -16,6 +17,13 @@ export const manageDismissals = prompts => {
 			};
 
 			closeButton.addEventListener( 'click', handleEvent );
+
+			// If a form inside an overlay prompt is submitted, closing it should not result in a `dismissed` action.
+			forms.forEach( form => {
+				form.addEventListener( 'submit', () =>
+					closeButton.removeEventListener( 'click', handleEvent )
+				);
+			} );
 		}
 	} );
 };


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

The `dismissed` GA event for overlay prompts should describe when a reader closes the prompt without interacting with its content. If the reader submits a form within the prompt (whether or not that submission results in a successful registration or login) that indicates a conversion intent and closing the prompt after that should not result in a `dismissed` event.

### How to test the changes in this Pull Request:

1. Check out this branch and open your GA real time events report.
2. In an overlay prompt, register/sign up for a newsletter and submit the form.
3. Close the overlay.
4. Confirm that after submitting the form, you do NOT see a `dismissed` event for this prompt

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
