### PR TITLE
feat: rearrange info on popup events metadata

### DIFF
--- a/includes/class-newspack-popups-data-api.php
+++ b/includes/class-newspack-popups-data-api.php
@@ -93,7 +93,8 @@ final class Newspack_Popups_Data_Api {
 			'newsletters_subscription' => 'newspack-newsletters/subscribe',
 		];
 
-		$data['prompt_blocks'] = [];
+		$data['prompt_blocks']    = [];
+		$data['interaction_data'] = [];
 
 		foreach ( $watched_blocks as $key => $block_name ) {
 			if ( \has_block( $block_name, $popup['content'] ) ) {
@@ -144,14 +145,12 @@ final class Newspack_Popups_Data_Api {
 						}
 
 						if ( ! empty( $suggested_summary ) ) {
-							$data['action_value'] = \wp_json_encode( $suggested_summary );
+							$data['interaction_data']['donation_suggested_values'] = \wp_json_encode( $suggested_summary );
 						}
 					}
 				}
 			}
 		}
-
-		$data['interaction_data'] = [];
 
 		return $data;
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Places the donation_suggested_values into the interaction_data key of the data events for popups.

### How to test the changes in this Pull Request:

1. Set up a site with back-end ga4 tracking
2. Make sure newspack plugin is running this branch -> https://github.com/Automattic/newspack-plugin/pull/2506
3. Make a donation via a popup
4. Make sure the `donation_suggested_values` parameters are sent alongside all the other `donation_*` params that are sent when a donation is submitted


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
