### PR TITLE
Fix the use of wp_terms() without checking it's an array

### DIFF
--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -1163,8 +1163,20 @@ final class Newspack_Popups {
 
 	/**
 	 * Retrieve campaigns.
+	 *
+	 * @return array An array of WP_Term objects.
 	 */
 	public static function get_groups() {
+		$terms = get_terms(
+			self::NEWSPACK_POPUPS_TAXONOMY,
+			[
+				'hide_empty' => false,
+			]
+		);
+		if ( ! is_array( $terms ) || empty( $terms ) ) {
+			return [];
+		}
+
 		$groups = array_map(
 			function( $group ) {
 				$group->status = get_term_meta(
@@ -1174,12 +1186,7 @@ final class Newspack_Popups {
 				);
 				return $group;
 			},
-			get_terms(
-				self::NEWSPACK_POPUPS_TAXONOMY,
-				[
-					'hide_empty' => false,
-				]
-			)
+			$terms
 		);
 		return $groups;
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Ensures that the return value of `get_terms()` is a usable array before passing it to `array_map()`.

Closes #1145 .

### How to test the changes in this Pull Request:

1. Activate Newspack Campaigns on a fresh install
2. Go to Newspack > Campaigns
3. Observe there is an error as described in #1145
4. Apply the PR
5. Refresh the Campaigns screen
6. Observe the error is gone

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
