### PR TITLE
proof of concept: segmentation criteria system

### DIFF
--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -78,6 +78,7 @@ final class Newspack_Popups {
 			add_action( 'init', [ __CLASS__, 'register_meta' ] );
 			add_action( 'init', [ __CLASS__, 'register_taxonomy' ] );
 			add_action( 'init', [ __CLASS__, 'disable_prompts_for_protected_pages' ] );
+			add_action( 'wp_enqueue_scripts', [ __CLASS__, 'enqueue_assets' ] );
 			add_action( 'enqueue_block_editor_assets', [ __CLASS__, 'enqueue_block_editor_assets' ] );
 			add_action( 'customize_controls_enqueue_scripts', [ __CLASS__, 'enqueue_customizer_assets' ] );
 			add_filter( 'display_post_states', [ __CLASS__, 'display_post_states' ], 10, 2 );
@@ -577,6 +578,19 @@ final class Newspack_Popups {
 		);
 		$recent_posts = $query->get_posts();
 		return $recent_posts && count( $recent_posts ) > 0 ? get_the_permalink( $recent_posts[0] ) : '';
+	}
+
+	/**
+	 * Enqueue front-end assets.
+	 */
+	public static function enqueue_assets() {
+		\wp_enqueue_script(
+			'newspack-popups-criteria',
+			plugins_url( '../dist/criteria.js', __FILE__ ),
+			[],
+			filemtime( dirname( NEWSPACK_POPUPS_PLUGIN_FILE ) . '/dist/criteria.js' ),
+			true
+		);
 	}
 
 	/**

--- a/src/criteria.js
+++ b/src/criteria.js
@@ -99,9 +99,9 @@ function registerCriteria( config ) {
 	if ( typeof criteria.matchingFunction !== 'function' ) {
 		throw new Error( 'Criteria must have a matching function.' );
 	}
-	// Set the value of the criteria.
-	criteria.setValue = ras => {
-		// Bail if value has already been set.
+	// Fetch the value for the criteria.
+	criteria.fetchValue = ras => {
+		// Bail if value has already been fetched.
 		if ( criteria.hasOwnProperty( 'value' ) ) {
 			return;
 		}
@@ -113,7 +113,7 @@ function registerCriteria( config ) {
 	};
 	// Check if the criteria matches the segment config.
 	criteria.matches = ( ras, segmentConfig ) => {
-		criteria.setValue( ras );
+		criteria.fetchValue( ras );
 		return criteria.matchingFunction( segmentConfig, ras.store );
 	};
 	registeredCriteria[ criteria.id ] = criteria;

--- a/src/criteria.js
+++ b/src/criteria.js
@@ -256,7 +256,7 @@ window.newspackRAS.push( ras => {
 	 */
 	for ( const criteriaId in sampleSegment.criteria ) {
 		const criteria = registeredCriteria[ criteriaId ];
-		// Bail if criteria is not registered or has no value
+		// Bail if criteria is not registered.
 		if ( ! criteria ) {
 			continue;
 		}

--- a/src/criteria.js
+++ b/src/criteria.js
@@ -182,12 +182,7 @@ const referrer_sources = {
 			: '';
 		// Persist the referrer in the store.
 		if ( value ) {
-			store.set(
-				'referrer',
-				document.referrer
-					? ( new URL( document?.referrer ).hostname.replace( 'www.', '' ) || '' ).toLowerCase()
-					: ''
-			);
+			store.set( 'referrer', value );
 		}
 		return store.get( 'referrer' );
 	},

--- a/src/criteria.js
+++ b/src/criteria.js
@@ -109,11 +109,10 @@ const newsletter = {
 		},
 	],
 	matchingFunction: ( store, config ) => {
-		const isSubscriber = store.get( 'is_subscriber' );
-		if ( ! isSubscriber ) {
-			return config.value === 2;
+		if ( store.get( 'is_subscriber' ) ) {
+			return config.value === 1;
 		}
-		return config.value === 1;
+		return config.value === 2;
 	},
 };
 registerCriteria( newsletter );
@@ -133,7 +132,7 @@ const referrer_sources = {
 registerCriteria( referrer_sources );
 
 /**
- * Sample segment configuration to test agains the registered criteria.
+ * Sample segment configuration to test against the registered criteria.
  */
 const sampleSegment = {
 	criteria: {

--- a/src/criteria.js
+++ b/src/criteria.js
@@ -104,6 +104,9 @@ function registerCriteria( config ) {
  */
 const articles_read = {
 	id: 'articles_read',
+	name: 'Articles read',
+	help: 'Number of articles read in the last 30 day period.',
+	category: 'reader_engagement',
 	matchingFunction: 'range',
 	matchingAttribute: ras => {
 		const views = ras.getActivities( 'article_view' );
@@ -114,6 +117,9 @@ registerCriteria( articles_read );
 
 const articles_read_in_session = {
 	id: 'articles_read_in_session',
+	name: 'Articles read in session',
+	help: 'Number of articles read in the current session (45 minutes).',
+	category: 'reader_engagement',
 	matchingFunction: 'range',
 	matchingAttribute: ras => {
 		const views = ras.getActivities( 'article_view' );
@@ -129,6 +135,22 @@ registerCriteria( articles_read_in_session );
  */
 const newsletter = {
 	id: 'newsletter',
+	name: 'Newsletter',
+	category: 'reader_activity',
+	options: [
+		{
+			label: 'Subscribers and non-subscribers',
+			value: 0,
+		},
+		{
+			label: 'Subscribers',
+			value: 1,
+		},
+		{
+			label: 'Non-Subscribers',
+			value: 2,
+		},
+	],
 	matchingFunction: ( config, store ) => {
 		if ( store.get( 'is_subscriber' ) ) {
 			return config.value === 1;
@@ -143,6 +165,10 @@ registerCriteria( newsletter );
  */
 const referrer_sources = {
 	id: 'referrer_sources',
+	name: 'Sources to match',
+	help: 'Segment based on traffic source',
+	description: 'A comma-separated list of domains.',
+	category: 'referrer_sources',
 	matchingFunction: 'list',
 	matchingAttribute: ( { store } ) => {
 		const value = document.referrer
@@ -166,6 +192,9 @@ registerCriteria( referrer_sources );
  */
 const favorite_categories = {
 	id: 'favorite_categories',
+	name: 'Favorite categories',
+	help: 'Most-read categories of the reader',
+	category: 'reader_engagement',
 	matchingFunction: 'list',
 	matchingAttribute: 'favorite_categories',
 };
@@ -174,7 +203,50 @@ registerCriteria( favorite_categories );
 /**
  * Sample segments to match.
  */
-const segments = [];
+const segments = [
+	{
+		id: 'segment-1',
+		name: 'Segment 1',
+		description: 'Segment 1 description',
+		criteria: {
+			articles_read: {
+				min: 1,
+				max: 10,
+			},
+		},
+	},
+	{
+		id: 'segment-2',
+		name: 'Segment 2',
+		description: 'Segment 2 description',
+		criteria: {
+			articles_read_in_session: {
+				min: 1,
+				max: 10,
+			},
+		},
+	},
+	{
+		id: 'segment-3',
+		name: 'Segment 3',
+		description: 'Segment 3 description',
+		criteria: {
+			newsletter: {
+				value: 1,
+			},
+		},
+	},
+	{
+		id: 'segment-4',
+		name: 'Segment 4',
+		description: 'Segment 4 description',
+		criteria: {
+			referrer_sources: {
+				value: 'google.com,facebook.com',
+			},
+		},
+	},
+];
 
 window.newspackRAS = window.newspackRAS || [];
 window.newspackRAS.push( ras => {
@@ -193,7 +265,7 @@ window.newspackRAS.push( ras => {
 	}
 
 	/**
-	 * Whether the reader matches the segment criteria.
+	 * Whether the segment matches the criteria.
 	 */
 	function matchSegment( segment ) {
 		for ( const criteriaId in segment.criteria ) {

--- a/src/criteria.js
+++ b/src/criteria.js
@@ -201,26 +201,52 @@ const favorite_categories = {
 registerCriteria( favorite_categories );
 
 /**
- * Sample segment configuration to test against the registered criteria.
+ * Sample segments to match.
  */
-const sampleSegment = {
-	criteria: {
-		articles_read: {
-			min: 1,
-			max: 10,
-		},
-		articles_read_in_session: {
-			min: 1,
-			max: 10,
-		},
-		newsletter: {
-			value: 1,
-		},
-		referrer_sources: {
-			value: 'google.com,facebook.com',
+const segments = [
+	{
+		id: 'segment-1',
+		name: 'Segment 1',
+		description: 'Segment 1 description',
+		criteria: {
+			articles_read: {
+				min: 1,
+				max: 10,
+			},
 		},
 	},
-};
+	{
+		id: 'segment-2',
+		name: 'Segment 2',
+		description: 'Segment 2 description',
+		criteria: {
+			articles_read_in_session: {
+				min: 1,
+				max: 10,
+			},
+		},
+	},
+	{
+		id: 'segment-3',
+		name: 'Segment 3',
+		description: 'Segment 3 description',
+		criteria: {
+			newsletter: {
+				value: 1,
+			},
+		},
+	},
+	{
+		id: 'segment-4',
+		name: 'Segment 4',
+		description: 'Segment 4 description',
+		criteria: {
+			referrer_sources: {
+				value: 'google.com,facebook.com',
+			},
+		},
+	},
+];
 
 window.newspackRAS = window.newspackRAS || [];
 window.newspackRAS.push( ras => {
@@ -239,20 +265,26 @@ window.newspackRAS.push( ras => {
 	}
 
 	/**
+	 * Whether the segment matches the criteria.
+	 */
+	function matchSegment( segment ) {
+		for ( const criteriaId in segment.criteria ) {
+			const criteria = registeredCriteria[ criteriaId ];
+			if ( ! criteria ) {
+				continue;
+			}
+			const config = segment.criteria[ criteriaId ];
+			if ( ! criteria.matchingFunction( config, store ) ) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	/**
 	 * Execute matching logic for each criteria in the sample segment.
 	 */
-	for ( const criteriaId in sampleSegment.criteria ) {
-		const criteria = registeredCriteria[ criteriaId ];
-		// Bail if criteria is not registered.
-		if ( ! criteria ) {
-			continue;
-		}
-		const config = sampleSegment.criteria[ criteriaId ];
-		// Bail if there's no value to match against.
-		if ( ! config.value && ! config.min && ! config.max ) {
-			continue;
-		}
-		const matched = criteria.matchingFunction( config, store );
-		console.log( { criteriaId, matched } ); // eslint-disable-line no-console
+	for ( const segment of segments ) {
+		console.log( { segmentId: segment.id, matched: matchSegment( segment ) } ); // eslint-disable-line no-console
 	}
 } );

--- a/src/criteria.js
+++ b/src/criteria.js
@@ -104,9 +104,6 @@ function registerCriteria( config ) {
  */
 const articles_read = {
 	id: 'articles_read',
-	name: 'Articles read',
-	help: 'Number of articles read in the last 30 day period.',
-	category: 'reader_engagement',
 	matchingFunction: 'range',
 	matchingAttribute: ras => {
 		const views = ras.getActivities( 'article_view' );
@@ -117,9 +114,6 @@ registerCriteria( articles_read );
 
 const articles_read_in_session = {
 	id: 'articles_read_in_session',
-	name: 'Articles read in session',
-	help: 'Number of articles read in the current session (45 minutes).',
-	category: 'reader_engagement',
 	matchingFunction: 'range',
 	matchingAttribute: ras => {
 		const views = ras.getActivities( 'article_view' );
@@ -135,22 +129,6 @@ registerCriteria( articles_read_in_session );
  */
 const newsletter = {
 	id: 'newsletter',
-	name: 'Newsletter',
-	category: 'reader_activity',
-	options: [
-		{
-			label: 'Subscribers and non-subscribers',
-			value: 0,
-		},
-		{
-			label: 'Subscribers',
-			value: 1,
-		},
-		{
-			label: 'Non-Subscribers',
-			value: 2,
-		},
-	],
 	matchingFunction: ( config, store ) => {
 		if ( store.get( 'is_subscriber' ) ) {
 			return config.value === 1;
@@ -165,10 +143,6 @@ registerCriteria( newsletter );
  */
 const referrer_sources = {
 	id: 'referrer_sources',
-	name: 'Sources to match',
-	help: 'Segment based on traffic source',
-	description: 'A comma-separated list of domains.',
-	category: 'referrer_sources',
 	matchingFunction: 'list',
 	matchingAttribute: ( { store } ) => {
 		const value = document.referrer
@@ -192,9 +166,6 @@ registerCriteria( referrer_sources );
  */
 const favorite_categories = {
 	id: 'favorite_categories',
-	name: 'Favorite categories',
-	help: 'Most-read categories of the reader',
-	category: 'reader_engagement',
 	matchingFunction: 'list',
 	matchingAttribute: 'favorite_categories',
 };
@@ -203,50 +174,7 @@ registerCriteria( favorite_categories );
 /**
  * Sample segments to match.
  */
-const segments = [
-	{
-		id: 'segment-1',
-		name: 'Segment 1',
-		description: 'Segment 1 description',
-		criteria: {
-			articles_read: {
-				min: 1,
-				max: 10,
-			},
-		},
-	},
-	{
-		id: 'segment-2',
-		name: 'Segment 2',
-		description: 'Segment 2 description',
-		criteria: {
-			articles_read_in_session: {
-				min: 1,
-				max: 10,
-			},
-		},
-	},
-	{
-		id: 'segment-3',
-		name: 'Segment 3',
-		description: 'Segment 3 description',
-		criteria: {
-			newsletter: {
-				value: 1,
-			},
-		},
-	},
-	{
-		id: 'segment-4',
-		name: 'Segment 4',
-		description: 'Segment 4 description',
-		criteria: {
-			referrer_sources: {
-				value: 'google.com,facebook.com',
-			},
-		},
-	},
-];
+const segments = [];
 
 window.newspackRAS = window.newspackRAS || [];
 window.newspackRAS.push( ras => {
@@ -265,7 +193,7 @@ window.newspackRAS.push( ras => {
 	}
 
 	/**
-	 * Whether the segment matches the criteria.
+	 * Whether the reader matches the segment criteria.
 	 */
 	function matchSegment( segment ) {
 		for ( const criteriaId in segment.criteria ) {

--- a/src/criteria.js
+++ b/src/criteria.js
@@ -1,0 +1,177 @@
+/**
+ * This file is a proof-of-concept of how the criteria registration and matching
+ * system could work.
+ */
+
+/**
+ * This is the object that will hold all the registered criteria.
+ *
+ * @type {Object}
+ */
+const registeredCriteria = {};
+
+/**
+ * Common matching functions that can be used by criteria.
+ */
+const matchingFunctions = {
+	range: ( criteria, store, config ) => {
+		const value = store.get( criteria.matchingAttribute );
+		const { min, max } = config;
+		if ( ! value || ( min && value < min ) || ( max && value > max ) ) {
+			return false;
+		}
+		return true;
+	},
+	dropdown: ( criteria, store, config ) => {
+		const value = store.get( criteria.matchingAttribute );
+		if ( ! value || value !== config.value ) {
+			return false;
+		}
+		return true;
+	},
+	list: ( criteria, store, config ) => {
+		const list = config.value.split( ',' ).map( item => item.trim() );
+		const value = store.get( criteria.matchingAttribute );
+		if ( ! value || ! list.includes( value ) ) {
+			return false;
+		}
+		return true;
+	},
+};
+
+/**
+ * Registers a criteria.
+ *
+ * @param {Object}   config                   The criteria configuration.
+ * @param {string}   config.id                ID.
+ * @param {string}   config.name              Name.
+ * @param {string}   config.help              Help text.
+ * @param {string}   config.description       Description.
+ * @param {string}   config.category          Category.
+ * @param {string}   config.type              Type. One of 'range', 'dropdown' or 'list'.
+ * @param {string}   config.matchingAttribute The attribute to match against from the reader data library store.
+ * @param {Function} config.matchingFunction  A custom function to use for matching.
+ * @param {Array}    config.options           The options for criteria of type 'dropdown'.
+ * @param {number}   config.options[].value   Option value.
+ * @param {string}   config.options[].label   Option label.
+ */
+function registerCriteria( config ) {
+	if ( ! config.matchingFunction && matchingFunctions[ config.type ] && config.matchingAttribute ) {
+		config.matchingFunction = matchingFunctions[ config.type ].bind( null, config );
+	}
+	registeredCriteria[ config.id ] = config;
+}
+
+/**
+ * Registering a criteria that will use the default matching function based on
+ * type and matchingAttribute.
+ */
+const articles_read = {
+	id: 'articles_read',
+	name: 'Articles read',
+	help: 'Number of articles read in the last 30 day period.',
+	category: 'reader_engagement',
+	type: 'range',
+	matchingAttribute: 'articles_read_30_days',
+};
+registerCriteria( articles_read );
+
+const articles_read_in_session = {
+	id: 'articles_read_in_session',
+	name: 'Articles read in session',
+	help: 'Number of articles read in the current session (45 minutes).',
+	category: 'reader_engagement',
+	type: 'range',
+	matchingAttribute: 'articles_read_in_session',
+};
+registerCriteria( articles_read_in_session );
+
+/**
+ * Registering a criteria that will use dropdown and a custom matching function.
+ */
+const newsletter = {
+	id: 'newsletter',
+	name: 'Newsletter',
+	category: 'reader_activity',
+	type: 'dropdown',
+	options: [
+		{
+			label: 'Subscribers and non-subscribers',
+			value: 0,
+		},
+		{
+			label: 'Subscribers',
+			value: 1,
+		},
+		{
+			label: 'Non-Subscribers',
+			value: 2,
+		},
+	],
+	matchingFunction: ( store, config ) => {
+		const isSubscriber = store.get( 'is_subscriber' );
+		if ( ! isSubscriber ) {
+			return config.value === 2;
+		}
+		return config.value === 1;
+	},
+};
+registerCriteria( newsletter );
+
+/**
+ * Registering a criteria that will use the comma-separated list matching function.
+ */
+const referrer_sources = {
+	id: 'referrer_sources',
+	name: 'Sources to match',
+	help: 'Segment based on traffic source',
+	description: 'A comma-separated list of domains.',
+	category: 'referrer_sources',
+	type: 'list',
+	matchingAttribute: 'referrer',
+};
+registerCriteria( referrer_sources );
+
+/**
+ * Sample segment configuration to test agains the registered criteria.
+ */
+const sampleSegment = {
+	criteria: {
+		articles_read: {
+			min: 1,
+			max: 10,
+		},
+		articles_read_in_session: {
+			min: 1,
+			max: 10,
+		},
+		newsletter: {
+			value: 1,
+		},
+		referrer_sources: {
+			value: 'google.com,facebook.com',
+		},
+	},
+};
+
+/**
+ * Run the sample segment against the registered criteria.
+ */
+window.newspackRAS = window.newspackRAS || [];
+window.newspackRAS.push( ras => {
+	const { store } = ras;
+	for ( const criteriaId in sampleSegment.criteria ) {
+		const criteria = registeredCriteria[ criteriaId ];
+		// Bail if criteria is not registered.
+		if ( ! criteria ) {
+			continue;
+		}
+		const config = sampleSegment.criteria[ criteriaId ];
+		// Bail if there's no value to match against.
+		if ( ! config.value && ! config.min && ! config.max ) {
+			continue;
+		}
+		const matched = criteria.matchingFunction( store, config );
+		console.log( { criteriaId, matched } ); // eslint-disable-line no-console
+	}
+} );

--- a/src/criteria.js
+++ b/src/criteria.js
@@ -45,7 +45,11 @@ const matchingFunctions = {
 	 */
 	range: ( criteria, config ) => {
 		const { min, max } = config;
-		if ( ! criteria.value || ( min && criteria.value < min ) || ( max && criteria.value > max ) ) {
+		if (
+			! criteria.value ||
+			( min && criteria.value <= min ) ||
+			( max && criteria.value >= max )
+		) {
 			return false;
 		}
 		return true;

--- a/src/criteria.js
+++ b/src/criteria.js
@@ -265,7 +265,7 @@ window.newspackRAS.push( ras => {
 	}
 
 	/**
-	 * Whether the segment matches the criteria.
+	 * Whether the reader matches the segment criteria.
 	 */
 	function matchSegment( segment ) {
 		for ( const criteriaId in segment.criteria ) {

--- a/src/criteria.js
+++ b/src/criteria.js
@@ -282,7 +282,7 @@ window.newspackRAS.push( ras => {
 	}
 
 	/**
-	 * Execute matching logic for each criteria in the sample segment.
+	 * Match each segment.
 	 */
 	for ( const segment of segments ) {
 		console.log( { segmentId: segment.id, matched: matchSegment( segment ) } ); // eslint-disable-line no-console

--- a/src/criteria.js
+++ b/src/criteria.js
@@ -63,9 +63,9 @@ const matchingFunctions = {
  * @param {string}          config.help              Help text.
  * @param {string}          config.description       Description.
  * @param {string}          config.category          Category. Defaults to 'reader_activity'.
- * @param {string|Function} config.matchingAttribute Either the attribute name to match or a function that return the attribute name.
+ * @param {string|Function} config.matchingAttribute Either the attribute name to match or a function that return the attribute name. Defaults to ID.
  * @param {string|Function} config.matchingFunction  Function to use for matching. Defaults to 'default'.
- * @param {Array}           config.options           The options for criteria of type 'dropdown'.
+ * @param {Array}           config.options           The options for criteria that will be rendered in the segment UI.
  * @param {number}          config.options[].value   Option value.
  * @param {string}          config.options[].label   Option label.
  */

--- a/src/criteria.js
+++ b/src/criteria.js
@@ -57,12 +57,13 @@ const matchingFunctions = {
  *
  * @param {Object}          config                   The criteria configuration.
  * @param {string}          config.id                ID. (required)
- * @param {string}          config.name              Name. Defaults to ID.
+ * @param {string}          config.name              Name. Defaults to the ID.
  * @param {string}          config.help              Help text.
  * @param {string}          config.description       Description.
  * @param {string}          config.category          Category. Defaults to 'reader_activity'.
- * @param {string|Function} config.matchingAttribute Either the attribute name to match or a function that return the attribute name. Defaults to ID.
  * @param {string|Function} config.matchingFunction  Function to use for matching. Defaults to 'default'.
+ * @param {string|Function} config.matchingAttribute Either the attribute name to match from the reader data library
+ *                                                   store or a function that returns the value. Defaults to the ID.
  * @param {Array}           config.options           The options for criteria that will be rendered in the segment UI.
  * @param {number}          config.options[].value   Option value.
  * @param {string}          config.options[].label   Option label.

--- a/src/criteria.js
+++ b/src/criteria.js
@@ -15,16 +15,16 @@ const registeredCriteria = {};
  */
 const matchingFunctions = {
 	/**
-	 * The 'default' matching function will match the exact value of the attribute
-	 * from the given segment config.
+	 * The 'default' matching function will match the exact value from the
+	 * criteria with the given segment config.
 	 */
 	default: ( criteria, config ) => criteria.value === config.value,
 	/**
-	 * The 'list' matching function will match the value of the attribute against
-	 * a list of values from the given segment config.
+	 * The 'list' matching function will match the criteria value against a list
+	 * provided by the segment config.
 	 *
 	 * The list can be a string of comma-separated values or an array and returns
-	 * true if the value is in the list.
+	 * true if the value exists in the list.
 	 */
 	list: ( criteria, config ) => {
 		let list = config.value;
@@ -40,8 +40,8 @@ const matchingFunctions = {
 		return true;
 	},
 	/**
-	 * The 'range' matching function will match the value of the attribute against
-	 * a range of values from the given segment config.
+	 * The 'range' matching function will match the criteria value against a range
+	 * between 'min' and 'max' provided by the segment config.
 	 */
 	range: ( criteria, config ) => {
 		const { min, max } = config;
@@ -96,12 +96,7 @@ function registerCriteria( config ) {
 }
 
 /**
- * Registering 'Articles Read' criteria.
- *
- * The initialization function for this criteria will set the matching attribute
- * based on the number of article views in the set time period. The views are
- * set as reader activity through ras.dispatchActivity(), which also belong in
- * the reader data library store.
+ * Registers the 'Articles Read' criteria.
  */
 const articles_read = {
 	id: 'articles_read',
@@ -130,13 +125,9 @@ const articles_read_in_session = {
 registerCriteria( articles_read_in_session );
 
 /**
- * Registering a criteria that will use a custom matching function and 'options'
- * to render in the segment UI.
+ * Registers the 'Newsletter' criteria.
  *
- * This criteria may not need an initialization function and have its matching
- * attribute set by another logic, likely through the backend.
- *
- * Check the \Newspack\Reader_Data class from newspack-plugin for more details.
+ * This criteria's matching attribute will likely be set by another logic.
  */
 const newsletter = {
 	id: 'newsletter',
@@ -166,9 +157,7 @@ const newsletter = {
 registerCriteria( newsletter );
 
 /**
- * Registering the 'Sources to match' criteria.
- *
- * This criteria will use the comma-separated list matching function.
+ * Registers the 'Sources to match' criteria.
  */
 const referrer_sources = {
 	id: 'referrer_sources',
@@ -191,13 +180,11 @@ const referrer_sources = {
 registerCriteria( referrer_sources );
 
 /**
- * Registering 'Favorite Categories' criteria.
+ * Registers the 'Favorite Categories' criteria.
  *
- * This criteria will use the 'list' type and matching function, but the UI
- * should be tweaked in the editor UI to render a category selector.
- *
- * This selector UI shouldn't be here due to the number of components it needs,
- * which cannot be in the frontend.
+ * The UI should be tweaked in the editor UI to render a category selector and
+ * can be achieved by using @wordpress/hooks/applyFilters while iterating
+ * through the criteria to render.
  */
 const favorite_categories = {
 	id: 'favorite_categories',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,6 +2,7 @@
  **** WARNING: No ES6 modules here. Not transpiled! ****
  */
 /* eslint-disable import/no-nodejs-modules */
+/* eslint-disable @typescript-eslint/no-var-requires */
 
 /**
  * External dependencies
@@ -19,6 +20,7 @@ const documentSettings = path.join( __dirname, 'src', 'document-settings' );
 const settings = path.join( __dirname, 'src', 'settings' );
 const blocks = path.join( __dirname, 'src', 'blocks' );
 const customizer = path.join( __dirname, 'src', 'customizer' );
+const criteria = path.join( __dirname, 'src', 'criteria' );
 
 const webpackConfig = getBaseWebpackConfig(
 	{ WP: true },
@@ -31,6 +33,7 @@ const webpackConfig = getBaseWebpackConfig(
 			settings,
 			blocks,
 			customizer,
+			criteria,
 		},
 		'output-path': path.join( __dirname, 'dist' ),
 	}


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

pemhSX-jU-p2

This is a proof of concept of how the segmentation criteria can be abstracted into a system that allows criteria registration and the use of custom or common matching functions. The common matching function will work according to its criteria type and matching attribute in the reader data library store.

The script is currently being enqueued and creates a sample segmentation config with the following criteria config values for matching:

```json
{
  "articles_read": {
    "min": 1,
    "max": 10
  },
  "articles_read_in_session": {
    "min": 1,
    "max": 10
  },
  "newsletter": {
    "value": 1
  },
  "referrer_sources": {
    "value": "google.com,facebook.com"
  }
}
```

It can be tested by populating the reader data library store with values expected by the config.

### How to test the changes in this Pull Request:

1. Make sure you have newspack-plugin updated with the most recent master (to include https://github.com/Automattic/newspack-plugin/pull/2451)
2. Open the site in incognito and open the browser console
3. Confirm you see the following logged:
     ```
     {criteriaId: 'articles_read', matched: false}
     {criteriaId: 'articles_read_in_session', matched: false}
     {criteriaId: 'newsletter', matched: false}
     {criteriaId: 'referrer_sources', matched: false}
     ```
4. Push a manual `article_view` activity to satisfy the `articles_read` criteria by entering the following in the console:
     ```js
     newspackRAS.push( [ 'article_view' ] );
     ```
5. Refresh and confirm the `articles_read` and  `articles_read_in_session` criteria has `matched` as `true`
6. Do the same for the other criteria:
     ```js
     newspackReaderActivation.store.set( 'is_subscriber', true );
     newspackReaderActivation.store.set( 'referrer', 'google.com' );
     ```
7. Refresh and confirm all logged entries have `matched` as `true`

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
