### PR TITLE
fix: when comparing filtered vs post content, compare only 1st paragraph

### DIFF
--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -452,6 +452,8 @@ final class Newspack_Popups_Inserter {
 	 * @param string $content The content of the post.
 	 */
 	public static function insert_popups_in_content( $content = '' ) {
+		$filtered_content = explode( "\n", $content );
+		$post_content     = explode( "\n", get_post()->post_content );
 		if (
 			// Avoid duplicate execution.
 			true === self::$the_content_has_rendered
@@ -467,7 +469,7 @@ final class Newspack_Popups_Inserter {
 			// It doesn't make sense with a paywall message and also causes an infinite loop.
 			|| self::is_memberships_restricted()
 			// At filter priority 1, $content should be the same as the unfiltered post_content. This guards against inserting in other content such as featured image captions/descriptions.
-			|| get_post()->post_content !== $content
+			|| ( ! empty( $filtered_content ) && ! empty( $post_content ) && $filtered_content[0] !== $post_content[0] )
 		) {
 			return $content;
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Walks back a change made in #1137 that only inserts inline prompts in post content if the post content being filtered by the `the_content` filter matches the content of the main query object post. #1137 introduced a weakness in that content filters that run on priority `1` may run before our comparison, which could cause the content to not match exactly. This change updates the comparison so that we only consider the first paragraph of the content, instead of the entire content string. It's still possible that another filter could mutate the first paragraph before this comparison runs, but much less likely.

### How to test the changes in this Pull Request:

You could try adding a filter callback on `the_content` that runs at priority 1, and adding some random text to the middle or end of the output. Inline prompts should still be inserted into the main post content.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
