### PR TITLE
fix: move the close button when Hide Padding is enabled

### DIFF
--- a/src/view/style.scss
+++ b/src/view/style.scss
@@ -129,12 +129,10 @@ $width__tablet: 782px;
 			margin: 32px;
 		}
 
-		&.newspack-lightbox-featured-image {
-			@media only screen and ( min-width: $width__tablet ) {
-				.newspack-lightbox__close {
-					right: #{2 * $overlay__gap};
-					top: #{2 * $overlay__gap};
-				}
+		@media only screen and ( min-width: $width__tablet ) {
+			.newspack-lightbox__close {
+				right: #{2 * $overlay__gap};
+				top: #{2 * $overlay__gap};
 			}
 		}
 	}

--- a/src/view/style.scss
+++ b/src/view/style.scss
@@ -124,16 +124,19 @@ $width__tablet: 782px;
 			background-color: transparent;
 			box-shadow: none;
 		}
+
+		.newspack-popup__content {
+			padding-top: 32px;
+		}
+
 		.newspack-popup__content-wrapper {
 			box-shadow: 0 0 1em 0.5em rgba( black, 0.1 );
 			margin: 32px;
 		}
 
-		@media only screen and ( min-width: $width__tablet ) {
-			.newspack-lightbox__close {
-				right: #{2 * $overlay__gap};
-				top: #{2 * $overlay__gap};
-			}
+		.newspack-lightbox__close {
+			right: #{2 * $overlay__gap};
+			top: #{2 * $overlay__gap};
 		}
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR moves the close button to inside of the popup when you're using the Hide Padding option, to the same placement it has when the prompt has a featured image in the same situation. This helps make sure the close button is always easy to see, since it's contrast depends on the prompt's background, not the overlay's background.

See 1200550061930446-as-1204474693104072

### How to test the changes in this Pull Request:

1. Set up a prompt that's an overlay, and have it use the Hide Padding style.
2. Preview the prompt; note that the close button is outside of the prompt area, and, if you're using the default colours, is dark against a dark overlay (and possibly dark text!):

![image](https://github.com/Automattic/newspack-popups/assets/177561/44888d3e-6466-4e82-8e03-319068f24918)

3. Apply the PR, and run `npm run build`.
4. Preview your prompt again and confirm that the close button is now inside of the prompt itself, and easier to see:

![image](https://github.com/Automattic/newspack-popups/assets/177561/02416f62-2891-4d8f-8bf8-dd50af46e03e)

5. Try testing a few different settings (different screen sizes, with and without an image, different sizes, different background colours), and confirm that the button placement is always within the prompt, and doesn't interfere with the prompt's contents.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
