### PR TITLE
fix(criteria): warn when criteria value is not available

### DIFF
--- a/src/criteria/utils.js
+++ b/src/criteria/utils.js
@@ -68,7 +68,14 @@ export function registerCriteria( id, config = {} ) {
 		if ( typeof criteria.matchingAttribute === 'function' ) {
 			criteria.value = criteria.matchingAttribute( ras );
 		} else if ( typeof criteria.matchingAttribute === 'string' ) {
-			criteria.value = ras?.store?.get( criteria.matchingAttribute ) || null;
+			if ( typeof ras?.store?.get === 'function' ) {
+				criteria.value = ras.store.get( criteria.matchingAttribute );
+			} else {
+				// eslint-disable-next-line no-console
+				console.warn(
+					`Reader data library not loaded. Unable to fetch value for '${ criteria.id }'`
+				);
+			}
 		}
 	};
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Addresses [this suggestion](https://github.com/Automattic/newspack-popups/pull/1155#discussion_r1262777158) from #1155 to have a more descriptive log when the reader data library is not loaded.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
