### PR TITLE
fix(criteria): allow async matching configuration

### DIFF
--- a/includes/class-newspack-popups-criteria.php
+++ b/includes/class-newspack-popups-criteria.php
@@ -63,14 +63,6 @@ final class Newspack_Popups_Criteria {
 			]
 		);
 		wp_enqueue_script(
-			'newspack-popups-default-criteria',
-			plugins_url( '../dist/defaultCriteria.js', __FILE__ ),
-			[ self::SCRIPT_HANDLE ],
-			filemtime( dirname( NEWSPACK_POPUPS_PLUGIN_FILE ) . '/dist/defaultCriteria.js' ),
-			true
-		);
-		wp_script_add_data( 'newspack-popups-default-criteria', 'defer', true );
-		wp_enqueue_script(
 			'newspack-popups-segments-example',
 			plugins_url( '../dist/segmentsExample.js', __FILE__ ),
 			[ self::SCRIPT_HANDLE ],

--- a/src/criteria/index.js
+++ b/src/criteria/index.js
@@ -2,14 +2,13 @@
 
 import { registerCriteria } from './utils';
 
-/**
- * Initialize the criteria object.
- */
+// Default criteria matching strategy.
+import './default';
+
+// Initialize the criteria object.
 newspackPopupsCriteria.criteria = {};
 
-/**
- * Register criteria from the global newspackPopupsCriteria object.
- */
+// Register criteria from the global newspackPopupsCriteria object.
 if ( newspackPopupsCriteria?.config ) {
 	for ( const id in newspackPopupsCriteria.config ) {
 		registerCriteria( id, newspackPopupsCriteria.config[ id ] );

--- a/src/criteria/utils.js
+++ b/src/criteria/utils.js
@@ -1,5 +1,6 @@
 import matchingFunctions from './matching-functions';
 
+window.newspackPopupsCriteria = window.newspackPopupsCriteria || { criteria: {} };
 window.newspackPopupsCriteria.criteria = window.newspackPopupsCriteria.criteria || {};
 
 const pendingConfig = {};

--- a/src/criteria/utils.js
+++ b/src/criteria/utils.js
@@ -1,6 +1,8 @@
-/* globals newspackPopupsCriteria */
-
 import matchingFunctions from './matching-functions';
+
+window.newspackPopupsCriteria.criteria = window.newspackPopupsCriteria.criteria || {};
+
+const pendingConfig = {};
 
 /**
  * Registers a criteria.
@@ -23,6 +25,7 @@ export function registerCriteria( id, config = {} ) {
 		id,
 		matchingFunction: 'default',
 		...config,
+		...pendingConfig[ id ],
 	};
 
 	/**
@@ -94,10 +97,10 @@ export function registerCriteria( id, config = {} ) {
 		criteria._matched[ configString ] = criteria.matchingFunction( segmentConfig, ras );
 		return criteria._matched[ configString ];
 	};
-	if ( ! newspackPopupsCriteria.criteria ) {
-		newspackPopupsCriteria.criteria = {};
+	if ( ! window.newspackPopupsCriteria.criteria ) {
+		window.newspackPopupsCriteria.criteria = {};
 	}
-	newspackPopupsCriteria.criteria[ id ] = criteria;
+	window.newspackPopupsCriteria.criteria[ id ] = criteria;
 
 	return criteria;
 }
@@ -112,9 +115,9 @@ export function registerCriteria( id, config = {} ) {
  */
 export function getCriteria( id ) {
 	if ( id ) {
-		return newspackPopupsCriteria.criteria[ id ];
+		return window.newspackPopupsCriteria.criteria[ id ];
 	}
-	return newspackPopupsCriteria.criteria;
+	return window.newspackPopupsCriteria.criteria;
 }
 
 /**
@@ -127,9 +130,10 @@ export function getCriteria( id ) {
  * @throws {Error} If the criteria ID is not found.
  */
 export function setMatchingAttribute( id, matchingAttribute ) {
-	const criteria = getCriteria( id );
+	let criteria = getCriteria( id );
 	if ( ! criteria ) {
-		throw new Error( `Criteria ${ id } not found.` );
+		pendingConfig[ id ] = pendingConfig[ id ] || {};
+		criteria = pendingConfig[ id ];
 	}
 	criteria._matched = {}; // Clear matched cache.
 	criteria.matchingAttribute = matchingAttribute;
@@ -144,9 +148,10 @@ export function setMatchingAttribute( id, matchingAttribute ) {
  * @throws {Error} If the criteria ID is not found.
  */
 export function setMatchingFunction( id, matchingFunction ) {
-	const criteria = getCriteria( id );
+	let criteria = getCriteria( id );
 	if ( ! criteria ) {
-		throw new Error( `Criteria ${ id } not found.` );
+		pendingConfig[ id ] = pendingConfig[ id ] || {};
+		criteria = pendingConfig[ id ];
 	}
 	criteria._matched = {}; // Clear matched cache.
 	criteria.matchingFunction = matchingFunction;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Allows the criteria matching configuration to run before the criteria are registered.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
