### PR TITLE
feat: migrate reader data

### DIFF
--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -1359,10 +1359,6 @@ final class Newspack_Popups {
 	 * @param false|int $user_id       The created user id.
 	 */
 	public static function migrate_new_user_data( $email, $authenticate, $user_id ) {
-		if ( get_option( 'newspack_popups_reader_data_migrated' ) ) {
-			return;
-		}
-
 		// Bail if no user ID (user already exists).
 		if ( ! $user_id ) {
 			return;

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -1384,7 +1384,7 @@ final class Newspack_Popups {
 		// Update user meta so we don't run this again for this user.
 		update_user_meta( $user_id, $user_meta_name, true );
 
-		// Drop table if most recent event in 6 months old.
+		// Drop table if most recent event is 6 months old.
 		$age_to_drop = 6 * MONTH_IN_SECONDS;
 		$last_item   = $wpdb->get_results( "SELECT 1 FROM $table_name WHERE date_created > NOW() - INTERVAL $age_to_drop SECOND LIMIT 1" ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		if ( empty( $last_item ) ) {

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -1387,16 +1387,6 @@ final class Newspack_Popups {
 
 		// Update user meta so we don't run this again for this user.
 		update_user_meta( $user_id, $user_meta_name, true );
-
-		// Drop table if most recent event is older than 6 months.
-		$age_to_drop  = 6 * MONTH_IN_SECONDS;
-		$recent_event = $wpdb->get_results( "SELECT 1 FROM $table_name WHERE date_created > NOW() - INTERVAL $age_to_drop SECOND LIMIT 1" ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-		if ( empty( $recent_event ) ) {
-			$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}newspack_campaigns_reader_events" ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.SchemaChange
-			$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}newspack_campaigns_readers" ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.SchemaChange
-			// Table has been dropped, update site option so we don't run this again ever.
-			update_option( $option_name, true );
-		}
 	}
 }
 Newspack_Popups::instance();

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -1388,7 +1388,8 @@ final class Newspack_Popups {
 		$age_to_drop  = 6 * MONTH_IN_SECONDS;
 		$recent_event = $wpdb->get_results( "SELECT 1 FROM $table_name WHERE date_created > NOW() - INTERVAL $age_to_drop SECOND LIMIT 1" ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		if ( empty( $recent_event ) ) {
-			$wpdb->query( "DROP TABLE IF EXISTS $table_name" ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.SchemaChange
+			$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}newspack_campaigns_reader_events" ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.SchemaChange
+			$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}newspack_campaigns_readers" ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.SchemaChange
 			// Table has been dropped, update site option so we don't run this again ever.
 			update_option( $option_name, true );
 		}

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -1312,7 +1312,6 @@ final class Newspack_Popups {
 	 */
 	public static function migrate_user_data() {
 		if (
-			get_option( 'newspack_popups_reader_data_migrated' ) ||
 			! is_user_logged_in() ||
 			get_user_meta( get_current_user_id(), 'newspack_popups_reader_data_migrated', true ) ||
 			! class_exists( 'Newspack\Reader_Data' )

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -86,7 +86,7 @@ final class Newspack_Popups {
 			add_filter( 'show_admin_bar', [ __CLASS__, 'show_admin_bar' ], 10, 2 ); // phpcs:ignore WordPressVIPMinimum.UserExperience.AdminBarRemoval.RemovalDetected
 
 			add_action( 'wp', [ __CLASS__, 'migrate_user_data' ] );
-			add_action( 'user_register', [ __CLASS__, 'migrate_new_user_data' ], 10, 3 );
+			add_action( 'user_register', [ __CLASS__, 'migrate_new_user_data' ], 10, 2 );
 
 			include_once dirname( __FILE__ ) . '/class-newspack-popups-model.php';
 			include_once dirname( __FILE__ ) . '/class-newspack-segments-model.php';

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -1384,10 +1384,10 @@ final class Newspack_Popups {
 		// Update user meta so we don't run this again for this user.
 		update_user_meta( $user_id, $user_meta_name, true );
 
-		// Drop table if most recent event is 6 months old.
-		$age_to_drop = 6 * MONTH_IN_SECONDS;
-		$last_item   = $wpdb->get_results( "SELECT 1 FROM $table_name WHERE date_created > NOW() - INTERVAL $age_to_drop SECOND LIMIT 1" ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-		if ( empty( $last_item ) ) {
+		// Drop table if most recent event is older than 6 months.
+		$age_to_drop  = 6 * MONTH_IN_SECONDS;
+		$recent_event = $wpdb->get_results( "SELECT 1 FROM $table_name WHERE date_created > NOW() - INTERVAL $age_to_drop SECOND LIMIT 1" ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		if ( empty( $recent_event ) ) {
 			$wpdb->query( "DROP TABLE IF EXISTS $table_name" ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.SchemaChange
 			// Table has been dropped, update site option so we don't run this again ever.
 			update_option( $option_name, true );

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -86,7 +86,7 @@ final class Newspack_Popups {
 			add_filter( 'show_admin_bar', [ __CLASS__, 'show_admin_bar' ], 10, 2 ); // phpcs:ignore WordPressVIPMinimum.UserExperience.AdminBarRemoval.RemovalDetected
 
 			add_action( 'wp', [ __CLASS__, 'migrate_user_data' ] );
-			add_action( 'newspack_registered_reader', [ __CLASS__, 'migrate_new_user_data' ], 10, 3 );
+			add_action( 'user_register', [ __CLASS__, 'migrate_new_user_data' ], 10, 3 );
 
 			include_once dirname( __FILE__ ) . '/class-newspack-popups-model.php';
 			include_once dirname( __FILE__ ) . '/class-newspack-segments-model.php';
@@ -1354,13 +1354,11 @@ final class Newspack_Popups {
 	 * Look for client IDs attached to the registered user email to migrate data
 	 * generated before registration.
 	 *
-	 * @param string    $email         Email address.
-	 * @param bool      $authenticate  Whether to authenticate after registering.
-	 * @param false|int $user_id       The created user id.
+	 * @param int   $user_id  User ID.
+	 * @param array $userdata The raw array of data passed to wp_insert_user().
 	 */
-	public static function migrate_new_user_data( $email, $authenticate, $user_id ) {
-		// Bail if no user ID (user already exists).
-		if ( ! $user_id ) {
+	public static function migrate_new_user_data( $user_id, $userdata ) {
+		if ( empty( $userdata['user_email'] ) ) {
 			return;
 		}
 
@@ -1374,7 +1372,7 @@ final class Newspack_Popups {
 					FROM {$wpdb->prefix}newspack_campaigns_reader_events
 					WHERE type = 'subscription' AND context = %s
 				",
-				$email
+				$userdata['user_email']
 			),
 			ARRAY_N
 		);

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -1388,7 +1388,7 @@ final class Newspack_Popups {
 		$age_to_drop = 6 * MONTH_IN_SECONDS;
 		$last_item   = $wpdb->get_results( "SELECT 1 FROM $table_name WHERE date_created > NOW() - INTERVAL $age_to_drop SECOND LIMIT 1" ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		if ( empty( $last_item ) ) {
-			$wpdb->query( "DROP TABLE $table_name" ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.SchemaChange
+			$wpdb->query( "DROP TABLE IF EXISTS $table_name" ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.SchemaChange
 			// Table has been dropped, update site option so we don't run this again ever.
 			update_option( $option_name, true );
 		}

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -1347,7 +1347,11 @@ final class Newspack_Popups {
 
 		// Fetch all events for the user based on the client ids attached to them.
 		$client_id_placeholders = implode( ', ', array_fill( 0, count( $client_ids ), '%s' ) );
-		$events_sql             = "SELECT * FROM $table_name WHERE client_id IN ( $client_id_placeholders ) ORDER BY date_created ASC";
+		$events_sql             = "
+			SELECT * FROM $table_name
+			WHERE client_id IN ( $client_id_placeholders ) AND type IN ( 'subscription', 'donation', 'donation_cancelled' )
+			ORDER BY date_created ASC
+		";
 		$events_query           = call_user_func_array( [ $wpdb, 'prepare' ], array_merge( [ $events_sql ], $client_ids ) );
 		$events                 = $wpdb->get_results( $events_query, ARRAY_A ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.PreparedSQL.NotPrepared
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Implements a migration strategy from the `wp_newspack_reader_data_events` table to Newspack's reader data library.

The proposed approach migrates on demand, executing on an authenticated reader's page load. It works as follows:
1. Fetch all event IDs from the reader
2. Fetch all events from the collection of event IDs attached to that reader
3. In ascending order by creation date, iterate through each event to build an object with:
    ```
    {
    	"is_newsletter_subscriber": Boolean, 
    	"is_donor": Boolean,
    	"is_former_donor": Boolean
    }
    ```
    The order matters so that the latest `donation` or `donation_cancelled` event establishes the former donor or donor state.
4. If no recent reader data item exists for each data key, create them
5. Delete all the rows that match the client IDs from the reader and update a user meta to prevent this from running again for this user
6. <s>Check if the most recent of the remaining rows are older than 6 months. In this case, drop the table and add a site option to prevent this from running again for anyone.</s> (this might be an aggressive strategy, I would like an opinion). Let's go with a more manual approach for this

### How to test the changes in this Pull Request:

1. While on the master branch (make sure you have `master` on newspack-plugin and newspack-blocks as well), start a fresh session
7. Subscribe to a newsletter with a new account
8. Close the session, start a new one, authenticated with the same account, and donate (so we get another event with a different client ID)
10. Inspect the `wp_newspack_reader_data_events` and confirm the events are registered with different client IDs
11. Check out this branch as well as https://github.com/Automattic/newspack-plugin/pull/2582 and https://github.com/Automattic/newspack-blocks/pull/1498
12. Refresh the page, inspect the table, and confirm the rows are no longer there
13. Open DevTools and confirm you have the localStorage with:
     ```
     np_reader_1_is_newsletter_subscriber: true
     np_reader_1_is_donor: true
     ```

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
