### PR TITLE
feat: favorite categories segmentation logic

### DIFF
--- a/src/criteria/default/favorite-categories.js
+++ b/src/criteria/default/favorite-categories.js
@@ -14,6 +14,17 @@ setMatchingFunction( 'favorite_categories', ( config, ras ) => {
 	}, {} );
 	const countsArray = Object.entries( counts );
 	countsArray.sort( ( a, b ) => b[ 1 ] - a[ 1 ] );
-	/* TODO: Decide how to rank categories. */
-	return false;
+
+	let match = false;
+
+	// Must have viewed at least 2 categories or 2 posts within the same category in order to rank.
+	if ( 1 < countsArray.length || 1 < countsArray[ 0 ][ 1 ] ) {
+		config.value.forEach( categoryId => {
+			// Return true if one of the categories in the criteria is the most-read category.
+			if ( parseInt( countsArray[ 0 ][ 0 ] ) === parseInt( categoryId ) ) {
+				match = true;
+			}
+		} );
+	}
+	return match;
 } );

--- a/src/criteria/default/favorite-categories.js
+++ b/src/criteria/default/favorite-categories.js
@@ -1,7 +1,13 @@
 import { setMatchingFunction } from '../utils';
 
 setMatchingFunction( 'favorite_categories', ( config, ras ) => {
+	let match = false;
 	const views = ras.getUniqueActivitiesBy( 'article_view', 'post_id' );
+
+	if ( 1 >= views.length ) {
+		return match;
+	}
+
 	const categories = views.reduce( ( c, v ) => {
 		if ( v.data?.categories?.length ) {
 			c.push( ...v.data.categories );
@@ -15,20 +21,16 @@ setMatchingFunction( 'favorite_categories', ( config, ras ) => {
 	const countsArray = Object.entries( counts );
 	countsArray.sort( ( a, b ) => b[ 1 ] - a[ 1 ] );
 
-	let match = false;
-
 	if ( ! countsArray || ! countsArray.length ) {
 		return match;
 	}
 
 	// Must have viewed at least 2 categories or 2 posts within the same category in order to rank.
-	if ( 1 < views.length && countsArray[ 0 ][ 1 ] > countsArray[ 1 ][ 1 ] ) {
-		config.value.forEach( categoryId => {
-			// Return true if one of the categories in the criteria is the most-read category.
-			if ( parseInt( countsArray[ 0 ][ 0 ] ) === parseInt( categoryId ) ) {
-				match = true;
-			}
-		} );
+	if ( ! countsArray[ 1 ] || countsArray[ 0 ][ 1 ] > countsArray[ 1 ][ 1 ] ) {
+		if ( config.value.indexOf( parseInt( countsArray[ 0 ][ 0 ] ) ) ) {
+			match = true;
+		}
 	}
+
 	return match;
 } );

--- a/src/criteria/default/favorite-categories.js
+++ b/src/criteria/default/favorite-categories.js
@@ -18,7 +18,10 @@ setMatchingFunction( 'favorite_categories', ( config, ras ) => {
 	let match = false;
 
 	// Must have viewed at least 2 categories or 2 posts within the same category in order to rank.
-	if ( 1 < countsArray.length || 1 < countsArray[ 0 ][ 1 ] ) {
+	if (
+		( 1 < countsArray.length && countsArray[ 0 ][ 1 ] > countsArray[ 1 ][ 1 ] ) ||
+		1 < countsArray[ 0 ][ 1 ]
+	) {
 		config.value.forEach( categoryId => {
 			// Return true if one of the categories in the criteria is the most-read category.
 			if ( parseInt( countsArray[ 0 ][ 0 ] ) === parseInt( categoryId ) ) {

--- a/src/criteria/default/favorite-categories.js
+++ b/src/criteria/default/favorite-categories.js
@@ -17,11 +17,12 @@ setMatchingFunction( 'favorite_categories', ( config, ras ) => {
 
 	let match = false;
 
+	if ( ! countsArray || ! countsArray.length ) {
+		return match;
+	}
+
 	// Must have viewed at least 2 categories or 2 posts within the same category in order to rank.
-	if (
-		( 1 < countsArray.length && countsArray[ 0 ][ 1 ] > countsArray[ 1 ][ 1 ] ) ||
-		1 < countsArray[ 0 ][ 1 ]
-	) {
+	if ( 1 < views.length && countsArray[ 0 ][ 1 ] > countsArray[ 1 ][ 1 ] ) {
 		config.value.forEach( categoryId => {
 			// Return true if one of the categories in the criteria is the most-read category.
 			if ( parseInt( countsArray[ 0 ][ 0 ] ) === parseInt( categoryId ) ) {

--- a/src/criteria/default/favorite-categories.js
+++ b/src/criteria/default/favorite-categories.js
@@ -27,7 +27,7 @@ setMatchingFunction( 'favorite_categories', ( config, ras ) => {
 
 	// Must have viewed at least 2 categories or 2 posts within the same category in order to rank.
 	if ( ! countsArray[ 1 ] || countsArray[ 0 ][ 1 ] > countsArray[ 1 ][ 1 ] ) {
-		if ( config.value.indexOf( parseInt( countsArray[ 0 ][ 0 ] ) ) ) {
+		if ( -1 < config.value.indexOf( parseInt( countsArray[ 0 ][ 0 ] ) ) ) {
 			match = true;
 		}
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Proposes logic for segmenting by favorite category. Picking up a thread from https://github.com/Automattic/newspack-popups/pull/1155#discussion_r1261746719. Note that I was slightly incorrect in my description of the logic in that thread; I missed the `key()` function in the current logic which means that the criteria categories are only compared against the top-most-viewed category.

The way the current (non-rearchitected) logic [works](https://github.com/Automattic/newspack-popups/blob/master/api/campaigns/class-campaign-data-utils.php#L263-L269) is that a category is considered "favorite" if it's been viewed more times than any other category. This could result in a slightly awkward situation where if the very first post visited matches the segment criteria, it would make for a match on that very first pageview.

The proposed logic is almost the same, but tweaks it so that a category isn't considered favorite unless the reader has viewed at least two different articles, either in the same category or different categories. If the reader has viewed multiple articles in different categories, the top category must actually have more views than the other categories in order to be considered a favorite. This prevents the criteria from matching if, for example, the reader only views a single article in several different categories (in which case none can be considered a favorite).

### How to test the changes in this Pull Request:

1. Create a segment at top priority and assign several categories to the "Favorite categories" criteria.
2. On the front-end, view some articles that don't match any of the categories in the segment. Confirm that you don't match the segment.
3. In the same session, view multiple articles in one of the segment's categories (more than you viewed in step 2). Confirm that you do match the segment now that you've viewed more articles in at least one of the segment's categories than any other category you've viewed.
4. In a new session, view at least two articles in any of the segment's categories. Confirm that you match the segment after viewing at least two articles in one of the segment's categories. This is so that readers who only ever view articles from a single category can still match the segment.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
