### PR TITLE
fix: fallback if no newspack plugin

### DIFF
--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -658,22 +658,28 @@ final class Newspack_Popups_Inserter {
 				true
 			);
 
-			$segments = Newspack_Popups_Segmentation::get_segments( false );
-
-			// Gather segments for all prompts to be displayed.
-			foreach ( $segments as $segment ) {
-				if ( ! empty( $segment ) && ! empty( $segment['criteria'] ) && ! isset( self::$segments[ $segment['id'] ] ) ) {
-					self::$segments[ $segment['id'] ] = [
-						'criteria' => $segment['criteria'],
-						'priority' => $segment['priority'],
-					];
-				}
-			}
-
 			$script_data = [
-				'debug'    => defined( 'WP_DEBUG' ) && WP_DEBUG,
-				'segments' => self::$segments,
+				'debug' => defined( 'WP_DEBUG' ) && WP_DEBUG,
 			];
+
+			if ( class_exists( '\Newspack\Reader_Data' ) ) {
+				$segments = Newspack_Popups_Segmentation::get_segments( false );
+
+				// Gather segments for all prompts to be displayed.
+				foreach ( $segments as $segment ) {
+					if ( ! empty( $segment ) && ! empty( $segment['criteria'] ) && ! isset( self::$segments[ $segment['id'] ] ) ) {
+						self::$segments[ $segment['id'] ] = [
+							'criteria' => $segment['criteria'],
+							'priority' => $segment['priority'],
+						];
+					}
+				}
+
+				$script_data['segments'] = self::$segments;
+
+			} else {
+				$script_data['segmentation_disabled'] = true;
+			}
 
 			\wp_localize_script( $script_handle, 'newspack_popups_view', $script_data );
 			\wp_enqueue_script( $script_handle );

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -682,6 +682,7 @@ final class Newspack_Popups {
 					)
 				),
 				'preview_query_keys'           => self::PREVIEW_QUERY_KEYS,
+				'segmentation_enabled'         => class_exists( '\Newspack\Reader_Data' ),
 			]
 		);
 		\wp_enqueue_style(

--- a/src/editor/index.js
+++ b/src/editor/index.js
@@ -80,29 +80,31 @@ registerPlugin( 'newspack-popups', {
 	icon: null,
 } );
 
-registerPlugin( 'newspack-popups-frequency', {
-	render: () => (
-		<PluginDocumentSettingPanel
-			name="-frequency-panel"
-			title={ __( 'Frequency', 'newspack-popups' ) }
-		>
-			<FrequencySidebarWithData />
-		</PluginDocumentSettingPanel>
-	),
-	icon: null,
-} );
+if ( window?.newspack_popups_data?.segmentation_enabled ) {
+	registerPlugin( 'newspack-popups-frequency', {
+		render: () => (
+			<PluginDocumentSettingPanel
+				name="-frequency-panel"
+				title={ __( 'Frequency', 'newspack-popups' ) }
+			>
+				<FrequencySidebarWithData />
+			</PluginDocumentSettingPanel>
+		),
+		icon: null,
+	} );
 
-registerPlugin( 'newspack-popups-segmentation', {
-	render: () => (
-		<PluginDocumentSettingPanel
-			name="popup-segmentation-panel"
-			title={ __( 'Segmentation', 'newspack-popups' ) }
-		>
-			<SegmentationSidebarWithData />
-		</PluginDocumentSettingPanel>
-	),
-	icon: null,
-} );
+	registerPlugin( 'newspack-popups-segmentation', {
+		render: () => (
+			<PluginDocumentSettingPanel
+				name="popup-segmentation-panel"
+				title={ __( 'Segmentation', 'newspack-popups' ) }
+			>
+				<SegmentationSidebarWithData />
+			</PluginDocumentSettingPanel>
+		),
+		icon: null,
+	} );
+}
 
 registerPlugin( 'newspack-popups-colors', {
 	render: () => (

--- a/src/view/segmentation.js
+++ b/src/view/segmentation.js
@@ -14,13 +14,14 @@ import {
  * Match reader to segments.
  */
 export const handleSegmentation = prompts => {
-	window.newspackRAS = window.newspackRAS || [];
-	window.newspackRAS.push( ras => {
+	const maybeDisplayPrompts = ( ras = null ) => {
 		const segments = newspack_popups_view?.segments || {};
 		const matchingSegment = getBestPrioritySegment( segments );
 		debug( 'matchingSegment', matchingSegment );
 		// Log a pageview for frequency counts.
-		logPageview( ras );
+		if ( ras ) {
+			logPageview( ras );
+		}
 		let overlayDisplayed;
 
 		prompts.forEach( prompt => {
@@ -54,7 +55,9 @@ export const handleSegmentation = prompts => {
 					prompt.classList.remove( 'hidden' );
 
 					// Log a "prompt_seen" activity when the prompt becomes visible.
-					handleSeen( prompt, ras );
+					if ( ras ) {
+						handleSeen( prompt, ras );
+					}
 				};
 				if ( isOverlay ) {
 					const scroll = prompt.getAttribute( 'data-scroll' );
@@ -77,5 +80,12 @@ export const handleSegmentation = prompts => {
 			// Debug logging for prompt display.
 			debug( promptId, shouldDisplay );
 		} );
-	} );
+	};
+
+	if ( newspack_popups_view.segmentation_disabled ) {
+		maybeDisplayPrompts();
+	} else {
+		window.newspackRAS = window.newspackRAS || [];
+		window.newspackRAS.push( maybeDisplayPrompts );
+	}
 };


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Segmentation and frequency-based features in the rearchitected plugin rely on APIs from the main Newspack Plugin. This PR ensures that if those APIs are not available, prompts will still be displayed, albeit without any regard to segmentation or frequency options.

Closes `1204189396255901/1204850211981984`.

### How to test the changes in this Pull Request:

1. Check out this branch and disable the main plugin: `wp plugin deactivate newspack-plugin`
2. In WP admin, confirm that the Prompts menu item is available and that it lists all prompts in a standard CPT UI.
3. Edit a prompt and confirm that the "Frequency" and "Segments" sidebar panels don't appear, as those options won't work without the main Newspack plugin.
4. View the front-end and confirm that all published prompts are displayed (although only one overlay prompt will be displayed).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
