### PR TITLE
fix: undefined user meta key

### DIFF
--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -1337,7 +1337,7 @@ final class Newspack_Popups {
 			ARRAY_N
 		);
 		if ( empty( $client_ids ) ) {
-			update_user_meta( $user_id, $user_meta_name, true );
+			update_user_meta( $user_id, 'newspack_popups_reader_data_migrated', true );
 			return;
 		}
 		$client_ids = array_map(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

#1176 introduced a means to migrate previously registered readers to the new rearchitecture data scheme. This also has a mechanism to add a `newspack_popups_reader_data_migrated` user meta key to readers that have already been migrated so that this migration will only run once per reader, but some changes along the way dropped the variable. 

### How to test the changes in this Pull Request:

1. On `master` for this plugin as well as the main plugin and Newspack Blocks, register a reader by signing up for a newsletter with RAS and/or donating.
2. Check out this branch as well as https://github.com/Automattic/newspack-plugin/pull/2558 and https://github.com/Automattic/newspack-blocks/pull/1498.
3. In a new session, sign into the reader account registered during step 1. Navigate to a new page or two to make sure the async migration functions are triggered for the reader.
4. Confirm that the reader continues to be segmented but using the new reader data API in `localStorage`, as in #1176 (e.g. inspect and verify `localStorage` values indicating newsletter signup and donation status).
5. Confirm that the reader has a `newspack_popups_reader_data_migrated` meta key with a truthy value (`wp user meta get <user ID> newspack_popups_reader_data_migrated`
6. In another new session, sign into the same reader account and confirm that the `migrate_user_data` function does not run past [this condition](https://github.com/Automattic/newspack-popups/compare/epic/rearchitecture...fix/undefined-user-meta-key?expand=1#diff-c7efd1b032b601286ed42b644beb0443eaa33ce019c42dc068c443adaf1028fdR1314-R1320) due to the migration meta value existing on that reader.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
