### PR TITLE
fix: update plugin description

### DIFF
--- a/newspack-popups.php
+++ b/newspack-popups.php
@@ -2,9 +2,9 @@
 /**
  * Plugin Name:     Newspack Campaigns
  * Plugin URI:      https://newspack.blog
- * Description:     AMP-compatible overlay and inline Campaigns.
+ * Description:     Build persuasive call-to-action prompts from scratch and display them as overlays, inline with the story, or above the site header.
  * Author:          Automattic
- * Author URI:      https://newspack.blog
+ * Author URI:      https://newspack.com
  * Text Domain:     newspack-popups
  * Domain Path:     /languages
  * Version:         2.22.0


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

With AMP having been deprecated from the Newspack platform in H1 2023, it's no longer relevant to describe this plugin as "AMP-compatible overlay and inline Campaigns." This PR updates the "Description" and "Author URI" fields in the plugin header.

### How to test the changes in this Pull Request:

No code has changed; no testing is needed.

### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [X] Have you written new tests for your changes, as applicable?
* [X] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
