### PR TITLE
chore: remove lightweight api setup

### DIFF
--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -69,37 +69,33 @@ final class Newspack_Popups {
 	 * Constructor.
 	 */
 	public function __construct() {
-		add_action( 'admin_init', [ __CLASS__, 'create_lightweight_api_config' ] );
-		add_action( 'admin_notices', [ __CLASS__, 'api_config_missing_notice' ] );
 		add_action( 'cli_init', [ __CLASS__, 'register_cli_commands' ] );
 
-		if ( self::is_api_configured() ) {
-			add_action( 'init', [ __CLASS__, 'register_cpt' ] );
-			add_action( 'init', [ __CLASS__, 'register_meta' ] );
-			add_action( 'init', [ __CLASS__, 'register_taxonomy' ] );
-			add_action( 'init', [ __CLASS__, 'disable_prompts_for_protected_pages' ] );
-			add_action( 'enqueue_block_editor_assets', [ __CLASS__, 'enqueue_block_editor_assets' ] );
-			add_filter( 'display_post_states', [ __CLASS__, 'display_post_states' ], 10, 2 );
-			add_action( 'save_post_' . self::NEWSPACK_POPUPS_CPT, [ __CLASS__, 'popup_default_fields' ], 10, 3 );
-			add_action( 'transition_post_status', [ __CLASS__, 'prevent_default_category_on_publish' ], 10, 3 );
-			add_action( 'pre_delete_term', [ __CLASS__, 'prevent_default_category_on_term_delete' ], 10, 2 );
-			add_filter( 'show_admin_bar', [ __CLASS__, 'show_admin_bar' ], 10, 2 ); // phpcs:ignore WordPressVIPMinimum.UserExperience.AdminBarRemoval.RemovalDetected
+		add_action( 'init', [ __CLASS__, 'register_cpt' ] );
+		add_action( 'init', [ __CLASS__, 'register_meta' ] );
+		add_action( 'init', [ __CLASS__, 'register_taxonomy' ] );
+		add_action( 'init', [ __CLASS__, 'disable_prompts_for_protected_pages' ] );
+		add_action( 'enqueue_block_editor_assets', [ __CLASS__, 'enqueue_block_editor_assets' ] );
+		add_filter( 'display_post_states', [ __CLASS__, 'display_post_states' ], 10, 2 );
+		add_action( 'save_post_' . self::NEWSPACK_POPUPS_CPT, [ __CLASS__, 'popup_default_fields' ], 10, 3 );
+		add_action( 'transition_post_status', [ __CLASS__, 'prevent_default_category_on_publish' ], 10, 3 );
+		add_action( 'pre_delete_term', [ __CLASS__, 'prevent_default_category_on_term_delete' ], 10, 2 );
+		add_filter( 'show_admin_bar', [ __CLASS__, 'show_admin_bar' ], 10, 2 ); // phpcs:ignore WordPressVIPMinimum.UserExperience.AdminBarRemoval.RemovalDetected
 
-			add_action( 'wp', [ __CLASS__, 'migrate_user_data' ] );
-			add_action( 'user_register', [ __CLASS__, 'migrate_new_user_data' ], 10, 2 );
+		add_action( 'wp', [ __CLASS__, 'migrate_user_data' ] );
+		add_action( 'user_register', [ __CLASS__, 'migrate_new_user_data' ], 10, 2 );
 
-			include_once dirname( __FILE__ ) . '/class-newspack-popups-model.php';
-			include_once dirname( __FILE__ ) . '/class-newspack-segments-model.php';
-			include_once dirname( __FILE__ ) . '/class-newspack-popups-presets.php';
-			include_once dirname( __FILE__ ) . '/class-newspack-popups-inserter.php';
-			include_once dirname( __FILE__ ) . '/class-newspack-popups-api.php';
-			include_once dirname( __FILE__ ) . '/class-newspack-popups-settings.php';
-			include_once dirname( __FILE__ ) . '/class-newspack-popups-segmentation.php';
-			include_once dirname( __FILE__ ) . '/class-newspack-popups-custom-placements.php';
-			include_once dirname( __FILE__ ) . '/class-newspack-popups-view-as.php';
-			include_once dirname( __FILE__ ) . '/class-newspack-popups-data-api.php';
-			include_once dirname( __FILE__ ) . '/class-newspack-popups-criteria.php';
-		}
+		include_once dirname( __FILE__ ) . '/class-newspack-popups-model.php';
+		include_once dirname( __FILE__ ) . '/class-newspack-segments-model.php';
+		include_once dirname( __FILE__ ) . '/class-newspack-popups-presets.php';
+		include_once dirname( __FILE__ ) . '/class-newspack-popups-inserter.php';
+		include_once dirname( __FILE__ ) . '/class-newspack-popups-api.php';
+		include_once dirname( __FILE__ ) . '/class-newspack-popups-settings.php';
+		include_once dirname( __FILE__ ) . '/class-newspack-popups-segmentation.php';
+		include_once dirname( __FILE__ ) . '/class-newspack-popups-custom-placements.php';
+		include_once dirname( __FILE__ ) . '/class-newspack-popups-view-as.php';
+		include_once dirname( __FILE__ ) . '/class-newspack-popups-data-api.php';
+		include_once dirname( __FILE__ ) . '/class-newspack-popups-criteria.php';
 	}
 
 	/**
@@ -837,91 +833,6 @@ final class Newspack_Popups {
 		if ( $group ) {
 			wp_set_post_terms( $post_id, [ $group ], self::NEWSPACK_POPUPS_TAXONOMY );
 		}
-	}
-
-	/**
-	 * Create the config file for the API, unless it exists.
-	 */
-	public static function create_lightweight_api_config() {
-		// Don't create a config file if it's already there.
-		if (
-			( file_exists( self::LIGHTWEIGHT_API_CONFIG_FILE_PATH_LEGACY ) || file_exists( self::LIGHTWEIGHT_API_CONFIG_FILE_PATH ) )
-		) {
-			return;
-		}
-		// Don't create a config file if the directory is not writable.
-		if ( ! is_writable( dirname( self::LIGHTWEIGHT_API_CONFIG_FILE_PATH ) ) ) { // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_is_writable
-			return;
-		}
-		global $wpdb;
-		$config_vars = [
-			'DB_NAME',
-			'DB_USER',
-			'DB_PASSWORD',
-			'DB_HOST',
-			'DB_CHARSET',
-			'DB_COLLATE',
-			'DB_PREFIX',
-			'WP_CACHE_KEY_SALT',
-			'NEWSPACK_POPUPS_DEBUG',
-		];
-
-		$new_config_file = file_put_contents( // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_file_put_contents -- VIP will have to create a config manually
-			self::LIGHTWEIGHT_API_CONFIG_FILE_PATH,
-			"<?php\n" .
-			implode(
-				"\n",
-				array_map(
-					function( $config_var ) use ( $wpdb ) {
-						// Skip if it's set through an env var.
-						if ( getenv( $config_var ) ) {
-							return '';
-						}
-						if ( defined( $config_var ) ) {
-							$value = constant( $config_var );
-						}
-						if ( 'DB_PREFIX' === $config_var ) {
-							$value = $wpdb->prefix;
-						}
-						if ( ! isset( $value ) ) {
-							return '';
-						}
-						$value = addslashes( $value );
-						return "define( '" . $config_var . "', '" . $value . "' );";
-					},
-					$config_vars
-				)
-			)
-		);
-		if ( $new_config_file ) {
-			error_log( 'Created the config file: ' . self::LIGHTWEIGHT_API_CONFIG_FILE_PATH ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
-		}
-	}
-
-	/**
-	 * Is the API configured?
-	 */
-	public static function is_api_configured() {
-		return file_exists( self::LIGHTWEIGHT_API_CONFIG_FILE_PATH_LEGACY ) || file_exists( self::LIGHTWEIGHT_API_CONFIG_FILE_PATH );
-	}
-
-	/**
-	 * Add an admin notice if config is missing.
-	 */
-	public static function api_config_missing_notice() {
-		if ( self::is_api_configured() ) {
-			return;
-		}
-		?>
-			<div class="notice notice-error">
-				<p>
-					<?php _e( 'Newspack Campaigns requires a custom configuration file, which is missing. Please create this file by following ', 'newspack-popups' ); ?>
-					<a href="https://github.com/Automattic/newspack-popups/blob/master/README.md#config-file">
-						<?php _e( 'these instructions.', 'newspack-popups' ); ?>
-					</a>
-				</p>
-			</div>
-		<?php
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Removes the lightweight API checks and setup.

### How to test the changes in this Pull Request:

1. Check out this branch, navigate to the wizard and confirm you're able to create prompts and segments
2. Create a prompt and assign to a segment
3. In a fresh session, confirm the prompt renders when matching the segment

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
