### PR TITLE
Update/remove category cleanup

### DIFF
--- a/includes/class-newspack-segments-model.php
+++ b/includes/class-newspack-segments-model.php
@@ -475,27 +475,6 @@ final class Newspack_Segments_Model {
 			);
 		}
 
-		// Filter out non-existing categories.
-		$existing_categories_ids = get_categories(
-			[
-				'hide_empty' => false,
-				'fields'     => 'ids',
-			]
-		);
-		foreach ( $segments as &$segment ) {
-			if ( ! isset( $segment['configuration']['favorite_categories'] ) ) {
-				continue;
-			}
-			$fav_categories = $segment['configuration']['favorite_categories'];
-			if ( ! empty( $fav_categories ) ) {
-				$segment['configuration']['favorite_categories'] = array_values(
-					array_intersect(
-						$existing_categories_ids,
-						$fav_categories
-					)
-				);
-			}
-		}
 		return $segments;
 	}
 

--- a/tests/test-segments.php
+++ b/tests/test-segments.php
@@ -241,29 +241,6 @@ class SegmentsTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test get_segments fill in empty priorities.
-	 */
-	public function test_get_segments_rremove_non_existent_categories() {
-		$cat_1 = $this->factory()->category->create_and_get( [ 'name' => 'Category 1' ] );
-		$cat_2 = $this->factory()->category->create_and_get( [ 'name' => 'Category 2' ] );
-
-
-		$modified = $this->complete_and_valid;
-		$modified['configuration']['favorite_categories'] = [ $cat_1->term_id, $cat_2->term_id, 9999 ];
-		Newspack_Popups_Segmentation::create_segment( $modified );
-
-		$modified = $this->valid;
-		$modified['configuration']['favorite_categories'] = [ 8888 ];
-		Newspack_Popups_Segmentation::create_segment( $modified );
-
-		$segments = Newspack_Popups_Segmentation::get_segments();
-
-		$this->assertSame( 2, count( $segments ) );
-		$this->assertSame( [ $cat_1->term_id, $cat_2->term_id ], $segments[0]['configuration']['favorite_categories'] );
-		$this->assertSame( [], $segments[1]['configuration']['favorite_categories'] );
-	}
-
-	/**
 	 * Test get_segment_ids
 	 */
 	public function test_get_segment_ids() {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Removes the unecessary favorite categories cleanup.

Now that the front end and criteria system was refactored, this should not be a problem

### How to test the changes in this Pull Request:

1. Create a few categories
2. Create segments that use favorite categories
3. Delete one of the categories
4. Make sure that the segments that used the deleted categories still work without error, both in the admin and in the front-end, working with the remaining criteria they had

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
