### PR TITLE
fix: missing release files

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -47,4 +47,8 @@ node_modules
 /tests
 /bin
 /release
-/src
+/src/assets
+/src/document-settings
+/src/editor
+/src/settings
+/src/view

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -663,7 +663,7 @@ final class Newspack_Popups {
 				'taxonomy'                     => self::NEWSPACK_POPUPS_TAXONOMY,
 				'is_prompt'                    => self::NEWSPACK_POPUPS_CPT == get_post_type(),
 				'segments_taxonomy'            => Newspack_Segments_Model::TAX_SLUG,
-				'segments_admin_page'          => admin_url( 'admin.php?page=newspack-popups-wizard#/segments' ),
+				'segments_admin_url'           => admin_url( 'admin.php?page=newspack-popups-wizard#/segments' ),
 				'available_post_types'         => array_values(
 					get_post_types(
 						[


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes some bugs introduced in #1168 and #1169.

### How to test the changes in this Pull Request:

#### Release files

1. On `epic/rearchitecture`, run `npm run release:archive` to build a release package.
2. Install the package on a fresh site. Observe a fatal PHP error due to missing files in the `src/criteria` and `src/blocks` folders.
3. Check out this branch and confirm the fatals no longer occur.

#### Missing segments admin link

1. On `epic/rearchitecture`, edit a prompt and expand the "Segments" panel.
2. Observe that the "Manage segments" link doesn't go anywhere.
3. Check out this branch and confirm it now links to the segments page of the Campaigns wizard.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
