### PR TITLE
fix: include missing file

### DIFF
--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -95,6 +95,7 @@ final class Newspack_Popups {
 		add_filter( 'show_admin_bar', [ __CLASS__, 'show_admin_bar' ], 10, 2 ); // phpcs:ignore WordPressVIPMinimum.UserExperience.AdminBarRemoval.RemovalDetected
 
 		include_once dirname( __FILE__ ) . '/class-newspack-popups-model.php';
+		include_once dirname( __FILE__ ) . '/class-newspack-popups-migration.php';
 		include_once dirname( __FILE__ ) . '/class-newspack-segments-model.php';
 		include_once dirname( __FILE__ ) . '/class-newspack-popups-presets.php';
 		include_once dirname( __FILE__ ) . '/class-newspack-popups-inserter.php';

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -95,7 +95,7 @@ final class Newspack_Popups {
 		add_filter( 'show_admin_bar', [ __CLASS__, 'show_admin_bar' ], 10, 2 ); // phpcs:ignore WordPressVIPMinimum.UserExperience.AdminBarRemoval.RemovalDetected
 
 		include_once dirname( __FILE__ ) . '/class-newspack-popups-model.php';
-		include_once dirname( __FILE__ ) . '/class-newspack-popups-migration.php';
+		include_once dirname( __FILE__ ) . '/class-newspack-segments-migration.php';
 		include_once dirname( __FILE__ ) . '/class-newspack-segments-model.php';
 		include_once dirname( __FILE__ ) . '/class-newspack-popups-presets.php';
 		include_once dirname( __FILE__ ) . '/class-newspack-popups-inserter.php';

--- a/includes/class-newspack-segments-migration.php
+++ b/includes/class-newspack-segments-migration.php
@@ -150,7 +150,7 @@ final class Newspack_Segments_Migration {
 	 *
 	 * @return array
 	 */
-	private static function migrate_criteria_configuration( $segment ) {
+	public static function migrate_criteria_configuration( $segment ) {
 		if ( empty( $segment['configuration'] ) || ! empty( $segment['criteria'] ) ) {
 			return $segment;
 		}

--- a/includes/class-newspack-segments-model.php
+++ b/includes/class-newspack-segments-model.php
@@ -431,7 +431,8 @@ final class Newspack_Segments_Model {
 			$segment[ $meta_key ] = $stored_value;
 		}
 
-		return $segment;
+		// Ensure we got the segment in its latest version.
+		return Newspack_Segments_Migration::migrate_criteria_configuration( $segment );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes an issue with the migration of segments from the `wp_options` implementation (pre- #1192) to segments as a term with registered criteria.

To replicate the issue:

1. Create a new site using the latest releases of Newspack Plugin, Blocks, and Campaigns
2. Create a bunch of different segments with different criteria and prompts in each (and/or complete the RAS setup wizard to generate them), and make sure to disable one or two
3. Upgrade all three plugins at once to the current alphas:
 - https://github.com/Automattic/newspack-plugin/releases/tag/v2.4.0-alpha.1
 - https://github.com/Automattic/newspack-blocks/releases/tag/v1.74.0-alpha.1
 - https://github.com/Automattic/newspack-popups/releases/tag/v2.23.0-alpha.1

7. Observe that the prompts lose their segment assignments as above.
8. Also observe that the segments seem to have lost their criteria settings.

### How to test the changes in this Pull Request:

1. Repeat steps 1-2 in the replication steps above.
2. Upgrade Newspack Plugin + Blocks to the alphas, and Popups to this branch.
3. Confirm that all segments remain intact after upgrading. Check the following:
 - All segments still exist and in the correct priority order
 - Disabled segments remain disabled
 - All segments retain their criteria configuration
 - All prompts retain their segment assignments
 - Segmentation + prompt display work as expected on the front-end
 - Segment terms exist in the DB and reflect their criteria and configuration (use `wp term list popup_segment` and then `wp term meta list <term ID>`)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
