### PR TITLE
fix: ensure url param segment is set

### DIFF
--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -844,6 +844,10 @@ final class Newspack_Popups {
 		if ( $group ) {
 			wp_set_post_terms( $post_id, [ $group ], self::NEWSPACK_POPUPS_TAXONOMY );
 		}
+
+		if ( $segment && ! wp_get_post_terms( $post_id, Newspack_Segments_Model::TAX_SLUG ) ) {
+			wp_set_post_terms( $post_id, [ $segment ], Newspack_Segments_Model::TAX_SLUG );
+		}
 	}
 
 	/**

--- a/src/editor/index.js
+++ b/src/editor/index.js
@@ -154,11 +154,14 @@ const PluginPostStatusInfoTest = () => (
 );
 registerPlugin( 'newspack-popups-preview', { render: PluginPostStatusInfoTest } );
 
+let updatedWithGetParam = false;
+
 /**
  * Adds a help message to the Segment selector
  */
 const NewspackPopupsSegmentsHelper = ( { slug } ) => {
 	const { editPost } = useDispatch( editorStore );
+	const { openGeneralSidebar } = useDispatch( 'core/edit-post' );
 	const { terms, taxonomy } = useSelect(
 		select => {
 			const { getEditedPostAttribute } = select( 'core/editor' );
@@ -178,13 +181,10 @@ const NewspackPopupsSegmentsHelper = ( { slug } ) => {
 		const currentURL = new URL( window.location );
 		const searchParams = currentURL.searchParams;
 		const initialSegment = searchParams.get( 'segment' );
-		if ( initialSegment ) {
+		if ( ! updatedWithGetParam && initialSegment ) {
+			openGeneralSidebar( 'edit-post/document' );
 			editPost( { [ taxonomy.rest_base ]: [ parseInt( initialSegment ) ] } );
-
-			// This avoids thes callback from being called again when you toggle the Segments form visibility.
-			searchParams.delete( 'segment' );
-			currentURL.search = searchParams.toString();
-			window.history.pushState( { path: currentURL.toString() }, '', currentURL.toString() );
+			updatedWithGetParam = true;
 		}
 	}, [] );
 

--- a/src/editor/index.js
+++ b/src/editor/index.js
@@ -161,7 +161,6 @@ let updatedWithGetParam = false;
  */
 const NewspackPopupsSegmentsHelper = ( { slug } ) => {
 	const { editPost } = useDispatch( editorStore );
-	const { openGeneralSidebar } = useDispatch( 'core/edit-post' );
 	const { terms, taxonomy } = useSelect(
 		select => {
 			const { getEditedPostAttribute } = select( 'core/editor' );
@@ -182,7 +181,6 @@ const NewspackPopupsSegmentsHelper = ( { slug } ) => {
 		const searchParams = currentURL.searchParams;
 		const initialSegment = searchParams.get( 'segment' );
 		if ( ! updatedWithGetParam && initialSegment ) {
-			openGeneralSidebar( 'edit-post/document' );
 			editPost( { [ taxonomy.rest_base ]: [ parseInt( initialSegment ) ] } );
 			updatedWithGetParam = true;
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

When creating a prompt from the "Add new prompt" button in a segment section, the segment will not be stored with the segment taxonomy sidebar panel closed, which is the default state on a fresh session.

This PR fixes it through the backend, by detecting the URL param and setting the term if there are no selected segments.

This PR also changes the strategy to avoid always updating the input on mount.

### How to test the changes in this Pull Request:

1. While on the master branch confirm the bug by visiting "Campaigns" in a fresh session (the sidebar panel closed) and clicking "Add New Prompt" from any existing segment
2. Publish, go back to "Campaigns" and confirm the prompt is set to "Everyone"
3. Check out this branch, repeat, and confirm the proper segment is set
4. Create a new prompt in a segment and select multiple segments
5. Close and open the panel and confirm the selected segments are preserved
6. Publish, go back to "Campaigns" and confirm the prompt is set to the selected segments

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
