### PR TITLE
fix: account for frequency presets in printed config

### DIFF
--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -139,7 +139,7 @@ final class Newspack_Popups_Model {
 		foreach ( $options as $key => $value ) {
 			switch ( $key ) {
 				case 'frequency':
-					if ( ! in_array( $value, [ 'once', 'daily', 'always', 'custom' ] ) ) {
+					if ( ! in_array( $value, [ 'once', 'weekly', 'daily', 'always', 'custom' ] ) ) {
 						return new \WP_Error(
 							'newspack_popups_invalid_option_value',
 							esc_html__( 'Invalid frequency value.', 'newspack-popups' ),
@@ -998,6 +998,44 @@ final class Newspack_Popups_Model {
 	}
 
 	/**
+	 * Get a string representing the prompt's frequency config.
+	 *
+	 * @param string $popup The popup object.
+	 * @return string The frequency config in the following format: n1,n2,n3,s1 where n and s = the following from popup_options:
+	 *   - n1: frequency_start
+	 *   - n2: frequency_between
+	 *   - n3: frequency_max
+	 *   - s: frequency_reset ("month", "week", "day")
+	 */
+	private static function get_frequency_config( $popup ) {
+		$frequency   = $popup['options']['frequency'];
+		$freq_config = [];
+
+		switch ( $frequency ) {
+			case 'custom':
+				$freq_config = [ $popup['options']['frequency_start'], $popup['options']['frequency_between'], $popup['options']['frequency_max'], $popup['options']['frequency_reset'] ];
+				break;
+			case 'once':
+				$freq_config = [ 0, 0, 1, 'month' ];
+				break;
+			case 'weekly':
+				$freq_config = [ 0, 0, 1, 'week' ];
+				break;
+			case 'daily':
+				$freq_config = [ 0, 0, 1, 'day' ];
+				break;
+			case 'always':
+				$freq_config = [ 0, 0, 0, 'month' ];
+				break;
+			default:
+				$freq_config = [ 0, 0, 0, 'month' ];
+				break;
+		}
+
+		return implode( ',', $freq_config );
+	}
+
+	/**
 	 * Generate markup for an inline popup.
 	 *
 	 * @param string $popup The popup object.
@@ -1029,7 +1067,7 @@ final class Newspack_Popups_Model {
 		$classes[]            = $is_newsletter_prompt ? 'newspack-newsletter-prompt-inline' : null;
 		$classes              = array_merge( $classes, explode( ' ', $popup['options']['additional_classes'] ) );
 		$assigned_segments    = Newspack_Segments_Model::get_popup_segments_ids_string( $popup['id'] );
-		$frequency_config     = [ $popup['options']['frequency_start'], $popup['options']['frequency_between'], $popup['options']['frequency_max'], $popup['options']['frequency_reset'] ];
+		$frequency_config     = self::get_frequency_config( $popup );
 
 		$analytics_events = self::get_analytics_events( $popup, $body, $element_id );
 		if ( ! empty( $analytics_events ) ) {
@@ -1051,7 +1089,7 @@ final class Newspack_Popups_Model {
 				style="<?php echo esc_attr( self::container_style( $popup ) ); ?>"
 				id="<?php echo esc_attr( $element_id ); ?>"
 				data-segments="<?php echo esc_attr( $assigned_segments ); ?>"
-				data-frequency="<?php echo esc_attr( implode( ',', $frequency_config ) ); ?>"
+				data-frequency="<?php echo esc_attr( $frequency_config ); ?>"
 			>
 				<?php echo do_shortcode( $body ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 			</div>
@@ -1117,7 +1155,7 @@ final class Newspack_Popups_Model {
 		$wrapper_classes[]     = 'publish' !== $popup['status'] ? 'newspack-inactive-popup-status' : null;
 		$is_scroll_triggered   = 'scroll' === $popup['options']['trigger_type'];
 		$assigned_segments     = Newspack_Segments_Model::get_popup_segments_ids_string( $popup['id'] );
-		$frequency_config      = [ $popup['options']['frequency_start'], $popup['options']['frequency_between'], $popup['options']['frequency_max'], $popup['options']['frequency_reset'] ];
+		$frequency_config      = self::get_frequency_config( $popup );
 
 		add_filter(
 			'newspack_analytics_events',
@@ -1137,7 +1175,7 @@ final class Newspack_Popups_Model {
 			tabindex="0"
 			id="<?php echo esc_attr( $element_id ); ?>"
 			data-segments="<?php echo esc_attr( $assigned_segments ); ?>"
-			data-frequency="<?php echo esc_attr( implode( ',', $frequency_config ) ); ?>"
+			data-frequency="<?php echo esc_attr( $frequency_config ); ?>"
 
 			<?php if ( $is_scroll_triggered ) : ?>
 			data-scroll="<?php echo esc_attr( $popup['options']['trigger_scroll_progress'] ); ?>"


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

#1192 didn't account for frequency presets, which should override individual frequency settings. Also fixes a long-lingering bug where the "weekly" preset couldn't be chosen in the Campaigns settings modal.

### How to test the changes in this Pull Request:

#### Frequency presets

1. On `master`, create a new prompt, set it to a frequency of "Once a month", "Once a week", or "Once a day". Don't choose "Custom" at any point while editing.
2. View the prompt on the front-end and observe that it's shown on every page view, no matter which frequency preset you've chosen.
3. Check out this branch and repeat step 2. Confirm that it now shows only once.
4. Play with various presets and confirm that the prompt shows according to the selected preset in all cases. You can also inspect the prompt's HTML wrapper element `.newspack-popup-container` and confirm that the `data-frequency` string matches the preset as described in the `get_frequency_config` docblock.

#### "Weekly" preset in wizard UI

1. On `master`, go to **Newspack > Campagns** and open the Prompt Settings modal (using the sliders icon button).
2. Try to set the frequency to "Weekly" and observe an error:

<img width="1118" alt="Screenshot 2023-08-21 at 11 36 50 AM" src="https://github.com/Automattic/newspack-popups/assets/2230142/e2d804d6-30c4-46db-9a88-934bbf8f3972">

3. Check out this branch, repeat step 2, and confirm it now allows the "Weekly" preset to chosen and saved.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
