### PR TITLE
fix: add .hidden styles for above header prompts

### DIFF
--- a/src/view/style.scss
+++ b/src/view/style.scss
@@ -480,10 +480,13 @@ $width__tablet: 782px;
 .newspack-above-header-popup {
 	display: block;
 	clear: both;
-	padding: 0.75em 0;
 
 	&:focus {
 		outline: none;
+	}
+
+	&.hidden {
+		display: none;
 	}
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds CSS to hide above-header prompts with a `.hidden`. class. Also removes the small amount of padding from above-header prompts so that it's easier to make "full-bleed" prompts (since desired padding can now be configured via block controls).

### How to test the changes in this Pull Request:

1. On `master`, publish an above-header prompt in a segment that you won't match as a new reader (e.g. registered).
2. View the front-end and observe that the above-header prompt appears despite not matching its segment and `newspack_popups_debug` showing it as not displayed.
3. Check out this branch, repeat step 2, and confirm that the prompt is now hidden.
4. Perform the action to match the segment (e.g. register for an account), navigate to another page, and confirm that the prompt is now displayed when you match its segment.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
