### PR TITLE
fix: avoid SQL error if legacy table doesn't exist

### DIFF
--- a/includes/class-newspack-segments-migration.php
+++ b/includes/class-newspack-segments-migration.php
@@ -271,6 +271,11 @@ final class Newspack_Segments_Migration {
 
 		global $wpdb;
 
+		// No need to migrate if the old tables don't exist.
+		if ( empty( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $wpdb->prefix . 'newspack_campaigns_reader_events' ) ) ) ) { // phpcs:ignore WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.DirectQuery
+			return;
+		}
+
 		// Fetch the user's client ids.
 		$client_ids = $wpdb->get_results( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.DirectQuery
 			$wpdb->prepare(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Avoids running a SQL query on a non-existent table when attempting to migrate reader data from legacy tables.

### How to test the changes in this Pull Request:

1. On `master`, set up a brand new site with Campaigns.
2. Register a new reader account in a new session.
3. In another new session, log into the reader account.
4. Observe an error in your debug.log:

```
WordPress database error Table 'wordpress.wp_newspack_campaigns_reader_events' doesn't exist for query 
					SELECT DISTINCT client_id
					FROM wp_newspack_campaigns_reader_events
					WHERE type = 'user_account' AND context = '2'
				 made by require('wp-blog-header.php'), wp, WP->main, do_action_ref_array('wp'), WP_Hook->do_action, WP_Hook->apply_filters, Newspack_Segments_Migration::migrate_user_data
```
5. Check out this branch and repeat step 3 in a new session. Confirm that the error doesn't occur and that the `migrate_user_data` function exits silently without attempting to migrate any data.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
