### PR TITLE
feat: remove is_non_interactive method

### DIFF
--- a/includes/class-newspack-popups-settings.php
+++ b/includes/class-newspack-popups-settings.php
@@ -350,17 +350,6 @@ class Newspack_Popups_Settings {
 	}
 
 	/**
-	 * Is the non-interactive setting on?
-	 *
-	 * Deprecated: There is no longer a non interactive mode
-	 *
-	 * @deprecated
-	 */
-	public static function is_non_interactive() {
-		return false;
-	}
-
-	/**
 	 * Donor landing page.
 	 */
 	public static function donor_landing_page() {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Removes the reference to the deprecated non-interactive mode.

### How to test the changes in this Pull Request:

There should be no changes, this method is not used anywhere. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->