### PR TITLE
fix(data-api): handle errored default donation settings

### DIFF
--- a/includes/class-newspack-popups-data-api.php
+++ b/includes/class-newspack-popups-data-api.php
@@ -113,9 +113,12 @@ final class Newspack_Popups_Data_Api {
 					)[0];
 
 					if ( $donate_block && method_exists( '\Newspack\Donations', 'get_donation_settings' ) ) {
-						$is_manual         = $donate_block['attrs']['manual'] ?? false;
-						$is_layout_tiers   = isset( $donate_block['attrs']['layoutOption'] ) && 'tiers' === $donate_block['attrs']['layoutOption'];
-						$default_settings  = \Newspack\Donations::get_donation_settings();
+						$is_manual        = $donate_block['attrs']['manual'] ?? false;
+						$is_layout_tiers  = isset( $donate_block['attrs']['layoutOption'] ) && 'tiers' === $donate_block['attrs']['layoutOption'];
+						$default_settings = \Newspack\Donations::get_donation_settings();
+						if ( ! $default_settings || is_wp_error( $default_settings ) ) {
+							$default_settings = [];
+						}
 						$donation_settings = $is_manual ? \wp_parse_args( $donate_block['attrs'], $default_settings ) : $default_settings;
 						$is_tiered         = $donation_settings['tiered'] ?? false;
 						$suggested_amounts = $donation_settings['amounts'] ?? [];


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Handles error coming from `\Newspack\Donations::get_donation_settings()`. Also, see https://github.com/Automattic/newspack-plugin/pull/2675

### How to test the changes in this Pull Request:

1. While on the master branch, force `\Newspack\Donations::get_donation_settings()` to throw an error by adding `return new \WP_Error( 'test_error',  'Test error' );` to line `291` of `includes/class-donations.php` in `newspack-plugin`
2. Visit a page that has a prompt with the Donate block and confirm the fatal error
3. Check out this branch and confirm the page doesn't throw a fatal error

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
