### PR TITLE
fix: deduplication strategy for Homepage Posts block

### DIFF
--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -44,6 +44,13 @@ final class Newspack_Popups_Model {
 	protected static $form_hooks_popup_id;
 
 	/**
+	 * The current popup.
+	 *
+	 * @var array|null
+	 */
+	protected static $current_popup = null;
+
+	/**
 	 * Retrieve all Popups (first 100).
 	 *
 	 * @param  boolean $include_unpublished Whether to include unpublished posts.
@@ -976,7 +983,17 @@ final class Newspack_Popups_Model {
 				<?php echo do_shortcode( $body ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 			</div>
 		<?php
+		self::$current_popup = false;
 		return ob_get_clean();
+	}
+
+	/**
+	 * Return the current popup.
+	 *
+	 * @return array|null The current popup or null if it's not set.
+	 */
+	public static function get_current_popup() {
+		return self::$current_popup;
 	}
 
 	/**
@@ -997,10 +1014,7 @@ final class Newspack_Popups_Model {
 			$popup = Newspack_Popups_Presets::retrieve_preset_popup( Newspack_Popups::preset_popup_id() );
 		}
 
-		if ( self::is_overlay( $popup ) && self::is_overlay( $popup ) && has_block( 'newspack-blocks/homepage-articles', $popup['content'] ) ) {
-			add_filter( 'newspack_blocks_homepage_enable_duplication', '__return_true' );
-			add_filter( 'newspack_blocks_homepage_shown_rendered_posts', '__return_true' );
-		}
+		self::$current_popup = $popup;
 
 		if ( ! self::is_overlay( $popup ) ) {
 			return self::generate_inline_popup( $popup );
@@ -1084,12 +1098,7 @@ final class Newspack_Popups_Model {
 			<div id="page-position-marker_<?php echo esc_attr( $element_id ); ?>" class="page-position-marker" style="position: absolute; top: <?php echo esc_attr( $popup['options']['trigger_scroll_progress'] ); ?>%"></div>
 		<?php endif; ?>
 		<?php
-		if ( self::is_overlay( $popup ) && has_block( 'newspack-blocks/homepage-articles', $popup['content'] ) ) {
-			add_filter( 'newspack_blocks_homepage_enable_duplication', '__return_false' );
-			add_filter( 'newspack_blocks_homepage_shown_rendered_posts', '__return_false' );
-		}
-		?>
-		<?php
+		self::$current_popup = null;
 		return ob_get_clean();
 	}
 

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -983,7 +983,7 @@ final class Newspack_Popups_Model {
 				<?php echo do_shortcode( $body ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 			</div>
 		<?php
-		self::$current_popup = false;
+		self::$current_popup = null;
 		return ob_get_clean();
 	}
 

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -93,6 +93,7 @@ final class Newspack_Popups {
 		add_action( 'transition_post_status', [ __CLASS__, 'prevent_default_category_on_publish' ], 10, 3 );
 		add_action( 'pre_delete_term', [ __CLASS__, 'prevent_default_category_on_term_delete' ], 10, 2 );
 		add_filter( 'show_admin_bar', [ __CLASS__, 'show_admin_bar' ], 10, 2 ); // phpcs:ignore WordPressVIPMinimum.UserExperience.AdminBarRemoval.RemovalDetected
+		add_filter( 'newspack_blocks_should_deduplicate', [ __CLASS__, 'newspack_blocks_should_deduplicate' ], 10, 2 );
 
 		include_once dirname( __FILE__ ) . '/class-newspack-popups-model.php';
 		include_once dirname( __FILE__ ) . '/class-newspack-segments-migration.php';
@@ -106,6 +107,22 @@ final class Newspack_Popups {
 		include_once dirname( __FILE__ ) . '/class-newspack-popups-view-as.php';
 		include_once dirname( __FILE__ ) . '/class-newspack-popups-data-api.php';
 		include_once dirname( __FILE__ ) . '/class-newspack-popups-criteria.php';
+	}
+
+	/**
+	 * Handle deduplication of "Homepage Posts" block from Newspack Blocks.
+	 *
+	 * @param boolean $deduplicate Whether to deduplicate.
+	 * @param array   $attributes  Block attributes.
+	 *
+	 * @return boolean
+	 */
+	public static function newspack_blocks_should_deduplicate( $deduplicate, $attributes ) {
+		$current_popup = Newspack_Popups_Model::get_current_popup();
+		if ( $current_popup && Newspack_Popups_Model::is_overlay( $current_popup ) ) {
+			$deduplicate = false;
+		}
+		return $deduplicate;
 	}
 
 	/**

--- a/src/editor/index.js
+++ b/src/editor/index.js
@@ -20,7 +20,7 @@ import { useEffect } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { optionsFieldsSelector } from './utils';
+import { optionsFieldsSelector, isOverlayPlacement } from './utils';
 import Sidebar from './Sidebar';
 import StylesSidebar from './StylesSidebar';
 import FrequencySidebar from './FrequencySidebar';
@@ -148,13 +148,13 @@ registerPlugin( 'newspack-popups-editor', {
 // Hide Newspack's Homepage Posts block deduplication toggle when the popup is an overlay.
 registerPlugin( 'newspack-popups-disable-newspack-blocks-deduplication', {
 	render: function HideDeduplicationToggle() {
-		const { isOverlay } = useSelect( select => {
+		const { placement } = useSelect( select => {
 			const { getEditedPostAttribute } = select( 'core/editor' );
 			return {
-				isOverlay: getEditedPostAttribute( 'meta' )?.placement === 'center',
+				placement: getEditedPostAttribute( 'meta' )?.placement,
 			};
 		} );
-		if ( ! isOverlay ) {
+		if ( ! isOverlayPlacement( placement ) ) {
 			return null;
 		}
 		return <style>{ '.newspack-blocks-deduplication-toggle {display: none;}' }</style>;

--- a/src/editor/index.js
+++ b/src/editor/index.js
@@ -145,6 +145,23 @@ registerPlugin( 'newspack-popups-editor', {
 	icon: null,
 } );
 
+// Hide Newspack's Homepage Posts block deduplication toggle when the popup is an overlay.
+registerPlugin( 'newspack-popups-disable-newspack-blocks-deduplication', {
+	render: function HideDeduplicationToggle() {
+		const { isOverlay } = useSelect( select => {
+			const { getEditedPostAttribute } = select( 'core/editor' );
+			return {
+				isOverlay: getEditedPostAttribute( 'meta' )?.placement === 'center',
+			};
+		} );
+		if ( ! isOverlay ) {
+			return null;
+		}
+		return <style>{ '.newspack-blocks-deduplication-toggle {display: none;}' }</style>;
+	},
+	icon: null,
+} );
+
 // Add a button in post status section
 const PluginPostStatusInfoTest = () => (
 	<PluginPostStatusInfo className="newspack-popups__status-options">


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

https://github.com/Automattic/newspack-blocks/pull/1543 proposes a new strategy for opting out of the deduplication logic in the Homepage Posts block. This requires a change in how it's implemented for campaigns.

This PR implements the necessary changes to the logic initially implemented in #630 so it continues to work as expected.

### How to test the changes in this Pull Request:

1. Checkout https://github.com/Automattic/newspack-blocks/pull/1543 and this branch
2. Create a page and a campaign prompt with matching Homepage Posts blocks (so they display the same content)
3. Make sure the prompt is displayed as an overlay and can be rendered on the created page
4. Visit the page and confirm the expected duplicated posts rendered on the page and the prompt

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
