### PR TITLE
fix: handle no post when the the_content is run

### DIFF
--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -460,8 +460,12 @@ final class Newspack_Popups_Inserter {
 	 * @param string $content The content of the post.
 	 */
 	public static function insert_popups_in_content( $content = '' ) {
+		$post = get_post();
+		if ( ! $post ) {
+			return $content;
+		}
 		$filtered_content = explode( "\n", $content );
-		$post_content     = explode( "\n", get_post()->post_content );
+		$post_content     = explode( "\n", $post->post_content );
 		if (
 			// Avoid duplicate execution.
 			true === self::$the_content_has_rendered


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fix for a weird case: `the_content` hook was run when I was editing a post, without any relation to Campaigns. `the_post()` returned `null` and so a PHP Warning was logged (because of trying to invoke `post_content` on `null`). 

### How to test the changes in this Pull Request:

1. On `master`,
1. Edit a post, insert a Checkout Button block (that's how it happened to me, don't know why)
2. Observe warnings logged in the debug log
3. Switch to this branch, observe no warnings logged

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->