### PR TITLE
fix(settings): get_setting method

### DIFF
--- a/includes/class-newspack-popups-settings.php
+++ b/includes/class-newspack-popups-settings.php
@@ -186,7 +186,20 @@ class Newspack_Popups_Settings {
 	 * @param string $key Key name.
 	 */
 	public static function get_setting( $key ) {
-		return get_option( $key, true );
+		$settings = self::get_settings();
+		foreach ( $settings as $setting ) {
+			if ( $key === $setting['key'] ) {
+				return $setting['value'];
+			}
+		}
+		return new \WP_Error(
+			'newspack_popups_settings_error',
+			sprintf(
+				// Translators: Invalid settings key error.
+				__( 'Invalid settings key: %s', 'newpack-popups' ),
+				$key
+			)
+		);
 	}
 
 	/**
@@ -231,7 +244,7 @@ class Newspack_Popups_Settings {
 
 		$settings_list = [
 			[
-				'description' => __( 'Donor Settings', 'newspack-ads' ),
+				'description' => __( 'Donor Settings', 'newspack-popups' ),
 				'help'        => __( 'Configure when readers are considered donors.', 'newspack-ads' ),
 				'section'     => 'donor_settings',
 				'key'         => 'active',
@@ -339,6 +352,9 @@ class Newspack_Popups_Settings {
 			$settings_list = array_reduce(
 				$settings_list,
 				function ( $carry, $item ) {
+					if ( ! isset( $carry[ $item['section'] ] ) ) {
+						$carry[ $item['section'] ] = [];
+					}
 					$carry[ $item['section'] ][] = $item;
 					return $carry;
 				},

--- a/tests/test-model.php
+++ b/tests/test-model.php
@@ -180,4 +180,14 @@ class ModelTest extends WP_UnitTestCase {
 		self::assertNotNull( $popup, 'Unable to retrieve popup by id.' );
 		self::assertSame( $draf_prompt, $popup['id'], 'Unable to retrieve popup by id.' );
 	}
+
+	/**
+	 * Tests fetching default settings.
+	 */
+	public function test_settings() {
+		\delete_option( 'newspack_popups_mc_donor_merge_field' );
+		$setting = Newspack_Popups_Settings::get_setting( 'newspack_popups_mc_donor_merge_field' );
+
+		self::assertSame( $setting, 'DONAT' );
+	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a logical error in the `Newspack_Popups_Settings::get_setting` method. If getting an invalid setting key or a setting key that doesn't have a saved option, it would always return `true` instead of the setting's default value. This PR validates the key and also returns the default value if a value hasn't been saved before.

### How to test the changes in this Pull Request:

1. On a fresh site, install Campaigns from `master`.
2. Run `wp shell`, then `Newspack_Popups_Settings::get_setting( 'newspack_popups_mc_donor_merge_field' )`. Observe that it returns `true`.
3. Check out this branch and repeat step 2 in a new `wp shell` session. Confirm it now returns `DONAT`.
4. Update the settings in Newspack > Campaigns > Settings and repeat with various keys ([see here](https://github.com/Automattic/newspack-popups/blob/master/includes/class-newspack-popups-settings.php#L232) for keys to check).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
