### PR TITLE
Fix/ras presets duplication

### DIFF
--- a/includes/class-newspack-popups-logger.php
+++ b/includes/class-newspack-popups-logger.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Newspack Popups Logger
+ *
+ * @package Newspack
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Logger.
+ */
+class Newspack_Popups_Logger {
+	/**
+	 * A logger.
+	 *
+	 * @param string $payload The payload to log.
+	 */
+	public static function log( $payload ) {
+		if ( ! defined( 'NEWSPACK_LOG_LEVEL' ) || 0 > (int) NEWSPACK_LOG_LEVEL || 'string' !== gettype( $payload ) ) {
+			return;
+		}
+
+		$header = 'NEWSPACK-POPUPS';
+		if ( class_exists( '\Newspack\Logger' ) ) {
+			\Newspack\Logger::log( $payload, $header );
+		} else {
+			error_log( '[' . $header . ']: ' . $payload ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+		}
+	}
+}

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -95,18 +95,19 @@ final class Newspack_Popups {
 		add_filter( 'show_admin_bar', [ __CLASS__, 'show_admin_bar' ], 10, 2 ); // phpcs:ignore WordPressVIPMinimum.UserExperience.AdminBarRemoval.RemovalDetected
 		add_filter( 'newspack_blocks_should_deduplicate', [ __CLASS__, 'newspack_blocks_should_deduplicate' ], 10, 2 );
 
-		include_once dirname( __FILE__ ) . '/class-newspack-popups-model.php';
-		include_once dirname( __FILE__ ) . '/class-newspack-segments-migration.php';
-		include_once dirname( __FILE__ ) . '/class-newspack-segments-model.php';
-		include_once dirname( __FILE__ ) . '/class-newspack-popups-presets.php';
-		include_once dirname( __FILE__ ) . '/class-newspack-popups-inserter.php';
-		include_once dirname( __FILE__ ) . '/class-newspack-popups-api.php';
-		include_once dirname( __FILE__ ) . '/class-newspack-popups-settings.php';
-		include_once dirname( __FILE__ ) . '/class-newspack-popups-segmentation.php';
-		include_once dirname( __FILE__ ) . '/class-newspack-popups-custom-placements.php';
-		include_once dirname( __FILE__ ) . '/class-newspack-popups-view-as.php';
-		include_once dirname( __FILE__ ) . '/class-newspack-popups-data-api.php';
-		include_once dirname( __FILE__ ) . '/class-newspack-popups-criteria.php';
+		include_once __DIR__ . '/class-newspack-popups-logger.php';
+		include_once __DIR__ . '/class-newspack-popups-model.php';
+		include_once __DIR__ . '/class-newspack-segments-migration.php';
+		include_once __DIR__ . '/class-newspack-segments-model.php';
+		include_once __DIR__ . '/class-newspack-popups-presets.php';
+		include_once __DIR__ . '/class-newspack-popups-inserter.php';
+		include_once __DIR__ . '/class-newspack-popups-api.php';
+		include_once __DIR__ . '/class-newspack-popups-settings.php';
+		include_once __DIR__ . '/class-newspack-popups-segmentation.php';
+		include_once __DIR__ . '/class-newspack-popups-custom-placements.php';
+		include_once __DIR__ . '/class-newspack-popups-view-as.php';
+		include_once __DIR__ . '/class-newspack-popups-data-api.php';
+		include_once __DIR__ . '/class-newspack-popups-criteria.php';
 	}
 
 	/**

--- a/includes/class-newspack-segments-model.php
+++ b/includes/class-newspack-segments-model.php
@@ -419,7 +419,7 @@ final class Newspack_Segments_Model {
 	 *
 	 * @param int $segment_id The segment ID.
 	 */
-	private static function get_segments_prompts_ids( $segment_id ) {
+	private static function get_segment_prompts_ids( $segment_id ) {
 		return get_posts(
 			[
 				'post_type'      => Newspack_Popups::NEWSPACK_POPUPS_CPT,
@@ -444,7 +444,7 @@ final class Newspack_Segments_Model {
 	public static function remove_duplicates() {
 		foreach ( self::get_segments() as $segment ) {
 			if ( $segment['is_criteria_duplicated'] ) {
-				$assigned_prompts_count = count( self::get_segments_prompts_ids( $segment['id'] ) );
+				$assigned_prompts_count = count( self::get_segment_prompts_ids( $segment['id'] ) );
 				if ( 0 === $assigned_prompts_count ) {
 					Newspack_Popups_Logger::log( sprintf( 'Segment "%s" is duplicated, it will be removed.', $segment['name'] ) );
 					self::delete_segment( $segment['id'] );

--- a/tests/test-segments.php
+++ b/tests/test-segments.php
@@ -277,9 +277,10 @@ class SegmentsTest extends WP_UnitTestCase {
 		foreach ( $segments as $segment ) {
 			$segment_id      = $segment['id'];
 			$segment_from_db = Newspack_Popups_Segmentation::get_segment( $segment_id );
+			unset( $segment['criteria_hash'] );
+			unset( $segment['is_criteria_duplicated'] );
 			$this->assertSame( $segment, $segment_from_db );
 		}
-
 	}
 
 	/**
@@ -310,7 +311,6 @@ class SegmentsTest extends WP_UnitTestCase {
 
 		$delete_result2 = Newspack_Popups_Segmentation::delete_segment( 'non-existent' );
 		$this->assertSame( $delete_result, $delete_result2 );
-
 	}
 
 	/**
@@ -343,7 +343,6 @@ class SegmentsTest extends WP_UnitTestCase {
 		$this->assertNotContains( 'other_properties', $result[0], 'additional properties should not be included' );
 
 		$this->assertSame( $this->valid['name'], $result[1]['name'] );
-
 	}
 
 	/**
@@ -430,7 +429,6 @@ class SegmentsTest extends WP_UnitTestCase {
 			),
 			'Should return wp error if an invalid id is part of the array'
 		);
-
 	}
 
 	/**
@@ -618,5 +616,4 @@ class SegmentsTest extends WP_UnitTestCase {
 			$this->assertSame( $key, $last_segment['name'] );
 		}
 	}
-
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds means of removing duplicate segments (if no active prompts are assigned to them). This does not handle duplicate prompts, since we haven't observed this issue on live sites. Probably duplicate segments have been created accidentally during RAS beta phase. 

See 1200133283036252-as-1205733927102145

### How to test the changes in this Pull Request:

1. Switch `newspack-plugin` to `fix/duplicate-segments` branch (https://github.com/Automattic/newspack-plugin/pull/2766)
1. Run `$ wp newspack-popups import --ras-defaults` at least twice, so you end up with some duplicate prompts & segments
2. Observe "DUPLICATE" badges displayed in Campaigns wizard -> Segments tab
3. Run `$ wp eval "\Newspack_Segments_Model::remove_duplicates();"`, observe that the duplicate segments have been removed

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->