### PR TITLE
feat: don't enqueue criteria if popups are disabled for post

### DIFF
--- a/includes/class-newspack-popups-criteria.php
+++ b/includes/class-newspack-popups-criteria.php
@@ -35,7 +35,7 @@ final class Newspack_Popups_Criteria {
 	 * Initialize the hooks.
 	 */
 	public static function init() {
-		require_once dirname( __FILE__ ) . '/../src/criteria/default/index.php';
+		require_once __DIR__ . '/../src/criteria/default/index.php';
 		add_action( 'wp_enqueue_scripts', [ __CLASS__, 'enqueue_scripts' ] );
 	}
 
@@ -44,6 +44,9 @@ final class Newspack_Popups_Criteria {
 	 */
 	public static function enqueue_scripts() {
 		if ( defined( 'IS_TEST_ENV' ) && IS_TEST_ENV ) {
+			return;
+		}
+		if ( Newspack_Popups_Inserter::assess_has_disabled_popups() ) {
 			return;
 		}
 

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -8,7 +8,7 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * API endpoints
+ * Popups Inserter class.
  */
 final class Newspack_Popups_Inserter {
 	/**
@@ -325,7 +325,7 @@ final class Newspack_Popups_Inserter {
 					$next_block               = $parsed_blocks[ $next_index ];
 					$group_blocks[]           = $next_block;
 					$grouped_blocks_indexes[] = $next_index;
-					$next_index ++;
+					$next_index++;
 					$index_in_group++;
 				}
 				// Always insert the initial block in the group (if the index in group was not incremented, this is the initial block).


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Prevents loading the criteria-handling JS if prompts are disabled on a page. 

### How to test the changes in this Pull Request:

1. Visit a page that will display a prompt and observe that the `criteria.js` file is loaded
2. Visit a page with prompts disabled, observe the file is not downloaded 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->