### PR TITLE
fix: dont change global post before header

### DIFF
--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -319,9 +319,7 @@ final class Newspack_Popups_Model {
 	protected static function retrieve_popups_with_query( WP_Query $query, $include_taxonomies = false ) {
 		$popups = [];
 		if ( $query->have_posts() ) {
-			while ( $query->have_posts() ) {
-				$query->the_post();
-				$popup_post = get_post( get_the_ID() );
+			foreach ( $query->posts as $popup_post ) {
 				if ( Newspack_Popups::NEWSPACK_POPUPS_CPT === $popup_post->post_type ) {
 					$popup = self::create_popup_object(
 						$popup_post,
@@ -334,7 +332,6 @@ final class Newspack_Popups_Model {
 					}
 				}
 			}
-			wp_reset_postdata();
 		}
 		return $popups;
 	}

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -888,6 +888,9 @@ final class Newspack_Popups {
 	 * @param WP_Post $post The prompt post object.
 	 */
 	public static function is_account_related_post( $post ) {
+		if ( ! $post instanceof WP_Post ) {
+			return false;
+		}
 		return has_shortcode( $post->post_content, 'woocommerce_my_account' );
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

When we loop through prompts before header, we use a standard WP Loop, and use `wp_reset_postdata` to reset the global `$post` object afterwards.

This works in most cases, but we just found a situation where this doesn't work and ends up messing up the global object.

When you are in an archive page that has no posts, `wp_reset_postdata()` will not reset post data, because there is no post. See this check -> https://github.com/WordPress/wordpress-develop/blob/trunk/src/wp-includes/class-wp-query.php#L4898

I modified the loop to use a simple foreach and to not touch the global post variable.

### How to test the changes in this Pull Request:

1. On `master`, create a new user and make sure there are no posts assigned to them
2. Using Newspack theme, visit this user archive
3. Confirm the user name displayed in the page title is not the user you are seeing the archive for
4. Checkout this branch and reload
5. Confirm the user now matches the user you are looking at
6. Confirm that popups are still working as expected!!!


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206059823028916