### PR TITLE
feat: fetch up to 1000 prompts

### DIFF
--- a/includes/class-newspack-popups-importer.php
+++ b/includes/class-newspack-popups-importer.php
@@ -241,7 +241,12 @@ class Newspack_Popups_Importer {
 				'post_status'  => $prompt['status'],
 				'post_type'    => Newspack_Popups::NEWSPACK_POPUPS_CPT,
 			];
-			$new_post  = wp_insert_post( $post_data );
+			if ( $prompt_slug ) {
+				$post_data['post_name'] = \sanitize_title( $prompt_slug );
+			}
+			$new_post = wp_insert_post( $post_data );
+			sleep( 1 ); // Pause to avoid duplicate post publish dates and unpredictable sort order.
+
 			if ( is_wp_error( $new_post ) ) {
 				$this->errors['prompts'][] = $new_post->get_error_message();
 				continue;

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -61,7 +61,7 @@ final class Newspack_Popups_Model {
 		$args = [
 			'post_type'      => Newspack_Popups::NEWSPACK_POPUPS_CPT,
 			'post_status'    => $include_unpublished ? [ 'draft', 'pending', 'future', 'publish' ] : [ 'publish' ],
-			'posts_per_page' => 100,
+			'posts_per_page' => 1000, // phpcs:ignore WordPress.WP.PostsPerPage.posts_per_page_posts_per_page
 		];
 		if ( $include_trash ) {
 			$args['post_status'][] = 'trash';

--- a/tests/test-importer.php
+++ b/tests/test-importer.php
@@ -219,6 +219,7 @@ class ImporterTest extends WP_UnitTestCase_PageWithPopups {
 			],
 			[
 				'title'           => 'Test Prompt 2',
+				'slug'            => 'Test Prompt Slug',
 				'content'         => 'Test content',
 				'status'          => 'draft',
 				'campaign_groups' => [
@@ -284,7 +285,7 @@ class ImporterTest extends WP_UnitTestCase_PageWithPopups {
 		$created_groups = Newspack_Popups::get_groups();
 		$this->assertSame( 2, count( $created_groups ) );
 
-		// Test if segmentes were properly created.
+		// Test if segments were properly created.
 		$created_segments = Newspack_Popups_Segmentation::get_segments();
 		$this->assertSame( 2, count( $created_segments ) );
 		$this->assertSame( 'Test Segment', $created_segments[0]['name'] );
@@ -300,6 +301,9 @@ class ImporterTest extends WP_UnitTestCase_PageWithPopups {
 		// Check if 2 prompts were created.
 		$created_prompts = Newspack_Popups_Model::retrieve_popups( true );
 		$this->assertSame( 2, count( $created_prompts ) );
+
+		// Check if the slug is set correctly if passed.
+		$this->assertSame( sanitize_title( $package['prompts'][1]['slug'] ), get_post( $created_prompts[0]['id'] )->post_name );
 
 		// Check if the prompts were properly mapped to the segments.
 		$this->assertSame( 1, count( $created_prompts[0]['segments'] ) );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Bumps the max number of prompts fetched by the API from 100 to 1000.

### How to test the changes in this Pull Request:

1. Test with a site that already has more than 100 prompts, or generate more than 100.
2. On `release`, visit Newspack > Campaigns and observe that only 100 prompts are shown.
3. Check out this branch, refresh, and confirm that up to 1000 prompts are now shown.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
