### PR TITLE
fix: ga4 events

### DIFF
--- a/src/view/analytics/clicked.js
+++ b/src/view/analytics/clicked.js
@@ -8,9 +8,7 @@ import { getEventPayload, getRawId, sendEvent } from '../utils';
 
 export const manageClickedEvents = prompts => {
 	prompts.forEach( prompt => {
-		const anchorLinks = [
-			...prompt.querySelectorAll( '.newspack-inline-popup a, .newspack-popup__content a' ),
-		];
+		const anchorLinks = [ ...prompt.querySelectorAll( '.newspack-popup-container a' ) ];
 		const handleEvent = e => {
 			const extraParams = {};
 

--- a/src/view/analytics/dismissed.js
+++ b/src/view/analytics/dismissed.js
@@ -9,7 +9,7 @@ import { getEventPayload, getRawId, sendEvent } from '../utils';
 export const manageDismissals = prompts => {
 	prompts.forEach( prompt => {
 		const closeButton = prompt.querySelector( '.newspack-lightbox__close' );
-		const forms = [ ...prompt.querySelectorAll( '.newspack-popup__content form' ) ];
+		const forms = [ ...prompt.querySelectorAll( '.newspack-popup-container form' ) ];
 		if ( closeButton ) {
 			const handleEvent = () => {
 				const payload = getEventPayload( 'dismissed', getRawId( prompt.getAttribute( 'id' ) ) );

--- a/src/view/analytics/submitted.js
+++ b/src/view/analytics/submitted.js
@@ -8,9 +8,7 @@ import { getEventPayload, getRawId, sendEvent } from '../utils';
 
 export const manageFormSubmissions = prompts => {
 	prompts.forEach( prompt => {
-		const forms = [
-			...prompt.querySelectorAll( '.newspack-popup__content form, .newspack-inline-popup form' ),
-		];
+		const forms = [ ...prompt.querySelectorAll( '.newspack-popup-container form' ) ];
 		const handleEvent = () => {
 			const payload = getEventPayload( 'form_submission', getRawId( prompt.getAttribute( 'id' ) ) );
 			sendEvent( payload );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes above-header GA4 event handling.

Also simplifies the element selectors – @dkoo or @leogermani I'd be grateful for a review here since you were involved with the original implementation (https://github.com/Automattic/newspack-popups/pull/1136). 

### How to test the changes in this Pull Request:

1. On `trunk`, create a new above-header prompt. Insert a link (make it at `#hash` link for convenience)
2. Create an inline prompt, also with a link
3. Ensure you have GA4 configured via Site Kit
4. Use [an extension](https://chromewebstore.google.com/detail/google-analytics-debugger/jnkmfdileelhofjcijamephohjechhna) or simply monitor `collect` requests in the network tab
5. Click the links in both prompts, observe that only the inline one triggers a GA4 event to be sent
6. Switch to this branch, observe that both prompts trigger a GA4 event when then link within is clicked
 
### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->