### PR TITLE
fix(preview): handle additional_classes

### DIFF
--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -257,6 +257,7 @@ final class Newspack_Popups_Model {
 			'archive_insertion_posts_count'  => FILTER_SANITIZE_FULL_SPECIAL_CHARS,
 			'archive_insertion_is_repeating' => FILTER_VALIDATE_BOOLEAN,
 			'utm_suppression'                => FILTER_SANITIZE_FULL_SPECIAL_CHARS,
+			'additional_classes'             => FILTER_SANITIZE_FULL_SPECIAL_CHARS,
 		];
 
 		$options = [];

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -40,6 +40,7 @@ final class Newspack_Popups {
 		'archive_insertion_posts_count'  => 'n_ac',
 		'archive_insertion_is_repeating' => 'n_ar',
 		'utm_suppression'                => 'n_ut',
+		'additional_classes'             => 'n_acl',
 	];
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a bug where additional CSS classes were not applied in editor previews. 

See 1200550061930446-as-1206541498328358

### How to test the changes in this Pull Request:

1. On `trunk`, edit a prompt and set some CSS classes in "Advanced Settings" sidebar panel
2. Trigger a preview, observe the classes are not applied 
3. Switch to this branch, try again, observe the classes are applied to the `newspack-popup-container` element

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->