### PR TITLE
fix: update no-padding popup styles

### DIFF
--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -1034,8 +1034,8 @@ final class Newspack_Popups_Model {
 		$overlay_color         = $popup['options']['overlay_color'];
 		$overlay_size          = 'full' === $popup['options']['overlay_size'] ? 'full-width' : $popup['options']['overlay_size'];
 		$no_overlay_background = $popup['options']['no_overlay_background'];
-		$close_button_color    = $no_overlay_background ? '#000' : self::foreground_color_for_background( $popup['options']['overlay_color'] );
-		$close_button_shadow   = $no_overlay_background ? 'transparent' : $overlay_color . 'aa';
+		$close_button_color    = ( ! $no_overlay_background && $hide_border ) ? self::foreground_color_for_background( $popup['options']['overlay_color'] ) : '#000';
+		$close_button_shadow   = ( ! $no_overlay_background && $hide_border ) ? $overlay_color . 'aa' : 'transparent';
 		$hidden_fields         = self::get_hidden_fields( $popup );
 		$is_newsletter_prompt  = self::has_newsletter_prompt( $popup );
 		$has_featured_image    = has_post_thumbnail( $popup['id'] ) || ! empty( $popup['options']['featured_image_id'] );

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -1034,6 +1034,8 @@ final class Newspack_Popups_Model {
 		$overlay_color         = $popup['options']['overlay_color'];
 		$overlay_size          = 'full' === $popup['options']['overlay_size'] ? 'full-width' : $popup['options']['overlay_size'];
 		$no_overlay_background = $popup['options']['no_overlay_background'];
+		$close_button_color    = $no_overlay_background ? '#000' : self::foreground_color_for_background( $popup['options']['overlay_color'] );
+		$close_button_shadow   = $no_overlay_background ? 'transparent' : $overlay_color . 'aa';
 		$hidden_fields         = self::get_hidden_fields( $popup );
 		$is_newsletter_prompt  = self::has_newsletter_prompt( $popup );
 		$has_featured_image    = has_post_thumbnail( $popup['id'] ) || ! empty( $popup['options']['featured_image_id'] );
@@ -1079,8 +1081,10 @@ final class Newspack_Popups_Model {
 					<div class="newspack-popup__content">
 						<?php echo do_shortcode( $body ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 					</div>
-					<button class="newspack-lightbox__close" aria-label="<?php esc_html_e( 'Close Pop-up', 'newspack-popups' ); // phpcs:ignore WordPressVIPMinimum.Security.ProperEscapingFunction.htmlAttrNotByEscHTML ?>">
-						<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" role="img" aria-hidden="true" focusable="false"><path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12 19 6.41z"/></svg>
+					<button class="newspack-lightbox__close" style="color: <?php echo esc_attr( $close_button_color ); ?>"aria-label="<?php esc_html_e( 'Close Pop-up', 'newspack-popups' ); // phpcs:ignore WordPressVIPMinimum.Security.ProperEscapingFunction.htmlAttrNotByEscHTML ?>">
+						<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" role="img" aria-hidden="true" focusable="false">
+							<path style="filter: drop-shadow(0 0 3px <?php echo esc_attr( $close_button_shadow ); ?>); " d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12 19 6.41z"/>
+						</svg>
 					</button>
 				</div>
 			</div>

--- a/src/view/style.scss
+++ b/src/view/style.scss
@@ -147,6 +147,12 @@ $width__tablet: 782px;
 				}
 			}
 		}
+
+		.newspack-inactive-popup-status {
+			&::before {
+				left: 32px;
+			}
+		}
 	}
 
 	&.newspack-lightbox-large-border {
@@ -463,17 +469,18 @@ $width__tablet: 782px;
 .newspack-inactive-popup-status {
 	&::before {
 		background: black;
+		border-radius: 2px;
 		color: white;
 		content: attr( data-popup-status );
 		font-family: $font__system;
-		font-size: 0.8em;
-		font-weight: bold;
+		font-size: 12px;
+		font-weight: 600;
 		text-transform: uppercase;
-		left: 6px;
-		line-height: 1.5;
-		padding: 0 0.25em;
+		left: 4px;
+		line-height: 2;
+		padding: 0 0.5em;
 		position: absolute;
-		top: 6px;
+		top: 4px;
 		z-index: 1;
 	}
 }

--- a/src/view/style.scss
+++ b/src/view/style.scss
@@ -130,18 +130,22 @@ $width__tablet: 782px;
 			box-shadow: none;
 		}
 
-		.newspack-popup__content {
-			padding-top: 32px;
-		}
-
 		.newspack-popup__content-wrapper {
 			box-shadow: 0 0 1em 0.5em rgba( black, 0.1 );
 			margin: 32px;
 		}
 
-		.newspack-lightbox__close {
-			right: #{2 * $overlay__gap};
-			top: #{2 * $overlay__gap};
+		.newspack-popup__content {
+			padding: 0;
+		}
+
+		&.newspack-lightbox-featured-image {
+			@media only screen and ( min-width: $width__tablet ) {
+				.newspack-lightbox__close {
+					right: #{2 * $overlay__gap};
+					top: #{2 * $overlay__gap};
+				}
+			}
 		}
 	}
 

--- a/src/view/style.scss
+++ b/src/view/style.scss
@@ -238,7 +238,7 @@ $width__tablet: 782px;
 			.newspack-lightbox__close {
 				background-color: rgba( black, 0.5 );
 				border-radius: 3px;
-				color: white;
+				color: white !important; // !important to override inline styles.
 				height: 48px;
 				margin: 8px;
 				width: 48px;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Right now, the Default and Hide Padding styles for the overlay prompts look the same. This PR makes the 'No Padding' style a true no padding style, but it's worth flagging that prior to this, that style has always had some padding.

I think it's naming/styling came from trying to be a popup variation of the inline prompt's no border style, but unlike removing the border and padding from the inline prompts, an overlay prompt with no padding and no blocks inside with padding looks broken:

![image](https://github.com/Automattic/newspack-popups/assets/177561/a7212090-55fe-4e34-b64f-9b1ee6f93ba8)

No padding also adds a lot of flexibility to the designs, but I'd appreciate some feedback around whether this seems like an okay trade off: 

![image](https://github.com/Automattic/newspack-popups/assets/177561/3f2c94fe-1206-4623-976a-f84cfcc4cfe4)

If we do opt to go with this, we should probably present it as something of a breaking change, as it'll change the appearance of this style in ways that may not work with live prompts that are using it.

See 1200550061930446-as-1206132801968396.

### How to test the changes in this Pull Request:

1. Create a new campaign prompt, and set it to display as an overlay. Give it some regular content.
2. Under the Styles panel on the right, set the prompt to have 'Hide Padding'.
3. Preview and note that the overlay popup has padding:

![image](https://github.com/Automattic/newspack-popups/assets/177561/c5fe0f93-871c-41cb-b9f0-0eae2de0a133)

4. Apply the PR and run `npm run build`.
5. Refresh the preview and confirm that the popup now has no padding: 

![image](https://github.com/Automattic/newspack-popups/assets/177561/bd4b5338-1507-4617-a954-52fe94f8b522)

6. Switch out the content blocks to add something a little more logical -- for example, a Cover Block, Media & Text Block, or Group block + padding as a base. Preview again and confirm this works well, and that there truly is no padding: 

![image](https://github.com/Automattic/newspack-popups/assets/177561/8ff8f1c9-bd9c-4477-b4e6-0ef42e01598d)

7. Test on smaller screen sizes, too, and make sure things look okay.
8. As part of this PR, I also added some styles to make sure the overlay always contrasts against the overlay when using the 'No Padding' style. To test this, try to change the overlay colour from a dark to a light colour, and confirm that the close button contrasts against it; test this with a few different colours:

![image](https://github.com/Automattic/newspack-popups/assets/177561/2e51a40a-e8d2-41a9-9062-77d48926972b)

9. Test this with the 'No Overlay' option, and confirm that the close button is black.
10. Switch the overlay back on and back to a dark colour, and test the Default and Large Styles for the overlay; confirm that the close button is black for both, even though it would be white for the Hide Padding style.
11. Add a featured image to the prompt; confirm that the button colour remains white, even when the overlay is light:

![image](https://github.com/Automattic/newspack-popups/assets/177561/e5b49883-472d-4c8c-a6f2-e71992cf6667)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
