### PR TITLE
fix: disable manual & custom placement prompts when prompts are disabled

### DIFF
--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -721,6 +721,10 @@ final class Newspack_Popups_Inserter {
 	 * @return HTML
 	 */
 	public static function popup_shortcode( $atts = array() ) {
+		if ( self::assess_has_disabled_popups() ) {
+			return;
+		}
+
 		$default_atts = [
 			'id'    => 0,
 			'class' => '',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

When the "Disable prompts on this post or page" setting is turned on for a post or page, the shortcode render method for prompts doesn't pay attention to this filter, which means that any prompts rendered via the shortcode (including Custom Placements and Manual placement prompts) will continue to render. This PR fixes this.

### How to test the changes in this Pull Request:

1. Publish two prompts: one with a custom placement, and the other set to "Manual Only" in the "Everyone" segment.
2. On a post or page, add a Custom Placement and Single Prompt block, and select the prompts you created in step 1. Enable the "Disable prompts on this post or page" option in the sidebar and publish.
3. On `release`, visit the post as a reader and observe that both prompts are rendered despite the option.
4. Check out this branch and refresh, and confirm that neither prompt is rendered.
5. Uncheck the "Disable prompts on this post or page" option and save. Refresh the post and confirm that both prompts reappear.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207114585939226