### PR TITLE
Update above-header hook used by plugin

### DIFF
--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -91,7 +91,7 @@ final class Newspack_Popups_Inserter {
 		add_filter( 'the_content', [ $this, 'insert_popups_in_content' ], 1 );
 		add_shortcode( 'newspack-popup', [ $this, 'popup_shortcode' ] );
 		add_action( 'after_header', [ $this, 'insert_popups_after_header' ] ); // This is a Newspack theme hook. When used with other themes, popups won't be inserted on archive pages.
-		add_action( 'before_header', [ $this, 'insert_before_header' ] );
+		add_action( 'wp_body_open', [ $this, 'insert_before_header' ] );
 		add_action( 'after_archive_post', [ $this, 'insert_inline_prompt_in_archive_pages' ] );
 		add_action( 'wp_before_admin_bar_render', [ $this, 'add_preview_toggle' ] );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR updates the `before_header` used by the plugin for the more standard `wp_body_open`, which is already included in our classic theme and that appears by default in block themes.

This fixes a couple small issues with this plugin + block themes, and hopefully doesn't cause any weirdness with our existing theme.

I think this is a pretty harmless change -- the two hooks [are stacked in our current theme](https://github.com/Automattic/newspack-theme/blob/trunk/newspack-theme/header.php#L23-L24) -- but definitely would appreciate an eye to potential issues!

Closes 1203518336360239-as-1203518336360246, 1203518336360239-as-1203518336360244

### How to test the changes in this Pull Request:

1. Using a block theme (like [ours](https://github.com/automattic/newspack-block-theme)), and starting on trunk, set up an above header prompt.
2. View on the front end and note it doesn't work.
3. Set up a popup prompt.
4. View on the front-end and note that while it works, you can't close it.
5. Apply this PR.
6. Repeat steps 1-4 and confirm that both are now working.
7. Switch to our classic theme, and [repeat steps 1-4](https://github.com/automattic/newspack-theme) and confirm they're still okay.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
