### PR TITLE
feat: prompt expiration date

### DIFF
--- a/includes/class-newspack-popups-expiry.php
+++ b/includes/class-newspack-popups-expiry.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Newspack Popups Expiry
+ *
+ * @package Newspack
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Main Newspack Popups Expiry Class.
+ */
+final class Newspack_Popups_Expiry {
+	/**
+	 * Hook name for the cron job.
+	 */
+	const CRON_HOOK = 'newspack_popups_check_expiry';
+
+	/**
+	 * Init Newspack Popups Expiry.
+	 */
+	public static function init() {
+		add_action( 'transition_post_status', [ __CLASS__, 'transition_post_status' ], 10, 3 );
+		add_action( self::CRON_HOOK, [ __CLASS__, 'revert_expired_to_draft' ] );
+		if ( ! wp_next_scheduled( self::CRON_HOOK ) ) {
+			wp_schedule_event( time(), 'hourly', self::CRON_HOOK );
+		}
+	}
+
+	/**
+	 * Revert expired prompts to draft state.
+	 */
+	public static function revert_expired_to_draft() {
+		// Get all prompts with the expiration_date in the past.
+		$expired_prompts = get_posts(
+			[
+				'post_type'      => Newspack_Popups::NEWSPACK_POPUPS_CPT,
+				'posts_per_page' => -1,
+				'meta_query'     => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+					[
+						'key'     => 'expiration_date',
+						'value'   => gmdate( 'Y-m-d H:i:s' ),
+						'compare' => '<=',
+					],
+				],
+			]
+		);
+		foreach ( $expired_prompts as $prompt_post ) {
+			// Change the post status to draft.
+			wp_update_post(
+				[
+					'ID'          => $prompt_post->ID,
+					'post_status' => 'draft',
+				]
+			);
+		}
+	}
+
+	/**
+	 * If the post is published, and it has an expiry date in the past, remove the expiry data.
+	 *
+	 * @param string  $new_status New post status.
+	 * @param string  $old_status Old post status.
+	 * @param WP_Post $post       Post object.
+	 */
+	public static function transition_post_status( $new_status, $old_status, $post ) {
+		if ( $old_status !== 'publish' && $new_status === 'publish' ) {
+			$expiration_date = get_post_meta( $post->ID, 'expiration_date', true );
+			if ( $expiration_date && strtotime( $expiration_date ) < time() ) {
+				delete_post_meta( $post->ID, 'expiration_date' );
+			}
+		}
+	}
+}
+
+Newspack_Popups_Expiry::init();

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -106,6 +106,7 @@ final class Newspack_Popups {
 		include_once __DIR__ . '/class-newspack-popups-view-as.php';
 		include_once __DIR__ . '/class-newspack-popups-data-api.php';
 		include_once __DIR__ . '/class-newspack-popups-criteria.php';
+		include_once __DIR__ . '/class-newspack-popups-expiry.php';
 	}
 
 	/**
@@ -519,6 +520,18 @@ final class Newspack_Popups {
 				],
 				'type'           => 'array',
 				'default'        => [],
+				'single'         => true,
+				'auth_callback'  => '__return_true',
+			]
+		);
+
+		\register_meta(
+			'post',
+			'expiration_date',
+			[
+				'object_subtype' => self::NEWSPACK_POPUPS_CPT,
+				'show_in_rest'   => true,
+				'type'           => 'string',
 				'single'         => true,
 				'auth_callback'  => '__return_true',
 			]

--- a/includes/schemas/class-prompts.php
+++ b/includes/schemas/class-prompts.php
@@ -368,6 +368,12 @@ class Prompts extends Schema {
 								],
 							],
 						],
+						'expiration_date'                => [
+							'name'     => 'expiration_date',
+							'type'     => 'string',
+							'required' => false,
+							'default'  => false,
+						],
 						'newspack_popups_has_disabled_popups' => [
 							'name'     => 'newspack_popups_has_disabled_popups',
 							'type'     => 'boolean',

--- a/src/editor/ExpirationPanel.js
+++ b/src/editor/ExpirationPanel.js
@@ -4,7 +4,7 @@
 import { __, sprintf } from '@wordpress/i18n';
 import { ToggleControl, DatePicker } from '@wordpress/components';
 import { isInTheFuture } from '@wordpress/date';
-import { useEffect, useState } from '@wordpress/element';
+import { useEffect, useState, useMemo } from '@wordpress/element';
 
 const ExpirationPanel = ( {
 	expiration_date = null,
@@ -54,18 +54,24 @@ const ExpirationPanel = ( {
 		}
 	}, [ postStatus ] );
 
+	const defaultExpirationDate = useMemo( () => {
+		const date = new Date();
+		date.setHours( date.getHours() + 24 );
+		return date;
+	}, [] );
+
 	return (
 		<>
 			<ToggleControl
 				label={ __( 'Expiration Date', 'newspack-newsletters' ) }
 				checked={ !! expiration_date }
 				onChange={ () => {
-					if ( expiration_date ) {
-						onMetaFieldChange( { expiration_date: null } );
-					} else {
-						onMetaFieldChange( { expiration_date: new Date() } );
-					}
+					onMetaFieldChange( { expiration_date: expiration_date ? null : defaultExpirationDate } );
 				} }
+				help={ __(
+					'If set, the prompt will be automatically unpublished after this date.',
+					'newspack-popups'
+				) }
 			/>
 			{ expiration_date ? (
 				<DatePicker

--- a/src/editor/ExpirationPanel.js
+++ b/src/editor/ExpirationPanel.js
@@ -1,0 +1,81 @@
+/**
+ * WordPress dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+import { ToggleControl, DatePicker } from '@wordpress/components';
+import { isInTheFuture } from '@wordpress/date';
+import { useEffect, useState } from '@wordpress/element';
+
+const ExpirationPanel = ( {
+	expiration_date = null,
+	postStatus,
+	onMetaFieldChange,
+	createNotice,
+	removeNotice,
+} ) => {
+	const [ noticeId, setNoticeId ] = useState( false );
+	useEffect( () => {
+		if ( expiration_date && ! isInTheFuture( expiration_date ) ) {
+			if ( noticeId ) {
+				return;
+			}
+			createNotice(
+				'warning',
+				sprintf(
+					/* translators: %s is the expiration date */
+					__(
+						'This prompt has expired on %s and has been reverted to draft. Publishing it will reset the expiration date.',
+						'newspack-plugin'
+					),
+					new Date( expiration_date ).toLocaleDateString()
+				),
+				{
+					isDismissible: false,
+				}
+			).then( ( { notice } ) => {
+				setNoticeId( notice.id );
+			} );
+		}
+	}, [ expiration_date ] );
+
+	useEffect( () => {
+		if ( postStatus === 'publish' && noticeId ) {
+			removeNotice( noticeId );
+			createNotice(
+				'info',
+				__(
+					'This prompt has been published. The expiration date has been removed.',
+					'newspack-plugin'
+				)
+			);
+			// This is just for quicked feedback, the actual meta field deletion will
+			// happen on the backend.
+			onMetaFieldChange( { expiration_date: null } );
+		}
+	}, [ postStatus ] );
+
+	return (
+		<>
+			<ToggleControl
+				label={ __( 'Expiration Date', 'newspack-newsletters' ) }
+				checked={ !! expiration_date }
+				onChange={ () => {
+					if ( expiration_date ) {
+						onMetaFieldChange( { expiration_date: null } );
+					} else {
+						onMetaFieldChange( { expiration_date: new Date() } );
+					}
+				} }
+			/>
+			{ expiration_date ? (
+				<DatePicker
+					currentDate={ expiration_date }
+					onChange={ value => onMetaFieldChange( { expiration_date: value } ) }
+					isInvalidDate={ date => ! isInTheFuture( date ) }
+				/>
+			) : null }
+		</>
+	);
+};
+
+export default ExpirationPanel;

--- a/src/editor/index.js
+++ b/src/editor/index.js
@@ -20,7 +20,7 @@ import { useEffect } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { optionsFieldsSelector, isOverlayPlacement } from './utils';
+import { promptEditorPropsSelector, isOverlayPlacement } from './utils';
 import Sidebar from './Sidebar';
 import StylesSidebar from './StylesSidebar';
 import FrequencySidebar from './FrequencySidebar';
@@ -30,6 +30,7 @@ import Preview from './Preview';
 import Duplicate from './Duplicate';
 import EditorAdditions from './EditorAdditions';
 import PostTypesPanel from './PostTypesPanel';
+import ExpirationPanel from './ExpirationPanel';
 import './style.scss';
 
 const EMPTY_ARRAY = [];
@@ -53,7 +54,7 @@ const mapDispatchToProps = dispatch => {
 };
 
 const connectData = compose( [
-	withSelect( optionsFieldsSelector ),
+	withSelect( promptEditorPropsSelector ),
 	withDispatch( mapDispatchToProps ),
 ] );
 
@@ -63,6 +64,7 @@ const StylesSidebarWithData = connectData( StylesSidebar );
 const FrequencySidebarWithData = connectData( FrequencySidebar );
 const ColorsSidebarWithData = connectData( ColorsSidebar );
 const PostTypesPanelWithData = connectData( PostTypesPanel );
+const ExpirationPanelWithData = connectData( ExpirationPanel );
 const AdvancedSidebarWithData = connectData( AdvancedSidebar );
 
 // Register components.
@@ -123,6 +125,18 @@ registerPlugin( 'newspack-popups-post-types', {
 			title={ __( 'Post Types', 'newspack-popups' ) }
 		>
 			<PostTypesPanelWithData />
+		</PluginDocumentSettingPanel>
+	),
+	icon: null,
+} );
+
+registerPlugin( 'newspack-popups-expiration', {
+	render: () => (
+		<PluginDocumentSettingPanel
+			name="expiration-panel"
+			title={ __( 'Expiration', 'newspack-popups' ) }
+		>
+			<ExpirationPanelWithData />
 		</PluginDocumentSettingPanel>
 	),
 	icon: null,

--- a/src/editor/style.scss
+++ b/src/editor/style.scss
@@ -202,3 +202,7 @@ $size__large: 1264px;
 		font-weight: bold;
 	}
 }
+
+.components-datetime__date h3 {
+	margin: 0;
+}

--- a/src/editor/utils.js
+++ b/src/editor/utils.js
@@ -5,7 +5,7 @@ import { __, sprintf, _n } from '@wordpress/i18n';
  *
  * @param {Function} select Select function
  */
-export const optionsFieldsSelector = select => {
+export const promptEditorPropsSelector = select => {
 	const { getEditedPostAttribute } = select( 'core/editor' );
 	const meta = getEditedPostAttribute( 'meta' );
 	const {
@@ -34,9 +34,11 @@ export const optionsFieldsSelector = select => {
 		additional_classes,
 		excluded_categories,
 		excluded_tags,
+		expiration_date,
 	} = meta || {};
 
 	const isOverlay = isOverlayPlacement( placement );
+	const postStatus = select( 'core/editor' ).getEditedPostAttribute( 'status' );
 
 	return {
 		background_color,
@@ -65,6 +67,8 @@ export const optionsFieldsSelector = select => {
 		additional_classes,
 		excluded_categories,
 		excluded_tags,
+		expiration_date,
+		postStatus,
 	};
 };
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -41,3 +41,5 @@ require_once __DIR__ . '/../vendor/autoload.php';
 // Start up the WP testing environment.
 require $_tests_dir . '/includes/bootstrap.php';
 require dirname( __DIR__ ) . '/tests/wp-unittestcase-pagewithpopups.php';
+
+ini_set( 'error_log', 'php://stdout' ); // phpcs:ignore WordPress.PHP.IniSet.Risky

--- a/tests/test-popups-expiry.php
+++ b/tests/test-popups-expiry.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Class Test_Newspack_Popups_Expiry
+ *
+ * @package Newspack_Popups
+ */
+
+/**
+ * Prompt expiry test case.
+ */
+class Test_Newspack_Popups_Expiry extends WP_UnitTestCase {
+
+	/**
+	 * A single example test.
+	 */
+	public function test_prompt_expiry_constants() {
+		$this->assertEquals( 'newspack_popups_check_expiry', Newspack_Popups_Expiry::CRON_HOOK );
+	}
+
+	/**
+	 * Test the init function.
+	 */
+	public function test_prompt_expiry_init() {
+		Newspack_Popups_Expiry::init();
+		$this->assertEquals( 10, has_action( 'transition_post_status', [ 'Newspack_Popups_Expiry', 'transition_post_status' ] ) );
+		$this->assertEquals( 10, has_action( Newspack_Popups_Expiry::CRON_HOOK, [ 'Newspack_Popups_Expiry', 'revert_expired_to_draft' ] ) );
+	}
+
+	/**
+	 * Test the revert_expired_to_draft function.
+	 */
+	public function test_prompt_expiry_revert_expired_to_draft() {
+		// Create a post with an expiration date in the past.
+		$post_id = $this->factory->post->create(
+			[
+				'post_type' => Newspack_Popups::NEWSPACK_POPUPS_CPT,
+			]
+		);
+		// Set post expiration date meta - for some reason setting this as 'meta_input' while post status is publish does not work.
+		update_post_meta( $post_id, 'expiration_date', gmdate( 'Y-m-d H:i:s', strtotime( '-1 day' ) ) );
+
+		$this->assertEquals( 'publish', get_post_status( $post_id ) );
+
+		// This will run in a cron job.
+		Newspack_Popups_Expiry::revert_expired_to_draft();
+
+		$this->assertEquals( 'draft', get_post_status( $post_id ) );
+	}
+
+	/**
+	 * Test the transition_post_status function.
+	 */
+	public function test_prompt_expiry_transition_post_status() {
+		// Create a post with an expiration date in the past.
+		$expiration_date = gmdate( 'Y-m-d H:i:s', strtotime( '-1 day' ) );
+		$post_id = $this->factory->post->create(
+			[
+				'post_type'   => Newspack_Popups::NEWSPACK_POPUPS_CPT,
+				'post_status' => 'draft',
+				// meta_input only works if the post_status is not 'publish'.
+				'meta_input'  => [
+					'expiration_date' => $expiration_date,
+				],
+			]
+		);
+		$this->assertEquals( get_post_meta( $post_id, 'expiration_date', true ), $expiration_date );
+
+		// Publish the post.
+		wp_update_post(
+			[
+				'ID'          => $post_id,
+				'post_status' => 'publish',
+			]
+		);
+
+		// Check that the expiration_date meta is now deleted.
+		$this->assertEmpty( get_post_meta( $post_id, 'expiration_date', true ) );
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds a prompt expiration date, so prompts can be set to automatically revert to draft state at a certain date.

### How to test the changes in this Pull Request:

1. Create or edit a prompt
2. Open the new sidebar panel called "Expiration", toggle the setting on and choose a date 
3. Save the prompt
4. Using WP CLI, set an expiration date in the past (the UI will obviously block such possibility) (`wp post meta set <post-id> expiration_date '2024-03-13T10:43:06'`)
5. Verify that the `newspack_popups_check_expiry` cron event is set to run in under an hour (`wp cron event list`)
6. Either wait for an hour or trigger the cron event (`wp cron event run newspack_popups_check_expiry`)
7. Edit to post – observe that it has been reverted to draft, with a notice saying so at the top of the editor
8. Publish the post, observe that the expiration date has been removed and there's a notice saying so

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205701744717479