### PR TITLE
fix: prevent prompt expiration with invalid expiration date

### DIFF
--- a/includes/class-newspack-popups-expiry.php
+++ b/includes/class-newspack-popups-expiry.php
@@ -37,10 +37,16 @@ final class Newspack_Popups_Expiry {
 				'post_type'      => Newspack_Popups::NEWSPACK_POPUPS_CPT,
 				'posts_per_page' => -1,
 				'meta_query'     => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+					'relation' => 'AND',
 					[
 						'key'     => 'expiration_date',
 						'value'   => gmdate( 'Y-m-d H:i:s' ),
 						'compare' => '<=',
+					],
+					[
+						'key'     => 'expiration_date',
+						'compare' => 'REGEXP', // phpcs:ignore WordPressVIPMinimum.Performance.RegexpCompare.compare_compare
+						'value'   => '[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}',
 					],
 				],
 			]

--- a/tests/test-popups-expiry.php
+++ b/tests/test-popups-expiry.php
@@ -76,4 +76,26 @@ class Test_Newspack_Popups_Expiry extends WP_UnitTestCase {
 		// Check that the expiration_date meta is now deleted.
 		$this->assertEmpty( get_post_meta( $post_id, 'expiration_date', true ) );
 	}
+
+	/**
+	 * Test invalid expiration_date value.
+	 */
+	public function test_prompt_expiry_invalid_meta() {
+		// Create a post with an invalid expiration date.
+		$post_id = $this->factory->post->create(
+			[
+				'post_type' => Newspack_Popups::NEWSPACK_POPUPS_CPT,
+			]
+		);
+		// Set post expiration date meta - for some reason setting this as 'meta_input' while post status is publish does not work.
+		update_post_meta( $post_id, 'expiration_date', '' );
+
+		$this->assertEquals( 'publish', get_post_status( $post_id ) );
+
+		// This will run in a cron job.
+		Newspack_Popups_Expiry::revert_expired_to_draft();
+
+		// Should not have been reverted to draft.
+		$this->assertEquals( 'publish', get_post_status( $post_id ) );
+	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a regression introduced in https://github.com/Automattic/newspack-popups/pull/1305. For some reason, some posts did get `expiration_date` with empty value assigned. Unfortunately, there's no way to fix these (re-publish), since we can't know which prompts were supposed to be published or not in the first place.

### How to test the changes in this Pull Request:

1. On `release`, assign empty value to a published prompt `expiration_date` meta 
2. Run `wp cron event run newspack_popups_check_expiry`, observe the prompt has been reverted to draft
3. Switch to this branch, repeat, observe the prompt with invalid `expiration_date` is not reverted to draft

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207591595670229