### PR TITLE
fix: use loose type comparison for list__in and list__not_in

### DIFF
--- a/src/criteria/index.test.js
+++ b/src/criteria/index.test.js
@@ -104,6 +104,18 @@ describe( 'criteria matching', () => {
 		expect( criteria.matches( { value: '' } ) ).toEqual( false );
 		expect( criteria.matches( { value: [] } ) ).toEqual( false );
 	} );
+	it( 'should match "list__in" matching function with loose type comparison', () => {
+		setMatchingAttribute( criteriaId, () => 2 );
+		setMatchingFunction( criteriaId, 'list__in' );
+		const criteria = getCriteria( criteriaId );
+		expect( criteria.matches( { value: [ '1', '2' ] } ) ).toEqual( true );
+		expect( criteria.matches( { value: [ 1, 2 ] } ) ).toEqual( true );
+		expect( criteria.matches( { value: '1, 2' } ) ).toEqual( true );
+		expect( criteria.matches( { value: '2' } ) ).toEqual( true );
+		expect( criteria.matches( { value: [ 1 ] } ) ).toEqual( false );
+		expect( criteria.matches( { value: '1' } ) ).toEqual( false );
+		expect( criteria.matches( { value: 1 } ) ).toEqual( false );
+	} );
 	it( 'should match "list__not_in" matching function', () => {
 		setMatchingAttribute( criteriaId, () => 'bar' );
 		setMatchingFunction( criteriaId, 'list__not_in' );
@@ -127,6 +139,17 @@ describe( 'criteria matching', () => {
 		expect( criteria.matches( { value: [ 'fuu', 'baz' ] } ) ).toEqual( true );
 		expect( criteria.matches( { value: '' } ) ).toEqual( true );
 		expect( criteria.matches( { value: [] } ) ).toEqual( true );
+	} );
+	it( 'should match "list__not_in" matching function with loose type comparison', () => {
+		setMatchingAttribute( criteriaId, () => 2 );
+		setMatchingFunction( criteriaId, 'list__not_in' );
+		const criteria = getCriteria( criteriaId );
+		expect( criteria.matches( { value: [ '1', '2' ] } ) ).toEqual( false );
+		expect( criteria.matches( { value: [ 1, 2 ] } ) ).toEqual( false );
+		expect( criteria.matches( { value: '2' } ) ).toEqual( false );
+		expect( criteria.matches( { value: [ 1 ] } ) ).toEqual( true );
+		expect( criteria.matches( { value: '1' } ) ).toEqual( true );
+		expect( criteria.matches( { value: 1 } ) ).toEqual( true );
 	} );
 	it( 'should match custom matching function', () => {
 		setMatchingFunction( criteriaId, segmentConfig => {

--- a/src/criteria/matching-functions.js
+++ b/src/criteria/matching-functions.js
@@ -1,3 +1,5 @@
+/* eslint-disable eqeqeq */
+
 /**
  * Common matching functions that can be used by criteria.
  */
@@ -22,9 +24,9 @@ export default {
 			return false;
 		}
 		if ( Array.isArray( criteria.value ) ) {
-			return criteria.value.some( value => list.includes( value ) );
+			return criteria.value.some( value => list.some( configValue => configValue == value ) );
 		}
-		if ( ! criteria.value || ! list.includes( criteria.value ) ) {
+		if ( ! criteria.value || ! list.some( configValue => configValue == criteria.value ) ) {
 			return false;
 		}
 		return true;
@@ -45,9 +47,9 @@ export default {
 			return true;
 		}
 		if ( Array.isArray( criteria.value ) ) {
-			return ! criteria.value.some( value => list.includes( value ) );
+			return ! criteria.value.some( value => list.some( configValue => configValue == value ) );
 		}
-		if ( ! criteria.value || ! list.includes( criteria.value ) ) {
+		if ( ! criteria.value || ! list.some( configValue => configValue == criteria.value ) ) {
 			return true;
 		}
 		return false;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Currently `list__in` and `list__not_in` criteria matching functions use `includes` (which enforces strict type comparison) to compare segmentation criteria values with reader data values. However, we've seen varying behavior across different sites where IDs get stored in reader data as strings instead of integers, which causes these matching functions to fail.

This change allows the type comparison to be loose using `==`, which should solve the issue.

### How to test the changes in this Pull Request:

Unit tests should prove this, but to test functionally:

1. On `release`, create a segment and choose a product in the "Does not have active subscription" option. Publish a prompt to that segment.
2. Register a reader account and purchase the required subscription product. Visit at least a couple of pages to ensure that the reader data updates in localStorage and confirm that you don't see the prompt you created in step 1.
3. In dev tools, go to **Application > Storage**, unfurl "Local storage", and click on your dev site's URL. Note the `np_reader_1_active_subscriptions` value. If it's an array containing an integer click the value to edit it to a string with the same number, like so:

<img width="409" alt="Screenshot 2024-07-11 at 2 55 44 PM" src="https://github.com/Automattic/newspack-popups/assets/2230142/76788bb5-3945-4d69-a5ab-11a16510e1db">

4. Visit a couple more pages and confirm that you start seeing the prompt you created in step 1 (because your reader data value is `"275"` and the segment expects `275`).
5. Check out this branch, visit another page and confirm you no longer see the prompt.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207679631535856