### PR TITLE
feat: store prompt activation date

### DIFF
--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -89,7 +89,7 @@ final class Newspack_Popups {
 		add_filter( 'display_post_states', [ __CLASS__, 'display_post_states' ], 10, 2 );
 		add_action( 'save_post_' . self::NEWSPACK_POPUPS_CPT, [ __CLASS__, 'popup_default_fields' ], 10, 3 );
 		add_action( 'transition_post_status', [ __CLASS__, 'prevent_default_category_on_publish' ], 10, 3 );
-		add_action( 'transition_post_status', [ __CLASS__, 'store_activation_date' ], 10, 3 );
+		add_action( 'transition_post_status', [ __CLASS__, 'store_activation_dates' ], 10, 3 );
 		add_action( 'pre_delete_term', [ __CLASS__, 'prevent_default_category_on_term_delete' ], 10, 2 );
 		add_filter( 'show_admin_bar', [ __CLASS__, 'show_admin_bar' ], 10, 2 ); // phpcs:ignore WordPressVIPMinimum.UserExperience.AdminBarRemoval.RemovalDetected
 		add_filter( 'newspack_blocks_should_deduplicate', [ __CLASS__, 'newspack_blocks_should_deduplicate' ], 10, 2 );
@@ -1040,9 +1040,15 @@ final class Newspack_Popups {
 	 * @param string $old_status Old status.
 	 * @param bool   $post Post.
 	 */
-	public static function store_activation_date( $new_status, $old_status, $post ) {
-		if ( self::NEWSPACK_POPUPS_CPT === $post->post_type && 'publish' !== $old_status && 'publish' === $new_status ) {
+	public static function store_activation_dates( $new_status, $old_status, $post ) {
+		if ( self::NEWSPACK_POPUPS_CPT !== $post->post_type ) {
+			return;
+		}
+		if ( 'publish' !== $old_status && 'publish' === $new_status ) {
 			update_post_meta( $post->ID, 'activation_date', gmdate( 'Y-m-d H:i:s' ) );
+		}
+		if ( 'publish' === $old_status && 'publish' !== $new_status ) {
+			update_post_meta( $post->ID, 'deactivation_date', gmdate( 'Y-m-d H:i:s' ) );
 		}
 	}
 

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -89,6 +89,7 @@ final class Newspack_Popups {
 		add_filter( 'display_post_states', [ __CLASS__, 'display_post_states' ], 10, 2 );
 		add_action( 'save_post_' . self::NEWSPACK_POPUPS_CPT, [ __CLASS__, 'popup_default_fields' ], 10, 3 );
 		add_action( 'transition_post_status', [ __CLASS__, 'prevent_default_category_on_publish' ], 10, 3 );
+		add_action( 'transition_post_status', [ __CLASS__, 'store_activation_date' ], 10, 3 );
 		add_action( 'pre_delete_term', [ __CLASS__, 'prevent_default_category_on_term_delete' ], 10, 2 );
 		add_filter( 'show_admin_bar', [ __CLASS__, 'show_admin_bar' ], 10, 2 ); // phpcs:ignore WordPressVIPMinimum.UserExperience.AdminBarRemoval.RemovalDetected
 		add_filter( 'newspack_blocks_should_deduplicate', [ __CLASS__, 'newspack_blocks_should_deduplicate' ], 10, 2 );
@@ -528,6 +529,18 @@ final class Newspack_Popups {
 		\register_meta(
 			'post',
 			'expiration_date',
+			[
+				'object_subtype' => self::NEWSPACK_POPUPS_CPT,
+				'show_in_rest'   => true,
+				'type'           => 'string',
+				'single'         => true,
+				'auth_callback'  => '__return_true',
+			]
+		);
+
+		\register_meta(
+			'post',
+			'activation_date',
 			[
 				'object_subtype' => self::NEWSPACK_POPUPS_CPT,
 				'show_in_rest'   => true,
@@ -1017,6 +1030,19 @@ final class Newspack_Popups {
 	public static function prevent_default_category_on_publish( $new_status, $old_status, $post ) {
 		if ( self::NEWSPACK_POPUPS_CPT === $post->post_type && 'publish' !== $old_status && 'publish' === $new_status ) {
 			self::remove_default_category( $post->ID );
+		}
+	}
+
+	/**
+	 * Stores the activation date of the prompt.
+	 *
+	 * @param string $new_status New status.
+	 * @param string $old_status Old status.
+	 * @param bool   $post Post.
+	 */
+	public static function store_activation_date( $new_status, $old_status, $post ) {
+		if ( self::NEWSPACK_POPUPS_CPT === $post->post_type && 'publish' !== $old_status && 'publish' === $new_status ) {
+			update_post_meta( $post->ID, 'activation_date', gmdate( 'Y-m-d H:i:s' ) );
 		}
 	}
 

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -550,6 +550,18 @@ final class Newspack_Popups {
 			]
 		);
 
+		\register_meta(
+			'post',
+			'deactivation_date',
+			[
+				'object_subtype' => self::NEWSPACK_POPUPS_CPT,
+				'show_in_rest'   => true,
+				'type'           => 'string',
+				'single'         => true,
+				'auth_callback'  => '__return_true',
+			]
+		);
+
 		// Meta field for all post types.
 		\register_meta(
 			'post',


### PR DESCRIPTION
For future analytics purposes

### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Stores the activation date of the prompts so we can later use for analytics purposes

### How to test the changes in this Pull Request:

1. create or activate an inactive prompt
2. Check that the `activation_date` metadata was created with the current date
3. Deactivate the prompt
4. Confirm the `dectivation_date` metadata was created with the current date
5. Activate it again
6. Confirm the activation date was updated

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
