### PR TITLE
fix: prioritize ras overlays for delayed prompts

### DIFF
--- a/src/view/segmentation.js
+++ b/src/view/segmentation.js
@@ -48,7 +48,17 @@ export const handleSegmentation = prompts => {
 
 			// Unhide the prompt.
 			if ( shouldDisplay ) {
+				const delayPrompt = () => {
+					// By delay.
+					const delay = prompt.getAttribute( 'data-delay' ) || 0;
+					setTimeout( unhide, delay );
+				}
 				const unhide = () => {
+					// Prioritize RAS overlays. If there are any reinitiate the delay and return early.
+					if ( ras?.overlays && ras.overlays.get().length ) {
+						delayPrompt();
+						return;
+					}
 					prompt.classList.remove( 'hidden' );
 
 					// Log a "prompt_seen" activity when the prompt becomes visible.
@@ -70,9 +80,7 @@ export const handleSegmentation = prompts => {
 							getIntersectionObserver( unhide ).observe( marker );
 						}
 					} else {
-						// By delay.
-						const delay = prompt.getAttribute( 'data-delay' ) || 0;
-						setTimeout( unhide, delay );
+						delayPrompt();
 					}
 				} else {
 					unhide();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://app.asana.com/0/1207817176293825/1207922674964414/f

This fixes an issue where it's possible for delayed prompts to overlap with modal checkout during the transition in the auth + checkout flow. This happens because the moment the auth flow ends, the delayed prompt is ready to render. The problem is we don't want this to happen until all ras overlays have been added/removed during the auth + checkout flow.

This PR fixes this by reinitiating the delay whenever a ras overlay is present.

![Screenshot 2024-08-29 at 11 03 24](https://github.com/user-attachments/assets/381041b9-7224-4a79-9164-30a463acc992)

Note: Rather than create a new `epic/ras-acc` branch for this, I'm targeting `trunk` here since the change can be useful for the current implementation of ras. But if we prefer to move this to a new epic branch in popups let me know!

### How to test the changes in this Pull Request:

Before testing be sure to checkout `epic/ras-acc` on both newspack plugin and newspack blocks

1. Set up a delayed overlay campaign targeting everyone
2. On a post or page the campaign targets add a checkout button or donation block
3. As a logged out reader, visit the page or post and click donation or checkout button BEFORE the campaign popup renders
4. Complete the auth form
5. On `trunk`, the campaign prompt will render just before the transition to modal checkout as pictured above. Confirm it does not on this branch.
6. Still on this branch, complete modal checkout. Confirm the prompt appears shortly after the modal checkout flow completes.

Bonus: Smoke test the prompt during the auth and modal checkout flows with newspack plugin and newspack blocks on `trunk`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
