### PR TITLE
fix(segmentation): handle bad MC API key

### DIFF
--- a/includes/class-newspack-popups-segmentation.php
+++ b/includes/class-newspack-popups-segmentation.php
@@ -194,9 +194,6 @@ final class Newspack_Popups_Segmentation {
 	 * @param array $data      Data associated with the event.
 	 */
 	public static function reader_logged_in( $timestamp, $data ) {
-		$user_id = $data['user_id'];
-		$email   = $data['email'];
-
 		// See newspack-newsletters/includes/class-newspack-newsletters.php:827.
 		$api_key = \get_option( 'newspack_mailchimp_api_key', false );
 
@@ -204,8 +201,16 @@ final class Newspack_Popups_Segmentation {
 			return;
 		}
 
-		$mailchimp = new Mailchimp( $api_key );
-		$contacts  = $mailchimp->get(
+		try {
+			$mailchimp = new Mailchimp( $api_key );
+		} catch ( \Exception $th ) {
+			return;
+		}
+
+		$user_id = $data['user_id'];
+		$email   = $data['email'];
+
+		$contacts = $mailchimp->get(
 			'search-members',
 			[
 				'fields' => [ 'members.email_address', 'members.merge_fields' ],


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds handling of invalid Mailchimp API key.
Submitting as a hotfix, because the issue triggers PHP Fatals, which pollute our logs.

### How to test the changes in this Pull Request:

1. On `release`, update the value of the `newspack_mailchimp_api_key` option to an empty string
2. Run `wp eval "\Newspack_Popups_Segmentation::reader_logged_in(111, []);"`, observe a PHP Fatal is logged
3. Switch to this branch, repeat, observe the Fatal is logged no more

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->