### PR TITLE
fix: verify delayed prompt can still be displayed before showing

### DIFF
--- a/src/view/segmentation.js
+++ b/src/view/segmentation.js
@@ -54,6 +54,12 @@ export const handleSegmentation = prompts => {
 					setTimeout( unhide, delay );
 				}
 				const unhide = () => {
+					// Conditions may have changed since the prompt was delayed.
+					// Verify whether the prompt can still be displayed.
+					const updatedMatchingSegment = getBestPrioritySegment( segments );
+					if ( ! shouldPromptBeDisplayed( prompt, updatedMatchingSegment, ras, override ) ) {
+						return;
+					}
 					// Prioritize RAS overlays. If there are any reinitiate the delay and return early.
 					if ( ras?.overlays && ras.overlays.get().length ) {
 						delayPrompt();


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://app.asana.com/0/1207817176293825/1208253149260198/f

With ras-acc, it is now possible for segment conditions to change for the reader between when a delayed prompt is "queued" and when it is displayed. This PR adds a check for delayed prompts to ensure it should still be displayed before unhiding:

![CleanShot 2024-09-08 at 14 31 15](https://github.com/user-attachments/assets/987c48e1-0cfa-4734-b3e7-f567b2c86a9a)

### How to test the changes in this Pull Request:

To test, be sure to check out `epic/ras-acc` in blocks, theme, newsletters, and plugin

1. As admin, set up a registration block campaign for unregistered readers to render on every page or post view after a few seconds delay 
2. As a logged out reader, visit the any page or post and confirm the registration overlay appears as expected (I had to clear local storage before this worked for me)
3. Refresh the page, and BEFORE the overlay appears quickly click the sign in button in the site header
4. Complete either the registration flow, or the sign in flow until the modal closes
5. On `trunk` the registration overlay will appear, but since you are signed in, you will see the success state of the registration block. On this branch, the overlay should no longer appear as the reader no longer matches the segment.
6. As admin again, disable the registration overlay and enable a new overlay (with any type of content) that targets everyone and appears on every page view after a few seconds delay.
7. Repeat steps 1-5, but this time verify the prompt DOES appear once the auth modal closes.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
