### PR TITLE
fix: check for non-preview logged in user on account criteria

### DIFF
--- a/includes/class-newspack-popups-criteria.php
+++ b/includes/class-newspack-popups-criteria.php
@@ -62,7 +62,8 @@ final class Newspack_Popups_Criteria {
 			self::SCRIPT_HANDLE,
 			'newspackPopupsCriteria',
 			[
-				'config' => self::get_criteria_config(),
+				'is_non_preview_user' => is_user_logged_in() && ! Newspack_Popups::is_user_admin(),
+				'config'              => self::get_criteria_config(),
 			]
 		);
 	}

--- a/src/criteria/default/user-account.js
+++ b/src/criteria/default/user-account.js
@@ -1,10 +1,11 @@
+/* globals newspackPopupsCriteria */
 import { setMatchingFunction } from '../utils';
 
 setMatchingFunction( 'user_account', ( config, { store } ) => {
 	switch ( config.value ) {
 		case 'with-account':
-			return store.get( 'reader' )?.email;
+			return newspackPopupsCriteria.is_non_preview_user || store.get( 'reader' )?.email;
 		case 'without-account':
-			return ! store.get( 'reader' )?.email;
+			return ! newspackPopupsCriteria.is_non_preview_user && ! store.get( 'reader' )?.email;
 	}
 } );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

1200550061930446-as-1207301960751644/f

The user account criteria only checks for the `reader.email` store item, which is not available for non-reader accounts (admin, editor, author, contributor). This is fine for admins and editors, because we allow prompts to render for preview purposes. For example, the `Newspack_Popups::is_user_admin()` method is used in the reader registration block so it renders a preview of the block.

For authors and contributors it's not the case, so they end up rendering the prompt because they don't match the criteria, but in a success state, because they don't match `Newspack_Popups::is_user_admin()` either.

This PR tweaks the criteria to account for "non-preview users".

### How to test the changes in this Pull Request:

1. Make sure you have RAS setup with RAS' default prompts
2. While in `trunk`, create a new author user
3. In a fresh session (fresh localstorage), sign in as the author
4. Confirm you get the reader registration prompt in a success state
5. Also confirm in the console that `newspack_popups_debug.matchingSegment` contains the ID of the "Not registered and not signed up for a newsletter" segment 
6. Check out this branch, clear your localstorage and refresh the page
7. Confirm you don't get prompt
8. Confirm `newspack_popups_debug.matchingSegment` is `null`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
