### PR TITLE
fix: position calculation for inline popups

### DIFF
--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -265,6 +265,18 @@ final class Newspack_Popups_Inserter {
 	}
 
 	/**
+	 * Get the length of a given block.
+	 *
+	 * @param array $block A block.
+	 *
+	 * @return int
+	 */
+	private static function get_block_length( $block ) {
+		$block_content = self::get_block_content( $block );
+		return strlen( wp_strip_all_tags( $block_content ) );
+	}
+
+	/**
 	 * Insert popups in a post content.
 	 *
 	 * @param string $content The post content.
@@ -349,8 +361,7 @@ final class Newspack_Popups_Inserter {
 				// Give length-ignored blocks a length of 1 so that prompts at 0% can still be inserted before them.
 				$total_length++;
 			} else {
-				$block_content = self::get_block_content( $block );
-				$total_length += strlen( wp_strip_all_tags( $block_content ) );
+				$total_length += self::get_block_length( $block );
 			}
 		}
 
@@ -385,7 +396,7 @@ final class Newspack_Popups_Inserter {
 					// Give length-ignored blocks a length of 1 so that prompts at 0% can still be inserted before them.
 					$pos++;
 				} else {
-					$pos += strlen( wp_strip_all_tags( $block['innerHTML'] ) );
+					$pos += self::get_block_length( $block );
 				}
 			}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

https://app.asana.com/0/1200550061930446/1206767149727703/f

The logic used to calculate the position for the inline popups is not the same as applied to determining the position of the blocks.

When doing it for the block positions it's ignoring the HTML for inner blocks, causing blocks like lists to be miscalculated and inline prompts using percentage positioning to appear further down than they should.

This PR introduces a `get_block_length` method to normalize how they are calculated, also fixing the issue with lists.

### How to test the changes in this Pull Request:

1. While on the master branch, create a post with several list blocks, with 3/4 list items each, in the first half and paragraphs in the second half
2. Create an inline prompt to appear at 50%
3. Visit the post and confirm the prompt renders way below the 50% threshold
4. Checkout this branch, refresh, and confirm it's now more within acceptable margins

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
