### PR TITLE
fix: prevent extra scrollbar with certain settings

### DIFF
--- a/src/view/style.scss
+++ b/src/view/style.scss
@@ -130,6 +130,10 @@ $width__tablet: 782px;
 			box-shadow: none;
 		}
 
+		&.newspack-lightbox-placement-center .newspack-popup-wrapper {
+			overflow: hidden;
+		}
+
 		.newspack-popup__content {
 			padding-top: 32px;
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

If you have a really specific set of settings, you can end up with two scrollbars on the campaign popups.

This came up in our RAS-ACC testing, but it affects trunk, too.

See: 1207817176293825-as-1208541857637839

### How to test the changes in this Pull Request:

1. On Mac, set scrollbars to always be visible under System Settings > Appearance.
2. Set up a centred popup campaign, and give it a lot of content so it will scroll easily.
3. Under the 'Styles' panel, set the modal to Hide Padding.
4. Preview your prompt; if the modal doesn't fill the browser window, shrink the window until it's getting cut off at the bottom.
5. Note you have two scrollbars: one for the popup content, and one for the popup's containing HTML element. It looks strange, and the outer scrolling isn't necessary since the inside also scrolls.

![CleanShot 2024-10-17 at 10 28 46](https://github.com/user-attachments/assets/53fbc91c-3be3-4694-b867-9f8705cb2e5c)

6. Apply the PR and run `npm run build`.
7. Confirm that the double scrollbars go away, and you're left with just the one (necessary) one:

![CleanShot 2024-10-17 at 10 26 33](https://github.com/user-attachments/assets/d3ec6d36-8957-446a-909c-b8e8ad085514)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
