### PR TITLE
fix: remove inline-block display type from radio-control option

### DIFF
--- a/src/editor/style.scss
+++ b/src/editor/style.scss
@@ -32,8 +32,6 @@ $size__large: 1264px;
 		}
 
 		.components-radio-control__option {
-			display: inline-block;
-
 			&:first-of-type {
 				margin-right: 1rem;
 			}


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://app.asana.com/0/1206274567818686/1208604801170731/f

Looks like [the display type for radio control option has been set to `grid` in WP 6.7](https://github.com/WordPress/gutenberg/pull/63751/files). This PR removes our `display` type of `inline-block` so as not to interfere with the new grid styling.

Before:
![Screenshot 2024-10-31 at 11 17 57](https://github.com/user-attachments/assets/149cfa8c-105f-4aa7-9e46-d5822c0db486)

After:
![Screenshot 2024-10-31 at 13 06 07](https://github.com/user-attachments/assets/e44b0873-15b0-4545-bb9c-bec10497a8bc)

### How to test the changes in this Pull Request:

1. On WP 6.6 edit any prompt via Newspack > Campaigns
2. In the editor look for the prompt type radio inputs. There will be no margin as pictured in the `Before` screenshot above.
3. Update to 6.7-RC2 and view the editor for the same prompt
4. The radio inputs should have proper right margin as pictured in the `After` screenshot above

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
