### PR TITLE
fix: account for unauthenticated readers when matching user_account criteria

### DIFF
--- a/src/criteria/default/user-account.js
+++ b/src/criteria/default/user-account.js
@@ -2,10 +2,11 @@
 import { setMatchingFunction } from '../utils';
 
 setMatchingFunction( 'user_account', ( config, { store } ) => {
+	const reader = store?.get?.( 'reader' );
 	switch ( config.value ) {
 		case 'with-account':
-			return newspackPopupsCriteria.is_non_preview_user || store.get( 'reader' )?.email;
+			return newspackPopupsCriteria.is_non_preview_user || ( reader?.email && reader?.authenticated );
 		case 'without-account':
-			return ! newspackPopupsCriteria.is_non_preview_user && ! store.get( 'reader' )?.email;
+			return ! newspackPopupsCriteria.is_non_preview_user && ( ! reader?.email || ! reader?.authenticated );
 	}
 } );


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://app.asana.com/0/1208604368072430/1208670219439751/f

This PR addresses an issue where our criteria matching logic was not accounting for RAS readers that had logged out. We address this by also checking the RAS `authenticated` flag.

### How to test the changes in this Pull Request:

1. Set up two custom campaign prompts, one for logged in users and one for logged out users
2. Add the prompt to any page or post
3. As a reader, login and view the page or post where the prompt is set
4. Verify the logged in prompt is visible
5. Go to my account and log out
6. Once again visit the prompt page
7. On `trunk` the logged in prompt will still be present, on this branch the logged out prompt will be present.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
