### PR TITLE
fix: avoid fatal on get_segments

### DIFF
--- a/includes/class-newspack-segments-model.php
+++ b/includes/class-newspack-segments-model.php
@@ -352,6 +352,11 @@ final class Newspack_Segments_Model {
 			]
 		);
 
+		// if, for any reason, this was called too early and we don't have a registered taxonomy yet, let's not break the site.
+		if ( ! is_array( $terms ) ) {
+			return [];
+		}
+
 		$segments = array_map(
 			function ( $segment ) {
 				return self::get_segment_from_term( $segment );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes an odd issue where this would break the sites in a combination of S3 Uploads and Newspack S3 Performance plugins...

See 1200550061930446-as-1203093685387025

### How to test the changes in this Pull Request:

1. Smoke test

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203093685387025