### PR TITLE
fix: ensure localized segments object is an object, not array

### DIFF
--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -690,7 +690,7 @@ final class Newspack_Popups_Inserter {
 					}
 				}
 
-				$script_data['segments'] = self::$segments;
+				$script_data['segments'] = (object) self::$segments;
 			}
 
 			$donor_landing_page = Newspack_Popups_Settings::donor_landing_page();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Casts localized `segments` data as an object to ensure that it's of the expected type when read by the segmentation API. Avoids potential type errors in JS.

### How to test the changes in this Pull Request:

1. On `release`, disable or delete all segments in **Newspack > Campaigns > Segments**.
2. On the front-end, in the JS console type `newspack_popups_view.segments` and observe that it's an empty array:

<img width="231" alt="Screenshot 2024-11-12 at 4 05 15 PM" src="https://github.com/user-attachments/assets/5bc1068f-dfd9-442d-9b1e-c758bf23bd4d">

3. Check out this branch, refresh, and confirm that it's now an object:

<img width="244" alt="Screenshot 2024-11-12 at 4 07 23 PM" src="https://github.com/user-attachments/assets/8100f749-dcaf-4218-a150-79ba272deb1c">

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208718504240401