### PR TITLE
fix: hide cpt from menu

### DIFF
--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -161,6 +161,7 @@ final class Newspack_Popups {
 		$cpt_args = [
 			'labels'       => $labels,
 			'public'       => false,
+			'show_in_menu' => false,
 			'show_ui'      => true,
 			'show_in_rest' => true,
 			'supports'     => [ 'editor', 'title', 'custom-fields', 'thumbnail', 'revisions' ],


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This is a fix for https://github.com/Automattic/newspack-plugin/pull/3549.

Popups post type is already not shown in the menu, but without the explicit flag, [WP will override](https://github.com/WordPress/wordpress-develop/blob/e9dfa8c34c74cb51da93ae4b4e61c1df0378b3d7/src/wp-admin/menu-header.php#L50) (more specifically [here](https://github.com/WordPress/wordpress-develop/blob/e9dfa8c34c74cb51da93ae4b4e61c1df0378b3d7/src/wp-admin/includes/plugin.php#L2007-L2009)) the `parent_file` filter we're using to activate a custom menu when creating a new prompt:

<img width="836" alt="image" src="https://github.com/user-attachments/assets/654cbc67-ff7d-44b9-b64a-13898c6f5586">

### How to test the changes in this Pull Request:

1. Checkout on https://github.com/Automattic/newspack-plugin/pull/3549 and while on `trunk`, navigate to create a new segment (`/wp-admin/post-new.php?post_type=newspack_popups_cpt`)
2. Confirm no menu items are active
3. Checkout this branch, refresh the page and confirm the "Audience -> Campaigns" menu is active

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
