### PR TITLE
fix: prevent issue with double-scrollbars in really specific circumstances

### DIFF
--- a/src/view/style.scss
+++ b/src/view/style.scss
@@ -71,7 +71,7 @@ $width__tablet: 782px;
 		background: white;
 		border: none;
 		box-shadow: 0 0 1em 0.5em rgba(black, 0.1);
-		overflow-x: hidden;
+		overflow: hidden;
 		position: relative;
 		transform: none;
 		transition: transform 0.2s ease-in-out;

--- a/src/view/style.scss
+++ b/src/view/style.scss
@@ -267,7 +267,6 @@ $width__tablet: 782px;
 	&.newspack-lightbox-placement-top_right {
 		.newspack-popup-wrapper {
 			max-height: calc(100% - #{$overlay__gap});
-			overflow-y: auto;
 		}
 	}
 
@@ -275,7 +274,6 @@ $width__tablet: 782px;
 	&.newspack-lightbox-placement-top {
 		.newspack-popup-wrapper {
 			max-height: 100%;
-			overflow-y: auto;
 		}
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This came out of our RAS-ACC beta testing: if you have a really specific setup for campaigns, you can get a double-scrollbar in an overlay. It's totally an edge case, but this will hopefully prevent it going forward!


### How to test the changes in this Pull Request:

1. If on a Mac, enable your scrollbars all the time under System Settings -- this just makes it easier to test.
2. Make an overlay campaign and add contents pretty long and will require scrolling.
3. On the front end, make the browser window shorter than the campaign will be, then load a page that the campaign will show on. Note the double scrollbar:

![CleanShot 2024-11-18 at 12 05 48](https://github.com/user-attachments/assets/0da8d571-3091-4abe-a790-da4b15238fed)

4. Apply this PR and run `npm run build`.
5. Confirm that you only have one scrollbar now:

![CleanShot 2024-11-18 at 12 06 58](https://github.com/user-attachments/assets/edff9365-570f-40c0-9f45-ca616dc9b43a)

6. Do a bit of smoke testing to make sure your longer popups still scroll (just with one bar) with different settings, just in case!

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
