### PR TITLE
fix: ensure prompts with expiration dates expire correctly

### DIFF
--- a/src/editor/ExpirationPanel.js
+++ b/src/editor/ExpirationPanel.js
@@ -6,6 +6,11 @@ import { ToggleControl, DatePicker } from '@wordpress/components';
 import { isInTheFuture } from '@wordpress/date';
 import { useEffect, useState, useMemo } from '@wordpress/element';
 
+/**
+ * Internal dependencies
+ */
+import { convertDateToString } from './utils';
+
 const ExpirationPanel = ( {
 	expiration_date = null,
 	postStatus,
@@ -57,7 +62,7 @@ const ExpirationPanel = ( {
 	const defaultExpirationDate = useMemo( () => {
 		const date = new Date();
 		date.setHours( date.getHours() + 24 );
-		return date;
+		return convertDateToString( date );
 	}, [] );
 
 	return (
@@ -76,7 +81,7 @@ const ExpirationPanel = ( {
 			{ expiration_date ? (
 				<DatePicker
 					currentDate={ expiration_date }
-					onChange={ value => onMetaFieldChange( { expiration_date: value } ) }
+					onChange={ value => onMetaFieldChange( { expiration_date: convertDateToString( new Date( value ) ) } ) }
 					isInvalidDate={ date => ! isInTheFuture( date ) }
 				/>
 			) : null }

--- a/src/editor/ExpirationPanel.js
+++ b/src/editor/ExpirationPanel.js
@@ -35,6 +35,7 @@ const ExpirationPanel = ( {
 					new Date( expiration_date ).toLocaleDateString()
 				),
 				{
+					id: 'newspack-popups__expired',
 					isDismissible: false,
 				}
 			).then( ( { notice } ) => {
@@ -51,7 +52,10 @@ const ExpirationPanel = ( {
 				__(
 					'This prompt has been published. The expiration date has been removed.',
 					'newspack-plugin'
-				)
+				),
+				{
+					id: 'newspack-popups__expiration-date-removed',
+				}
 			);
 			// This is just for quicked feedback, the actual meta field deletion will
 			// happen on the backend.
@@ -74,7 +78,7 @@ const ExpirationPanel = ( {
 					onMetaFieldChange( { expiration_date: expiration_date ? null : defaultExpirationDate } );
 				} }
 				help={ __(
-					'If set, the prompt will be automatically unpublished after this date.',
+					'If set, the prompt will be automatically unpublished at midnight on this date.',
 					'newspack-popups'
 				) }
 			/>

--- a/src/editor/utils.js
+++ b/src/editor/utils.js
@@ -287,3 +287,18 @@ export const getPlacementHelpMessage = props => {
 			return __( 'The placement where the prompt can appear.', 'newspack-popups' );
 	}
 };
+
+/**
+ * Convert a date object to a string in YYYY-MM-DDTHH:MM:SS format.
+ * Omit Z timezone so the date is parsed in the site's local timezone.
+ *
+ * @param {Date} date
+ * @return {string} Date string in Y-m-d H:i:s format or empty string if the given date can't be parsed.
+ */
+export const convertDateToString = date => {
+	if ( ! ( date instanceof Date ) ) {
+		return '';
+	}
+
+	return date.toISOString().split( '.' )[ 0 ];
+}

--- a/tests/test-popups-expiry.php
+++ b/tests/test-popups-expiry.php
@@ -27,7 +27,7 @@ class Test_Newspack_Popups_Expiry extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test the revert_expired_to_draft function.
+	 * Test the revert_expired_to_draft function with PHP date format  (YYYY-MM-DD HH:MM:SS).
 	 */
 	public function test_prompt_expiry_revert_expired_to_draft() {
 		// Create a post with an expiration date in the past.
@@ -97,5 +97,55 @@ class Test_Newspack_Popups_Expiry extends WP_UnitTestCase {
 
 		// Should not have been reverted to draft.
 		$this->assertEquals( 'publish', get_post_status( $post_id ) );
+	}
+
+	/**
+	 * Test different expiry logic with various date string formats.
+	 */
+	public function test_date_string_formats() {
+		$this->assertTrue(
+			Newspack_Popups_Expiry::is_expired( gmdate( 'Y-m-d H:i:s', strtotime( '-1 day' ) ) ),
+			'Anytime yesterday in PHP date format (YYYY-MM-DD HH:MM:SS) is expired.'
+		);
+		$this->assertTrue(
+			Newspack_Popups_Expiry::is_expired( gmdate( 'Y-m-d H:i:s', time() ) ),
+			'Anytime today in PHP date format (YYYY-MM-DD HH:MM:SS) is expired.'
+		);
+		$this->assertFalse(
+			Newspack_Popups_Expiry::is_expired( gmdate( 'Y-m-d H:i:s', strtotime( '+1 day' ) ) ),
+			'Anytime tomorrow in PHP date format (YYYY-MM-DD HH:MM:SS) is NOT expired.'
+		);
+		$this->assertTrue(
+			Newspack_Popups_Expiry::is_expired( gmdate( 'Y-m-d\TH:i:s', strtotime( '-1 day' ) ) ),
+			'Anytime yesterday in JS date format (YYYY-MM-DDTHH:MM:SS) is expired.'
+		);
+		$this->assertTrue(
+			Newspack_Popups_Expiry::is_expired( gmdate( 'Y-m-d\TH:i:s', time() ) ),
+			'Anytime today in JS date format (YYYY-MM-DDTHH:MM:SS) is expired.'
+		);
+		$this->assertFalse(
+			Newspack_Popups_Expiry::is_expired( gmdate( 'Y-m-d\TH:i:s', strtotime( '+1 day' ) ) ),
+			'Anytime tomorrow in JS date format (YYYY-MM-DDTHH:MM:SS) is NOT expired.'
+		);
+		$this->assertTrue(
+			Newspack_Popups_Expiry::is_expired( gmdate( 'F j, Y g:i:s A', strtotime( '-1 day' ) ) ),
+			'Anytime yesterday in human-readable date format is expired.'
+		);
+		$this->assertTrue(
+			Newspack_Popups_Expiry::is_expired( gmdate( 'F j, Y g:i:s A', time() ) ),
+			'Anytime today in human-readable date format is expired.'
+		);
+		$this->assertFalse(
+			Newspack_Popups_Expiry::is_expired( gmdate( 'F j, Y g:i:s A', strtotime( '+1 day' ) ) ),
+			'Anytime tomorrow in human-readable date format is NOT expired.'
+		);
+		$this->assertFalse(
+			Newspack_Popups_Expiry::is_expired( 'invalid date' ),
+			'Invalid date string is NOT expired.'
+		);
+		$this->assertFalse(
+			Newspack_Popups_Expiry::is_expired( '' ),
+			'Empty date string is NOT expired.'
+		);
 	}
 }

--- a/tests/test-popups-expiry.php
+++ b/tests/test-popups-expiry.php
@@ -100,7 +100,7 @@ class Test_Newspack_Popups_Expiry extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test different expiry logic with various date string formats.
+	 * Test date expiry logic with various datetime string formats.
 	 */
 	public function test_date_string_formats() {
 		$this->assertTrue(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Expands expiration date logic implemented in #1305 so it can handle dates in various formats. The server-side cron job expected dates to be in standard SQL datetime format (`YYYY-MM-DD HH:MI:SS`), the [`DateTime` React component](https://developer.wordpress.org/block-editor/reference-guides/components/date-time/) parses dates into JS-style [ISO 8601 format](https://en.wikipedia.org/wiki/ISO_8601) (`YYYY-MM-DDTHH:MI:SS`), sometimes with a `Z` timezone suffix as well (`YYYY-MM-DDTHH:MI:SS.000Z` for UTC). The dates are stored as post meta in ISO-style format, causing the meta query comparison to fail, as it compares dates using SQL-style datetime format.

This PR also standardizes the exact time that prompts expire to midnight of the selected date, instead of the time at which the expiration date post meta was saved. This should hopefully make it more predictable exactly when prompts with future dates will expire.

Note: #1305 was working at the time of deployment, so I'm not sure when or why the SQL query using date compare stopped working.

### How to test the changes in this Pull Request:

Follow testing instructions in #1305, but repeat with datetime strings in various formats in step 4 (you can use [any format that can be parsed by `strtotime`](https://www.php.net/manual/en/function.strtotime.php)).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208791422053209