### PR TITLE
fix: copy original segments when duplicating prompt

### DIFF
--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -91,7 +91,7 @@ final class Newspack_Popups_Model {
 	 * Set terms for a Popup.
 	 *
 	 * @param integer $id ID of Popup.
-	 * @param array   $terms Array of terms to be set.
+	 * @param array   $terms Array of term objects or IDs to be set.
 	 * @param string  $taxonomy Taxonomy slug.
 	 */
 	public static function set_popup_terms( $id, $terms, $taxonomy ) {
@@ -117,7 +117,11 @@ final class Newspack_Popups_Model {
 			);
 		}
 		$term_ids = array_map(
-			function( $term ) {
+			function( $term ) use ( $taxonomy ) {
+				if ( is_int( $term ) ) {
+					$term       = get_term_by( 'id', $term, $taxonomy, ARRAY_A );
+					$term['id'] = $term['term_id'];
+				}
 				return $term['id'];
 			},
 			$terms

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -1252,6 +1252,14 @@ final class Newspack_Popups {
 			);
 			wp_set_post_terms( $new_popup_id, $old_campaigns, self::NEWSPACK_POPUPS_TAXONOMY );
 
+			// Apply segment terms.
+			$old_segments = wp_get_post_terms(
+				$id,
+				Newspack_Segments_Model::TAX_SLUG,
+				[ 'fields' => 'ids' ]
+			);
+			wp_set_post_terms( $new_popup_id, $old_segments, Newspack_Segments_Model::TAX_SLUG );
+
 			// Set prompt options to match old prompt.
 			$old_popup_options = Newspack_Popups_Model::get_popup_options( $id );
 			foreach ( $old_popup_options as $key => $value ) {

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -334,6 +334,9 @@ final class Newspack_Popups {
 				'single'            => true,
 				'auth_callback'     => '__return_true',
 				'sanitize_callback' => function( $input ) {
+					if ( empty( $input ) ) {
+						return '';
+					}
 					return preg_replace( '~[^-\w0-9_\s]+~', '', $input );
 				},
 			]

--- a/tests/test-e2e.php
+++ b/tests/test-e2e.php
@@ -46,9 +46,17 @@ class E2ETest extends WP_UnitTestCase_PageWithPopups {
 				'slug'     => 'everyday',
 			]
 		);
-		wp_set_post_terms( $original_popup_id, [ $category_id ], 'category' );
-		wp_set_post_terms( $original_popup_id, [ $tag_id ], 'post_tag' );
-		wp_set_post_terms( $original_popup_id, [ $campaign_id ], Newspack_Popups::NEWSPACK_POPUPS_TAXONOMY );
+		$segment_id  = self::factory()->term->create(
+			[
+				'name'     => 'Loyal Readers',
+				'taxonomy' => Newspack_Segments_Model::TAX_SLUG,
+				'slug'     => 'loyal-readers',
+			]
+		);
+		Newspack_Popups_Model::set_popup_terms( $original_popup_id, [ $category_id ], 'category' );
+		Newspack_Popups_Model::set_popup_terms( $original_popup_id, [ $tag_id ], 'post_tag' );
+		Newspack_Popups_Model::set_popup_terms( $original_popup_id, [ $campaign_id ], Newspack_Popups::NEWSPACK_POPUPS_TAXONOMY );
+		Newspack_Popups_Model::set_popup_terms( $original_popup_id, [ $segment_id ], Newspack_Segments_Model::TAX_SLUG );
 
 		$duplicate_popup_id          = Newspack_Popups::duplicate_popup( $original_popup_id );
 		$second_duplicate_id         = Newspack_Popups::duplicate_popup( $duplicate_popup_id );
@@ -93,6 +101,12 @@ class E2ETest extends WP_UnitTestCase_PageWithPopups {
 			Newspack_Popups_Model::get_popup_options( $original_popup_id ),
 			Newspack_Popups_Model::get_popup_options( $duplicate_popup_id ),
 			'Duplicated prompt has the same prompt options as the original prompt.'
+		);
+
+		self::assertEquals(
+			Newspack_Popups_Model::get_popup_segments( $original_popup_id ),
+			Newspack_Popups_Model::get_popup_segments( $duplicate_popup_id ),
+			'Duplicate prompt has the same segments as the original prompt.'
 		);
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

#1106 refactored the way we store and handle segments from a flat array of segment IDs stored in prompt post meta to a proper custom taxonomy. However, we never added handling for segments-as-taxonomy-terms when duplicating prompts. This fixes that.

Also fixes a random PHP warning I saw when running `phpcs` (`PHP Deprecated:  preg_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated in /newspack-repos/newspack-popups/includes/class-newspack-popups.php on line 337`)

### How to test the changes in this Pull Request:

1. On `trunk`, duplicate a prompt that has one or more segments. Observe that the created duplicate prompt has no segments applied.
2. Check out this branch, repeat, and confirm that the duplicated prompt always has the same segments as the original.
3. Confirm that unit tests are passing 👇 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208801695972665