### PR TITLE
fix: restore UTM suppression feature

### DIFF
--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -969,6 +969,7 @@ final class Newspack_Popups_Model {
 		$classes              = array_merge( $classes, explode( ' ', $popup['options']['additional_classes'] ) );
 		$assigned_segments    = Newspack_Segments_Model::get_popup_segments_ids_string( $popup['id'] );
 		$frequency_config     = self::get_frequency_config( $popup );
+		$utm_suppression      = $popup['options']['utm_suppression'];
 
 		ob_start();
 		?>
@@ -981,6 +982,9 @@ final class Newspack_Popups_Model {
 				id="<?php echo esc_attr( $element_id ); ?>"
 				data-segments="<?php echo esc_attr( $assigned_segments ); ?>"
 				data-frequency="<?php echo esc_attr( $frequency_config ); ?>"
+				<?php if ( ! empty( $utm_suppression ) ) : ?>
+					data-suppression="<?php echo esc_attr( $utm_suppression ); ?>"
+				<?php endif; ?>
 			>
 				<?php echo do_shortcode( $body ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 			</div>

--- a/src/view/utils/segments.js
+++ b/src/view/utils/segments.js
@@ -127,6 +127,7 @@ export const shouldPromptBeDisplayed = ( prompt, matchingSegment, ras, override 
 	const debugInfo = {
 		element: prompt,
 	};
+	const suppressByUTM = prompt.getAttribute( 'data-suppression' );
 
 	// By override.
 	if ( true === override || false === override ) {
@@ -134,6 +135,22 @@ export const shouldPromptBeDisplayed = ( prompt, matchingSegment, ras, override 
 		if ( ! override ) {
 			display = false;
 			suppression.push( 'Prompt suppressed by override.' );
+		}
+	} else if ( suppressByUTM ) {
+		const suppressionValues = ras.store.get( 'utm_source' ) || [];
+		const params = new URLSearchParams( window.location.search );
+		const currentUTM = params.get( 'utm_source' )
+		let suppressedByUTM = false;
+		if ( -1 < suppressionValues.indexOf( suppressByUTM ) ) {
+			suppressedByUTM = true;
+		}
+		if ( ! suppressedByUTM && suppressByUTM === currentUTM ) {
+			suppressedByUTM = true;
+			ras.store.set( 'utm_source', [ ...suppressionValues, currentUTM ] );
+		}
+		if ( suppressedByUTM ) {
+			suppression.push( `Prompt suppressed by utm_source=${ suppressByUTM }.` );
+			display = false;
 		}
 	} else if ( ras ) {
 		// eslint-disable-next-line @wordpress/no-unused-vars-before-return

--- a/src/view/utils/segments.test.js
+++ b/src/view/utils/segments.test.js
@@ -1,6 +1,28 @@
 import { registerCriteria } from '../../criteria/utils';
 import { getBestPrioritySegment, getOverride, shouldPromptBeDisplayed, periods } from './index.js';
 
+// Mock the window.location object. See: https://developer.mozilla.org/en-US/docs/Web/API/Location
+const setWindowLocation = ( domain = 'example.com', search = '' ) => {
+	delete global.window.location;
+	global.window = Object.create( window );
+	global.window.location = {
+		ancestorOrigins: null,
+		hash: null,
+		host: domain,
+		port: '80',
+		protocol: 'http:',
+		hostname: domain,
+		href: 'https://' + domain + search,
+		origin: 'https://' + domain,
+		pathname: null,
+		search,
+		assign: null,
+		reload: null,
+		replace: null,
+		toString: () => 'https://' + domain + search,
+	};
+};
+
 // Mock some test criteria.
 const criteria = {
 	simple: {},
@@ -109,12 +131,17 @@ const createPrompt = (
 	assignedSegments = [],
 	frequency = '0,0,0,month',
 	id = '1',
-	type = 'inline'
+	type = 'inline',
+	utmSuppression = ''
 ) => {
 	const prompt = document.createElement( 'div' );
 	prompt.setAttribute( 'id', 'id_' + id );
 	prompt.setAttribute( 'data-segments', assignedSegments.join( ',' ) );
 	prompt.setAttribute( 'data-frequency', frequency );
+
+	if ( utmSuppression ) {
+		prompt.setAttribute( 'data-suppression', utmSuppression );
+	}
 
 	if ( 'inline' === type ) {
 		prompt.classList.add( 'newspack-inline-popup' );
@@ -127,6 +154,7 @@ const createPrompt = (
 
 describe( 'segmentation API', () => {
 	beforeEach( () => {
+		setWindowLocation();
 		window.newspackPopupsCriteria = { criteria: {} };
 		for ( const criteriaId in criteria ) {
 			registerCriteria( criteriaId, criteria[ criteriaId ] );
@@ -220,5 +248,20 @@ describe( 'segmentation API', () => {
 		const prompt = createPrompt( [], '0,0,0,month', '123' );
 		const pidOverride = getOverride( 123, false, false, '?pid=123' );
 		expect( shouldPromptBeDisplayed( prompt, null, ras, pidOverride ) ).toBeTruthy();
+	} );
+
+	it ( 'should return false if the reader has or had the UTM Suppression value in utm_source params', () => {
+		const prompt = createPrompt( [], '0,0,0,month', '1', 'inline', 'suppress_this' );
+
+		// If the URL does not contain the prompt's UTM suppression value in utm_source, the prompt should be displayed.
+		expect( shouldPromptBeDisplayed( prompt, null, ras ) ).toBeTruthy();
+
+		// If the URL has the prompt's UTM suppression value in utm_source, the prompt should not be displayed.
+		setWindowLocation( 'example.com', '?utm_source=suppress_this' );
+		expect( shouldPromptBeDisplayed( prompt, null, ras ) ).toBeFalsy();
+
+		// Once the reader has had the UTM suppression value, the prompt should no longer be displayed.
+		setWindowLocation( 'example.com', '' );
+		expect( shouldPromptBeDisplayed( prompt, null, ras ) ).toBeFalsy();
 	} );
 } );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Looks like we never implemented the UTM Suppression feature in the big refactor we did in #1192. This restores it.

Cloes `1200550061930446/1208670219439755`.

### How to test the changes in this Pull Request:

1. Publish a new prompt to the "Everyone" segment or any other segment and set it to display on every pageview. Also add a value to the "UTM Suppression" option in the sidebar (make sure to add some spaces which will be URL-encoded), for example `Newspack suppression`:

<img width="271" alt="Screenshot 2025-02-24 at 5 07 16 PM" src="https://github.com/user-attachments/assets/765916ae-7603-49ff-8885-33ff323a626c" />

2. On `release`, in a new reader session, visit the site with a `utm_source` param set to the encoded version of the UTM Suppression value you set in step 1. For example, for `Newspack suppression`, add `?utm_source=Newspack%20suppression` to the URL. Make sure you match the prompt's segment, if you set one.
3. Observe that the prompt is shown.
4. Check out this branch, repeat step 2, and confirm that the prompt is not shown.
5. In the same browser session, visit some other pages on the site and confirm that the prompt continues to be suppressed.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208670219439755