### PR TITLE
fix: update merge tags data reference to use window

### DIFF
--- a/src/editor/index.js
+++ b/src/editor/index.js
@@ -1,4 +1,4 @@
-/* global newspack_popups_data, newspack_popups_merge_tags */
+/* global newspack_popups_data */
 
 /**
  * Popup Custom Post Type
@@ -143,7 +143,7 @@ registerPlugin( 'newspack-popups-expiration', {
 	icon: null,
 } );
 
-if ( newspack_popups_merge_tags?.tags?.length ) {
+if ( window.newspack_popups_merge_tags?.tags?.length ) {
 	wp.hooks.addFilter(
 		'editor.BlockEdit',
 		'newspack-popups/merge-tags-block-control',
@@ -161,7 +161,7 @@ if ( newspack_popups_merge_tags?.tags?.length ) {
 				return (
 					<>
 						<BlockEdit { ...props } />
-						<MergeTagsBlockControl tags={ newspack_popups_merge_tags.tags } { ...props } />
+						<MergeTagsBlockControl tags={ window.newspack_popups_merge_tags.tags } { ...props } />
 					</>
 				);
 			}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fixes a fatal error when the merge tags feature flag is off.

### How to test the changes in this Pull Request:

1. While on `trunk` make sure you don't have `define( 'NEWSPACK_MERGE_TAGS', true );` in your `wp-config.php`
2. Edit a campaign prompt and confirm you get a js fatal error
3. Checkout this branch, confirm the error is gone and you are able to edit a campaign
4. Add `define( 'NEWSPACK_MERGE_TAGS', true );` to your `wp-config.php`
5. Confirm you are able to use the #1400 feature

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
