### PR TITLE
feat(segments): add screen size criteria

### DIFF
--- a/src/criteria/default/devices.js
+++ b/src/criteria/default/devices.js
@@ -1,49 +1,27 @@
-import { setMatchingFunction } from '../utils';
+import {setMatchingFunction} from '../utils';
 
 setMatchingFunction('devices', (config) => {
 	const selectedDevices = Array.isArray(config.value) ? config.value : [];
-
 	if (selectedDevices.length === 0) {
 		return false;
 	}
 
 	const width = window.innerWidth;
-	// On desktop if the screen is wide enough, no need for more checks.
-	if (width > 1280 && selectedDevices.includes('desktop')) {
+	if (width >= 1280 && selectedDevices.includes('desktop')) {
+		return true;
+	}
+	if (width <= 1024 && width > 768 && selectedDevices.includes('laptop')) {
+		return true;
+	}
+	if (width <= 768 && width > 480 && selectedDevices.includes('tablet')) {
+		return true;
+	}
+	if (width <= 480 && width > 360 && selectedDevices.includes('mobile')) {
+		return true;
+	}
+	if (width < 360 && selectedDevices.includes('mobile_small')) {
 		return true;
 	}
 
-	const isPortrait = window.innerHeight > width;
-	const orientationMode = isPortrait ? 'portrait' : 'landscape';
-
-	const breakpoints = {
-		mobile_small: {
-			portrait: { min: 0, max: 360 },
-			landscape: { min: 0, max: 640 },
-		},
-		mobile: {
-			portrait: { min: 361, max: 480 },
-			landscape: { min: 641, max: 768 },
-		},
-		tablet: {
-			portrait: { min: 481, max: 768 },
-			landscape: { min: 769, max: 1024 },
-		},
-		laptop: {
-			portrait: { min: 769, max: 1024 },
-			landscape: { min: 1025, max: 1280 },
-		},
-	};
-
-	for (const device of selectedDevices) {
-		if (!breakpoints[device]) {
-			continue;
-		}
-
-		const { min, max } = breakpoints[device][orientationMode];
-		if (width >= min && width <= max) {
-			return true;
-		}
-	}
 	return false;
 });

--- a/src/criteria/default/devices.js
+++ b/src/criteria/default/devices.js
@@ -10,13 +10,13 @@ setMatchingFunction('devices', (config) => {
 	if (width >= 1280 && selectedDevices.includes('desktop')) {
 		return true;
 	}
-	if (width <= 1024 && width > 768 && selectedDevices.includes('laptop')) {
+	if (width >= 1024 && width < 1280 && selectedDevices.includes('laptop')) {
 		return true;
 	}
-	if (width <= 768 && width > 480 && selectedDevices.includes('tablet')) {
+	if (width >= 768 && width < 1024 && selectedDevices.includes('tablet')) {
 		return true;
 	}
-	if (width <= 480 && width > 360 && selectedDevices.includes('mobile')) {
+	if (width >= 360 && width < 768 && selectedDevices.includes('mobile')) {
 		return true;
 	}
 	if (width < 360 && selectedDevices.includes('mobile_small')) {

--- a/src/criteria/default/devices.js
+++ b/src/criteria/default/devices.js
@@ -1,0 +1,52 @@
+import { setMatchingFunction } from '../utils';
+
+setMatchingFunction('devices', (config) => {
+	const selectedDevices = Array.isArray(config.value) ? config.value : [];
+
+	if (selectedDevices.length === 0) {
+		return false;
+	}
+
+	// Get window dimensions once
+	const width = window.innerWidth;
+	// On desktop if the screen is wide enough, no need for more checks.
+	if (width > 1280 && selectedDevices.includes('desktop')) {
+		return true;
+	}
+
+	const isPortrait = window.innerHeight > width;
+	const orientationMode = isPortrait ? 'portrait' : 'landscape';
+
+	const breakpoints = {
+		mobile_small: {
+			portrait: { min: 0, max: 360 },
+			landscape: { min: 0, max: 640 },
+		},
+		mobile: {
+			portrait: { min: 361, max: 480 },
+			landscape: { min: 641, max: 768 },
+		},
+		tablet: {
+			portrait: { min: 481, max: 768 },
+			landscape: { min: 769, max: 1024 },
+		},
+		laptop: {
+			portrait: { min: 769, max: 1024 },
+			landscape: { min: 1025, max: 1280 },
+		},
+	};
+
+	// Check each requested type and return the matching one
+	for (const device of selectedDevices) {
+		if (!breakpoints[device]) {
+			continue;
+		}
+
+		const { min, max } = breakpoints[device][orientationMode];
+
+		if (width >= min && width <= max) {
+			return true;
+		}
+	}
+	return false;
+});

--- a/src/criteria/default/devices.js
+++ b/src/criteria/default/devices.js
@@ -1,27 +1,20 @@
 import {setMatchingFunction} from '../utils';
 
-setMatchingFunction('devices', (config) => {
+setMatchingFunction('devices', ( config, ras, { optionParams } )  => {
 	const selectedDevices = Array.isArray(config.value) ? config.value : [];
 	if (selectedDevices.length === 0) {
 		return false;
 	}
 
 	const width = window.innerWidth;
-	if (width >= 1280 && selectedDevices.includes('desktop')) {
-		return true;
-	}
-	if (width >= 1024 && width < 1280 && selectedDevices.includes('laptop')) {
-		return true;
-	}
-	if (width >= 768 && width < 1024 && selectedDevices.includes('tablet')) {
-		return true;
-	}
-	if (width >= 360 && width < 768 && selectedDevices.includes('mobile')) {
-		return true;
-	}
-	if (width < 360 && selectedDevices.includes('mobile_small')) {
-		return true;
-	}
 
-	return false;
+	return selectedDevices.some(deviceType => {
+		const device = optionParams[deviceType];
+		if (!device || !device.min_width || !device.max_width) {
+			return false;
+		}
+
+		return width >= device.min_width && width < device.max_width;
+	});
+
 });

--- a/src/criteria/default/devices.js
+++ b/src/criteria/default/devices.js
@@ -10,7 +10,7 @@ setMatchingFunction('devices', ( config, ras, { optionParams } )  => {
 
 	return selectedDevices.some(deviceType => {
 		const device = optionParams[deviceType];
-		if (!device || !device.min_width || !device.max_width) {
+		if (isNaN(device?.min_width) || isNaN(device?.max_width)) {
 			return false;
 		}
 

--- a/src/criteria/default/devices.js
+++ b/src/criteria/default/devices.js
@@ -7,7 +7,6 @@ setMatchingFunction('devices', (config) => {
 		return false;
 	}
 
-	// Get window dimensions once
 	const width = window.innerWidth;
 	// On desktop if the screen is wide enough, no need for more checks.
 	if (width > 1280 && selectedDevices.includes('desktop')) {
@@ -36,14 +35,12 @@ setMatchingFunction('devices', (config) => {
 		},
 	};
 
-	// Check each requested type and return the matching one
 	for (const device of selectedDevices) {
 		if (!breakpoints[device]) {
 			continue;
 		}
 
 		const { min, max } = breakpoints[device][orientationMode];
-
 		if (width >= min && width <= max) {
 			return true;
 		}

--- a/src/criteria/default/index.js
+++ b/src/criteria/default/index.js
@@ -1,4 +1,5 @@
 import './articles-read';
+import './devices';
 import './favorite-categories';
 import './donation';
 import './newsletter';

--- a/src/criteria/default/index.php
+++ b/src/criteria/default/index.php
@@ -37,24 +37,44 @@ $criteria = [
 		'category'    => 'reader_engagement',
 		'options'     => [
 			[
-				'label' => __( 'Desktop - 1280 px and above', 'newspack-popups' ),
-				'value' => 'desktop',
+				'label'  => __( 'Desktop - 1280 px and above', 'newspack-popups' ),
+				'value'  => 'Desktop',
+				'params' => [
+					'max_width' => PHP_INT_MAX,
+					'min_width' => 1280,
+				],
 			],
 			[
-				'label' => __( 'Laptop - 1024 px wide', 'newspack-popups' ),
-				'value' => 'laptop',
+				'label'  => __( 'Laptop - 1024 px wide', 'newspack-popups' ),
+				'value'  => 'Laptop',
+				'params' => [
+					'max_width' => 1280,
+					'min_width' => 1024,
+				],
 			],
 			[
-				'label' => __( 'Tablet - 768 px wide', 'newspack-popups' ),
-				'value' => 'tablet',
+				'label'  => __( 'Tablet - 768 px wide', 'newspack-popups' ),
+				'value'  => 'Tablet',
+				'params' => [
+					'max_width' => 1024,
+					'min_width' => 768,
+				],
 			],
 			[
-				'label' => __( 'Mobile (large phones) - 480 px wide', 'newspack-popups' ),
-				'value' => 'mobile',
+				'label'  => __( 'Mobile (large phones) - 480 px wide', 'newspack-popups' ),
+				'value'  => 'Mobile',
+				'params' => [
+					'max_width' => 768,
+					'min_width' => 480,
+				],
 			],
 			[
-				'label' => __( 'Mobile (small phones) - 360 px wide', 'newspack-popups' ),
-				'value' => 'mobile_small',
+				'label'  => __( 'Mobile (small phones) - 360 px wide', 'newspack-popups' ),
+				'value'  => 'Mobile small',
+				'params' => [
+					'max_width' => 360,
+					'min_width' => 0,
+				],
 			],
 		],
 	],

--- a/src/criteria/default/index.php
+++ b/src/criteria/default/index.php
@@ -33,28 +33,28 @@ $criteria = [
 	],
 	'devices'                  => [
 		'name'        => __( 'Devices', 'newspack-popups' ),
-		'description' => __( "Device – segment based on the user's device", 'newspack-popups' ),
-		'help'        => __( 'TODO', 'newspack-popups' ),
+		'description' => __( "Segment based on the user's device", 'newspack-popups' ),
+		'help'        => __( 'The device the user is viewing the site on – e.g. mobile, tablet, etc.', 'newspack-popups' ),
 		'category'    => 'reader_engagement',
 		'options'     => [
 			[
-				'label' => __( 'Mobile (small phones) - 360px/640px', 'newspack-popups' ),
+				'label' => __( 'Mobile (small phones) - 360/640 px wide', 'newspack-popups' ),
 				'value' => 'mobile_small',
 			],
 			[
-				'label' => __( 'Mobile (large phones)', 'newspack-popups' ),
+				'label' => __( 'Mobile (large phones) - 480/768 px wide', 'newspack-popups' ),
 				'value' => 'mobile',
 			],
 			[
-				'label' => __( 'Tablet', 'newspack-popups' ),
+				'label' => __( 'Tablet - 768/1024 px wide', 'newspack-popups' ),
 				'value' => 'tablet',
 			],
 			[
-				'label' => __( 'Laptop', 'newspack-popups' ),
+				'label' => __( 'Laptop - 1024/1280 px wide', 'newspack-popups' ),
 				'value' => 'laptop',
 			],
 			[
-				'label' => __( 'Desktop', 'newspack-popups' ),
+				'label' => __( 'Desktop - 1280 px and above', 'newspack-popups' ),
 				'value' => 'desktop',
 			],
 		],

--- a/src/criteria/default/index.php
+++ b/src/criteria/default/index.php
@@ -33,29 +33,28 @@ $criteria = [
 	],
 	'devices'                  => [
 		'name'        => __( 'Devices', 'newspack-popups' ),
-		'description' => __( "Segment based on the user's device", 'newspack-popups' ),
-		'help'        => __( 'The device the user is viewing the site on – e.g. mobile, tablet, etc.', 'newspack-popups' ),
+		'description' => __( 'The device the user is viewing the site on – e.g. mobile, tablet, etc.', 'newspack-popups' ),
 		'category'    => 'reader_engagement',
 		'options'     => [
 			[
-				'label' => __( 'Mobile (small phones) - 360/640 px wide', 'newspack-popups' ),
-				'value' => 'mobile_small',
+				'label' => __( 'Desktop - 1280 px and above', 'newspack-popups' ),
+				'value' => 'desktop',
 			],
 			[
-				'label' => __( 'Mobile (large phones) - 480/768 px wide', 'newspack-popups' ),
-				'value' => 'mobile',
-			],
-			[
-				'label' => __( 'Tablet - 768/1024 px wide', 'newspack-popups' ),
-				'value' => 'tablet',
-			],
-			[
-				'label' => __( 'Laptop - 1024/1280 px wide', 'newspack-popups' ),
+				'label' => __( 'Laptop - 1024 px wide', 'newspack-popups' ),
 				'value' => 'laptop',
 			],
 			[
-				'label' => __( 'Desktop - 1280 px and above', 'newspack-popups' ),
-				'value' => 'desktop',
+				'label' => __( 'Tablet - 768 px wide', 'newspack-popups' ),
+				'value' => 'tablet',
+			],
+			[
+				'label' => __( 'Mobile (large phones) - 480 px wide', 'newspack-popups' ),
+				'value' => 'mobile',
+			],
+			[
+				'label' => __( 'Mobile (small phones) - 360 px wide', 'newspack-popups' ),
+				'value' => 'mobile_small',
 			],
 		],
 	],

--- a/src/criteria/default/index.php
+++ b/src/criteria/default/index.php
@@ -45,7 +45,7 @@ $criteria = [
 				],
 			],
 			[
-				'label'  => __( 'Laptop - 1024 px wide', 'newspack-popups' ),
+				'label'  => __( 'Laptop - between 1024 and 1280 px wide', 'newspack-popups' ),
 				'value'  => 'Laptop',
 				'params' => [
 					'max_width' => 1280,
@@ -53,7 +53,7 @@ $criteria = [
 				],
 			],
 			[
-				'label'  => __( 'Tablet - 768 px wide', 'newspack-popups' ),
+				'label'  => __( 'Tablet - between 768 and 1024 px wide', 'newspack-popups' ),
 				'value'  => 'Tablet',
 				'params' => [
 					'max_width' => 1024,
@@ -61,7 +61,7 @@ $criteria = [
 				],
 			],
 			[
-				'label'  => __( 'Mobile (large phones) - 480 px wide', 'newspack-popups' ),
+				'label'  => __( 'Mobile (large phones) - between 480 and 786 px wide', 'newspack-popups' ),
 				'value'  => 'Mobile',
 				'params' => [
 					'max_width' => 768,
@@ -69,10 +69,10 @@ $criteria = [
 				],
 			],
 			[
-				'label'  => __( 'Mobile (small phones) - 360 px wide', 'newspack-popups' ),
+				'label'  => __( 'Mobile (small phones) - 480 px and below wide', 'newspack-popups' ),
 				'value'  => 'Mobile small',
 				'params' => [
-					'max_width' => 360,
+					'max_width' => 480,
 					'min_width' => 0,
 				],
 			],

--- a/src/criteria/default/index.php
+++ b/src/criteria/default/index.php
@@ -31,6 +31,34 @@ $criteria = [
 		'category'          => 'reader_engagement',
 		'matching_function' => 'list__in',
 	],
+	'devices'                  => [
+		'name'        => __( 'Devices', 'newspack-popups' ),
+		'description' => __( "Device – segment based on the user's device", 'newspack-popups' ),
+		'help'        => __( 'TODO', 'newspack-popups' ),
+		'category'    => 'reader_engagement',
+		'options'     => [
+			[
+				'label' => __( 'Mobile (small phones) - 360px/640px', 'newspack-popups' ),
+				'value' => 'mobile_small',
+			],
+			[
+				'label' => __( 'Mobile (large phones)', 'newspack-popups' ),
+				'value' => 'mobile',
+			],
+			[
+				'label' => __( 'Tablet', 'newspack-popups' ),
+				'value' => 'tablet',
+			],
+			[
+				'label' => __( 'Laptop', 'newspack-popups' ),
+				'value' => 'laptop',
+			],
+			[
+				'label' => __( 'Desktop', 'newspack-popups' ),
+				'value' => 'desktop',
+			],
+		],
+	],
 	/**
 	 * Reader Activity.
 	 */


### PR DESCRIPTION
* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:
 This adds a segmentation for device sizes. I used these sizes suggested by Miguel:

<img width="772" alt="image" src="https://github.com/user-attachments/assets/dbb98b4e-95c3-4a57-974e-bf9580c71e04" />

For sniffing out the device, I was going to use [window.matchMedia()](https://developer.mozilla.org/en-US/docs/Web/API/Window/matchMedia) but since I would have to query multiple times to match all devices chosen, I went with a more hand held version where I get width and height (browser support is the same or better than matchMedia) and return as soon as we have a match.

Note that the labels (e.g. Mobile (large phones) - 480/768 px wide) is a bit long and cryptic, and I wanted `description` an `help` to help explain that. Not sure if it's a bug, but the (i) info icon does nothing on `wp-admin/admin.php?page=newspack-audience-campaigns#/segments` when clicked and the description is not shown on any items.


### How to test the changes in this Pull Request:

1. You need this PR from `newspack-plugin` too: https://github.com/Automattic/newspack-plugin/pull/3880
2. Build both repos `npm run build`
3. Go to `wp-admin/admin.php?page=newspack-audience-campaigns#/segments` and add a segment with some devices.
4. Add some prompts to the segment
5. Go to a page that should display the prompt and resize the browser to ensure that the device-sizes you chose in the segment show the prompt and the ones that don't - don't.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209596441047349