### PR TITLE
Fix: prevent date picker from jumping

### DIFF
--- a/src/editor/ExpirationPanel.js
+++ b/src/editor/ExpirationPanel.js
@@ -65,7 +65,7 @@ const ExpirationPanel = ( {
 
 	const defaultExpirationDate = useMemo( () => {
 		const date = new Date();
-		date.setDate(date.getDate() + 1);
+		date.setHours( date.getHours() + 24 );
 		return convertDateToString( date );
 	}, [] );
 
@@ -85,10 +85,7 @@ const ExpirationPanel = ( {
 			{ expiration_date ? (
 				<DatePicker
 					currentDate={ expiration_date }
-					onChange={ value => {
-						const selectedDate = new Date( value );
-						onMetaFieldChange( { expiration_date: convertDateToString( selectedDate ) } );
-					} }
+					onChange={ value => onMetaFieldChange( { expiration_date: convertDateToString( new Date( value ) ) } ) }
 					isInvalidDate={ date => ! isInTheFuture( date ) }
 				/>
 			) : null }

--- a/src/editor/ExpirationPanel.js
+++ b/src/editor/ExpirationPanel.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import { ToggleControl, DatePicker } from '@wordpress/components';
+import { ToggleControl, DateTimePicker } from '@wordpress/components';
 import { isInTheFuture } from '@wordpress/date';
 import { useEffect, useState, useMemo } from '@wordpress/element';
 
@@ -65,7 +65,9 @@ const ExpirationPanel = ( {
 
 	const defaultExpirationDate = useMemo( () => {
 		const date = new Date();
-		date.setHours( date.getHours() + 24 );
+		date.setDate( date.getDate() + 1 );
+		// Set time to 23:59:59
+		date.setHours( 23, 59, 59, 999 );
 		return convertDateToString( date );
 	}, [] );
 
@@ -83,9 +85,14 @@ const ExpirationPanel = ( {
 				) }
 			/>
 			{ expiration_date ? (
-				<DatePicker
+				<DateTimePicker
 					currentDate={ expiration_date }
-					onChange={ value => onMetaFieldChange( { expiration_date: convertDateToString( new Date( value ) ) } ) }
+					onChange={ value => {
+						const selectedDate = new Date( value );
+						// Set time to 23:59:59
+						selectedDate.setHours( 23, 59, 59, 999 );
+						onMetaFieldChange( { expiration_date: convertDateToString( selectedDate ) } );
+					} }
 					isInvalidDate={ date => ! isInTheFuture( date ) }
 				/>
 			) : null }

--- a/src/editor/ExpirationPanel.js
+++ b/src/editor/ExpirationPanel.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import { ToggleControl, DateTimePicker } from '@wordpress/components';
+import { ToggleControl, DatePicker } from '@wordpress/components';
 import { isInTheFuture } from '@wordpress/date';
 import { useEffect, useState, useMemo } from '@wordpress/element';
 
@@ -65,9 +65,7 @@ const ExpirationPanel = ( {
 
 	const defaultExpirationDate = useMemo( () => {
 		const date = new Date();
-		date.setDate( date.getDate() + 1 );
-		// Set time to 23:59:59
-		date.setHours( 23, 59, 59, 999 );
+		date.setDate(date.getDate() + 1);
 		return convertDateToString( date );
 	}, [] );
 
@@ -85,12 +83,10 @@ const ExpirationPanel = ( {
 				) }
 			/>
 			{ expiration_date ? (
-				<DateTimePicker
+				<DatePicker
 					currentDate={ expiration_date }
 					onChange={ value => {
 						const selectedDate = new Date( value );
-						// Set time to 23:59:59
-						selectedDate.setHours( 23, 59, 59, 999 );
 						onMetaFieldChange( { expiration_date: convertDateToString( selectedDate ) } );
 					} }
 					isInvalidDate={ date => ! isInTheFuture( date ) }

--- a/src/editor/utils.js
+++ b/src/editor/utils.js
@@ -311,9 +311,7 @@ export const convertDateToString = date => {
 	const year = date.getFullYear();
 	const month = String( date.getMonth() + 1 ).padStart( 2, '0' );
 	const day = String( date.getDate() ).padStart( 2, '0' );
-	const hours = String( date.getHours() ).padStart( 2, '0' );
-	const minutes = String( date.getMinutes() ).padStart( 2, '0' );
-	const seconds = String( date.getSeconds() ).padStart( 2, '0' );
+	const time = 'T23:59:59'; // Set to the very end of the day.
 
-	return `${ year }-${ month }-${ day }T${ hours }:${ minutes }:${ seconds }`;
+	return `${ year }-${ month }-${ day }${ time }`;
 };

--- a/src/editor/utils.js
+++ b/src/editor/utils.js
@@ -298,7 +298,6 @@ export const getPlacementHelpMessage = props => {
 
 /**
  * Convert a date object to a string in YYYY-MM-DDTHH:MM:SS format.
- * Omit Z timezone so the date is parsed in the site's local timezone.
  *
  * @param {Date} date
  * @return {string} Date string in Y-m-d H:i:s format or empty string if the given date can't be parsed.
@@ -308,5 +307,13 @@ export const convertDateToString = date => {
 		return '';
 	}
 
-	return date.toISOString().split( '.' )[ 0 ];
-}
+	// Format the date string
+	const year = date.getFullYear();
+	const month = String( date.getMonth() + 1 ).padStart( 2, '0' );
+	const day = String( date.getDate() ).padStart( 2, '0' );
+	const hours = String( date.getHours() ).padStart( 2, '0' );
+	const minutes = String( date.getMinutes() ).padStart( 2, '0' );
+	const seconds = String( date.getSeconds() ).padStart( 2, '0' );
+
+	return `${ year }-${ month }-${ day }T${ hours }:${ minutes }:${ seconds }`;
+};


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR fixes an issue where the Expiration Date date picker occasionally jumped forward a day.

Best I can tell, the issue was related to `toISOString()` switching the date to UTC -- every time you pick a date, the time is set based on UTC, and then if you pick another date, the new UTC time is based off of that. So for me at -7:00 UTC, every time I change the date, the time would jump forward 7 hours. Sometimes this still landed on the same day, sometimes it landed on the next day.

You can see this by switching the `DatePicker` component to `DateTimePicker` -- it will be different based on your time zone, but for me it consistently jumped 7 hours each change:

![plus-seven](https://github.com/user-attachments/assets/6418ef6b-e1d0-48d5-9542-d1464f7dfe1e)

My fix was to replace `toISOString()` with something more manual that also set the time to `23:59:59` but I'm open to suggestions about that -- I'm not sure it's the best approach.

See: 1200550061930446-as-1209825755063362

### How to test the changes in this Pull Request:

1. Create a new prompt, and enable Expiration Date.
2. Confirm that the selected default date is tomorrow.
3. Try picking different dates and ensure the date you pick is what ends up selected.
4. Bonus: Swap `DatePicker` for `DateTimePicker` and confirm that the time is always set to `23:59:59` regardless of the date.
5. Try saving the prompt and refreshing, and making sure the expiration date is still accurate.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
