### PR TITLE
feat: merge tags outside the feature flag

### DIFF
--- a/includes/merge-tags/class-merge-tags.php
+++ b/includes/merge-tags/class-merge-tags.php
@@ -24,14 +24,9 @@ class Merge_Tags {
 	 * Initialize hooks.
 	 */
 	public static function init_hooks() {
-		if (
-			( defined( 'IS_TEST_ENV' ) && IS_TEST_ENV ) ||
-			( defined( 'NEWSPACK_MERGE_TAGS' ) && NEWSPACK_MERGE_TAGS )
-		) {
-			add_action( 'init', [ __CLASS__, 'register_default_tags' ] );
-			add_filter( 'newspack_popups_popup_content', [ __CLASS__, 'parse_tags' ] );
-			add_action( 'enqueue_block_editor_assets', [ __CLASS__, 'enqueue_block_editor_assets' ], 11 );
-		}
+		add_action( 'init', [ __CLASS__, 'register_default_tags' ] );
+		add_filter( 'newspack_popups_popup_content', [ __CLASS__, 'parse_tags' ] );
+		add_action( 'enqueue_block_editor_assets', [ __CLASS__, 'enqueue_block_editor_assets' ], 11 );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Removes the feature flag from #1400.

### How to test the changes in this Pull Request:

Make sure your `wp-config.php` doesn't have the `NEWSPACK_MERGE_TAGS` constant defined and repeat steps from  #1400.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
