### PR TITLE
fix(segmentation): fix range criteria

### DIFF
--- a/src/criteria/matching-functions.js
+++ b/src/criteria/matching-functions.js
@@ -59,8 +59,11 @@ export default {
 	 * the segment config.
 	 */
 	range: ( criteria, config ) => {
+		if ( isNaN( criteria.value ) ) {
+			return false;
+		}
 		const { min, max } = config.value;
-		if ( ! criteria.value || ( min && criteria.value < min ) || ( max && criteria.value > max ) ) {
+		if ( ( min && criteria.value < min ) || ( max && criteria.value > max ) ) {
 			return false;
 		}
 		return true;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes the range-type criteria handling of `0` values.

### How to test the changes in this Pull Request:

1. On `trunk`
1. Create a new segment and set it to `Articles read` of 100 and same for `Articles read in session` 

<img width="392" alt="image" src="https://github.com/user-attachments/assets/70236c6e-6066-4316-b63f-7c2cacac6c78" />

3. Add a prompt to this segment
4. Visit the front-end in a new session, observe the prompt is not displayed
5. Switch to this branch, observe the prompt is displayed 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->