### PR TITLE
feat(criteria): option parameters

### DIFF
--- a/includes/class-newspack-popups-criteria.php
+++ b/includes/class-newspack-popups-criteria.php
@@ -104,9 +104,31 @@ final class Newspack_Popups_Criteria {
 			$config[ $criteria['id'] ] = [
 				'matchingFunction'  => $criteria['matching_function'],
 				'matchingAttribute' => $criteria['matching_attribute'],
+				'optionParams'      => self::get_criteria_option_params( $criteria ),
 			];
 		}
 		return $config;
+	}
+
+	/**
+	 * Get the option params for the criteria.
+	 *
+	 * @param array $criteria The criteria.
+	 *
+	 * @return array Option params keyed by option value.
+	 */
+	protected static function get_criteria_option_params( $criteria ) {
+		if ( empty( $criteria['options'] ) ) {
+			return [];
+		}
+		$option_params = [];
+		foreach ( $criteria['options'] as $option ) {
+			if ( empty( $option['params'] ) ) {
+				continue;
+			}
+			$option_params[ $option['value'] ] = $option['params'];
+		}
+		return $option_params;
 	}
 
 	/**

--- a/src/criteria/index.test.js
+++ b/src/criteria/index.test.js
@@ -169,4 +169,20 @@ describe( 'criteria matching', () => {
 		expect( criteria.matches( { value: 'bar' } ) ).toEqual( true );
 		expect( matchingFunction ).toHaveBeenCalledTimes( 2 );
 	} );
+	it( 'should pass option params to matching function', () => {
+		registerCriteria( criteriaId, {
+			matchingAttribute: 'my-custom-attribute',
+			matchingFunction: ( config, ras, { optionParams } ) => {
+				expect( optionParams ).toBeDefined();
+				expect( optionParams[ config.value ] ).toBeDefined();
+				return true;
+			},
+			optionParams: {
+				1: { foo: 'bar' },
+				2: { foo: 'baz' },
+			},
+		} );
+		// Trigger the matching function for assertions.
+		getCriteria( criteriaId ).matches( { value: '1' } );
+	} );
 } );

--- a/src/criteria/utils.js
+++ b/src/criteria/utils.js
@@ -100,7 +100,7 @@ export function registerCriteria( id, config = {} ) {
 			console.warn( 'Reader activation script not loaded.' ); // eslint-disable-line no-console
 		}
 		setup( ras );
-		criteria._matched[ configString ] = criteria.matchingFunction( segmentConfig, ras );
+		criteria._matched[ configString ] = criteria.matchingFunction( segmentConfig, ras, criteria );
 		return criteria._matched[ configString ];
 	};
 	if ( ! window.newspackPopupsCriteria.criteria ) {

--- a/tests/test-criteria.php
+++ b/tests/test-criteria.php
@@ -80,4 +80,49 @@ class CriteriaTest extends WP_UnitTestCase {
 		$this->assertEquals( $config['matching_attribute'], $criteria['matching_attribute'] );
 		$this->assertEquals( $config['matching_function'], $criteria['matching_function'] );
 	}
+
+	/**
+	 * Test get_criteria_config()
+	 */
+	public function test_get_criteria_config() {
+		$config = [
+			'name'               => 'Criteria Name',
+			'matching_function'  => 'list__in',
+			'matching_attribute' => 'criteria_attribute',
+			'options'            => [
+				[
+					'name'   => 'Option 1',
+					'value'  => '1',
+					'params' => [
+						'foo' => 'bar',
+					],
+				],
+				[
+					'name'   => 'Option 2',
+					'value'  => '2',
+					'params' => [
+						'foo' => 'baz',
+					],
+				],
+			],
+		];
+
+		Newspack_Popups_Criteria::register_criteria( 'test_criteria_config', $config );
+
+		$criteria_config = Newspack_Popups_Criteria::get_criteria_config();
+
+		$this->assertEquals( $config['matching_function'], $criteria_config['test_criteria_config']['matchingFunction'] );
+		$this->assertEquals( $config['matching_attribute'], $criteria_config['test_criteria_config']['matchingAttribute'] );
+		$this->assertEquals(
+			[
+				'1' => [
+					'foo' => 'bar',
+				],
+				'2' => [
+					'foo' => 'baz',
+				],
+			],
+			$criteria_config['test_criteria_config']['optionParams']
+		);
+	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Introduces criteria option parameters so the matching function can receive additional data related to the option for its business logic.

Related discussion: https://github.com/Automattic/newspack-popups/pull/1414/files#r2032653663

### How to test the changes in this Pull Request:

1. Make sure php and js unit tests are accurate and passing
2. Register a new criteria with option parameters:

```php
Newspack_Popups_Criteria::register_criteria(
	'my_criteria',
	[
		'options' => [
			[
				'name' => 'Option 1',
				'value' => 'option_1',
				'params' => [
					'foo' => 'bar',
				],
			]
		]
	]
);
```

3. Confirm the matching function can use the parameter by registering it in `src/criteria/default`:

```javascript
import { setMatchingFunction } from '../utils.js';

setMatchingFunction( 'my_criteria', ( config, ras, { optionParams } ) {
	console.log( { optionParams } );
	return true;
} );
```

4. Visit your site and in the browser console run the criteria match to see the log:

```
window.newspackPopupsCriteria.criteria.my_criteria.matches( { value: null } );
```

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
