### PR TITLE
fix: pass popup ID param through order

### DIFF
--- a/includes/class-newspack-popups-data-api.php
+++ b/includes/class-newspack-popups-data-api.php
@@ -27,6 +27,11 @@ final class Newspack_Popups_Data_Api {
 	public static function init() {
 		\add_action( 'newspack_campaigns_after_campaign_render', [ __CLASS__, 'get_rendered_popups' ] );
 		\add_action( 'wp_footer', [ __CLASS__, 'print_popups_data' ], 999 );
+		add_filter( 'newspack_blocks_modal_checkout_cart_item_data', [ __CLASS__, 'checkout_cart_item_data' ], 10, 2 );
+		add_action( 'woocommerce_checkout_create_order_line_item', [ __CLASS__, 'checkout_create_order_line_item' ], 10, 4 );
+		add_filter( 'newspack_auth_form_metadata', [ __CLASS__, 'register_reader_metadata' ] );
+		add_filter( 'newspack_register_reader_form_metadata', [ __CLASS__, 'register_reader_metadata' ] );
+		add_filter( 'newspack_newsletters_subscription_form_metadata', [ __CLASS__, 'register_reader_metadata' ] );
 	}
 
 	/**
@@ -237,6 +242,52 @@ final class Newspack_Popups_Data_Api {
 			var newspackPopupsData = <?php echo \wp_json_encode( $popups ); ?>;
 		</script>
 		<?php
+	}
+
+	/**
+	 * Add content gate metadata to the cart item.
+	 *
+	 * @param array $cart_item_data The cart item data.
+	 *
+	 * @return array
+	 */
+	public static function checkout_cart_item_data( $cart_item_data ) {
+		$popup_id = filter_input( INPUT_GET, 'newspack_popup_id', FILTER_SANITIZE_NUMBER_INT );
+		if ( ! empty( $gate_post_id ) ) {
+			$cart_item_data['newspack_popup_id'] = $popup_id;
+		}
+		return $cart_item_data;
+	}
+
+	/**
+	 * Add content gate metadata from the cart item to the order.
+	 *
+	 * @param \WC_Order_Item_Product $item The cart item.
+	 * @param string                 $cart_item_key The cart item key.
+	 * @param array                  $values The cart item values.
+	 * @param \WC_Order              $order The order.
+	 * @return void
+	 */
+	public static function checkout_create_order_line_item( $item, $cart_item_key, $values, $order ) {
+		if ( ! empty( $values['newspack_popup_id'] ) ) {
+			$order->add_meta_data( '_newspack_popup_id', $values['newspack_popup_id'] );
+		}
+	}
+
+	/**
+	 * Add content gate metadata on reader registration.
+	 *
+	 * @param array $metadata The metadata.
+	 *
+	 * @return array
+	 */
+	public static function register_reader_metadata( $metadata ) {
+		$popup_id = filter_input( INPUT_POST, 'newspack_popup_id', FILTER_SANITIZE_NUMBER_INT );
+		if ( ! empty( $popup_id ) && isset( $metadata['registration_method'] ) ) {
+			$metadata['newspack_popup_id']   = $popup_id;
+			$metadata['registration_method'] = $metadata['registration_method'] . '-popup';
+		}
+		return $metadata;
 	}
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Changes required for https://github.com/Automattic/newspack-plugin/pull/3895. Standardizes how prompt data is propagated throughout modal checkouts and registrations so it now happens the same way as with content gates.

### How to test the changes in this Pull Request:

See https://github.com/Automattic/newspack-plugin/pull/3895

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
