### PR TITLE
fix(criteria): filter on segment if passed in "view_as"

### DIFF
--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -66,14 +66,13 @@ final class Newspack_Popups_Inserter {
 		$view_as_spec        = Newspack_Popups_View_As::parse_view_as();
 		$campaign_id         = isset( $view_as_spec['campaign'] ) ? $view_as_spec['campaign'] : false;
 		$include_unpublished = isset( $view_as_spec['show_unpublished'] ) && 'true' === $view_as_spec['show_unpublished'] ? true : false;
+		$segment_id          = $view_as_spec['segment'] ?? false;
 
 		// Retrieve all prompts eligible for display.
 		$popups_to_maybe_display = Newspack_Popups_Model::retrieve_eligible_popups( $include_unpublished, $campaign_id );
-		$popups_to_display       = array_filter(
+		$popups_to_display = array_filter(
 			$popups_to_maybe_display,
-			function( $popup ) {
-				return self::should_display( $popup, true );
-			}
+			fn( $popup ) => self::should_display( $popup, true ) && ( empty( $segment_id ) || in_array( $segment_id, wp_list_pluck( $popup['segments'], 'term_id' ) ) )
 		);
 
 		// Cache results so we don't have to query again.

--- a/includes/class-newspack-popups-view-as.php
+++ b/includes/class-newspack-popups-view-as.php
@@ -49,7 +49,7 @@ final class Newspack_Popups_View_As {
 	 * Parse "view as" spec.
 	 *
 	 * @param string|null $raw_spec Raw spec. If null, read from $_GET['view_as'].
-	 * @return object Parsed spac.
+	 * @return array Parsed spec.
 	 */
 	public static function parse_view_as( $raw_spec = null ) {
 		if ( empty( $raw_spec ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?


### Changes proposed in this Pull Request:
This adds a filter (and that might be a bit too late in the process) that filters out all prompts that don't have the right segment if the `segment=xx` is in the url. It's used for previewing segments.

Should we filter it earlier? It's pretty rare that the `$segment_id` variable will be not empty, so this is maybe the most performant so we don't have to add a query or similar.


### How to test the changes in this Pull Request:

1. Without the branch – in `wp-admin/admin.php?page=newspack-audience-campaigns#/campaigns`, click "Preview segment" on one of the segments. You get _all_ campaigns.
2. Now switch to this branch and click "preview segment" again. You should only see the segment's campaigns.
3. Test that you still get the right campaigns elsewhere on the site.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209918677142618