### PR TITLE
fix(segmentation): log page view even if page is not showing prompts

### DIFF
--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -623,6 +623,20 @@ final class Newspack_Popups_Inserter {
 			return;
 		}
 
+		$script_handle = 'log-page-view';
+		\wp_register_script(
+			$script_handle,
+			plugins_url( '../dist/logPageView.js', __FILE__ ),
+			[],
+			filemtime( dirname( NEWSPACK_POPUPS_PLUGIN_FILE ) . '/dist/logPageView.js' ),
+			[
+				'strategy'  => 'defer',
+				'in_footer' => true,
+			]
+		);
+		\wp_localize_script( $script_handle, 'newspack_popups_view', [ 'donor_landing_page' => Newspack_Popups_Settings::donor_landing_page() ] );
+		\wp_enqueue_script( $script_handle );
+
 		// Don't enqueue assets if prompts are disabled on this post.
 		$has_disabled_prompts = is_singular() && ! empty( get_post_meta( get_the_ID(), 'newspack_popups_has_disabled_popups', true ) );
 		if ( $has_disabled_prompts ) {
@@ -691,11 +705,6 @@ final class Newspack_Popups_Inserter {
 				}
 
 				$script_data['segments'] = (object) self::$segments;
-			}
-
-			$donor_landing_page = Newspack_Popups_Settings::donor_landing_page();
-			if ( ! empty( $donor_landing_page ) ) {
-				$script_data['donor_landing_page'] = $donor_landing_page;
 			}
 
 			\wp_localize_script( $script_handle, 'newspack_popups_view', $script_data );

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -634,7 +634,7 @@ final class Newspack_Popups_Inserter {
 				'in_footer' => true,
 			]
 		);
-		\wp_localize_script( $script_handle, 'newspack_popups_view', [ 'donor_landing_page' => Newspack_Popups_Settings::donor_landing_page() ] );
+		\wp_localize_script( $script_handle, 'newspack_popups_log_pageview_data', [ 'donor_landing_page' => Newspack_Popups_Settings::donor_landing_page() ] );
 		\wp_enqueue_script( $script_handle );
 
 		// Don't enqueue assets if prompts are disabled on this post.

--- a/src/view/log-page-view.js
+++ b/src/view/log-page-view.js
@@ -1,0 +1,12 @@
+/**
+ * Internal dependencies
+ */
+import { domReady, logPageview } from './utils';
+
+if (typeof window !== 'undefined') {
+	domReady(() => {
+		// Log a pageview for frequency counts.
+		window.newspackRAS = window.newspackRAS || [];
+		window.newspackRAS.push(logPageview);
+	});
+}

--- a/src/view/segmentation.js
+++ b/src/view/segmentation.js
@@ -8,7 +8,6 @@ import {
 	getRawId,
 	getOverride,
 	handleSeen,
-	logPageview,
 	shouldPromptBeDisplayed,
 } from './utils';
 
@@ -20,10 +19,6 @@ export const handleSegmentation = prompts => {
 		const segments = newspack_popups_view?.segments || {};
 		const matchingSegment = getBestPrioritySegment( segments );
 		debug( 'matchingSegment', matchingSegment );
-		// Log a pageview for frequency counts.
-		if ( ras ) {
-			logPageview( ras );
-		}
 		let overlayDisplayed;
 
 		prompts.forEach( prompt => {

--- a/src/view/utils/index.js
+++ b/src/view/utils/index.js
@@ -1,4 +1,4 @@
-/* globals newspack_popups_view */
+/* globals newspack_popups_log_pageview_data */
 
 export * from './analytics';
 export * from './prompts';
@@ -113,7 +113,7 @@ export const logPageview = ras => {
 			pageId = parseInt( className.replace( 'page-id-', '' ) );
 		}
 	} );
-	if ( pageId && parseInt( newspack_popups_view?.donor_landing_page ) === pageId ) {
+	if ( pageId && parseInt( newspack_popups_log_pageview_data?.donor_landing_page ) === pageId ) {
 		ras.store.set( 'is_donor', true );
 	}
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,6 +16,7 @@ const path = require( 'path' );
 const entry = {
 	editor: path.join( __dirname, 'src', 'editor' ),
 	view: path.join( __dirname, 'src', 'view' ),
+	logPageView: path.join( __dirname, 'src', 'view', 'log-page-view' ),
 	admin: path.join( __dirname, 'src', 'view', 'admin' ),
 	documentSettings: path.join( __dirname, 'src', 'document-settings' ),
 	settings: path.join( __dirname, 'src', 'settings' ),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Updating pageview count and donor status would only be handled on posts/pages where prompts are not disabled. If the donor landing page has prompts disabled, no reader would ever be tagged as a donor. 

### How to test the changes in this Pull Request:

1. On `trunk`,
2. Set up a segment targeting Donors, create a page, and set is as the donor landing page in Audience -> Campaigns → Settings
3. Publish a prompt and assign it to the segment
4. Observe that the prompt is not displayed after visiting the donor landing page
5. Switch to this branch – be sure to retrigger JS builds – and observe that the prompt is displayed after visiting the donor landing page

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->