### PR TITLE
fix(preview): enqueue styles and scripts in preview mode

### DIFF
--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -625,7 +625,7 @@ final class Newspack_Popups_Inserter {
 
 		// Don't enqueue assets if prompts are disabled on this post.
 		$has_disabled_prompts = is_singular() && ! empty( get_post_meta( get_the_ID(), 'newspack_popups_has_disabled_popups', true ) );
-		if ( $has_disabled_prompts ) {
+		if ( $has_disabled_prompts && ! Newspack_Popups::is_preview_request() ) {
 			return;
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a bug with previewing prompts and the per-page prompt disabling

### How to test the changes in this Pull Request:

1. On `trunk`,
2. Create a page and disable prompts on it via the setting in the sidebar
3. Create an overlay prompt, add a button inside, and make the button link to the page created in the previous step
4. Preview the prompt, click the button → observe the page displays the prompt, but without styling
5. Switch to this branch, repeat previous step, observe the prompt is not visible

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->