### PR TITLE
fix: remove "-popup" suffix from method params, no longer needed

### DIFF
--- a/includes/class-newspack-popups-data-api.php
+++ b/includes/class-newspack-popups-data-api.php
@@ -284,8 +284,7 @@ final class Newspack_Popups_Data_Api {
 	public static function register_reader_metadata( $metadata ) {
 		$popup_id = filter_input( INPUT_POST, 'newspack_popup_id', FILTER_SANITIZE_NUMBER_INT );
 		if ( ! empty( $popup_id ) && isset( $metadata['registration_method'] ) ) {
-			$metadata['newspack_popup_id']   = $popup_id;
-			$metadata['registration_method'] = $metadata['registration_method'] . '-popup';
+			$metadata['newspack_popup_id'] = $popup_id;
 		}
 		return $metadata;
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Proposes removing the `-popup` suffix from activity `registration_method` and `login_method` data, as this info can be inferred from the existence of `newspack_popup_id`  or `gate_post_id` params in the activity.

### How to test the changes in this Pull Request:

See https://github.com/Automattic/newspack-plugin/pull/3956#discussion_r2072113556

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
