### PR TITLE
fix: revert "fix: restore UTM suppression for overlay prompts (#1429)"

### DIFF
--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -1082,7 +1082,6 @@ final class Newspack_Popups_Model {
 		$is_scroll_triggered            = 'scroll' === $popup['options']['trigger_type'];
 		$assigned_segments              = Newspack_Segments_Model::get_popup_segments_ids_string( $popup['id'] );
 		$frequency_config               = self::get_frequency_config( $popup );
-		$utm_suppression                = $popup['options']['utm_suppression'];
 
 		$close_button_styles = 'color: ' . $close_button_color . ';';
 		if ( $enable_close_button_background ) {
@@ -1101,9 +1100,6 @@ final class Newspack_Popups_Model {
 			id="<?php echo esc_attr( $element_id ); ?>"
 			data-segments="<?php echo esc_attr( $assigned_segments ); ?>"
 			data-frequency="<?php echo esc_attr( $frequency_config ); ?>"
-			<?php if ( ! empty( $utm_suppression ) ) : ?>
-				data-suppression="<?php echo esc_attr( $utm_suppression ); ?>"
-			<?php endif; ?>
 
 			<?php if ( $is_scroll_triggered ) : ?>
 			data-scroll="<?php echo esc_attr( $popup['options']['trigger_scroll_progress'] ); ?>"


### PR DESCRIPTION
This reverts commit e6c82ff145e0daa30641b5a1db14656162545a44.

### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

#1429 is reportedly causing unintended side effects with segmentation behavior. This PR reverts that change until we can figure out why.

### How to test the changes in this Pull Request:

Smoke test basic segmentation features.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
