### PR TITLE
fix(segmentation): "should display prompt" logic

### DIFF
--- a/src/view/utils/segments.js
+++ b/src/view/utils/segments.js
@@ -122,37 +122,27 @@ export const getBestPrioritySegment = ( segments, viewAsString = null ) => {
  */
 export const shouldPromptBeDisplayed = ( prompt, matchingSegment, ras, override = null ) => {
 	const id = prompt.getAttribute( 'id' );
-	let display = true;
 	const suppression = [];
 	const debugInfo = {
 		element: prompt,
 	};
-	const suppressByUTM = prompt.getAttribute( 'data-suppression' );
 
-	// By override.
-	if ( true === override || false === override ) {
-		debugInfo.override = true;
-		if ( ! override ) {
-			display = false;
-			suppression.push( 'Prompt suppressed by override.' );
+	const shouldDisplay = () => {
+		// By override.
+		if ( true === override || false === override ) {
+			debugInfo.override = true;
+			if ( ! override ) {
+				suppression.push( 'Prompt suppressed by override.' );
+			}
+			return override;
 		}
-	} else if ( suppressByUTM ) {
-		const suppressionValues = ras.store.get( 'utm_source' ) || [];
-		const params = new URLSearchParams( window.location.search );
-		const currentUTM = params.get( 'utm_source' )
-		let suppressedByUTM = false;
-		if ( -1 < suppressionValues.indexOf( suppressByUTM ) ) {
-			suppressedByUTM = true;
+
+		// If RAS is not available, the prompt should not be displayed.
+		if ( ! ras ) {
+			suppression.push( 'Prompt not displayed because RAS is not available.' );
+			return false;
 		}
-		if ( ! suppressedByUTM && suppressByUTM === currentUTM ) {
-			suppressedByUTM = true;
-			ras.store.set( 'utm_source', [ ...suppressionValues, currentUTM ] );
-		}
-		if ( suppressedByUTM ) {
-			suppression.push( `Prompt suppressed by utm_source=${ suppressByUTM }.` );
-			display = false;
-		}
-	} else if ( ras ) {
+
 		// eslint-disable-next-line @wordpress/no-unused-vars-before-return
 		const [ start, between, max, reset ] = prompt.getAttribute( 'data-frequency' ).split( ',' );
 		const pageviews = ras.store.get( 'pageviews' );
@@ -166,7 +156,7 @@ export const shouldPromptBeDisplayed = ( prompt, matchingSegment, ras, override 
 						parseInt( start ) + 1
 					}. Reader has only ${ views } pageviews.`
 				);
-				display = false;
+				return false;
 			}
 
 			// If not displaying every pageview.
@@ -174,7 +164,7 @@ export const shouldPromptBeDisplayed = ( prompt, matchingSegment, ras, override 
 				const viewsAfterStart = Math.max( 0, views - ( parseInt( start ) + 1 ) );
 				if ( 0 < viewsAfterStart % ( parseInt( between ) + 1 ) ) {
 					suppression.push( `Prompt displayed once every ${ parseInt( between ) + 1 } pageviews.` );
-					display = false;
+					return false;
 				}
 			}
 
@@ -188,7 +178,27 @@ export const shouldPromptBeDisplayed = ( prompt, matchingSegment, ras, override 
 			} );
 			if ( 0 < parseInt( max ) && seenEvents.length >= parseInt( max ) ) {
 				suppression.push( `Prompt already displayed the max of ${ max } times.` );
-				display = false;
+				return false;
+			}
+		}
+
+		// Handle UTM suppression.
+		const suppressByUTM = prompt.getAttribute( 'data-suppression' );
+		if ( suppressByUTM ) {
+			const suppressionValues = ras.store.get( 'utm_source' ) || [];
+			const params = new URLSearchParams( window.location.search );
+			const currentUTM = params.get( 'utm_source' )
+			let suppressedByUTM = false;
+			if ( -1 < suppressionValues.indexOf( suppressByUTM ) ) {
+				suppressedByUTM = true;
+			}
+			if ( ! suppressedByUTM && suppressByUTM === currentUTM ) {
+				suppressedByUTM = true;
+				ras.store.set( 'utm_source', [ ...suppressionValues, currentUTM ] );
+			}
+			if ( suppressedByUTM ) {
+				suppression.push( `Prompt suppressed by utm_source=${ suppressByUTM }.` );
+				return false;
 			}
 		}
 
@@ -198,10 +208,13 @@ export const shouldPromptBeDisplayed = ( prompt, matchingSegment, ras, override 
 			: null;
 		if ( assignedSegments && 0 > assignedSegments.indexOf( matchingSegment ) ) {
 			suppression.push( 'Reader does not match prompt’s assigned segments.' );
-			display = false;
+			return false;
 		}
-	}
 
+		return true;
+	};
+
+	const display = shouldDisplay();
 	debugInfo.displayed = display;
 	if ( 0 < suppression.length ) {
 		debugInfo.suppression = suppression;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The UTM suppression feature implemented in #1399 has a logic error. If a prompt has UTM suppression configured, it will never reach the remaining logic to match frequency, matching segment, etc. Because the UTM suppression logic only sets the `display = false` if it's meant to suppress, the starting `let display = true;` will remain, and the prompt will always render if the reader does not match the configured UTM.

That happens primarily because it's all in `else if` statements.

To fix the logic and improve readability, I propose we place the rules in guard clauses. The only caveat is that we'd lose the ability to know if a prompt would be suppressed by multiple rules, because we'd be returning on the first hit. IMO, it's a good compromise over a safer logic.

If we really want to keep that debugging ability, I think we should refactor this a bit further so that each added rule is a separate function called by `shouldPromptBeDisplayed()` instead of maintaining long conditional statements. This way, we can better manage the rules in a systematic way.

### How to test the changes in this Pull Request:

1. To reproduce the bug, create 2 prompts (overlay and inline) with UTM suppression and assign them to a segment that matches users who have an account
2. Make sure you are in the `release` branch and in a fresh incognito session, visit pages that would render those prompts
3. Confirm that both prompts render, even though the reader doesn't match the segment
4. Checkout this branch, refresh the page and confirm the prompts don't render
5. Authenticate and confirm the prompts render
6. Add `?utm_source={value}` to the URL and confirm the prompts don't render
7. In a fresh session, go through the RAS defaults funnel and confirm that the expected prompts render for each step:
   1. First visit (anonymous)
   2. Register
   3. Subscribe
   4. Donate
8. Confirm `src/view/utils/segments.test.js` tests are passing

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210191951891711