### PR TITLE
fix(data): hidden field integration with Checkout Button block

### DIFF
--- a/includes/class-newspack-popups-data-api.php
+++ b/includes/class-newspack-popups-data-api.php
@@ -253,7 +253,7 @@ final class Newspack_Popups_Data_Api {
 	 */
 	public static function checkout_cart_item_data( $cart_item_data ) {
 		$popup_id = filter_input( INPUT_GET, 'newspack_popup_id', FILTER_SANITIZE_NUMBER_INT );
-		if ( ! empty( $gate_post_id ) ) {
+		if ( ! empty( $popup_id ) ) {
 			$cart_item_data['newspack_popup_id'] = $popup_id;
 		}
 		return $cart_item_data;

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -34,6 +34,7 @@ final class Newspack_Popups_Model {
 		'newspack_registration_before_form_fields',
 		'newspack_newsletters_subscribe_block_before_form_fields',
 		'newspack_blocks_donate_before_form_fields',
+		'newspack_blocks_checkout_button_hidden_fields',
 	];
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fixes the data integration with the Checkout Button block. There was a typo when storing the cart item data, preventing `newspack_popup_id` from being passed along the checkout flow.

I couldn't identify where `newspack_popup_id` was ever being injected into the Checkout Button forms to get picked up by the cart item data filter. Added support by introducing a new action hook in the block.

### How to test the changes in this Pull Request:

1. While on release, publish a new prompt with a Checkout Button block
2. Confirm the `newspack_popup_id` hidden input is not rendered in the block's form
3. Checkout this branch and https://github.com/Automattic/newspack-blocks/pull/2134 and refresh the page
4. Confirm the `newspack_popup_id` hidden input is rendered in the block's form
5. Go through the checkout flow and confirm all `np_modal_checkout_interaction` GA events include the `newspack_popup_id` event param

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
