### PR TITLE
fix: correct URL for segments admin link

### DIFF
--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -765,7 +765,7 @@ final class Newspack_Popups {
 				'taxonomy'                     => self::NEWSPACK_POPUPS_TAXONOMY,
 				'is_prompt'                    => self::NEWSPACK_POPUPS_CPT == get_post_type(),
 				'segments_taxonomy'            => Newspack_Segments_Model::TAX_SLUG,
-				'segments_admin_url'           => admin_url( 'admin.php?page=newspack-audience-campaigns#/campaigns' ),
+				'segments_admin_url'           => admin_url( 'admin.php?page=newspack-audience-campaigns#/segments' ),
 				'available_post_types'         => array_values(
 					get_post_types(
 						[


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Tiny fix to get the url in the "Manage segments" link when editing prompts to point to the right place. It was taking you to `wp-admin/admin.php?page=newspack-audience-campaigns#/campaigns` instead of `wp-admin/admin.php?page=newspack-audience-campaigns#/segments`.


### How to test the changes in this Pull Request:

1.On `wp-admin/admin.php?page=newspack-audience-campaigns#/campaigns`, click a 3-dots menu on a prompt and choose "edit". 
2. In the editor's sidebar, scroll to "Segments" and click the link "Manage segments". It should take you to segments – not campaigns.


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
