### PR TITLE
fix(previews): handle categories

### DIFF
--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -825,8 +825,9 @@ final class Newspack_Popups_Inserter {
 	 * @return bool Whether the prompt should be shown based on matching terms.
 	 */
 	public static function assess_taxonomy_filter( $popup, $taxonomy = 'category' ) {
-		// If a preview request, ensure the prompt appears in the first post loaded in the preview window.
-		if ( Newspack_Popups::is_preview_request() ) {
+		// For single popup preview, ensure the prompt appears in the first post loaded in the preview window.
+		// But for view_as preview, we should still apply category filtering.
+		if ( Newspack_Popups::is_preview_request() && ! Newspack_Popups_View_As::viewing_as_spec() ) {
 			return true;
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes the segment previews, so category assignments are handles. Before this change, if a prompt was assigned to a category, this information would be disregarded in the segment preview, displaying all prompts in "Everyone" segment regardless of category assignment.

Closes NPPM-411

### How to test the changes in this Pull Request:

1. Create a prompt and assign it to a category
2. Preview a segment - observe the prompt is displayed only on a post or page from this category

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->