### PR TITLE
fix(rendering): enqueue styles for jetpack form

### DIFF
--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -705,6 +705,29 @@ final class Newspack_Popups_Inserter {
 		);
 		\wp_style_add_data( $script_handle, 'rtl', 'replace' );
 		\wp_enqueue_style( $script_handle );
+
+		// Enqueue Jetpack contact form styles if any active popups contain contact forms.
+		self::maybe_enqueue_contact_form_styles();
+	}
+
+	/**
+	 * Enqueue Jetpack contact form styles if any active popups contain contact forms.
+	 */
+	public static function maybe_enqueue_contact_form_styles() {
+		// Only proceed if Jetpack contact forms are available.
+		if ( ! class_exists( '\Automattic\Jetpack\Extensions\Contact_Form\Contact_Form_Block' ) ) {
+			return;
+		}
+
+		// Check if any active popups contain Jetpack contact forms.
+		$active_popups = Newspack_Popups_Model::retrieve_active_popups();
+		foreach ( $active_popups as $popup ) {
+			if ( false !== strpos( $popup['content'], 'wp:jetpack/contact-form' ) ) {
+				// Enqueue the grunion.css stylesheet.
+				\wp_enqueue_style( 'grunion.css' );
+				break;
+			}
+		}
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes an issue with the Jetpack Form block styles not being applied. With this change, Jetpack Form blocks will be styled as expected when rendered inside prompts.

Closes NPPM-2037

### How to test the changes in this Pull Request:

1. Insert a Jetpack form in a prompt
2. On `trunk`, observe lack of styling
3. On this branch, observe styling is applied

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->