### PR TITLE
feat: update ras default with modern style

### DIFF
--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -140,6 +140,7 @@ final class Newspack_Popups {
 		WP_CLI::add_command( 'newspack-popups export', 'Newspack\Campaigns\CLI\Export' );
 		WP_CLI::add_command( 'newspack-popups import', 'Newspack\Campaigns\CLI\Import' );
 		WP_CLI::add_command( 'newspack-popups prune-data', 'Newspack\Campaigns\CLI\Prune_Data' );
+		WP_CLI::add_command( 'newspack-popups delete-all', 'Newspack\Campaigns\CLI\Delete_All' );
 	}
 
 	/**

--- a/includes/class-newspack-segments-migration.php
+++ b/includes/class-newspack-segments-migration.php
@@ -34,7 +34,7 @@ final class Newspack_Segments_Migration {
 	/**
 	 * Option name for whether we should bother trying to migrate reader data.
 	 * If there are no legacy reader tables, then there's no need to migrate.
-	 * 
+	 *
 	 * @var string
 	 */
 	const SHOULD_MIGRATE_READER_DATA_OPTION_NAME = 'newspack_should_migrate_reader_data';

--- a/includes/cli/class-delete-all.php
+++ b/includes/cli/class-delete-all.php
@@ -1,0 +1,131 @@
+<?php
+/**
+ * Campaigns Delete All CLI command.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack\Campaigns\CLI;
+
+use WP_CLI;
+use WP_CLI_Command;
+use Newspack_Popups;
+use Newspack_Popups_Model;
+use Newspack_Segments_Model;
+
+/**
+ * Delete all campaigns, segments, and prompts.
+ */
+class Delete_All extends WP_CLI_Command {
+
+	/**
+	 * Permanently delete all campaigns, segments, and prompts.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--campaigns-only]
+	 * : Delete only campaigns.
+	 *
+	 * [--segments-only]
+	 * : Delete only segments.
+	 *
+	 * [--prompts-only]
+	 * : Delete only prompts.
+	 *
+	 * ## EXAMPLES
+	 *
+	 * wp newspack-popups delete-all
+	 * wp newspack-popups delete-all --campaigns-only
+	 * wp newspack-popups delete-all --segments-only
+	 * wp newspack-popups delete-all --prompts-only
+	 */
+	/**
+	 * Command entrypoint.
+	 *
+	 * @param array $args       Positional arguments.
+	 * @param array $assoc_args Associative arguments.
+	 * @return void
+	 */
+	public function __invoke( $args, $assoc_args ) {
+		$delete_campaigns = empty( $assoc_args['prompts-only'] ) && empty( $assoc_args['segments-only'] );
+		$delete_segments  = empty( $assoc_args['prompts-only'] ) && empty( $assoc_args['campaigns-only'] );
+		$delete_prompts   = empty( $assoc_args['segments-only'] ) && empty( $assoc_args['campaigns-only'] );
+
+		if ( $delete_campaigns ) {
+			$this->delete_all_campaigns();
+		}
+
+		if ( $delete_segments ) {
+			$this->delete_all_segments();
+		}
+
+		if ( $delete_prompts ) {
+			$this->delete_all_prompts();
+		}
+
+		WP_CLI::success( __( 'Requested data deleted!', 'newspack-popups' ) );
+	}
+
+	/**
+	 * Delete all campaigns.
+	 *
+	 * @return void
+	 */
+	private function delete_all_campaigns() {
+		$campaigns = \Newspack_Popups::get_groups();
+		foreach ( $campaigns as $campaign ) {
+			\wp_delete_term( $campaign->term_id, \Newspack_Popups::NEWSPACK_POPUPS_TAXONOMY );
+		}
+		$count = count( $campaigns );
+		if ( 1 === $count ) {
+			WP_CLI::success( __( 'Deleted 1 campaign', 'newspack-popups' ) );
+		} else {
+			// translators: %d is the number of deleted campaigns.
+			WP_CLI::success( sprintf( __( 'Deleted %d campaigns', 'newspack-popups' ), $count ) );
+		}
+	}
+
+	/**
+	 * Delete all segments.
+	 *
+	 * @return void
+	 */
+	private function delete_all_segments() {
+		$segments = \Newspack_Segments_Model::get_segments( true );
+		foreach ( $segments as $segment ) {
+			\wp_delete_term( $segment['id'], \Newspack_Segments_Model::TAX_SLUG );
+		}
+		$count = count( $segments );
+		if ( 1 === $count ) {
+			WP_CLI::success( __( 'Deleted 1 segment', 'newspack-popups' ) );
+		} else {
+			// translators: %d is the number of deleted segments.
+			WP_CLI::success( sprintf( __( 'Deleted %d segments', 'newspack-popups' ), $count ) );
+		}
+	}
+
+	/**
+	 * Delete all prompts.
+	 *
+	 * @return void
+	 */
+	private function delete_all_prompts() {
+		$prompts = \Newspack_Popups_Model::retrieve_popups( true, true );
+		$ids     = array_map(
+			function( $prompt ) {
+				return (int) $prompt['id'];
+			},
+			$prompts
+		);
+		foreach ( $ids as $post_id ) {
+			\wp_delete_post( $post_id, true );
+		}
+		$count = count( $ids );
+		if ( 1 === $count ) {
+			WP_CLI::success( __( 'Deleted 1 prompt', 'newspack-popups' ) );
+		} else {
+			// translators: %d is the number of deleted prompts.
+			WP_CLI::success( sprintf( __( 'Deleted %d prompts', 'newspack-popups' ), $count ) );
+		}
+	}
+}

--- a/presets/ras-defaults.json
+++ b/presets/ras-defaults.json
@@ -129,7 +129,7 @@
 			"status": "draft",
 			"slug": "ras_newsletter_overlay",
 			"title": "Newsletter Signup Overlay",
-			"content": "<!-- wp:heading -->\n<h2>{{heading}}<\/h2>\n<!-- \/wp:heading -->\n\n<!-- wp:paragraph -->\n<p>{{body}}<\/p>\n<!-- \/wp:paragraph -->\n\n<!-- wp:newspack-newsletters/subscribe {\"label\":\"{{button_label}}\",\"successMessage\":\"{{success_message}}\",{{lists}}} /-->",
+			"content": "<!-- wp:heading -->\n<h2>{{heading}}<\/h2>\n<!-- \/wp:heading -->\n\n<!-- wp:paragraph -->\n<p>{{body}}<\/p>\n<!-- \/wp:paragraph -->\n\n<!-- wp:newspack-newsletters/subscribe {\"className\":\"is-style-modern\",\"label\":\"{{button_label}}\",\"successMessage\":\"{{success_message}}\",{{lists}}} /-->",
 			"segments": [
 				{
 					"id": 1002,
@@ -254,7 +254,7 @@
 			"status": "draft",
 			"slug": "ras_donation_overlay",
 			"title": "Donation Overlay",
-			"content": "<!-- wp:heading -->\n<h2>{{heading}}<\/h2>\n<!-- \/wp:heading -->\n\n<!-- wp:paragraph -->\n<p>{{body}}<\/p>\n<!-- \/wp:paragraph -->\n\n<!-- wp:newspack-blocks\/donate {\"className\":\"is-style-alternate\",\"amounts\":{\"once\":[9,20,90,20],\"month\":[7,15,30,15],\"year\":[84,180,360,180]},\"disabledFrequencies\":{\"once\":false,\"month\":false,\"year\":false},\"thanksText\":\"{{thanks_message}}\",\"buttonText\": \"{{button_label}}\",\"minimumDonation\":5} \/-->",
+			"content": "<!-- wp:heading -->\n<h2>{{heading}}<\/h2>\n<!-- \/wp:heading -->\n\n<!-- wp:paragraph -->\n<p>{{body}}<\/p>\n<!-- \/wp:paragraph -->\n\n<!-- wp:newspack-blocks\/donate {\"className\":\"is-style-modern\",\"amounts\":{\"once\":[9,20,90,20],\"month\":[7,15,30,15],\"year\":[84,180,360,180]},\"disabledFrequencies\":{\"once\":false,\"month\":false,\"year\":false},\"thanksText\":\"{{thanks_message}}\",\"buttonText\": \"{{button_label}}\",\"minimumDonation\":5} \/-->",
 			"segments": [
 				{
 					"id": 1001,
@@ -371,7 +371,7 @@
 			"status": "draft",
 			"slug": "ras_newsletter_inline",
 			"title": "Inline Newsletter Signup (secondary)",
-			"content": "<!-- wp:paragraph -->\n<p>{{body}}</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:newspack-newsletters/subscribe {\"label\":\"{{button_label}}\",\"successMessage\":\"{{success_message}}\",{{lists}}} /-->",
+			"content": "<!-- wp:paragraph -->\n<p>{{body}}</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:newspack-newsletters/subscribe {\"className\":\"is-style-modern\",\"label\":\"{{button_label}}\",\"successMessage\":\"{{success_message}}\",{{lists}}} /-->",
 			"segments": [
 				{
 					"id": 1002,
@@ -481,7 +481,7 @@
 			"status": "draft",
 			"slug": "ras_donation_inline",
 			"title": "Inline Donation (secondary)",
-			"content": "<!-- wp:separator -->\n<hr class=\"wp-block-separator has-alpha-channel-opacity\"\/>\n<!-- \/wp:separator -->\n\n<!-- wp:heading -->\n<h2>{{heading}}<\/h2>\n<!-- \/wp:heading -->\n\n<!-- wp:paragraph -->\n<p>{{body}}<\/p>\n<!-- \/wp:paragraph -->\n\n<!-- wp:newspack-blocks\/donate {\"className\":\"is-style-alternate\",\"amounts\":{\"once\":[9,20,90,20],\"month\":[7,15,30,15],\"year\":[84,180,360,180]},\"disabledFrequencies\":{\"once\":false,\"month\":false,\"year\":false},\"thanksText\":\"{{thanks_message}}\",\"buttonText\": \"{{button_label}}\",\"minimumDonation\":5} \/-->",
+			"content": "<!-- wp:separator -->\n<hr class=\"wp-block-separator has-alpha-channel-opacity\"\/>\n<!-- \/wp:separator -->\n\n<!-- wp:heading -->\n<h2>{{heading}}<\/h2>\n<!-- \/wp:heading -->\n\n<!-- wp:paragraph -->\n<p>{{body}}<\/p>\n<!-- \/wp:paragraph -->\n\n<!-- wp:newspack-blocks\/donate {\"className\":\"is-style-modern\",\"amounts\":{\"once\":[9,20,90,20],\"month\":[7,15,30,15],\"year\":[84,180,360,180]},\"disabledFrequencies\":{\"once\":false,\"month\":false,\"year\":false},\"thanksText\":\"{{thanks_message}}\",\"buttonText\": \"{{button_label}}\",\"minimumDonation\":5} \/-->",
 			"options": {
 				"background_color": "#FFFFFF",
 				"hide_border": true,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This main purpose of this PR is to update the default RAS blocks to use the `modern` style instead of `default`/`alternate`.

I've also added a simple CLI command to permanently delete all prompts, segments, and/or campaigns.

### How to test the changes in this Pull Request:

1. If you had Audience Management already enabled, delete all the prompts. (you can use `wp newspack-popups delete-all`)
2. Now run `wp newspack-popups import --ras-defaults` – This will re-import all the default prompts etc...
3. Check if the prompts are using the modern style

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
