### PR TITLE
fix: don’t add overlays to ras store if locked via front-end metering

### DIFF
--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -653,10 +653,7 @@ final class Newspack_Popups_Inserter {
 			\wp_enqueue_style( $admin_script_handle );
 		}
 
-		if ( self::assess_has_disabled_popups() ) {
-			return;
-		}
-
+		// Note: always enqueue scripts even when prompts are disabled, to allow page view logging.
 		$script_handle = 'newspack-popups-view';
 
 		if ( ! self::is_amp() ) {

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -653,6 +653,10 @@ final class Newspack_Popups_Inserter {
 			\wp_enqueue_style( $admin_script_handle );
 		}
 
+		if ( self::assess_has_disabled_popups() ) {
+			return;
+		}
+
 		$script_handle = 'newspack-popups-view';
 
 		if ( ! self::is_amp() ) {

--- a/src/view/segmentation.js
+++ b/src/view/segmentation.js
@@ -16,6 +16,10 @@ import {
  */
 export const handleSegmentation = prompts => {
 	const maybeDisplayPrompts = ( ras = null ) => {
+		// Don't display prompts if the content is locked.
+		if ( document.body.classList.contains( 'newspack-content-locked' ) ) {
+			return;
+		}
 		const segments = newspack_popups_view?.segments || {};
 		const matchingSegment = getBestPrioritySegment( segments );
 		debug( 'matchingSegment', matchingSegment );
@@ -69,7 +73,9 @@ export const handleSegmentation = prompts => {
 
 					// Register the overlay in RAS.
 					if ( isOverlay && ras?.overlays ) {
-						prompt.overlayId = ras.overlays.add();
+						if ( ! document.body.classList.contains( 'newspack-content-locked' ) ) {
+							prompt.overlayId = ras.overlays.add( `prompt_${ promptId }` );
+						}
 					}
 				};
 				if ( isOverlay ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Avoids adding overlay prompts to the global `overlays` store on pages content-gated via front-end metering.

See https://github.com/Automattic/newspack-plugin/pull/4230.

### How to test the changes in this Pull Request:

See https://github.com/Automattic/newspack-plugin/pull/4230 for testing with front-end metering.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
