### PR TITLE
fix: update metering class namespace

### DIFF
--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -448,8 +448,8 @@ final class Newspack_Popups_Inserter {
 		}
 		$is_restricted = ! is_user_logged_in() || ! current_user_can( 'wc_memberships_view_restricted_post_content', $post_id ); // phpcs:ignore WordPress.WP.Capabilities.Unknown
 		// Detect Content Gate Metering.
-		if ( $is_restricted && method_exists( 'Newspack\Memberships\Metering', 'is_metering' ) ) {
-			$is_restricted = ! Newspack\Memberships\Metering::is_metering();
+		if ( $is_restricted && method_exists( 'Newspack\Metering', 'is_metering' ) ) {
+			$is_restricted = ! \Newspack\Metering::is_metering();
 		}
 		return $is_restricted;
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Update the class namespace for https://github.com/Automattic/newspack-plugin/pull/4196

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
