### PR TITLE
fix: revert #1485

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,5 @@
-require('@rushstack/eslint-patch/modern-module-resolution');
+require( '@rushstack/eslint-patch/modern-module-resolution' );
 
 module.exports = {
-	extends: ['./node_modules/newspack-scripts/config/eslintrc.js'],
+	extends: [ './node_modules/newspack-scripts/config/eslintrc.js' ],
 };

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,5 +1,5 @@
 module.exports = api => {
-	api.cache(true);
+	api.cache( true );
 	return {
 		extends: 'newspack-scripts/config/babel.config.js',
 	};

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,1 +1,1 @@
-module.exports = { extends: ['@commitlint/config-conventional'] };
+module.exports = { extends: [ '@commitlint/config-conventional' ] };

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
 				"@wordpress/browserslist-config": "^6.33.0",
 				"eslint": "^8.57.0",
 				"lint-staged": "^15.5.1",
-				"newspack-scripts": "^5.7.0",
+				"newspack-scripts": "^5.5.2",
 				"postcss-scss": "^4.0.9"
 			}
 		},
@@ -78,14 +78,12 @@
 			}
 		},
 		"node_modules/@babel/code-frame": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
-			"integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
-			"license": "MIT",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.7.tgz",
+			"integrity": "sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==",
 			"dependencies": {
-				"@babel/helper-validator-identifier": "^7.27.1",
-				"js-tokens": "^4.0.0",
-				"picocolors": "^1.1.1"
+				"@babel/highlight": "^7.24.7",
+				"picocolors": "^1.0.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -498,10 +496,9 @@
 			}
 		},
 		"node_modules/@babel/helper-validator-identifier": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
-			"integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
-			"license": "MIT",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.7.tgz",
+			"integrity": "sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==",
 			"engines": {
 				"node": ">=6.9.0"
 			}
@@ -541,6 +538,84 @@
 			},
 			"engines": {
 				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/highlight": {
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.7.tgz",
+			"integrity": "sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==",
+			"dependencies": {
+				"@babel/helper-validator-identifier": "^7.24.7",
+				"chalk": "^2.4.2",
+				"js-tokens": "^4.0.0",
+				"picocolors": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/highlight/node_modules/ansi-styles": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+			"dependencies": {
+				"color-convert": "^1.9.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/@babel/highlight/node_modules/chalk": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+			"dependencies": {
+				"ansi-styles": "^3.2.1",
+				"escape-string-regexp": "^1.0.5",
+				"supports-color": "^5.3.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/@babel/highlight/node_modules/color-convert": {
+			"version": "1.9.3",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+			"dependencies": {
+				"color-name": "1.1.3"
+			}
+		},
+		"node_modules/@babel/highlight/node_modules/color-name": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+			"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
+		},
+		"node_modules/@babel/highlight/node_modules/escape-string-regexp": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+			"engines": {
+				"node": ">=0.8.0"
+			}
+		},
+		"node_modules/@babel/highlight/node_modules/has-flag": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+			"integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/@babel/highlight/node_modules/supports-color": {
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+			"dependencies": {
+				"has-flag": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=4"
 			}
 		},
 		"node_modules/@babel/parser": {
@@ -2053,7 +2128,6 @@
 			"resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
 			"integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
 			"dev": true,
-			"license": "MIT",
 			"optional": true,
 			"engines": {
 				"node": ">=0.1.90"
@@ -3548,194 +3622,158 @@
 			}
 		},
 		"node_modules/@octokit/auth-token": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-4.0.0.tgz",
-			"integrity": "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==",
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-3.0.4.tgz",
+			"integrity": "sha512-TWFX7cZF2LXoCvdmJWY7XVPi74aSY0+FfBZNSXEXFkMpjcqsQwDSYVv5FhRFaI0V1ECnwbz4j59T/G+rXNWaIQ==",
 			"dev": true,
-			"license": "MIT",
 			"engines": {
-				"node": ">= 18"
+				"node": ">= 14"
 			}
 		},
 		"node_modules/@octokit/core": {
-			"version": "5.2.2",
-			"resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.2.tgz",
-			"integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
+			"version": "4.2.4",
+			"resolved": "https://registry.npmjs.org/@octokit/core/-/core-4.2.4.tgz",
+			"integrity": "sha512-rYKilwgzQ7/imScn3M9/pFfUf4I1AZEH3KhyJmtPdE2zfaXAn2mFfUy4FbKewzc2We5y/LlKLj36fWJLKC2SIQ==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
-				"@octokit/auth-token": "^4.0.0",
-				"@octokit/graphql": "^7.1.0",
-				"@octokit/request": "^8.4.1",
-				"@octokit/request-error": "^5.1.1",
-				"@octokit/types": "^13.0.0",
+				"@octokit/auth-token": "^3.0.0",
+				"@octokit/graphql": "^5.0.0",
+				"@octokit/request": "^6.0.0",
+				"@octokit/request-error": "^3.0.0",
+				"@octokit/types": "^9.0.0",
 				"before-after-hook": "^2.2.0",
 				"universal-user-agent": "^6.0.0"
 			},
 			"engines": {
-				"node": ">= 18"
+				"node": ">= 14"
 			}
 		},
 		"node_modules/@octokit/endpoint": {
-			"version": "9.0.6",
-			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-9.0.6.tgz",
-			"integrity": "sha512-H1fNTMA57HbkFESSt3Y9+FBICv+0jFceJFPWDePYlR/iMGrwM5ph+Dd4XRQs+8X+PUFURLQgX9ChPfhJ/1uNQw==",
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-7.0.6.tgz",
+			"integrity": "sha512-5L4fseVRUsDFGR00tMWD/Trdeeihn999rTMGRMC1G/Ldi1uWlWJzI98H4Iak5DB/RVvQuyMYKqSK/R6mbSOQyg==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
-				"@octokit/types": "^13.1.0",
+				"@octokit/types": "^9.0.0",
+				"is-plain-object": "^5.0.0",
 				"universal-user-agent": "^6.0.0"
 			},
 			"engines": {
-				"node": ">= 18"
+				"node": ">= 14"
 			}
 		},
 		"node_modules/@octokit/graphql": {
-			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-7.1.1.tgz",
-			"integrity": "sha512-3mkDltSfcDUoa176nlGoA32RGjeWjl3K7F/BwHwRMJUW/IteSa4bnSV8p2ThNkcIcZU2umkZWxwETSSCJf2Q7g==",
+			"version": "5.0.6",
+			"resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-5.0.6.tgz",
+			"integrity": "sha512-Fxyxdy/JH0MnIB5h+UQ3yCoh1FG4kWXfFKkpWqjZHw/p+Kc8Y44Hu/kCgNBT6nU1shNumEchmW/sUO1JuQnPcw==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
-				"@octokit/request": "^8.4.1",
-				"@octokit/types": "^13.0.0",
+				"@octokit/request": "^6.0.0",
+				"@octokit/types": "^9.0.0",
 				"universal-user-agent": "^6.0.0"
 			},
 			"engines": {
-				"node": ">= 18"
+				"node": ">= 14"
 			}
 		},
 		"node_modules/@octokit/openapi-types": {
-			"version": "24.2.0",
-			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
-			"integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
-			"dev": true,
-			"license": "MIT"
+			"version": "18.1.1",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-18.1.1.tgz",
+			"integrity": "sha512-VRaeH8nCDtF5aXWnjPuEMIYf1itK/s3JYyJcWFJT8X9pSNnBtriDf7wlEWsGuhPLl4QIH4xM8fqTXDwJ3Mu6sw==",
+			"dev": true
 		},
 		"node_modules/@octokit/plugin-paginate-rest": {
-			"version": "9.2.2",
-			"resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-9.2.2.tgz",
-			"integrity": "sha512-u3KYkGF7GcZnSD/3UP0S7K5XUFT2FkOQdcfXZGZQPGv3lm4F2Xbf71lvjldr8c1H3nNbF+33cLEkWYbokGWqiQ==",
+			"version": "6.1.2",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-6.1.2.tgz",
+			"integrity": "sha512-qhrmtQeHU/IivxucOV1bbI/xZyC/iOBhclokv7Sut5vnejAIAEXVcGQeRpQlU39E0WwK9lNvJHphHri/DB6lbQ==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
-				"@octokit/types": "^12.6.0"
+				"@octokit/tsconfig": "^1.0.2",
+				"@octokit/types": "^9.2.3"
 			},
 			"engines": {
-				"node": ">= 18"
+				"node": ">= 14"
 			},
 			"peerDependencies": {
-				"@octokit/core": "5"
-			}
-		},
-		"node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/openapi-types": {
-			"version": "20.0.0",
-			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-20.0.0.tgz",
-			"integrity": "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/types": {
-			"version": "12.6.0",
-			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-12.6.0.tgz",
-			"integrity": "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@octokit/openapi-types": "^20.0.0"
+				"@octokit/core": ">=4"
 			}
 		},
 		"node_modules/@octokit/plugin-retry": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/@octokit/plugin-retry/-/plugin-retry-6.1.0.tgz",
-			"integrity": "sha512-WrO3bvq4E1Xh1r2mT9w6SDFg01gFmP81nIG77+p/MqW1JeXXgL++6umim3t6x0Zj5pZm3rXAN+0HEjmmdhIRig==",
+			"version": "4.1.6",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-retry/-/plugin-retry-4.1.6.tgz",
+			"integrity": "sha512-obkYzIgEC75r8+9Pnfiiqy3y/x1bc3QLE5B7qvv9wi9Kj0R5tGQFC6QMBg1154WQ9lAVypuQDGyp3hNpp15gQQ==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
-				"@octokit/request-error": "^5.0.0",
-				"@octokit/types": "^13.0.0",
+				"@octokit/types": "^9.0.0",
 				"bottleneck": "^2.15.3"
 			},
 			"engines": {
-				"node": ">= 18"
+				"node": ">= 14"
 			},
 			"peerDependencies": {
-				"@octokit/core": "5"
+				"@octokit/core": ">=3"
 			}
 		},
 		"node_modules/@octokit/plugin-throttling": {
-			"version": "8.2.0",
-			"resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-8.2.0.tgz",
-			"integrity": "sha512-nOpWtLayKFpgqmgD0y3GqXafMFuKcA4tRPZIfu7BArd2lEZeb1988nhWhwx4aZWmjDmUfdgVf7W+Tt4AmvRmMQ==",
+			"version": "5.2.3",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-5.2.3.tgz",
+			"integrity": "sha512-C9CFg9mrf6cugneKiaI841iG8DOv6P5XXkjmiNNut+swePxQ7RWEdAZRp5rJoE1hjsIqiYcKa/ZkOQ+ujPI39Q==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
-				"@octokit/types": "^12.2.0",
+				"@octokit/types": "^9.0.0",
 				"bottleneck": "^2.15.3"
 			},
 			"engines": {
-				"node": ">= 18"
+				"node": ">= 14"
 			},
 			"peerDependencies": {
-				"@octokit/core": "^5.0.0"
-			}
-		},
-		"node_modules/@octokit/plugin-throttling/node_modules/@octokit/openapi-types": {
-			"version": "20.0.0",
-			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-20.0.0.tgz",
-			"integrity": "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/@octokit/plugin-throttling/node_modules/@octokit/types": {
-			"version": "12.6.0",
-			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-12.6.0.tgz",
-			"integrity": "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@octokit/openapi-types": "^20.0.0"
+				"@octokit/core": "^4.0.0"
 			}
 		},
 		"node_modules/@octokit/request": {
-			"version": "8.4.1",
-			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.4.1.tgz",
-			"integrity": "sha512-qnB2+SY3hkCmBxZsR/MPCybNmbJe4KAlfWErXq+rBKkQJlbjdJeS85VI9r8UqeLYLvnAenU8Q1okM/0MBsAGXw==",
+			"version": "6.2.8",
+			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-6.2.8.tgz",
+			"integrity": "sha512-ow4+pkVQ+6XVVsekSYBzJC0VTVvh/FCTUUgTsboGq+DTeWdyIFV8WSCdo0RIxk6wSkBTHqIK1mYuY7nOBXOchw==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
-				"@octokit/endpoint": "^9.0.6",
-				"@octokit/request-error": "^5.1.1",
-				"@octokit/types": "^13.1.0",
+				"@octokit/endpoint": "^7.0.0",
+				"@octokit/request-error": "^3.0.0",
+				"@octokit/types": "^9.0.0",
+				"is-plain-object": "^5.0.0",
+				"node-fetch": "^2.6.7",
 				"universal-user-agent": "^6.0.0"
 			},
 			"engines": {
-				"node": ">= 18"
+				"node": ">= 14"
 			}
 		},
 		"node_modules/@octokit/request-error": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-5.1.1.tgz",
-			"integrity": "sha512-v9iyEQJH6ZntoENr9/yXxjuezh4My67CBSu9r6Ve/05Iu5gNgnisNWOsoJHTP6k0Rr0+HQIpnH+kyammu90q/g==",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-3.0.3.tgz",
+			"integrity": "sha512-crqw3V5Iy2uOU5Np+8M/YexTlT8zxCfI+qu+LxUB7SZpje4Qmx3mub5DfEKSO8Ylyk0aogi6TYdf6kxzh2BguQ==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
-				"@octokit/types": "^13.1.0",
+				"@octokit/types": "^9.0.0",
 				"deprecation": "^2.0.0",
 				"once": "^1.4.0"
 			},
 			"engines": {
-				"node": ">= 18"
+				"node": ">= 14"
 			}
 		},
+		"node_modules/@octokit/tsconfig": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@octokit/tsconfig/-/tsconfig-1.0.2.tgz",
+			"integrity": "sha512-I0vDR0rdtP8p2lGMzvsJzbhdOWy405HcGovrspJ8RRibHnyRgggUSNO5AIox5LmqiwmatHKYsvj6VGFHkqS7lA==",
+			"dev": true
+		},
 		"node_modules/@octokit/types": {
-			"version": "13.10.0",
-			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
-			"integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+			"version": "9.3.2",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.3.2.tgz",
+			"integrity": "sha512-D4iHGTdAnEEVsB8fl95m1hiz7D5YiRdQ9b/OEb3BYRVwbLsGHcRVPz+u+BgRLNk0Q0/4iZCBqDN96j2XNxfXrA==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
-				"@octokit/openapi-types": "^24.2.0"
+				"@octokit/openapi-types": "^18.0.0"
 			}
 		},
 		"node_modules/@pkgr/core": {
@@ -3828,7 +3866,6 @@
 			"resolved": "https://registry.npmjs.org/@pnpm/config.env-replace/-/config.env-replace-1.1.0.tgz",
 			"integrity": "sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w==",
 			"dev": true,
-			"license": "MIT",
 			"engines": {
 				"node": ">=12.22.0"
 			}
@@ -3838,7 +3875,6 @@
 			"resolved": "https://registry.npmjs.org/@pnpm/network.ca-file/-/network.ca-file-1.0.2.tgz",
 			"integrity": "sha512-YcPQ8a0jwYU9bTdJDpXjMi7Brhkr1mXsXrUJvjqM2mQDgkRiz8jFaQGOdaLxgjtUfQgZhKy/O3cG/YwmgKaxLA==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"graceful-fs": "4.2.10"
 			},
@@ -3850,15 +3886,13 @@
 			"version": "4.2.10",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
 			"integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
-			"dev": true,
-			"license": "ISC"
+			"dev": true
 		},
 		"node_modules/@pnpm/npm-conf": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/@pnpm/npm-conf/-/npm-conf-2.3.1.tgz",
-			"integrity": "sha512-c83qWb22rNRuB0UaVCI0uRPNRr8Z0FWnEIvT47jiHAmOIUHbBOg5XvV7pM5x+rKn9HRpjxquDbXYSXr3fAKFcw==",
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/@pnpm/npm-conf/-/npm-conf-2.2.2.tgz",
+			"integrity": "sha512-UA91GwWPhFExt3IizW6bOeY/pQ0BkuNwKjk9iQW9KqxluGCrg4VenZ0/L+2Y0+ZOtme72EVvg6v0zo3AMQRCeA==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"@pnpm/config.env-replace": "^1.1.0",
 				"@pnpm/network.ca-file": "^1.0.1",
@@ -4331,106 +4365,57 @@
 			}
 		},
 		"node_modules/@semantic-release/commit-analyzer": {
-			"version": "11.1.0",
-			"resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-11.1.0.tgz",
-			"integrity": "sha512-cXNTbv3nXR2hlzHjAMgbuiQVtvWHTlwwISt60B+4NZv01y/QRY7p2HcJm8Eh2StzcTJoNnflvKjHH/cjFS7d5g==",
+			"version": "9.0.2",
+			"resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-9.0.2.tgz",
+			"integrity": "sha512-E+dr6L+xIHZkX4zNMe6Rnwg4YQrWNXK+rNsvwOPpdFppvZO1olE2fIgWhv89TkQErygevbjsZFSIxp+u6w2e5g==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
-				"conventional-changelog-angular": "^7.0.0",
-				"conventional-commits-filter": "^4.0.0",
-				"conventional-commits-parser": "^5.0.0",
+				"conventional-changelog-angular": "^5.0.0",
+				"conventional-commits-filter": "^2.0.0",
+				"conventional-commits-parser": "^3.2.3",
 				"debug": "^4.0.0",
-				"import-from-esm": "^1.0.3",
-				"lodash-es": "^4.17.21",
+				"import-from": "^4.0.0",
+				"lodash": "^4.17.4",
 				"micromatch": "^4.0.2"
 			},
 			"engines": {
-				"node": "^18.17 || >=20.6.1"
+				"node": ">=14.17"
 			},
 			"peerDependencies": {
-				"semantic-release": ">=20.1.0"
+				"semantic-release": ">=18.0.0-beta.1"
 			}
 		},
 		"node_modules/@semantic-release/commit-analyzer/node_modules/conventional-changelog-angular": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-7.0.0.tgz",
-			"integrity": "sha512-ROjNchA9LgfNMTTFSIWPzebCwOGFdgkEq45EnvvrmSLvCtAw0HSmrCs7/ty+wAeYUZyNay0YMUNYFTRL72PkBQ==",
+			"version": "5.0.13",
+			"resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.13.tgz",
+			"integrity": "sha512-i/gipMxs7s8L/QeuavPF2hLnJgH6pEZAttySB6aiQLWcX3puWDL3ACVmvBhJGxnAy52Qc15ua26BufY6KpmrVA==",
 			"dev": true,
-			"license": "ISC",
 			"dependencies": {
-				"compare-func": "^2.0.0"
+				"compare-func": "^2.0.0",
+				"q": "^1.5.1"
 			},
 			"engines": {
-				"node": ">=16"
+				"node": ">=10"
 			}
 		},
 		"node_modules/@semantic-release/commit-analyzer/node_modules/conventional-commits-parser": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-5.0.0.tgz",
-			"integrity": "sha512-ZPMl0ZJbw74iS9LuX9YIAiW8pfM5p3yh2o/NbXHbkFuZzY5jvdi5jFycEOkmBW5H5I7nA+D6f3UcsCLP2vvSEA==",
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.2.4.tgz",
+			"integrity": "sha512-nK7sAtfi+QXbxHCYfhpZsfRtaitZLIA6889kFIouLvz6repszQDgxBu7wf2WbU+Dco7sAnNCJYERCwt54WPC2Q==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
-				"is-text-path": "^2.0.0",
-				"JSONStream": "^1.3.5",
-				"meow": "^12.0.1",
-				"split2": "^4.0.0"
+				"is-text-path": "^1.0.1",
+				"JSONStream": "^1.0.4",
+				"lodash": "^4.17.15",
+				"meow": "^8.0.0",
+				"split2": "^3.0.0",
+				"through2": "^4.0.0"
 			},
 			"bin": {
-				"conventional-commits-parser": "cli.mjs"
+				"conventional-commits-parser": "cli.js"
 			},
 			"engines": {
-				"node": ">=16"
-			}
-		},
-		"node_modules/@semantic-release/commit-analyzer/node_modules/is-text-path": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/is-text-path/-/is-text-path-2.0.0.tgz",
-			"integrity": "sha512-+oDTluR6WEjdXEJMnC2z6A4FRwFoYuvShVVEGsS7ewc0UTi2QtAKMDJuL4BDEVt+5T7MjFo12RP8ghOM75oKJw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"text-extensions": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/@semantic-release/commit-analyzer/node_modules/meow": {
-			"version": "12.1.1",
-			"resolved": "https://registry.npmjs.org/meow/-/meow-12.1.1.tgz",
-			"integrity": "sha512-BhXM0Au22RwUneMPwSCnyhTOizdWoIEPU9sp0Aqa1PnDMR5Wv2FGXYDjuzJEIX+Eo2Rb8xuYe5jrnm5QowQFkw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=16.10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/@semantic-release/commit-analyzer/node_modules/split2": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
-			"integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": ">= 10.x"
-			}
-		},
-		"node_modules/@semantic-release/commit-analyzer/node_modules/text-extensions": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-2.4.0.tgz",
-			"integrity": "sha512-te/NtwBwfiNRLf9Ijqx3T0nlqZiQ2XrrtBvu+cLL8ZRrGkO0NHTug8MYFKyoSrv/sHTaSKfilUkizV6XhxMJ3g==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
+				"node": ">=10"
 			}
 		},
 		"node_modules/@semantic-release/error": {
@@ -4572,121 +4557,46 @@
 			}
 		},
 		"node_modules/@semantic-release/github": {
-			"version": "9.2.6",
-			"resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-9.2.6.tgz",
-			"integrity": "sha512-shi+Lrf6exeNZF+sBhK+P011LSbhmIAoUEgEY6SsxF8irJ+J2stwI5jkyDQ+4gzYyDImzV6LCKdYB9FXnQRWKA==",
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-8.1.0.tgz",
+			"integrity": "sha512-erR9E5rpdsz0dW1I7785JtndQuMWN/iDcemcptf67tBNOmBUN0b2YNOgcjYUnBpgRpZ5ozfBHrK7Bz+2ets/Dg==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
-				"@octokit/core": "^5.0.0",
-				"@octokit/plugin-paginate-rest": "^9.0.0",
-				"@octokit/plugin-retry": "^6.0.0",
-				"@octokit/plugin-throttling": "^8.0.0",
-				"@semantic-release/error": "^4.0.0",
-				"aggregate-error": "^5.0.0",
-				"debug": "^4.3.4",
-				"dir-glob": "^3.0.1",
-				"globby": "^14.0.0",
+				"@octokit/core": "^4.2.1",
+				"@octokit/plugin-paginate-rest": "^6.1.2",
+				"@octokit/plugin-retry": "^4.1.3",
+				"@octokit/plugin-throttling": "^5.2.3",
+				"@semantic-release/error": "^3.0.0",
+				"aggregate-error": "^3.0.0",
+				"debug": "^4.0.0",
+				"dir-glob": "^3.0.0",
+				"fs-extra": "^11.0.0",
+				"globby": "^11.0.0",
 				"http-proxy-agent": "^7.0.0",
 				"https-proxy-agent": "^7.0.0",
 				"issue-parser": "^6.0.0",
-				"lodash-es": "^4.17.21",
-				"mime": "^4.0.0",
-				"p-filter": "^4.0.0",
-				"url-join": "^5.0.0"
+				"lodash": "^4.17.4",
+				"mime": "^3.0.0",
+				"p-filter": "^2.0.0",
+				"url-join": "^4.0.0"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=14.17"
 			},
 			"peerDependencies": {
-				"semantic-release": ">=20.1.0"
-			}
-		},
-		"node_modules/@semantic-release/github/node_modules/@semantic-release/error": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-4.0.0.tgz",
-			"integrity": "sha512-mgdxrHTLOjOddRVYIYDo0fR3/v61GNN1YGkfbrjuIKg/uMgCd+Qzo3UAXJ+woLQQpos4pl5Esuw5A7AoNlzjUQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
+				"semantic-release": ">=18.0.0-beta.1"
 			}
 		},
 		"node_modules/@semantic-release/github/node_modules/agent-base": {
-			"version": "7.1.4",
-			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
-			"integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
+			"integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
 			"dev": true,
-			"license": "MIT",
+			"dependencies": {
+				"debug": "^4.3.4"
+			},
 			"engines": {
 				"node": ">= 14"
-			}
-		},
-		"node_modules/@semantic-release/github/node_modules/aggregate-error": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-5.0.0.tgz",
-			"integrity": "sha512-gOsf2YwSlleG6IjRYG2A7k0HmBMEo6qVNk9Bp/EaLgAJT5ngH6PXbqa4ItvnEwCm/velL5jAnQgsHsWnjhGmvw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"clean-stack": "^5.2.0",
-				"indent-string": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/@semantic-release/github/node_modules/clean-stack": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-5.3.0.tgz",
-			"integrity": "sha512-9ngPTOhYGQqNVSfeJkYXHmF7AGWp4/nN5D/QqNQs3Dvxd1Kk/WpjHfNujKHYUQ/5CoGyOyFNoWSPk5afzP0QVg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"escape-string-regexp": "5.0.0"
-			},
-			"engines": {
-				"node": ">=14.16"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/@semantic-release/github/node_modules/escape-string-regexp": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
-			"integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/@semantic-release/github/node_modules/globby": {
-			"version": "14.1.0",
-			"resolved": "https://registry.npmjs.org/globby/-/globby-14.1.0.tgz",
-			"integrity": "sha512-0Ia46fDOaT7k4og1PDW4YbodWWr3scS2vAr2lTbsplOt2WkKp0vQbkI9wKis/T5LV/dqPjO3bpS/z6GTJB82LA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@sindresorhus/merge-streams": "^2.1.0",
-				"fast-glob": "^3.3.3",
-				"ignore": "^7.0.3",
-				"path-type": "^6.0.0",
-				"slash": "^5.1.0",
-				"unicorn-magic": "^0.3.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/@semantic-release/github/node_modules/http-proxy-agent": {
@@ -4694,7 +4604,6 @@
 			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
 			"integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"agent-base": "^7.1.0",
 				"debug": "^4.3.4"
@@ -4704,512 +4613,216 @@
 			}
 		},
 		"node_modules/@semantic-release/github/node_modules/https-proxy-agent": {
-			"version": "7.0.6",
-			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
-			"integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+			"version": "7.0.4",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.4.tgz",
+			"integrity": "sha512-wlwpilI7YdjSkWaQ/7omYBMTliDcmCN8OLihO6I9B86g06lMyAoqgoDpV0XqoaPOKj+0DIdAvnsWfyAAhmimcg==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
-				"agent-base": "^7.1.2",
+				"agent-base": "^7.0.2",
 				"debug": "4"
 			},
 			"engines": {
 				"node": ">= 14"
 			}
 		},
-		"node_modules/@semantic-release/github/node_modules/ignore": {
-			"version": "7.0.5",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-			"integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 4"
-			}
-		},
-		"node_modules/@semantic-release/github/node_modules/indent-string": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
-			"integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/@semantic-release/github/node_modules/mime": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/mime/-/mime-4.1.0.tgz",
-			"integrity": "sha512-X5ju04+cAzsojXKes0B/S4tcYtFAJ6tTMuSPBEn9CPGlrWr8Fiw7qYeLT0XyH80HSoAoqWCaz+MWKh22P7G1cw==",
-			"dev": true,
-			"funding": [
-				"https://github.com/sponsors/broofa"
-			],
-			"license": "MIT",
-			"bin": {
-				"mime": "bin/cli.js"
-			},
-			"engines": {
-				"node": ">=16"
-			}
-		},
-		"node_modules/@semantic-release/github/node_modules/path-type": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/path-type/-/path-type-6.0.0.tgz",
-			"integrity": "sha512-Vj7sf++t5pBD637NSfkxpHSMfWaeig5+DKWLhcqIYx6mWQz5hdJTGDVMQiJcw1ZYkhs7AazKDGpRVji1LJCZUQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/@semantic-release/github/node_modules/slash": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
-			"integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=14.16"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/@semantic-release/npm": {
-			"version": "11.0.3",
-			"resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-11.0.3.tgz",
-			"integrity": "sha512-KUsozQGhRBAnoVg4UMZj9ep436VEGwT536/jwSqB7vcEfA6oncCUU7UIYTRdLx7GvTtqn0kBjnkfLVkcnBa2YQ==",
+			"version": "9.0.2",
+			"resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-9.0.2.tgz",
+			"integrity": "sha512-zgsynF6McdzxPnFet+a4iO9HpAlARXOM5adz7VGVCvj0ne8wtL2ZOQoDV2wZPDmdEotDIbVeJjafhelZjs9j6g==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
-				"@semantic-release/error": "^4.0.0",
-				"aggregate-error": "^5.0.0",
-				"execa": "^8.0.0",
+				"@semantic-release/error": "^3.0.0",
+				"aggregate-error": "^3.0.0",
+				"execa": "^5.0.0",
 				"fs-extra": "^11.0.0",
-				"lodash-es": "^4.17.21",
+				"lodash": "^4.17.15",
 				"nerf-dart": "^1.0.0",
-				"normalize-url": "^8.0.0",
-				"npm": "^10.5.0",
+				"normalize-url": "^6.0.0",
+				"npm": "^8.3.0",
 				"rc": "^1.2.8",
-				"read-pkg": "^9.0.0",
+				"read-pkg": "^5.0.0",
 				"registry-auth-token": "^5.0.0",
 				"semver": "^7.1.2",
-				"tempy": "^3.0.0"
+				"tempy": "^1.0.0"
 			},
 			"engines": {
-				"node": "^18.17 || >=20"
+				"node": ">=16 || ^14.17"
 			},
 			"peerDependencies": {
-				"semantic-release": ">=20.1.0"
+				"semantic-release": ">=19.0.0"
 			}
 		},
-		"node_modules/@semantic-release/npm/node_modules/@semantic-release/error": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-4.0.0.tgz",
-			"integrity": "sha512-mgdxrHTLOjOddRVYIYDo0fR3/v61GNN1YGkfbrjuIKg/uMgCd+Qzo3UAXJ+woLQQpos4pl5Esuw5A7AoNlzjUQ==",
+		"node_modules/@semantic-release/npm/node_modules/execa": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+			"integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
 			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@semantic-release/npm/node_modules/aggregate-error": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-5.0.0.tgz",
-			"integrity": "sha512-gOsf2YwSlleG6IjRYG2A7k0HmBMEo6qVNk9Bp/EaLgAJT5ngH6PXbqa4ItvnEwCm/velL5jAnQgsHsWnjhGmvw==",
-			"dev": true,
-			"license": "MIT",
 			"dependencies": {
-				"clean-stack": "^5.2.0",
-				"indent-string": "^5.0.0"
+				"cross-spawn": "^7.0.3",
+				"get-stream": "^6.0.0",
+				"human-signals": "^2.1.0",
+				"is-stream": "^2.0.0",
+				"merge-stream": "^2.0.0",
+				"npm-run-path": "^4.0.1",
+				"onetime": "^5.1.2",
+				"signal-exit": "^3.0.3",
+				"strip-final-newline": "^2.0.0"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/execa?sponsor=1"
+			}
+		},
+		"node_modules/@semantic-release/npm/node_modules/get-stream": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+			"integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/@semantic-release/npm/node_modules/clean-stack": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-5.3.0.tgz",
-			"integrity": "sha512-9ngPTOhYGQqNVSfeJkYXHmF7AGWp4/nN5D/QqNQs3Dvxd1Kk/WpjHfNujKHYUQ/5CoGyOyFNoWSPk5afzP0QVg==",
+		"node_modules/@semantic-release/npm/node_modules/human-signals": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+			"integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
 			"dev": true,
-			"license": "MIT",
+			"engines": {
+				"node": ">=10.17.0"
+			}
+		},
+		"node_modules/@semantic-release/npm/node_modules/is-stream": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+			"integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@semantic-release/npm/node_modules/mimic-fn": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+			"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/@semantic-release/npm/node_modules/npm-run-path": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+			"integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+			"dev": true,
 			"dependencies": {
-				"escape-string-regexp": "5.0.0"
+				"path-key": "^3.0.0"
 			},
 			"engines": {
-				"node": ">=14.16"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
+				"node": ">=8"
 			}
 		},
-		"node_modules/@semantic-release/npm/node_modules/escape-string-regexp": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
-			"integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+		"node_modules/@semantic-release/npm/node_modules/onetime": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+			"integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
 			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/@semantic-release/npm/node_modules/hosted-git-info": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
-			"integrity": "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==",
-			"dev": true,
-			"license": "ISC",
 			"dependencies": {
-				"lru-cache": "^10.0.1"
+				"mimic-fn": "^2.1.0"
 			},
 			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@semantic-release/npm/node_modules/indent-string": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
-			"integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
+				"node": ">=6"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/@semantic-release/npm/node_modules/lru-cache": {
-			"version": "10.4.3",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-			"dev": true,
-			"license": "ISC"
+		"node_modules/@semantic-release/npm/node_modules/signal-exit": {
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+			"dev": true
 		},
-		"node_modules/@semantic-release/npm/node_modules/normalize-package-data": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-6.0.2.tgz",
-			"integrity": "sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g==",
+		"node_modules/@semantic-release/npm/node_modules/strip-final-newline": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+			"integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
 			"dev": true,
-			"license": "BSD-2-Clause",
-			"dependencies": {
-				"hosted-git-info": "^7.0.0",
-				"semver": "^7.3.5",
-				"validate-npm-package-license": "^3.0.4"
-			},
 			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@semantic-release/npm/node_modules/parse-json": {
-			"version": "8.3.0",
-			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-8.3.0.tgz",
-			"integrity": "sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/code-frame": "^7.26.2",
-				"index-to-position": "^1.1.0",
-				"type-fest": "^4.39.1"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/@semantic-release/npm/node_modules/read-pkg": {
-			"version": "9.0.1",
-			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-9.0.1.tgz",
-			"integrity": "sha512-9viLL4/n1BJUCT1NXVTdS1jtm80yDEgR5T4yCelII49Mbj0v1rZdKqj7zCiYdbB0CuCgdrvHcNogAKTFPBocFA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/normalize-package-data": "^2.4.3",
-				"normalize-package-data": "^6.0.0",
-				"parse-json": "^8.0.0",
-				"type-fest": "^4.6.0",
-				"unicorn-magic": "^0.1.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/@semantic-release/npm/node_modules/type-fest": {
-			"version": "4.41.0",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
-			"integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
-			"dev": true,
-			"license": "(MIT OR CC0-1.0)",
-			"engines": {
-				"node": ">=16"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/@semantic-release/npm/node_modules/unicorn-magic": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.1.0.tgz",
-			"integrity": "sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
+				"node": ">=6"
 			}
 		},
 		"node_modules/@semantic-release/release-notes-generator": {
-			"version": "12.1.0",
-			"resolved": "https://registry.npmjs.org/@semantic-release/release-notes-generator/-/release-notes-generator-12.1.0.tgz",
-			"integrity": "sha512-g6M9AjUKAZUZnxaJZnouNBeDNTCUrJ5Ltj+VJ60gJeDaRRahcHsry9HW8yKrnKkKNkx5lbWiEP1FPMqVNQz8Kg==",
+			"version": "10.0.3",
+			"resolved": "https://registry.npmjs.org/@semantic-release/release-notes-generator/-/release-notes-generator-10.0.3.tgz",
+			"integrity": "sha512-k4x4VhIKneOWoBGHkx0qZogNjCldLPRiAjnIpMnlUh6PtaWXp/T+C9U7/TaNDDtgDa5HMbHl4WlREdxHio6/3w==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
-				"conventional-changelog-angular": "^7.0.0",
-				"conventional-changelog-writer": "^7.0.0",
-				"conventional-commits-filter": "^4.0.0",
-				"conventional-commits-parser": "^5.0.0",
+				"conventional-changelog-angular": "^5.0.0",
+				"conventional-changelog-writer": "^5.0.0",
+				"conventional-commits-filter": "^2.0.0",
+				"conventional-commits-parser": "^3.2.3",
 				"debug": "^4.0.0",
-				"get-stream": "^7.0.0",
-				"import-from-esm": "^1.0.3",
-				"into-stream": "^7.0.0",
-				"lodash-es": "^4.17.21",
-				"read-pkg-up": "^11.0.0"
+				"get-stream": "^6.0.0",
+				"import-from": "^4.0.0",
+				"into-stream": "^6.0.0",
+				"lodash": "^4.17.4",
+				"read-pkg-up": "^7.0.0"
 			},
 			"engines": {
-				"node": "^18.17 || >=20.6.1"
+				"node": ">=14.17"
 			},
 			"peerDependencies": {
-				"semantic-release": ">=20.1.0"
+				"semantic-release": ">=18.0.0-beta.1"
 			}
 		},
 		"node_modules/@semantic-release/release-notes-generator/node_modules/conventional-changelog-angular": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-7.0.0.tgz",
-			"integrity": "sha512-ROjNchA9LgfNMTTFSIWPzebCwOGFdgkEq45EnvvrmSLvCtAw0HSmrCs7/ty+wAeYUZyNay0YMUNYFTRL72PkBQ==",
+			"version": "5.0.13",
+			"resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.13.tgz",
+			"integrity": "sha512-i/gipMxs7s8L/QeuavPF2hLnJgH6pEZAttySB6aiQLWcX3puWDL3ACVmvBhJGxnAy52Qc15ua26BufY6KpmrVA==",
 			"dev": true,
-			"license": "ISC",
 			"dependencies": {
-				"compare-func": "^2.0.0"
+				"compare-func": "^2.0.0",
+				"q": "^1.5.1"
 			},
 			"engines": {
-				"node": ">=16"
+				"node": ">=10"
 			}
 		},
 		"node_modules/@semantic-release/release-notes-generator/node_modules/conventional-commits-parser": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-5.0.0.tgz",
-			"integrity": "sha512-ZPMl0ZJbw74iS9LuX9YIAiW8pfM5p3yh2o/NbXHbkFuZzY5jvdi5jFycEOkmBW5H5I7nA+D6f3UcsCLP2vvSEA==",
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.2.4.tgz",
+			"integrity": "sha512-nK7sAtfi+QXbxHCYfhpZsfRtaitZLIA6889kFIouLvz6repszQDgxBu7wf2WbU+Dco7sAnNCJYERCwt54WPC2Q==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
-				"is-text-path": "^2.0.0",
-				"JSONStream": "^1.3.5",
-				"meow": "^12.0.1",
-				"split2": "^4.0.0"
+				"is-text-path": "^1.0.1",
+				"JSONStream": "^1.0.4",
+				"lodash": "^4.17.15",
+				"meow": "^8.0.0",
+				"split2": "^3.0.0",
+				"through2": "^4.0.0"
 			},
 			"bin": {
-				"conventional-commits-parser": "cli.mjs"
+				"conventional-commits-parser": "cli.js"
 			},
 			"engines": {
-				"node": ">=16"
+				"node": ">=10"
 			}
 		},
 		"node_modules/@semantic-release/release-notes-generator/node_modules/get-stream": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-7.0.1.tgz",
-			"integrity": "sha512-3M8C1EOFN6r8AMUhwUAACIoXZJEOufDU5+0gFFN5uNs6XYOralD2Pqkl7m046va6x77FwposWXbAhPPIOus7mQ==",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+			"integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
 			"dev": true,
-			"license": "MIT",
 			"engines": {
-				"node": ">=16"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/@semantic-release/release-notes-generator/node_modules/hosted-git-info": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
-			"integrity": "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"lru-cache": "^10.0.1"
-			},
-			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@semantic-release/release-notes-generator/node_modules/is-text-path": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/is-text-path/-/is-text-path-2.0.0.tgz",
-			"integrity": "sha512-+oDTluR6WEjdXEJMnC2z6A4FRwFoYuvShVVEGsS7ewc0UTi2QtAKMDJuL4BDEVt+5T7MjFo12RP8ghOM75oKJw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"text-extensions": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/@semantic-release/release-notes-generator/node_modules/lru-cache": {
-			"version": "10.4.3",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-			"dev": true,
-			"license": "ISC"
-		},
-		"node_modules/@semantic-release/release-notes-generator/node_modules/meow": {
-			"version": "12.1.1",
-			"resolved": "https://registry.npmjs.org/meow/-/meow-12.1.1.tgz",
-			"integrity": "sha512-BhXM0Au22RwUneMPwSCnyhTOizdWoIEPU9sp0Aqa1PnDMR5Wv2FGXYDjuzJEIX+Eo2Rb8xuYe5jrnm5QowQFkw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=16.10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/@semantic-release/release-notes-generator/node_modules/normalize-package-data": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-6.0.2.tgz",
-			"integrity": "sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g==",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"dependencies": {
-				"hosted-git-info": "^7.0.0",
-				"semver": "^7.3.5",
-				"validate-npm-package-license": "^3.0.4"
-			},
-			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@semantic-release/release-notes-generator/node_modules/parse-json": {
-			"version": "8.3.0",
-			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-8.3.0.tgz",
-			"integrity": "sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/code-frame": "^7.26.2",
-				"index-to-position": "^1.1.0",
-				"type-fest": "^4.39.1"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/@semantic-release/release-notes-generator/node_modules/read-pkg": {
-			"version": "9.0.1",
-			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-9.0.1.tgz",
-			"integrity": "sha512-9viLL4/n1BJUCT1NXVTdS1jtm80yDEgR5T4yCelII49Mbj0v1rZdKqj7zCiYdbB0CuCgdrvHcNogAKTFPBocFA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/normalize-package-data": "^2.4.3",
-				"normalize-package-data": "^6.0.0",
-				"parse-json": "^8.0.0",
-				"type-fest": "^4.6.0",
-				"unicorn-magic": "^0.1.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/@semantic-release/release-notes-generator/node_modules/read-pkg-up": {
-			"version": "11.0.0",
-			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-11.0.0.tgz",
-			"integrity": "sha512-LOVbvF1Q0SZdjClSefZ0Nz5z8u+tIE7mV5NibzmE9VYmDe9CaBbAVtz1veOSZbofrdsilxuDAYnFenukZVp8/Q==",
-			"deprecated": "Renamed to read-package-up",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"find-up-simple": "^1.0.0",
-				"read-pkg": "^9.0.0",
-				"type-fest": "^4.6.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/@semantic-release/release-notes-generator/node_modules/split2": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
-			"integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": ">= 10.x"
-			}
-		},
-		"node_modules/@semantic-release/release-notes-generator/node_modules/text-extensions": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-2.4.0.tgz",
-			"integrity": "sha512-te/NtwBwfiNRLf9Ijqx3T0nlqZiQ2XrrtBvu+cLL8ZRrGkO0NHTug8MYFKyoSrv/sHTaSKfilUkizV6XhxMJ3g==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/@semantic-release/release-notes-generator/node_modules/type-fest": {
-			"version": "4.41.0",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
-			"integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
-			"dev": true,
-			"license": "(MIT OR CC0-1.0)",
-			"engines": {
-				"node": ">=16"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/@semantic-release/release-notes-generator/node_modules/unicorn-magic": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.1.0.tgz",
-			"integrity": "sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
+				"node": ">=10"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -5356,32 +4969,6 @@
 			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
 			"integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
 			"dev": true
-		},
-		"node_modules/@sindresorhus/is": {
-			"version": "4.6.0",
-			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
-			"integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sindresorhus/is?sponsor=1"
-			}
-		},
-		"node_modules/@sindresorhus/merge-streams": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-2.3.0.tgz",
-			"integrity": "sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
 		},
 		"node_modules/@sinonjs/commons": {
 			"version": "3.0.1",
@@ -8673,7 +8260,6 @@
 			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-6.2.1.tgz",
 			"integrity": "sha512-4nJ3yixlEthEJ9Rk4vPcdBRkZvQZlYyu8j4/Mqz5sgIkddmEnH2Yj2ZrnP9S3tQOvSNRUIgVNF/1yPpRAGNRig==",
 			"dev": true,
-			"license": "MIT",
 			"engines": {
 				"node": ">=14.16"
 			},
@@ -8733,8 +8319,7 @@
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
 			"integrity": "sha512-QXu7BPrP29VllRxH8GwB7x5iX5qWKAAMLqKQGWTeLWVlNHNOpVMJ91dsxQAIWXpjuW5wqvxu3Jd/nRjrJ+0pqg==",
-			"dev": true,
-			"license": "MIT"
+			"dev": true
 		},
 		"node_modules/anymatch": {
 			"version": "3.1.3",
@@ -9439,8 +9024,7 @@
 			"version": "2.2.3",
 			"resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
 			"integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==",
-			"dev": true,
-			"license": "Apache-2.0"
+			"dev": true
 		},
 		"node_modules/big.js": {
 			"version": "5.2.2",
@@ -9569,8 +9153,7 @@
 			"version": "2.19.5",
 			"resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
 			"integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==",
-			"dev": true,
-			"license": "MIT"
+			"dev": true
 		},
 		"node_modules/brace-expansion": {
 			"version": "1.1.11",
@@ -9859,7 +9442,6 @@
 			"resolved": "https://registry.npmjs.org/cardinal/-/cardinal-2.1.1.tgz",
 			"integrity": "sha512-JSr5eOgoEymtYHBjNWyjrMqet9Am2miJhlfKNdqLp6zoeAh0KN5dRAcxlecj5mAJrmQomgiOBj35xHLrFjqBpw==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"ansicolors": "~0.3.2",
 				"redeyed": "~2.1.0"
@@ -10124,7 +9706,6 @@
 			"resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.5.tgz",
 			"integrity": "sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"string-width": "^4.2.0"
 			},
@@ -10139,15 +9720,13 @@
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
 			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-			"dev": true,
-			"license": "MIT"
+			"dev": true
 		},
 		"node_modules/cli-table3/node_modules/is-fullwidth-code-point": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
 			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
 			"dev": true,
-			"license": "MIT",
 			"engines": {
 				"node": ">=8"
 			}
@@ -10157,7 +9736,6 @@
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
 			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"emoji-regex": "^8.0.0",
 				"is-fullwidth-code-point": "^3.0.0",
@@ -10545,7 +10123,6 @@
 			"resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
 			"integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"ini": "^1.3.4",
 				"proto-list": "~1.2.1"
@@ -10651,47 +10228,35 @@
 			}
 		},
 		"node_modules/conventional-changelog-writer": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-7.0.1.tgz",
-			"integrity": "sha512-Uo+R9neH3r/foIvQ0MKcsXkX642hdm9odUp7TqgFS7BsalTcjzRlIfWZrZR1gbxOozKucaKt5KAbjW8J8xRSmA==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-5.0.1.tgz",
+			"integrity": "sha512-5WsuKUfxW7suLblAbFnxAcrvf6r+0b7GvNaWUwUIk0bXMnENP/PEieGKVUQrjPqwPT4o3EPAASBXiY6iHooLOQ==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
-				"conventional-commits-filter": "^4.0.0",
+				"conventional-commits-filter": "^2.0.7",
+				"dateformat": "^3.0.0",
 				"handlebars": "^4.7.7",
 				"json-stringify-safe": "^5.0.1",
-				"meow": "^12.0.1",
-				"semver": "^7.5.2",
-				"split2": "^4.0.0"
+				"lodash": "^4.17.15",
+				"meow": "^8.0.0",
+				"semver": "^6.0.0",
+				"split": "^1.0.0",
+				"through2": "^4.0.0"
 			},
 			"bin": {
-				"conventional-changelog-writer": "cli.mjs"
+				"conventional-changelog-writer": "cli.js"
 			},
 			"engines": {
-				"node": ">=16"
+				"node": ">=10"
 			}
 		},
-		"node_modules/conventional-changelog-writer/node_modules/meow": {
-			"version": "12.1.1",
-			"resolved": "https://registry.npmjs.org/meow/-/meow-12.1.1.tgz",
-			"integrity": "sha512-BhXM0Au22RwUneMPwSCnyhTOizdWoIEPU9sp0Aqa1PnDMR5Wv2FGXYDjuzJEIX+Eo2Rb8xuYe5jrnm5QowQFkw==",
+		"node_modules/conventional-changelog-writer/node_modules/semver": {
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
 			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=16.10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/conventional-changelog-writer/node_modules/split2": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
-			"integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": ">= 10.x"
+			"bin": {
+				"semver": "bin/semver.js"
 			}
 		},
 		"node_modules/conventional-commit-types": {
@@ -10701,13 +10266,16 @@
 			"dev": true
 		},
 		"node_modules/conventional-commits-filter": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-4.0.0.tgz",
-			"integrity": "sha512-rnpnibcSOdFcdclpFwWa+pPlZJhXE7l+XK04zxhbWrhgpR96h33QLz8hITTXbcYICxVr3HZFtbtUAQ+4LdBo9A==",
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-2.0.7.tgz",
+			"integrity": "sha512-ASS9SamOP4TbCClsRHxIHXRfcGCnIoQqkvAzCSbZzTFLfcTqJVugB0agRgsEELsqaeWgsXv513eS116wnlSSPA==",
 			"dev": true,
-			"license": "MIT",
+			"dependencies": {
+				"lodash.ismatch": "^4.4.0",
+				"modify-values": "^1.0.0"
+			},
 			"engines": {
-				"node": ">=16"
+				"node": ">=10"
 			}
 		},
 		"node_modules/conventional-commits-parser": {
@@ -11436,6 +11004,15 @@
 				"url": "https://github.com/sponsors/kossnocorp"
 			}
 		},
+		"node_modules/dateformat": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
+			"integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==",
+			"dev": true,
+			"engines": {
+				"node": "*"
+			}
+		},
 		"node_modules/debounce": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
@@ -11873,8 +11450,7 @@
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
 			"integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
-			"dev": true,
-			"license": "ISC"
+			"dev": true
 		},
 		"node_modules/dequal": {
 			"version": "2.0.3",
@@ -12199,13 +11775,6 @@
 			"integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
 			"dev": true
 		},
-		"node_modules/emojilib": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/emojilib/-/emojilib-2.4.0.tgz",
-			"integrity": "sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/emojis-list": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
@@ -12280,17 +11849,124 @@
 			}
 		},
 		"node_modules/env-ci": {
-			"version": "10.0.0",
-			"resolved": "https://registry.npmjs.org/env-ci/-/env-ci-10.0.0.tgz",
-			"integrity": "sha512-U4xcd/utDYFgMh0yWj07R1H6L5fwhVbmxBCpnL0DbVSDZVnsC82HONw0wxtxNkIAcua3KtbomQvIk5xFZGAQJw==",
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/env-ci/-/env-ci-5.5.0.tgz",
+			"integrity": "sha512-o0JdWIbOLP+WJKIUt36hz1ImQQFuN92nhsfTkHHap+J8CiI8WgGpH/a9jEGHh4/TU5BUUGjlnKXNoDb57+ne+A==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
-				"execa": "^8.0.0",
-				"java-properties": "^1.0.2"
+				"execa": "^5.0.0",
+				"fromentries": "^1.3.2",
+				"java-properties": "^1.0.0"
 			},
 			"engines": {
-				"node": "^18.17 || >=20.6.1"
+				"node": ">=10.17"
+			}
+		},
+		"node_modules/env-ci/node_modules/execa": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+			"integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+			"dev": true,
+			"dependencies": {
+				"cross-spawn": "^7.0.3",
+				"get-stream": "^6.0.0",
+				"human-signals": "^2.1.0",
+				"is-stream": "^2.0.0",
+				"merge-stream": "^2.0.0",
+				"npm-run-path": "^4.0.1",
+				"onetime": "^5.1.2",
+				"signal-exit": "^3.0.3",
+				"strip-final-newline": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/execa?sponsor=1"
+			}
+		},
+		"node_modules/env-ci/node_modules/get-stream": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+			"integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/env-ci/node_modules/human-signals": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+			"integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+			"dev": true,
+			"engines": {
+				"node": ">=10.17.0"
+			}
+		},
+		"node_modules/env-ci/node_modules/is-stream": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+			"integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/env-ci/node_modules/mimic-fn": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+			"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/env-ci/node_modules/npm-run-path": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+			"integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+			"dev": true,
+			"dependencies": {
+				"path-key": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/env-ci/node_modules/onetime": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+			"integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+			"dev": true,
+			"dependencies": {
+				"mimic-fn": "^2.1.0"
+			},
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/env-ci/node_modules/signal-exit": {
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+			"dev": true
+		},
+		"node_modules/env-ci/node_modules/strip-final-newline": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+			"integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/envinfo": {
@@ -13537,17 +13213,16 @@
 			"dev": true
 		},
 		"node_modules/fast-glob": {
-			"version": "3.3.3",
-			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
-			"integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
+			"integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"@nodelib/fs.stat": "^2.0.2",
 				"@nodelib/fs.walk": "^1.2.3",
 				"glob-parent": "^5.1.2",
 				"merge2": "^1.3.0",
-				"micromatch": "^4.0.8"
+				"micromatch": "^4.0.4"
 			},
 			"engines": {
 				"node": ">=8.6.0"
@@ -13834,30 +13509,16 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/find-up-simple": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/find-up-simple/-/find-up-simple-1.0.1.tgz",
-			"integrity": "sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/find-versions": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/find-versions/-/find-versions-5.1.0.tgz",
-			"integrity": "sha512-+iwzCJ7C5v5KgcBuueqVoNiHVoQpwiUK5XFLjf0affFTep+Wcw93tPvmb8tqujDNmzhBDPddnWV/qgWSXgq+Hg==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/find-versions/-/find-versions-4.0.0.tgz",
+			"integrity": "sha512-wgpWy002tA+wgmO27buH/9KzyEOQnKsG/R0yrcjPT9BOFm0zRBVQbZ95nRGXWMywS8YR5knRbpohio0bcJABxQ==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
-				"semver-regex": "^4.0.5"
+				"semver-regex": "^3.1.2"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=10"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -14107,7 +13768,6 @@
 			"resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
 			"integrity": "sha512-OMcX/4IC/uqEPVgGeyfN22LJk6AZrMkRZHxcHBMBvHScDGgwTm2GT2Wkgtocyd3JfZffjj2kYUDXXII0Fk9W0g==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"inherits": "^2.0.1",
 				"readable-stream": "^2.0.0"
@@ -14117,15 +13777,13 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
 			"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-			"dev": true,
-			"license": "MIT"
+			"dev": true
 		},
 		"node_modules/from2/node_modules/readable-stream": {
 			"version": "2.3.8",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
 			"integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"core-util-is": "~1.0.0",
 				"inherits": "~2.0.3",
@@ -14140,18 +13798,36 @@
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
 			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-			"dev": true,
-			"license": "MIT"
+			"dev": true
 		},
 		"node_modules/from2/node_modules/string_decoder": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"safe-buffer": "~5.1.0"
 			}
+		},
+		"node_modules/fromentries": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/fromentries/-/fromentries-1.3.2.tgz",
+			"integrity": "sha512-cHEpEQHUg0f8XdtZCc2ZAhrHzKzT0MrFUTcvx+hfxYu7rGMDc5SKoXFh+n4YigxsHXRzc6OrCshdR1bWH6HHyg==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			]
 		},
 		"node_modules/fs-constants": {
 			"version": "1.0.0",
@@ -14713,7 +14389,6 @@
 			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
 			"integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"minimist": "^1.2.5",
 				"neo-async": "^2.6.2",
@@ -14735,7 +14410,6 @@
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
 			"dev": true,
-			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -14878,16 +14552,12 @@
 			}
 		},
 		"node_modules/hook-std": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/hook-std/-/hook-std-3.0.0.tgz",
-			"integrity": "sha512-jHRQzjSDzMtFy34AGj1DN+vq54WVuhSvKgrHf0OMiFQTwDD4L/qqofVEWjLOBMTn5+lCD3fPg32W9yOfnEJTTw==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/hook-std/-/hook-std-2.0.0.tgz",
+			"integrity": "sha512-zZ6T5WcuBMIUVh49iPQS9t977t7C0l7OtHrpeMb5uk48JdflRX0NSFvCekfYNmGQETnLq9W/isMyHl69kxGi8g==",
 			"dev": true,
-			"license": "MIT",
 			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
+				"node": ">=8"
 			}
 		},
 		"node_modules/hosted-git-info": {
@@ -15242,18 +14912,16 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/import-from-esm": {
-			"version": "1.3.4",
-			"resolved": "https://registry.npmjs.org/import-from-esm/-/import-from-esm-1.3.4.tgz",
-			"integrity": "sha512-7EyUlPFC0HOlBDpUFGfYstsU7XHxZJKAAMzCT8wZ0hMW7b+hG51LIKTDcsgtz8Pu6YC0HqRVbX+rVUtsGMUKvg==",
+		"node_modules/import-from": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/import-from/-/import-from-4.0.0.tgz",
+			"integrity": "sha512-P9J71vT5nLlDeV8FHs5nNxaLbrpfAV5cF5srvbZfpwpcJoM/xZR3hiv+q+SAnuSmuGbXMWud063iIMx/V/EWZQ==",
 			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"debug": "^4.3.4",
-				"import-meta-resolve": "^4.0.0"
-			},
 			"engines": {
-				"node": ">=16.20"
+				"node": ">=12.2"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/import-lazy": {
@@ -15290,17 +14958,6 @@
 			"integrity": "sha512-1/bPE89IZhyf7dr5Pkz7b4UyVXy5pEt7PTEfye15UEn3AK8+2zwcDCfKk9Pwun4ltfhOSszOrReSsFcDKw/yoA==",
 			"dev": true
 		},
-		"node_modules/import-meta-resolve": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
-			"integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
-			"dev": true,
-			"license": "MIT",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
-			}
-		},
 		"node_modules/imurmurhash": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -15317,19 +14974,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/index-to-position": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/index-to-position/-/index-to-position-1.2.0.tgz",
-			"integrity": "sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/inflight": {
@@ -15554,17 +15198,16 @@
 			"dev": true
 		},
 		"node_modules/into-stream": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/into-stream/-/into-stream-7.0.0.tgz",
-			"integrity": "sha512-2dYz766i9HprMBasCMvHMuazJ7u4WzhJwo5kb3iPSiW/iRYV6uPari3zHoqZlnuaR7V1bEiNMxikhp37rdBXbw==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/into-stream/-/into-stream-6.0.0.tgz",
+			"integrity": "sha512-XHbaOAvP+uFKUFsOgoNPRjLkwB+I22JFPFe5OjTkQ0nwgj6+pSjb4NmB6VMxaPshLiOf+zcpOCBQuLwC1KHhZA==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"from2": "^2.3.0",
 				"p-is-promise": "^3.0.0"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=10"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -16238,7 +15881,6 @@
 			"resolved": "https://registry.npmjs.org/issue-parser/-/issue-parser-6.0.0.tgz",
 			"integrity": "sha512-zKa/Dxq2lGsBIXQ7CUZWTHfvxPC2ej0KfO7fIPqLlHB9J2hJ7rGhZ5rilhuufylr4RXYPzJUeFjKxz305OsNlA==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"lodash.capitalize": "^4.2.1",
 				"lodash.escaperegexp": "^4.1.2",
@@ -16367,7 +16009,6 @@
 			"resolved": "https://registry.npmjs.org/java-properties/-/java-properties-1.0.2.tgz",
 			"integrity": "sha512-qjdpeo2yKlYTH7nFdK0vbZWuTCesk4o63v5iVOlhMQPfuIZQfW/HI35SjfhA+4qpg36rnFSvUK5b1m+ckIblQQ==",
 			"dev": true,
-			"license": "MIT",
 			"engines": {
 				"node": ">= 0.6.0"
 			}
@@ -17553,8 +17194,7 @@
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
 			"integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
-			"dev": true,
-			"license": "ISC"
+			"dev": true
 		},
 		"node_modules/json2php": {
 			"version": "0.0.7",
@@ -18174,13 +17814,6 @@
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
 			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
 		},
-		"node_modules/lodash-es": {
-			"version": "4.17.21",
-			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-			"integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/lodash.camelcase": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
@@ -18191,8 +17824,7 @@
 			"version": "4.2.1",
 			"resolved": "https://registry.npmjs.org/lodash.capitalize/-/lodash.capitalize-4.2.1.tgz",
 			"integrity": "sha512-kZzYOKspf8XVX5AvmQF94gQW0lejFVgb80G85bU4ZWzoJ6C03PQg3coYAUpSTpQWelrZELd3XWgHzw4Ck5kaIw==",
-			"dev": true,
-			"license": "MIT"
+			"dev": true
 		},
 		"node_modules/lodash.debounce": {
 			"version": "4.0.8",
@@ -18204,13 +17836,18 @@
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
 			"integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
-			"dev": true,
-			"license": "MIT"
+			"dev": true
 		},
 		"node_modules/lodash.isfunction": {
 			"version": "3.0.9",
 			"resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz",
 			"integrity": "sha512-AirXNj15uRIMMPihnkInB4i3NHeb4iBtNg9WRWuK2o31S+ePwwNmDPaTL3o7dTJ+VXNZim7rFs4rxN4YU1oUJw==",
+			"dev": true
+		},
+		"node_modules/lodash.ismatch": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz",
+			"integrity": "sha512-fPMfXjGQEV9Xsq/8MTSgUf255gawYRbjwMyDbcvDhXgV7enSZA0hynz6vMPnpAb5iONEzBHBPsT+0zes5Z301g==",
 			"dev": true
 		},
 		"node_modules/lodash.isplainobject": {
@@ -18223,8 +17860,7 @@
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
 			"integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
-			"dev": true,
-			"license": "MIT"
+			"dev": true
 		},
 		"node_modules/lodash.kebabcase": {
 			"version": "4.1.1",
@@ -18284,8 +17920,7 @@
 			"version": "4.7.0",
 			"resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz",
 			"integrity": "sha512-e/zcLx6CSbmaEgFHCA7BnoQKyCtKMxnuWrJygbwPs/AIn+IMKl66L8/s+wBUn5LRw2pZx3bUHibiV1b6aTWIww==",
-			"dev": true,
-			"license": "MIT"
+			"dev": true
 		},
 		"node_modules/lodash.upperfirst": {
 			"version": "4.3.1",
@@ -18626,67 +18261,47 @@
 			"dev": true
 		},
 		"node_modules/marked": {
-			"version": "9.1.6",
-			"resolved": "https://registry.npmjs.org/marked/-/marked-9.1.6.tgz",
-			"integrity": "sha512-jcByLnIFkd5gSXZmjNvS1TlmRhCXZjIzHYlaGkPlLIekG55JDR2Z4va9tZwCiP+/RDERiNhMOFu01xd6O5ct1Q==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+			"integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
 			"dev": true,
-			"license": "MIT",
 			"bin": {
 				"marked": "bin/marked.js"
 			},
 			"engines": {
-				"node": ">= 16"
+				"node": ">= 12"
 			}
 		},
 		"node_modules/marked-terminal": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-6.2.0.tgz",
-			"integrity": "sha512-ubWhwcBFHnXsjYNsu+Wndpg0zhY4CahSpPlA70PlO0rR9r2sZpkyU+rkCsOWH+KMEkx847UpALON+HWgxowFtw==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-5.2.0.tgz",
+			"integrity": "sha512-Piv6yNwAQXGFjZSaiNljyNFw7jKDdGrw70FSbtxEyldLsyeuV5ZHm/1wW++kWbrOF1VPnUgYOhB2oLL0ZpnekA==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"ansi-escapes": "^6.2.0",
 				"cardinal": "^2.1.1",
-				"chalk": "^5.3.0",
+				"chalk": "^5.2.0",
 				"cli-table3": "^0.6.3",
-				"node-emoji": "^2.1.3",
-				"supports-hyperlinks": "^3.0.0"
+				"node-emoji": "^1.11.0",
+				"supports-hyperlinks": "^2.3.0"
 			},
 			"engines": {
-				"node": ">=16.0.0"
+				"node": ">=14.13.1 || >=16.0.0"
 			},
 			"peerDependencies": {
-				"marked": ">=1 <12"
+				"marked": "^1.0.0 || ^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0"
 			}
 		},
 		"node_modules/marked-terminal/node_modules/chalk": {
-			"version": "5.6.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-			"integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+			"integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
 			"dev": true,
-			"license": "MIT",
 			"engines": {
 				"node": "^12.17.0 || ^14.13 || >=16.0.0"
 			},
 			"funding": {
 				"url": "https://github.com/chalk/chalk?sponsor=1"
-			}
-		},
-		"node_modules/marked-terminal/node_modules/supports-hyperlinks": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-3.2.0.tgz",
-			"integrity": "sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"has-flag": "^4.0.0",
-				"supports-color": "^7.0.0"
-			},
-			"engines": {
-				"node": ">=14.18"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/supports-hyperlinks?sponsor=1"
 			}
 		},
 		"node_modules/marky": {
@@ -19037,6 +18652,15 @@
 			"integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
 			"dev": true
 		},
+		"node_modules/modify-values": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.1.tgz",
+			"integrity": "sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/moment": {
 			"version": "2.30.1",
 			"resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
@@ -19152,8 +18776,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/nerf-dart/-/nerf-dart-1.0.0.tgz",
 			"integrity": "sha512-EZSPZB70jiVsivaBLYDCyntd5eH8NTSMOn3rB+HxwdmKThGELLdYv8qVIMWvZEFy9w8ZZpW9h9OB32l1rGtj7g==",
-			"dev": true,
-			"license": "MIT"
+			"dev": true
 		},
 		"node_modules/netmask": {
 			"version": "2.0.2",
@@ -19183,11 +18806,10 @@
 			}
 		},
 		"node_modules/newspack-scripts": {
-			"version": "5.7.0",
-			"resolved": "https://registry.npmjs.org/newspack-scripts/-/newspack-scripts-5.7.0.tgz",
-			"integrity": "sha512-/DN5MUX7WTp6Uta+BkRy2Pu5xkJXvVs77CtThQaQzoDPxHoSTwA0XWp/MXHkgsM3V2SsnWLWcxQC+6CrXC48PA==",
+			"version": "5.5.2",
+			"resolved": "https://registry.npmjs.org/newspack-scripts/-/newspack-scripts-5.5.2.tgz",
+			"integrity": "sha512-/nQ6AND9BbYMSrAuFhCjMQkCLn82RiZwrs9M1atG1wgFI2rJ33aS63necQ+62V76DSHAhjczb+VA3oEtJfz8Lw==",
 			"dev": true,
-			"license": "ISC",
 			"dependencies": {
 				"@commitlint/cli": "^17.8.1",
 				"@commitlint/config-conventional": "^17.8.1",
@@ -19235,7 +18857,7 @@
 				"postcss-focus-within": "^5.0.4",
 				"postcss-scss": "^4.0.9",
 				"prettier": "npm:wp-prettier@^3.0.3",
-				"semantic-release": "^22.0.0",
+				"semantic-release": "^19.0.5",
 				"semantic-release-version-bump": "^1.4.1",
 				"stylelint": "^14.2.0",
 				"typescript": "^5.4.5",
@@ -19399,19 +19021,12 @@
 			}
 		},
 		"node_modules/node-emoji": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-2.2.0.tgz",
-			"integrity": "sha512-Z3lTE9pLaJF47NyMhd4ww1yFTAP8YhYI8SleJiHzM46Fgpm5cnNzSl9XfzFNqbaz+VlJrIj3fXQ4DeN1Rjm6cw==",
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.11.0.tgz",
+			"integrity": "sha512-wo2DpQkQp7Sjm2A0cq+sN7EHKO6Sl0ctXeBdFZrL9T9+UywORbufTcTZxom8YqpLQt/FqNMUkOpkZrJVYSKD3A==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
-				"@sindresorhus/is": "^4.6.0",
-				"char-regex": "^1.0.2",
-				"emojilib": "^2.4.0",
-				"skin-tone": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=18"
+				"lodash": "^4.17.21"
 			}
 		},
 		"node_modules/node-fetch": {
@@ -19511,13 +19126,12 @@
 			}
 		},
 		"node_modules/normalize-url": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.1.0.tgz",
-			"integrity": "sha512-X06Mfd/5aKsRHc0O0J5CUedwnPmnDtLF2+nq+KN9KSDlJHkPuh0JUviWjEWMe0SW/9TDdSLVPuk7L5gGTIA1/w==",
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
+			"integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
 			"dev": true,
-			"license": "MIT",
 			"engines": {
-				"node": ">=14.16"
+				"node": ">=10"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -19530,26 +19144,26 @@
 			"dev": true
 		},
 		"node_modules/npm": {
-			"version": "10.9.4",
-			"resolved": "https://registry.npmjs.org/npm/-/npm-10.9.4.tgz",
-			"integrity": "sha512-OnUG836FwboQIbqtefDNlyR0gTHzIfwRfE3DuiNewBvnMnWEpB0VEXwBlFVgqpNzIgYo/MHh3d2Hel/pszapAA==",
+			"version": "8.19.4",
+			"resolved": "https://registry.npmjs.org/npm/-/npm-8.19.4.tgz",
+			"integrity": "sha512-3HANl8i9DKnUA89P4KEgVNN28EjSeDCmvEqbzOAuxCFDzdBZzjUl99zgnGpOUumvW5lvJo2HKcjrsc+tfyv1Hw==",
 			"bundleDependencies": [
 				"@isaacs/string-locale-compare",
 				"@npmcli/arborist",
+				"@npmcli/ci-detect",
 				"@npmcli/config",
 				"@npmcli/fs",
 				"@npmcli/map-workspaces",
 				"@npmcli/package-json",
-				"@npmcli/promise-spawn",
-				"@npmcli/redact",
 				"@npmcli/run-script",
-				"@sigstore/tuf",
 				"abbrev",
 				"archy",
 				"cacache",
 				"chalk",
-				"ci-info",
+				"chownr",
 				"cli-columns",
+				"cli-table3",
+				"columnify",
 				"fastest-levenshtein",
 				"fs-minipass",
 				"glob",
@@ -19574,10 +19188,11 @@
 				"minimatch",
 				"minipass",
 				"minipass-pipeline",
+				"mkdirp",
+				"mkdirp-infer-owner",
 				"ms",
 				"node-gyp",
 				"nopt",
-				"normalize-package-data",
 				"npm-audit-report",
 				"npm-install-checks",
 				"npm-package-arg",
@@ -19585,16 +19200,20 @@
 				"npm-profile",
 				"npm-registry-fetch",
 				"npm-user-validate",
+				"npmlog",
+				"opener",
 				"p-map",
 				"pacote",
 				"parse-conflict-json",
 				"proc-log",
 				"qrcode-terminal",
 				"read",
+				"read-package-json",
+				"read-package-json-fast",
+				"readdir-scoped-modules",
+				"rimraf",
 				"semver",
-				"spdx-expression-parse",
 				"ssri",
-				"supports-color",
 				"tar",
 				"text-table",
 				"tiny-relative-date",
@@ -19604,90 +19223,92 @@
 				"write-file-atomic"
 			],
 			"dev": true,
-			"license": "Artistic-2.0",
 			"workspaces": [
 				"docs",
 				"smoke-tests",
-				"mock-globals",
-				"mock-registry",
 				"workspaces/*"
 			],
 			"dependencies": {
 				"@isaacs/string-locale-compare": "^1.1.0",
-				"@npmcli/arborist": "^8.0.1",
-				"@npmcli/config": "^9.0.0",
-				"@npmcli/fs": "^4.0.0",
-				"@npmcli/map-workspaces": "^4.0.2",
-				"@npmcli/package-json": "^6.2.0",
-				"@npmcli/promise-spawn": "^8.0.2",
-				"@npmcli/redact": "^3.2.2",
-				"@npmcli/run-script": "^9.1.0",
-				"@sigstore/tuf": "^3.1.1",
-				"abbrev": "^3.0.1",
+				"@npmcli/arborist": "^5.6.3",
+				"@npmcli/ci-detect": "^2.0.0",
+				"@npmcli/config": "^4.2.1",
+				"@npmcli/fs": "^2.1.0",
+				"@npmcli/map-workspaces": "^2.0.3",
+				"@npmcli/package-json": "^2.0.0",
+				"@npmcli/run-script": "^4.2.1",
+				"abbrev": "~1.1.1",
 				"archy": "~1.0.0",
-				"cacache": "^19.0.1",
-				"chalk": "^5.4.1",
-				"ci-info": "^4.2.0",
+				"cacache": "^16.1.3",
+				"chalk": "^4.1.2",
+				"chownr": "^2.0.0",
 				"cli-columns": "^4.0.0",
-				"fastest-levenshtein": "^1.0.16",
-				"fs-minipass": "^3.0.3",
-				"glob": "^10.4.5",
-				"graceful-fs": "^4.2.11",
-				"hosted-git-info": "^8.1.0",
-				"ini": "^5.0.0",
-				"init-package-json": "^7.0.2",
-				"is-cidr": "^5.1.1",
-				"json-parse-even-better-errors": "^4.0.0",
-				"libnpmaccess": "^9.0.0",
-				"libnpmdiff": "^7.0.1",
-				"libnpmexec": "^9.0.1",
-				"libnpmfund": "^6.0.1",
-				"libnpmhook": "^11.0.0",
-				"libnpmorg": "^7.0.0",
-				"libnpmpack": "^8.0.1",
-				"libnpmpublish": "^10.0.1",
-				"libnpmsearch": "^8.0.0",
-				"libnpmteam": "^7.0.0",
-				"libnpmversion": "^7.0.0",
-				"make-fetch-happen": "^14.0.3",
-				"minimatch": "^9.0.5",
-				"minipass": "^7.1.1",
+				"cli-table3": "^0.6.2",
+				"columnify": "^1.6.0",
+				"fastest-levenshtein": "^1.0.12",
+				"fs-minipass": "^2.1.0",
+				"glob": "^8.0.1",
+				"graceful-fs": "^4.2.10",
+				"hosted-git-info": "^5.2.1",
+				"ini": "^3.0.1",
+				"init-package-json": "^3.0.2",
+				"is-cidr": "^4.0.2",
+				"json-parse-even-better-errors": "^2.3.1",
+				"libnpmaccess": "^6.0.4",
+				"libnpmdiff": "^4.0.5",
+				"libnpmexec": "^4.0.14",
+				"libnpmfund": "^3.0.5",
+				"libnpmhook": "^8.0.4",
+				"libnpmorg": "^4.0.4",
+				"libnpmpack": "^4.1.3",
+				"libnpmpublish": "^6.0.5",
+				"libnpmsearch": "^5.0.4",
+				"libnpmteam": "^4.0.4",
+				"libnpmversion": "^3.0.7",
+				"make-fetch-happen": "^10.2.0",
+				"minimatch": "^5.1.0",
+				"minipass": "^3.1.6",
 				"minipass-pipeline": "^1.2.4",
+				"mkdirp": "^1.0.4",
+				"mkdirp-infer-owner": "^2.0.0",
 				"ms": "^2.1.2",
-				"node-gyp": "^11.2.0",
-				"nopt": "^8.1.0",
-				"normalize-package-data": "^7.0.0",
-				"npm-audit-report": "^6.0.0",
-				"npm-install-checks": "^7.1.1",
-				"npm-package-arg": "^12.0.2",
-				"npm-pick-manifest": "^10.0.0",
-				"npm-profile": "^11.0.1",
-				"npm-registry-fetch": "^18.0.2",
-				"npm-user-validate": "^3.0.0",
-				"p-map": "^7.0.3",
-				"pacote": "^19.0.1",
-				"parse-conflict-json": "^4.0.0",
-				"proc-log": "^5.0.0",
+				"node-gyp": "^9.1.0",
+				"nopt": "^6.0.0",
+				"npm-audit-report": "^3.0.0",
+				"npm-install-checks": "^5.0.0",
+				"npm-package-arg": "^9.1.0",
+				"npm-pick-manifest": "^7.0.2",
+				"npm-profile": "^6.2.0",
+				"npm-registry-fetch": "^13.3.1",
+				"npm-user-validate": "^1.0.1",
+				"npmlog": "^6.0.2",
+				"opener": "^1.5.2",
+				"p-map": "^4.0.0",
+				"pacote": "^13.6.2",
+				"parse-conflict-json": "^2.0.2",
+				"proc-log": "^2.0.1",
 				"qrcode-terminal": "^0.12.0",
-				"read": "^4.1.0",
-				"semver": "^7.7.2",
-				"spdx-expression-parse": "^4.0.0",
-				"ssri": "^12.0.0",
-				"supports-color": "^9.4.0",
-				"tar": "^6.2.1",
+				"read": "~1.0.7",
+				"read-package-json": "^5.0.2",
+				"read-package-json-fast": "^2.0.3",
+				"readdir-scoped-modules": "^1.1.0",
+				"rimraf": "^3.0.2",
+				"semver": "^7.3.7",
+				"ssri": "^9.0.1",
+				"tar": "^6.1.11",
 				"text-table": "~0.2.0",
 				"tiny-relative-date": "^1.3.0",
-				"treeverse": "^3.0.0",
-				"validate-npm-package-name": "^6.0.1",
-				"which": "^5.0.0",
-				"write-file-atomic": "^6.0.0"
+				"treeverse": "^2.0.0",
+				"validate-npm-package-name": "^4.0.0",
+				"which": "^2.0.2",
+				"write-file-atomic": "^4.0.1"
 			},
 			"bin": {
 				"npm": "bin/npm-cli.js",
 				"npx": "bin/npx-cli.js"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm-bundled": {
@@ -19907,84 +19528,21 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/npm/node_modules/@isaacs/cliui": {
-			"version": "8.0.2",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"string-width": "^5.1.2",
-				"string-width-cjs": "npm:string-width@^4.2.0",
-				"strip-ansi": "^7.0.1",
-				"strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
-				"wrap-ansi": "^8.1.0",
-				"wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/npm/node_modules/@isaacs/cliui/node_modules/ansi-regex": {
-			"version": "6.1.0",
+		"node_modules/npm/node_modules/@colors/colors": {
+			"version": "1.5.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
+			"optional": true,
 			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
+				"node": ">=0.1.90"
 			}
 		},
-		"node_modules/npm/node_modules/@isaacs/cliui/node_modules/emoji-regex": {
-			"version": "9.2.2",
+		"node_modules/npm/node_modules/@gar/promisify": {
+			"version": "1.1.3",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT"
-		},
-		"node_modules/npm/node_modules/@isaacs/cliui/node_modules/string-width": {
-			"version": "5.1.2",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"eastasianwidth": "^0.2.0",
-				"emoji-regex": "^9.2.2",
-				"strip-ansi": "^7.0.1"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/npm/node_modules/@isaacs/cliui/node_modules/strip-ansi": {
-			"version": "7.1.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^6.0.1"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
-			}
-		},
-		"node_modules/npm/node_modules/@isaacs/fs-minipass": {
-			"version": "4.0.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"minipass": "^7.0.4"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
 		},
 		"node_modules/npm/node_modules/@isaacs/string-locale-compare": {
 			"version": "1.1.0",
@@ -19992,342 +19550,319 @@
 			"inBundle": true,
 			"license": "ISC"
 		},
-		"node_modules/npm/node_modules/@npmcli/agent": {
-			"version": "3.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"agent-base": "^7.1.0",
-				"http-proxy-agent": "^7.0.0",
-				"https-proxy-agent": "^7.0.1",
-				"lru-cache": "^10.0.1",
-				"socks-proxy-agent": "^8.0.3"
-			},
-			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
 		"node_modules/npm/node_modules/@npmcli/arborist": {
-			"version": "8.0.1",
+			"version": "5.6.3",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
 				"@isaacs/string-locale-compare": "^1.1.0",
-				"@npmcli/fs": "^4.0.0",
-				"@npmcli/installed-package-contents": "^3.0.0",
-				"@npmcli/map-workspaces": "^4.0.1",
-				"@npmcli/metavuln-calculator": "^8.0.0",
-				"@npmcli/name-from-folder": "^3.0.0",
-				"@npmcli/node-gyp": "^4.0.0",
-				"@npmcli/package-json": "^6.0.1",
-				"@npmcli/query": "^4.0.0",
-				"@npmcli/redact": "^3.0.0",
-				"@npmcli/run-script": "^9.0.1",
-				"bin-links": "^5.0.0",
-				"cacache": "^19.0.1",
+				"@npmcli/installed-package-contents": "^1.0.7",
+				"@npmcli/map-workspaces": "^2.0.3",
+				"@npmcli/metavuln-calculator": "^3.0.1",
+				"@npmcli/move-file": "^2.0.0",
+				"@npmcli/name-from-folder": "^1.0.1",
+				"@npmcli/node-gyp": "^2.0.0",
+				"@npmcli/package-json": "^2.0.0",
+				"@npmcli/query": "^1.2.0",
+				"@npmcli/run-script": "^4.1.3",
+				"bin-links": "^3.0.3",
+				"cacache": "^16.1.3",
 				"common-ancestor-path": "^1.0.1",
-				"hosted-git-info": "^8.0.0",
-				"json-parse-even-better-errors": "^4.0.0",
+				"hosted-git-info": "^5.2.1",
+				"json-parse-even-better-errors": "^2.3.1",
 				"json-stringify-nice": "^1.1.4",
-				"lru-cache": "^10.2.2",
-				"minimatch": "^9.0.4",
-				"nopt": "^8.0.0",
-				"npm-install-checks": "^7.1.0",
-				"npm-package-arg": "^12.0.0",
-				"npm-pick-manifest": "^10.0.0",
-				"npm-registry-fetch": "^18.0.1",
-				"pacote": "^19.0.0",
-				"parse-conflict-json": "^4.0.0",
-				"proc-log": "^5.0.0",
-				"proggy": "^3.0.0",
+				"minimatch": "^5.1.0",
+				"mkdirp": "^1.0.4",
+				"mkdirp-infer-owner": "^2.0.0",
+				"nopt": "^6.0.0",
+				"npm-install-checks": "^5.0.0",
+				"npm-package-arg": "^9.0.0",
+				"npm-pick-manifest": "^7.0.2",
+				"npm-registry-fetch": "^13.0.0",
+				"npmlog": "^6.0.2",
+				"pacote": "^13.6.1",
+				"parse-conflict-json": "^2.0.1",
+				"proc-log": "^2.0.0",
 				"promise-all-reject-late": "^1.0.0",
-				"promise-call-limit": "^3.0.1",
-				"read-package-json-fast": "^4.0.0",
+				"promise-call-limit": "^1.0.1",
+				"read-package-json-fast": "^2.0.2",
+				"readdir-scoped-modules": "^1.1.0",
+				"rimraf": "^3.0.2",
 				"semver": "^7.3.7",
-				"ssri": "^12.0.0",
-				"treeverse": "^3.0.0",
-				"walk-up-path": "^3.0.1"
+				"ssri": "^9.0.0",
+				"treeverse": "^2.0.0",
+				"walk-up-path": "^1.0.0"
 			},
 			"bin": {
 				"arborist": "bin/index.js"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/@npmcli/ci-detect": {
+			"version": "2.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^12.13.0 || ^14.15.0 || >=16"
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/config": {
-			"version": "9.0.0",
+			"version": "4.2.2",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/map-workspaces": "^4.0.1",
-				"@npmcli/package-json": "^6.0.1",
-				"ci-info": "^4.0.0",
-				"ini": "^5.0.0",
-				"nopt": "^8.0.0",
-				"proc-log": "^5.0.0",
+				"@npmcli/map-workspaces": "^2.0.2",
+				"ini": "^3.0.0",
+				"mkdirp-infer-owner": "^2.0.0",
+				"nopt": "^6.0.0",
+				"proc-log": "^2.0.0",
+				"read-package-json-fast": "^2.0.3",
 				"semver": "^7.3.5",
-				"walk-up-path": "^3.0.1"
+				"walk-up-path": "^1.0.0"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/@npmcli/disparity-colors": {
+			"version": "2.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"ansi-styles": "^4.3.0"
+			},
+			"engines": {
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/fs": {
-			"version": "4.0.0",
+			"version": "2.1.2",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
+				"@gar/promisify": "^1.1.3",
 				"semver": "^7.3.5"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/git": {
-			"version": "6.0.3",
+			"version": "3.0.2",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/promise-spawn": "^8.0.0",
-				"ini": "^5.0.0",
-				"lru-cache": "^10.0.1",
-				"npm-pick-manifest": "^10.0.0",
-				"proc-log": "^5.0.0",
+				"@npmcli/promise-spawn": "^3.0.0",
+				"lru-cache": "^7.4.4",
+				"mkdirp": "^1.0.4",
+				"npm-pick-manifest": "^7.0.0",
+				"proc-log": "^2.0.0",
+				"promise-inflight": "^1.0.1",
 				"promise-retry": "^2.0.1",
 				"semver": "^7.3.5",
-				"which": "^5.0.0"
+				"which": "^2.0.2"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/installed-package-contents": {
-			"version": "3.0.0",
+			"version": "1.0.7",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"npm-bundled": "^4.0.0",
-				"npm-normalize-package-bin": "^4.0.0"
+				"npm-bundled": "^1.1.1",
+				"npm-normalize-package-bin": "^1.0.1"
 			},
 			"bin": {
-				"installed-package-contents": "bin/index.js"
+				"installed-package-contents": "index.js"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": ">= 10"
+			}
+		},
+		"node_modules/npm/node_modules/@npmcli/installed-package-contents/node_modules/npm-bundled": {
+			"version": "1.1.2",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"npm-normalize-package-bin": "^1.0.1"
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/map-workspaces": {
-			"version": "4.0.2",
+			"version": "2.0.4",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/name-from-folder": "^3.0.0",
-				"@npmcli/package-json": "^6.0.0",
-				"glob": "^10.2.2",
-				"minimatch": "^9.0.0"
+				"@npmcli/name-from-folder": "^1.0.1",
+				"glob": "^8.0.1",
+				"minimatch": "^5.0.1",
+				"read-package-json-fast": "^2.0.3"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/metavuln-calculator": {
-			"version": "8.0.1",
+			"version": "3.1.1",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"cacache": "^19.0.0",
-				"json-parse-even-better-errors": "^4.0.0",
-				"pacote": "^20.0.0",
-				"proc-log": "^5.0.0",
+				"cacache": "^16.0.0",
+				"json-parse-even-better-errors": "^2.3.1",
+				"pacote": "^13.0.3",
 				"semver": "^7.3.5"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
-		"node_modules/npm/node_modules/@npmcli/metavuln-calculator/node_modules/pacote": {
-			"version": "20.0.0",
+		"node_modules/npm/node_modules/@npmcli/move-file": {
+			"version": "2.0.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"mkdirp": "^1.0.4",
+				"rimraf": "^3.0.2"
+			},
+			"engines": {
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/@npmcli/name-from-folder": {
+			"version": "1.0.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC"
+		},
+		"node_modules/npm/node_modules/@npmcli/node-gyp": {
+			"version": "2.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/@npmcli/package-json": {
+			"version": "2.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/git": "^6.0.0",
-				"@npmcli/installed-package-contents": "^3.0.0",
-				"@npmcli/package-json": "^6.0.0",
-				"@npmcli/promise-spawn": "^8.0.0",
-				"@npmcli/run-script": "^9.0.0",
-				"cacache": "^19.0.0",
-				"fs-minipass": "^3.0.0",
-				"minipass": "^7.0.2",
-				"npm-package-arg": "^12.0.0",
-				"npm-packlist": "^9.0.0",
-				"npm-pick-manifest": "^10.0.0",
-				"npm-registry-fetch": "^18.0.0",
-				"proc-log": "^5.0.0",
-				"promise-retry": "^2.0.1",
-				"sigstore": "^3.0.0",
-				"ssri": "^12.0.0",
-				"tar": "^6.1.11"
-			},
-			"bin": {
-				"pacote": "bin/index.js"
+				"json-parse-even-better-errors": "^2.3.1"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
-		"node_modules/npm/node_modules/@npmcli/name-from-folder": {
+		"node_modules/npm/node_modules/@npmcli/promise-spawn": {
 			"version": "3.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
-			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/npm/node_modules/@npmcli/node-gyp": {
-			"version": "4.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/npm/node_modules/@npmcli/package-json": {
-			"version": "6.2.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
 			"dependencies": {
-				"@npmcli/git": "^6.0.0",
-				"glob": "^10.2.2",
-				"hosted-git-info": "^8.0.0",
-				"json-parse-even-better-errors": "^4.0.0",
-				"proc-log": "^5.0.0",
-				"semver": "^7.5.3",
-				"validate-npm-package-license": "^3.0.4"
+				"infer-owner": "^1.0.4"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/npm/node_modules/@npmcli/promise-spawn": {
-			"version": "8.0.2",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"which": "^5.0.0"
-			},
-			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/query": {
-			"version": "4.0.1",
+			"version": "1.2.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"postcss-selector-parser": "^7.0.0"
+				"npm-package-arg": "^9.1.0",
+				"postcss-selector-parser": "^6.0.10",
+				"semver": "^7.3.7"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/npm/node_modules/@npmcli/redact": {
-			"version": "3.2.2",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/run-script": {
-			"version": "9.1.0",
+			"version": "4.2.1",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/node-gyp": "^4.0.0",
-				"@npmcli/package-json": "^6.0.0",
-				"@npmcli/promise-spawn": "^8.0.0",
-				"node-gyp": "^11.0.0",
-				"proc-log": "^5.0.0",
-				"which": "^5.0.0"
+				"@npmcli/node-gyp": "^2.0.0",
+				"@npmcli/promise-spawn": "^3.0.0",
+				"node-gyp": "^9.0.0",
+				"read-package-json-fast": "^2.0.3",
+				"which": "^2.0.2"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
-		"node_modules/npm/node_modules/@pkgjs/parseargs": {
-			"version": "0.11.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"optional": true,
-			"engines": {
-				"node": ">=14"
-			}
-		},
-		"node_modules/npm/node_modules/@sigstore/protobuf-specs": {
-			"version": "0.4.3",
-			"dev": true,
-			"inBundle": true,
-			"license": "Apache-2.0",
-			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/npm/node_modules/@sigstore/tuf": {
-			"version": "3.1.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@sigstore/protobuf-specs": "^0.4.1",
-				"tuf-js": "^3.0.1"
-			},
-			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/npm/node_modules/@tufjs/canonical-json": {
+		"node_modules/npm/node_modules/@tootallnate/once": {
 			"version": "2.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
+				"node": ">= 10"
 			}
 		},
 		"node_modules/npm/node_modules/abbrev": {
-			"version": "3.0.1",
+			"version": "1.1.1",
 			"dev": true,
 			"inBundle": true,
-			"license": "ISC",
-			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
+			"license": "ISC"
 		},
 		"node_modules/npm/node_modules/agent-base": {
-			"version": "7.1.3",
+			"version": "6.0.2",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
+			"dependencies": {
+				"debug": "4"
+			},
 			"engines": {
-				"node": ">= 14"
+				"node": ">= 6.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/agentkeepalive": {
+			"version": "4.2.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^4.1.0",
+				"depd": "^1.1.2",
+				"humanize-ms": "^1.2.1"
+			},
+			"engines": {
+				"node": ">= 8.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/aggregate-error": {
+			"version": "3.1.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"clean-stack": "^2.0.0",
+				"indent-string": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/npm/node_modules/ansi-regex": {
@@ -20340,12 +19875,15 @@
 			}
 		},
 		"node_modules/npm/node_modules/ansi-styles": {
-			"version": "6.2.1",
+			"version": "4.3.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=8"
 			},
 			"funding": {
 				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
@@ -20363,6 +19901,25 @@
 			"inBundle": true,
 			"license": "MIT"
 		},
+		"node_modules/npm/node_modules/are-we-there-yet": {
+			"version": "3.0.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"delegates": "^1.0.0",
+				"readable-stream": "^3.6.0"
+			},
+			"engines": {
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/asap": {
+			"version": "2.0.6",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT"
+		},
 		"node_modules/npm/node_modules/balanced-match": {
 			"version": "1.0.2",
 			"dev": true,
@@ -20370,35 +19927,42 @@
 			"license": "MIT"
 		},
 		"node_modules/npm/node_modules/bin-links": {
-			"version": "5.0.0",
+			"version": "3.0.3",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"cmd-shim": "^7.0.0",
-				"npm-normalize-package-bin": "^4.0.0",
-				"proc-log": "^5.0.0",
-				"read-cmd-shim": "^5.0.0",
-				"write-file-atomic": "^6.0.0"
+				"cmd-shim": "^5.0.0",
+				"mkdirp-infer-owner": "^2.0.0",
+				"npm-normalize-package-bin": "^2.0.0",
+				"read-cmd-shim": "^3.0.0",
+				"rimraf": "^3.0.0",
+				"write-file-atomic": "^4.0.0"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/bin-links/node_modules/npm-normalize-package-bin": {
+			"version": "2.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/binary-extensions": {
-			"version": "2.3.0",
+			"version": "2.2.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/npm/node_modules/brace-expansion": {
-			"version": "2.0.2",
+			"version": "2.0.1",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
@@ -20406,86 +19970,55 @@
 				"balanced-match": "^1.0.0"
 			}
 		},
-		"node_modules/npm/node_modules/cacache": {
-			"version": "19.0.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"@npmcli/fs": "^4.0.0",
-				"fs-minipass": "^3.0.0",
-				"glob": "^10.2.2",
-				"lru-cache": "^10.0.1",
-				"minipass": "^7.0.3",
-				"minipass-collect": "^2.0.1",
-				"minipass-flush": "^1.0.5",
-				"minipass-pipeline": "^1.2.4",
-				"p-map": "^7.0.2",
-				"ssri": "^12.0.0",
-				"tar": "^7.4.3",
-				"unique-filename": "^4.0.0"
-			},
-			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/npm/node_modules/cacache/node_modules/chownr": {
-			"version": "3.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "BlueOak-1.0.0",
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/npm/node_modules/cacache/node_modules/mkdirp": {
-			"version": "3.0.1",
+		"node_modules/npm/node_modules/builtins": {
+			"version": "5.0.1",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
-			"bin": {
-				"mkdirp": "dist/cjs/src/bin.js"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
+			"dependencies": {
+				"semver": "^7.0.0"
 			}
 		},
-		"node_modules/npm/node_modules/cacache/node_modules/tar": {
-			"version": "7.4.3",
+		"node_modules/npm/node_modules/cacache": {
+			"version": "16.1.3",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"@isaacs/fs-minipass": "^4.0.0",
-				"chownr": "^3.0.0",
-				"minipass": "^7.1.2",
-				"minizlib": "^3.0.1",
-				"mkdirp": "^3.0.1",
-				"yallist": "^5.0.0"
+				"@npmcli/fs": "^2.1.0",
+				"@npmcli/move-file": "^2.0.0",
+				"chownr": "^2.0.0",
+				"fs-minipass": "^2.1.0",
+				"glob": "^8.0.1",
+				"infer-owner": "^1.0.4",
+				"lru-cache": "^7.7.1",
+				"minipass": "^3.1.6",
+				"minipass-collect": "^1.0.2",
+				"minipass-flush": "^1.0.5",
+				"minipass-pipeline": "^1.2.4",
+				"mkdirp": "^1.0.4",
+				"p-map": "^4.0.0",
+				"promise-inflight": "^1.0.1",
+				"rimraf": "^3.0.2",
+				"ssri": "^9.0.0",
+				"tar": "^6.1.11",
+				"unique-filename": "^2.0.0"
 			},
 			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/npm/node_modules/cacache/node_modules/yallist": {
-			"version": "5.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "BlueOak-1.0.0",
-			"engines": {
-				"node": ">=18"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/chalk": {
-			"version": "5.4.1",
+			"version": "4.1.2",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			},
 			"engines": {
-				"node": "^12.17.0 || ^14.13 || >=16.0.0"
+				"node": ">=10"
 			},
 			"funding": {
 				"url": "https://github.com/chalk/chalk?sponsor=1"
@@ -20500,31 +20033,25 @@
 				"node": ">=10"
 			}
 		},
-		"node_modules/npm/node_modules/ci-info": {
-			"version": "4.2.0",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/sibiraj-s"
-				}
-			],
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/npm/node_modules/cidr-regex": {
-			"version": "4.1.3",
+			"version": "3.1.1",
 			"dev": true,
 			"inBundle": true,
 			"license": "BSD-2-Clause",
 			"dependencies": {
-				"ip-regex": "^5.0.0"
+				"ip-regex": "^4.1.0"
 			},
 			"engines": {
-				"node": ">=14"
+				"node": ">=10"
+			}
+		},
+		"node_modules/npm/node_modules/clean-stack": {
+			"version": "2.2.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/npm/node_modules/cli-columns": {
@@ -20540,13 +20067,40 @@
 				"node": ">= 10"
 			}
 		},
+		"node_modules/npm/node_modules/cli-table3": {
+			"version": "0.6.2",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"string-width": "^4.2.0"
+			},
+			"engines": {
+				"node": "10.* || >= 12.*"
+			},
+			"optionalDependencies": {
+				"@colors/colors": "1.5.0"
+			}
+		},
+		"node_modules/npm/node_modules/clone": {
+			"version": "1.0.4",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.8"
+			}
+		},
 		"node_modules/npm/node_modules/cmd-shim": {
-			"version": "7.0.0",
+			"version": "5.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
+			"dependencies": {
+				"mkdirp-infer-owner": "^2.0.0"
+			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/color-convert": {
@@ -20567,40 +20121,45 @@
 			"inBundle": true,
 			"license": "MIT"
 		},
+		"node_modules/npm/node_modules/color-support": {
+			"version": "1.1.3",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"bin": {
+				"color-support": "bin.js"
+			}
+		},
+		"node_modules/npm/node_modules/columnify": {
+			"version": "1.6.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"strip-ansi": "^6.0.1",
+				"wcwidth": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=8.0.0"
+			}
+		},
 		"node_modules/npm/node_modules/common-ancestor-path": {
 			"version": "1.0.1",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC"
 		},
-		"node_modules/npm/node_modules/cross-spawn": {
-			"version": "7.0.6",
+		"node_modules/npm/node_modules/concat-map": {
+			"version": "0.0.1",
 			"dev": true,
 			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"path-key": "^3.1.0",
-				"shebang-command": "^2.0.0",
-				"which": "^2.0.1"
-			},
-			"engines": {
-				"node": ">= 8"
-			}
+			"license": "MIT"
 		},
-		"node_modules/npm/node_modules/cross-spawn/node_modules/which": {
-			"version": "2.0.2",
+		"node_modules/npm/node_modules/console-control-strings": {
+			"version": "1.1.0",
 			"dev": true,
 			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"isexe": "^2.0.0"
-			},
-			"bin": {
-				"node-which": "bin/node-which"
-			},
-			"engines": {
-				"node": ">= 8"
-			}
+			"license": "ISC"
 		},
 		"node_modules/npm/node_modules/cssesc": {
 			"version": "3.0.0",
@@ -20615,12 +20174,12 @@
 			}
 		},
 		"node_modules/npm/node_modules/debug": {
-			"version": "4.4.1",
+			"version": "4.3.4",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
-				"ms": "^2.1.3"
+				"ms": "2.1.2"
 			},
 			"engines": {
 				"node": ">=6.0"
@@ -20631,20 +20190,63 @@
 				}
 			}
 		},
+		"node_modules/npm/node_modules/debug/node_modules/ms": {
+			"version": "2.1.2",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npm/node_modules/debuglog": {
+			"version": "1.0.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/npm/node_modules/defaults": {
+			"version": "1.0.3",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"clone": "^1.0.2"
+			}
+		},
+		"node_modules/npm/node_modules/delegates": {
+			"version": "1.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npm/node_modules/depd": {
+			"version": "1.1.2",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/npm/node_modules/dezalgo": {
+			"version": "1.0.4",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"asap": "^2.0.0",
+				"wrappy": "1"
+			}
+		},
 		"node_modules/npm/node_modules/diff": {
-			"version": "5.2.0",
+			"version": "5.1.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=0.3.1"
 			}
-		},
-		"node_modules/npm/node_modules/eastasianwidth": {
-			"version": "0.2.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT"
 		},
 		"node_modules/npm/node_modules/emoji-regex": {
 			"version": "8.0.0",
@@ -20677,117 +20279,159 @@
 			"inBundle": true,
 			"license": "MIT"
 		},
-		"node_modules/npm/node_modules/exponential-backoff": {
-			"version": "3.1.2",
-			"dev": true,
-			"inBundle": true,
-			"license": "Apache-2.0"
-		},
 		"node_modules/npm/node_modules/fastest-levenshtein": {
-			"version": "1.0.16",
+			"version": "1.0.12",
 			"dev": true,
 			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 4.9.1"
-			}
-		},
-		"node_modules/npm/node_modules/foreground-child": {
-			"version": "3.3.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"cross-spawn": "^7.0.6",
-				"signal-exit": "^4.0.1"
-			},
-			"engines": {
-				"node": ">=14"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
+			"license": "MIT"
 		},
 		"node_modules/npm/node_modules/fs-minipass": {
-			"version": "3.0.3",
+			"version": "2.1.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"minipass": "^7.0.3"
+				"minipass": "^3.0.0"
 			},
 			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+				"node": ">= 8"
+			}
+		},
+		"node_modules/npm/node_modules/fs.realpath": {
+			"version": "1.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC"
+		},
+		"node_modules/npm/node_modules/function-bind": {
+			"version": "1.1.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npm/node_modules/gauge": {
+			"version": "4.0.4",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"aproba": "^1.0.3 || ^2.0.0",
+				"color-support": "^1.1.3",
+				"console-control-strings": "^1.1.0",
+				"has-unicode": "^2.0.1",
+				"signal-exit": "^3.0.7",
+				"string-width": "^4.2.3",
+				"strip-ansi": "^6.0.1",
+				"wide-align": "^1.1.5"
+			},
+			"engines": {
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/glob": {
-			"version": "10.4.5",
+			"version": "8.0.3",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"foreground-child": "^3.1.0",
-				"jackspeak": "^3.1.2",
-				"minimatch": "^9.0.4",
-				"minipass": "^7.1.2",
-				"package-json-from-dist": "^1.0.0",
-				"path-scurry": "^1.11.1"
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^5.0.1",
+				"once": "^1.3.0"
 			},
-			"bin": {
-				"glob": "dist/esm/bin.mjs"
+			"engines": {
+				"node": ">=12"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/npm/node_modules/graceful-fs": {
-			"version": "4.2.11",
+			"version": "4.2.10",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC"
+		},
+		"node_modules/npm/node_modules/has": {
+			"version": "1.0.3",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"function-bind": "^1.1.1"
+			},
+			"engines": {
+				"node": ">= 0.4.0"
+			}
+		},
+		"node_modules/npm/node_modules/has-flag": {
+			"version": "4.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/npm/node_modules/has-unicode": {
+			"version": "2.0.1",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC"
 		},
 		"node_modules/npm/node_modules/hosted-git-info": {
-			"version": "8.1.0",
+			"version": "5.2.1",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"lru-cache": "^10.0.1"
+				"lru-cache": "^7.5.1"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/http-cache-semantics": {
-			"version": "4.2.0",
+			"version": "4.1.1",
 			"dev": true,
 			"inBundle": true,
 			"license": "BSD-2-Clause"
 		},
 		"node_modules/npm/node_modules/http-proxy-agent": {
-			"version": "7.0.2",
+			"version": "5.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
-				"agent-base": "^7.1.0",
-				"debug": "^4.3.4"
-			},
-			"engines": {
-				"node": ">= 14"
-			}
-		},
-		"node_modules/npm/node_modules/https-proxy-agent": {
-			"version": "7.0.6",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"agent-base": "^7.1.2",
+				"@tootallnate/once": "2",
+				"agent-base": "6",
 				"debug": "4"
 			},
 			"engines": {
-				"node": ">= 14"
+				"node": ">= 6"
+			}
+		},
+		"node_modules/npm/node_modules/https-proxy-agent": {
+			"version": "5.0.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "6",
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/npm/node_modules/humanize-ms": {
+			"version": "1.2.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"ms": "^2.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/iconv-lite": {
@@ -20804,15 +20448,15 @@
 			}
 		},
 		"node_modules/npm/node_modules/ignore-walk": {
-			"version": "7.0.0",
+			"version": "5.0.1",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"minimatch": "^9.0.0"
+				"minimatch": "^5.0.1"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/imurmurhash": {
@@ -20824,68 +20468,101 @@
 				"node": ">=0.8.19"
 			}
 		},
+		"node_modules/npm/node_modules/indent-string": {
+			"version": "4.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/npm/node_modules/infer-owner": {
+			"version": "1.0.4",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC"
+		},
+		"node_modules/npm/node_modules/inflight": {
+			"version": "1.0.6",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"once": "^1.3.0",
+				"wrappy": "1"
+			}
+		},
+		"node_modules/npm/node_modules/inherits": {
+			"version": "2.0.4",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC"
+		},
 		"node_modules/npm/node_modules/ini": {
-			"version": "5.0.0",
+			"version": "3.0.1",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/init-package-json": {
-			"version": "7.0.2",
+			"version": "3.0.2",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/package-json": "^6.0.0",
-				"npm-package-arg": "^12.0.0",
-				"promzard": "^2.0.0",
-				"read": "^4.0.0",
+				"npm-package-arg": "^9.0.1",
+				"promzard": "^0.3.0",
+				"read": "^1.0.7",
+				"read-package-json": "^5.0.0",
 				"semver": "^7.3.5",
 				"validate-npm-package-license": "^3.0.4",
-				"validate-npm-package-name": "^6.0.0"
+				"validate-npm-package-name": "^4.0.0"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
-		"node_modules/npm/node_modules/ip-address": {
-			"version": "9.0.5",
+		"node_modules/npm/node_modules/ip": {
+			"version": "2.0.0",
 			"dev": true,
 			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"jsbn": "1.1.0",
-				"sprintf-js": "^1.1.3"
-			},
-			"engines": {
-				"node": ">= 12"
-			}
+			"license": "MIT"
 		},
 		"node_modules/npm/node_modules/ip-regex": {
-			"version": "5.0.0",
+			"version": "4.3.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
+				"node": ">=8"
 			}
 		},
 		"node_modules/npm/node_modules/is-cidr": {
-			"version": "5.1.1",
+			"version": "4.0.2",
 			"dev": true,
 			"inBundle": true,
 			"license": "BSD-2-Clause",
 			"dependencies": {
-				"cidr-regex": "^4.1.1"
+				"cidr-regex": "^3.1.1"
 			},
 			"engines": {
-				"node": ">=14"
+				"node": ">=10"
+			}
+		},
+		"node_modules/npm/node_modules/is-core-module": {
+			"version": "2.10.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"has": "^1.0.3"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/npm/node_modules/is-fullwidth-code-point": {
@@ -20897,41 +20574,23 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/npm/node_modules/is-lambda": {
+			"version": "1.0.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT"
+		},
 		"node_modules/npm/node_modules/isexe": {
 			"version": "2.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC"
 		},
-		"node_modules/npm/node_modules/jackspeak": {
-			"version": "3.4.3",
-			"dev": true,
-			"inBundle": true,
-			"license": "BlueOak-1.0.0",
-			"dependencies": {
-				"@isaacs/cliui": "^8.0.2"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			},
-			"optionalDependencies": {
-				"@pkgjs/parseargs": "^0.11.0"
-			}
-		},
-		"node_modules/npm/node_modules/jsbn": {
-			"version": "1.1.0",
+		"node_modules/npm/node_modules/json-parse-even-better-errors": {
+			"version": "2.3.1",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT"
-		},
-		"node_modules/npm/node_modules/json-parse-even-better-errors": {
-			"version": "4.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
 		},
 		"node_modules/npm/node_modules/json-stringify-nice": {
 			"version": "1.1.4",
@@ -20952,222 +20611,223 @@
 			"license": "MIT"
 		},
 		"node_modules/npm/node_modules/just-diff": {
-			"version": "6.0.2",
+			"version": "5.1.1",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT"
 		},
 		"node_modules/npm/node_modules/just-diff-apply": {
-			"version": "5.5.0",
+			"version": "5.4.1",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT"
 		},
 		"node_modules/npm/node_modules/libnpmaccess": {
-			"version": "9.0.0",
+			"version": "6.0.4",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"npm-package-arg": "^12.0.0",
-				"npm-registry-fetch": "^18.0.1"
+				"aproba": "^2.0.0",
+				"minipass": "^3.1.1",
+				"npm-package-arg": "^9.0.1",
+				"npm-registry-fetch": "^13.0.0"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/libnpmdiff": {
-			"version": "7.0.1",
+			"version": "4.0.5",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/arborist": "^8.0.1",
-				"@npmcli/installed-package-contents": "^3.0.0",
-				"binary-extensions": "^2.3.0",
+				"@npmcli/disparity-colors": "^2.0.0",
+				"@npmcli/installed-package-contents": "^1.0.7",
+				"binary-extensions": "^2.2.0",
 				"diff": "^5.1.0",
-				"minimatch": "^9.0.4",
-				"npm-package-arg": "^12.0.0",
-				"pacote": "^19.0.0",
-				"tar": "^6.2.1"
+				"minimatch": "^5.0.1",
+				"npm-package-arg": "^9.0.1",
+				"pacote": "^13.6.1",
+				"tar": "^6.1.0"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/libnpmexec": {
-			"version": "9.0.1",
+			"version": "4.0.14",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/arborist": "^8.0.1",
-				"@npmcli/run-script": "^9.0.1",
-				"ci-info": "^4.0.0",
-				"npm-package-arg": "^12.0.0",
-				"pacote": "^19.0.0",
-				"proc-log": "^5.0.0",
-				"read": "^4.0.0",
-				"read-package-json-fast": "^4.0.0",
+				"@npmcli/arborist": "^5.6.3",
+				"@npmcli/ci-detect": "^2.0.0",
+				"@npmcli/fs": "^2.1.1",
+				"@npmcli/run-script": "^4.2.0",
+				"chalk": "^4.1.0",
+				"mkdirp-infer-owner": "^2.0.0",
+				"npm-package-arg": "^9.0.1",
+				"npmlog": "^6.0.2",
+				"pacote": "^13.6.1",
+				"proc-log": "^2.0.0",
+				"read": "^1.0.7",
+				"read-package-json-fast": "^2.0.2",
 				"semver": "^7.3.7",
-				"walk-up-path": "^3.0.1"
+				"walk-up-path": "^1.0.0"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/libnpmfund": {
-			"version": "6.0.1",
+			"version": "3.0.5",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/arborist": "^8.0.1"
+				"@npmcli/arborist": "^5.6.3"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/libnpmhook": {
-			"version": "11.0.0",
+			"version": "8.0.4",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
 				"aproba": "^2.0.0",
-				"npm-registry-fetch": "^18.0.1"
+				"npm-registry-fetch": "^13.0.0"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/libnpmorg": {
-			"version": "7.0.0",
+			"version": "4.0.4",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
 				"aproba": "^2.0.0",
-				"npm-registry-fetch": "^18.0.1"
+				"npm-registry-fetch": "^13.0.0"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/libnpmpack": {
-			"version": "8.0.1",
+			"version": "4.1.3",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/arborist": "^8.0.1",
-				"@npmcli/run-script": "^9.0.1",
-				"npm-package-arg": "^12.0.0",
-				"pacote": "^19.0.0"
+				"@npmcli/run-script": "^4.1.3",
+				"npm-package-arg": "^9.0.1",
+				"pacote": "^13.6.1"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/libnpmpublish": {
-			"version": "10.0.1",
+			"version": "6.0.5",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"ci-info": "^4.0.0",
-				"normalize-package-data": "^7.0.0",
-				"npm-package-arg": "^12.0.0",
-				"npm-registry-fetch": "^18.0.1",
-				"proc-log": "^5.0.0",
+				"normalize-package-data": "^4.0.0",
+				"npm-package-arg": "^9.0.1",
+				"npm-registry-fetch": "^13.0.0",
 				"semver": "^7.3.7",
-				"sigstore": "^3.0.0",
-				"ssri": "^12.0.0"
+				"ssri": "^9.0.0"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/libnpmsearch": {
-			"version": "8.0.0",
+			"version": "5.0.4",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"npm-registry-fetch": "^18.0.1"
+				"npm-registry-fetch": "^13.0.0"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/libnpmteam": {
-			"version": "7.0.0",
+			"version": "4.0.4",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
 				"aproba": "^2.0.0",
-				"npm-registry-fetch": "^18.0.1"
+				"npm-registry-fetch": "^13.0.0"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/libnpmversion": {
-			"version": "7.0.0",
+			"version": "3.0.7",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/git": "^6.0.1",
-				"@npmcli/run-script": "^9.0.1",
-				"json-parse-even-better-errors": "^4.0.0",
-				"proc-log": "^5.0.0",
+				"@npmcli/git": "^3.0.0",
+				"@npmcli/run-script": "^4.1.3",
+				"json-parse-even-better-errors": "^2.3.1",
+				"proc-log": "^2.0.0",
 				"semver": "^7.3.7"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/lru-cache": {
-			"version": "10.4.3",
+			"version": "7.13.2",
 			"dev": true,
 			"inBundle": true,
-			"license": "ISC"
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
 		},
 		"node_modules/npm/node_modules/make-fetch-happen": {
-			"version": "14.0.3",
+			"version": "10.2.1",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/agent": "^3.0.0",
-				"cacache": "^19.0.1",
-				"http-cache-semantics": "^4.1.1",
-				"minipass": "^7.0.2",
-				"minipass-fetch": "^4.0.0",
+				"agentkeepalive": "^4.2.1",
+				"cacache": "^16.1.0",
+				"http-cache-semantics": "^4.1.0",
+				"http-proxy-agent": "^5.0.0",
+				"https-proxy-agent": "^5.0.0",
+				"is-lambda": "^1.0.1",
+				"lru-cache": "^7.7.1",
+				"minipass": "^3.1.6",
+				"minipass-collect": "^1.0.2",
+				"minipass-fetch": "^2.0.3",
 				"minipass-flush": "^1.0.5",
 				"minipass-pipeline": "^1.2.4",
-				"negotiator": "^1.0.0",
-				"proc-log": "^5.0.0",
+				"negotiator": "^0.6.3",
 				"promise-retry": "^2.0.1",
-				"ssri": "^12.0.0"
+				"socks-proxy-agent": "^7.0.0",
+				"ssri": "^9.0.0"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/npm/node_modules/make-fetch-happen/node_modules/negotiator": {
-			"version": "1.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.6"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/minimatch": {
-			"version": "9.0.5",
+			"version": "5.1.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
@@ -21175,45 +20835,45 @@
 				"brace-expansion": "^2.0.1"
 			},
 			"engines": {
-				"node": ">=16 || 14 >=14.17"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
+				"node": ">=10"
 			}
 		},
 		"node_modules/npm/node_modules/minipass": {
-			"version": "7.1.2",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"engines": {
-				"node": ">=16 || 14 >=14.17"
-			}
-		},
-		"node_modules/npm/node_modules/minipass-collect": {
-			"version": "2.0.1",
+			"version": "3.3.4",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"minipass": "^7.0.3"
+				"yallist": "^4.0.0"
 			},
 			"engines": {
-				"node": ">=16 || 14 >=14.17"
+				"node": ">=8"
+			}
+		},
+		"node_modules/npm/node_modules/minipass-collect": {
+			"version": "1.0.2",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"minipass": "^3.0.0"
+			},
+			"engines": {
+				"node": ">= 8"
 			}
 		},
 		"node_modules/npm/node_modules/minipass-fetch": {
-			"version": "4.0.1",
+			"version": "2.1.1",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
-				"minipass": "^7.0.3",
+				"minipass": "^3.1.6",
 				"minipass-sized": "^1.0.3",
-				"minizlib": "^3.0.1"
+				"minizlib": "^2.1.2"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			},
 			"optionalDependencies": {
 				"encoding": "^0.1.13"
@@ -21231,16 +20891,14 @@
 				"node": ">= 8"
 			}
 		},
-		"node_modules/npm/node_modules/minipass-flush/node_modules/minipass": {
-			"version": "3.3.6",
+		"node_modules/npm/node_modules/minipass-json-stream": {
+			"version": "1.0.1",
 			"dev": true,
 			"inBundle": true,
-			"license": "ISC",
+			"license": "MIT",
 			"dependencies": {
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
+				"jsonparse": "^1.3.1",
+				"minipass": "^3.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/minipass-pipeline": {
@@ -21250,18 +20908,6 @@
 			"license": "ISC",
 			"dependencies": {
 				"minipass": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/npm/node_modules/minipass-pipeline/node_modules/minipass": {
-			"version": "3.3.6",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"yallist": "^4.0.0"
 			},
 			"engines": {
 				"node": ">=8"
@@ -21279,28 +20925,17 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/npm/node_modules/minipass-sized/node_modules/minipass": {
-			"version": "3.3.6",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/npm/node_modules/minizlib": {
-			"version": "3.0.2",
+			"version": "2.1.2",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
-				"minipass": "^7.1.2"
+				"minipass": "^3.0.0",
+				"yallist": "^4.0.0"
 			},
 			"engines": {
-				"node": ">= 18"
+				"node": ">= 8"
 			}
 		},
 		"node_modules/npm/node_modules/mkdirp": {
@@ -21315,6 +20950,20 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/npm/node_modules/mkdirp-infer-owner": {
+			"version": "2.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"chownr": "^2.0.0",
+				"infer-owner": "^1.0.4",
+				"mkdirp": "^1.0.3"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/npm/node_modules/ms": {
 			"version": "2.1.3",
 			"dev": true,
@@ -21322,140 +20971,166 @@
 			"license": "MIT"
 		},
 		"node_modules/npm/node_modules/mute-stream": {
-			"version": "2.0.0",
+			"version": "0.0.8",
 			"dev": true,
 			"inBundle": true,
-			"license": "ISC",
+			"license": "ISC"
+		},
+		"node_modules/npm/node_modules/negotiator": {
+			"version": "0.6.3",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": ">= 0.6"
 			}
 		},
 		"node_modules/npm/node_modules/node-gyp": {
-			"version": "11.2.0",
+			"version": "9.1.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
 				"env-paths": "^2.2.0",
-				"exponential-backoff": "^3.1.1",
+				"glob": "^7.1.4",
 				"graceful-fs": "^4.2.6",
-				"make-fetch-happen": "^14.0.3",
-				"nopt": "^8.0.0",
-				"proc-log": "^5.0.0",
+				"make-fetch-happen": "^10.0.3",
+				"nopt": "^5.0.0",
+				"npmlog": "^6.0.0",
+				"rimraf": "^3.0.2",
 				"semver": "^7.3.5",
-				"tar": "^7.4.3",
-				"tinyglobby": "^0.2.12",
-				"which": "^5.0.0"
+				"tar": "^6.1.2",
+				"which": "^2.0.2"
 			},
 			"bin": {
 				"node-gyp": "bin/node-gyp.js"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^12.22 || ^14.13 || >=16"
 			}
 		},
-		"node_modules/npm/node_modules/node-gyp/node_modules/chownr": {
-			"version": "3.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "BlueOak-1.0.0",
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/npm/node_modules/node-gyp/node_modules/mkdirp": {
-			"version": "3.0.1",
+		"node_modules/npm/node_modules/node-gyp/node_modules/brace-expansion": {
+			"version": "1.1.11",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
-			"bin": {
-				"mkdirp": "dist/cjs/src/bin.js"
+			"dependencies": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"node_modules/npm/node_modules/node-gyp/node_modules/glob": {
+			"version": "7.2.3",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.1.1",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
 			},
 			"engines": {
-				"node": ">=10"
+				"node": "*"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
-		"node_modules/npm/node_modules/node-gyp/node_modules/tar": {
-			"version": "7.4.3",
+		"node_modules/npm/node_modules/node-gyp/node_modules/minimatch": {
+			"version": "3.1.2",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"@isaacs/fs-minipass": "^4.0.0",
-				"chownr": "^3.0.0",
-				"minipass": "^7.1.2",
-				"minizlib": "^3.0.1",
-				"mkdirp": "^3.0.1",
-				"yallist": "^5.0.0"
+				"brace-expansion": "^1.1.7"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": "*"
 			}
 		},
-		"node_modules/npm/node_modules/node-gyp/node_modules/yallist": {
+		"node_modules/npm/node_modules/node-gyp/node_modules/nopt": {
 			"version": "5.0.0",
 			"dev": true,
 			"inBundle": true,
-			"license": "BlueOak-1.0.0",
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/npm/node_modules/nopt": {
-			"version": "8.1.0",
-			"dev": true,
-			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"abbrev": "^3.0.0"
+				"abbrev": "1"
 			},
 			"bin": {
 				"nopt": "bin/nopt.js"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": ">=6"
 			}
 		},
-		"node_modules/npm/node_modules/normalize-package-data": {
-			"version": "7.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "BSD-2-Clause",
-			"dependencies": {
-				"hosted-git-info": "^8.0.0",
-				"semver": "^7.3.5",
-				"validate-npm-package-license": "^3.0.4"
-			},
-			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/npm/node_modules/npm-audit-report": {
+		"node_modules/npm/node_modules/nopt": {
 			"version": "6.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
+			"dependencies": {
+				"abbrev": "^1.0.0"
+			},
+			"bin": {
+				"nopt": "bin/nopt.js"
+			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
-		"node_modules/npm/node_modules/npm-bundled": {
-			"version": "4.0.0",
+		"node_modules/npm/node_modules/normalize-package-data": {
+			"version": "4.0.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"hosted-git-info": "^5.0.0",
+				"is-core-module": "^2.8.1",
+				"semver": "^7.3.5",
+				"validate-npm-package-license": "^3.0.4"
+			},
+			"engines": {
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/npm-audit-report": {
+			"version": "3.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"npm-normalize-package-bin": "^4.0.0"
+				"chalk": "^4.0.0"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/npm-bundled": {
+			"version": "2.0.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"npm-normalize-package-bin": "^2.0.0"
+			},
+			"engines": {
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/npm-bundled/node_modules/npm-normalize-package-bin": {
+			"version": "2.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/npm-install-checks": {
-			"version": "7.1.1",
+			"version": "5.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "BSD-2-Clause",
@@ -21463,191 +21138,226 @@
 				"semver": "^7.1.1"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/npm-normalize-package-bin": {
-			"version": "4.0.0",
+			"version": "1.0.1",
 			"dev": true,
 			"inBundle": true,
-			"license": "ISC",
-			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
+			"license": "ISC"
 		},
 		"node_modules/npm/node_modules/npm-package-arg": {
-			"version": "12.0.2",
+			"version": "9.1.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"hosted-git-info": "^8.0.0",
-				"proc-log": "^5.0.0",
+				"hosted-git-info": "^5.0.0",
+				"proc-log": "^2.0.1",
 				"semver": "^7.3.5",
-				"validate-npm-package-name": "^6.0.0"
+				"validate-npm-package-name": "^4.0.0"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/npm-packlist": {
-			"version": "9.0.0",
+			"version": "5.1.3",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"ignore-walk": "^7.0.0"
+				"glob": "^8.0.1",
+				"ignore-walk": "^5.0.1",
+				"npm-bundled": "^2.0.0",
+				"npm-normalize-package-bin": "^2.0.0"
+			},
+			"bin": {
+				"npm-packlist": "bin/index.js"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/npm-packlist/node_modules/npm-normalize-package-bin": {
+			"version": "2.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/npm-pick-manifest": {
-			"version": "10.0.0",
+			"version": "7.0.2",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"npm-install-checks": "^7.1.0",
-				"npm-normalize-package-bin": "^4.0.0",
-				"npm-package-arg": "^12.0.0",
+				"npm-install-checks": "^5.0.0",
+				"npm-normalize-package-bin": "^2.0.0",
+				"npm-package-arg": "^9.0.0",
 				"semver": "^7.3.5"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/npm-pick-manifest/node_modules/npm-normalize-package-bin": {
+			"version": "2.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/npm-profile": {
-			"version": "11.0.1",
+			"version": "6.2.1",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"npm-registry-fetch": "^18.0.0",
-				"proc-log": "^5.0.0"
+				"npm-registry-fetch": "^13.0.1",
+				"proc-log": "^2.0.0"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/npm-registry-fetch": {
-			"version": "18.0.2",
+			"version": "13.3.1",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/redact": "^3.0.0",
-				"jsonparse": "^1.3.1",
-				"make-fetch-happen": "^14.0.0",
-				"minipass": "^7.0.2",
-				"minipass-fetch": "^4.0.0",
-				"minizlib": "^3.0.1",
-				"npm-package-arg": "^12.0.0",
-				"proc-log": "^5.0.0"
+				"make-fetch-happen": "^10.0.6",
+				"minipass": "^3.1.6",
+				"minipass-fetch": "^2.0.3",
+				"minipass-json-stream": "^1.0.1",
+				"minizlib": "^2.1.2",
+				"npm-package-arg": "^9.0.1",
+				"proc-log": "^2.0.0"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/npm-user-validate": {
-			"version": "3.0.0",
+			"version": "1.0.1",
 			"dev": true,
 			"inBundle": true,
-			"license": "BSD-2-Clause",
+			"license": "BSD-2-Clause"
+		},
+		"node_modules/npm/node_modules/npmlog": {
+			"version": "6.0.2",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"are-we-there-yet": "^3.0.0",
+				"console-control-strings": "^1.1.0",
+				"gauge": "^4.0.3",
+				"set-blocking": "^2.0.0"
+			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/once": {
+			"version": "1.4.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"wrappy": "1"
+			}
+		},
+		"node_modules/npm/node_modules/opener": {
+			"version": "1.5.2",
+			"dev": true,
+			"inBundle": true,
+			"license": "(WTFPL OR MIT)",
+			"bin": {
+				"opener": "bin/opener-bin.js"
 			}
 		},
 		"node_modules/npm/node_modules/p-map": {
-			"version": "7.0.3",
+			"version": "4.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
+			"dependencies": {
+				"aggregate-error": "^3.0.0"
+			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=10"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/npm/node_modules/package-json-from-dist": {
-			"version": "1.0.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "BlueOak-1.0.0"
-		},
 		"node_modules/npm/node_modules/pacote": {
-			"version": "19.0.1",
+			"version": "13.6.2",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/git": "^6.0.0",
-				"@npmcli/installed-package-contents": "^3.0.0",
-				"@npmcli/package-json": "^6.0.0",
-				"@npmcli/promise-spawn": "^8.0.0",
-				"@npmcli/run-script": "^9.0.0",
-				"cacache": "^19.0.0",
-				"fs-minipass": "^3.0.0",
-				"minipass": "^7.0.2",
-				"npm-package-arg": "^12.0.0",
-				"npm-packlist": "^9.0.0",
-				"npm-pick-manifest": "^10.0.0",
-				"npm-registry-fetch": "^18.0.0",
-				"proc-log": "^5.0.0",
+				"@npmcli/git": "^3.0.0",
+				"@npmcli/installed-package-contents": "^1.0.7",
+				"@npmcli/promise-spawn": "^3.0.0",
+				"@npmcli/run-script": "^4.1.0",
+				"cacache": "^16.0.0",
+				"chownr": "^2.0.0",
+				"fs-minipass": "^2.1.0",
+				"infer-owner": "^1.0.4",
+				"minipass": "^3.1.6",
+				"mkdirp": "^1.0.4",
+				"npm-package-arg": "^9.0.0",
+				"npm-packlist": "^5.1.0",
+				"npm-pick-manifest": "^7.0.0",
+				"npm-registry-fetch": "^13.0.1",
+				"proc-log": "^2.0.0",
 				"promise-retry": "^2.0.1",
-				"sigstore": "^3.0.0",
-				"ssri": "^12.0.0",
+				"read-package-json": "^5.0.0",
+				"read-package-json-fast": "^2.0.3",
+				"rimraf": "^3.0.2",
+				"ssri": "^9.0.0",
 				"tar": "^6.1.11"
 			},
 			"bin": {
-				"pacote": "bin/index.js"
+				"pacote": "lib/bin.js"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/parse-conflict-json": {
-			"version": "4.0.0",
+			"version": "2.0.2",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"json-parse-even-better-errors": "^4.0.0",
-				"just-diff": "^6.0.0",
+				"json-parse-even-better-errors": "^2.3.1",
+				"just-diff": "^5.0.1",
 				"just-diff-apply": "^5.2.0"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
-		"node_modules/npm/node_modules/path-key": {
-			"version": "3.1.1",
+		"node_modules/npm/node_modules/path-is-absolute": {
+			"version": "1.0.1",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/npm/node_modules/path-scurry": {
-			"version": "1.11.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "BlueOak-1.0.0",
-			"dependencies": {
-				"lru-cache": "^10.2.0",
-				"minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
-			},
-			"engines": {
-				"node": ">=16 || 14 >=14.18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/npm/node_modules/postcss-selector-parser": {
-			"version": "7.1.0",
+			"version": "6.0.10",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
@@ -21660,21 +21370,12 @@
 			}
 		},
 		"node_modules/npm/node_modules/proc-log": {
-			"version": "5.0.0",
+			"version": "2.0.1",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/npm/node_modules/proggy": {
-			"version": "3.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/promise-all-reject-late": {
@@ -21687,13 +21388,19 @@
 			}
 		},
 		"node_modules/npm/node_modules/promise-call-limit": {
-			"version": "3.0.2",
+			"version": "1.0.1",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
 			}
+		},
+		"node_modules/npm/node_modules/promise-inflight": {
+			"version": "1.0.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC"
 		},
 		"node_modules/npm/node_modules/promise-retry": {
 			"version": "2.0.1",
@@ -21709,15 +21416,12 @@
 			}
 		},
 		"node_modules/npm/node_modules/promzard": {
-			"version": "2.0.0",
+			"version": "0.3.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"read": "^4.0.0"
-			},
-			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"read": "1"
 			}
 		},
 		"node_modules/npm/node_modules/qrcode-terminal": {
@@ -21729,37 +21433,87 @@
 			}
 		},
 		"node_modules/npm/node_modules/read": {
-			"version": "4.1.0",
+			"version": "1.0.7",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"mute-stream": "^2.0.0"
+				"mute-stream": "~0.0.4"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": ">=0.8"
 			}
 		},
 		"node_modules/npm/node_modules/read-cmd-shim": {
-			"version": "5.0.0",
+			"version": "3.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
-		"node_modules/npm/node_modules/read-package-json-fast": {
-			"version": "4.0.0",
+		"node_modules/npm/node_modules/read-package-json": {
+			"version": "5.0.2",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"json-parse-even-better-errors": "^4.0.0",
-				"npm-normalize-package-bin": "^4.0.0"
+				"glob": "^8.0.1",
+				"json-parse-even-better-errors": "^2.3.1",
+				"normalize-package-data": "^4.0.0",
+				"npm-normalize-package-bin": "^2.0.0"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/read-package-json-fast": {
+			"version": "2.0.3",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"json-parse-even-better-errors": "^2.3.0",
+				"npm-normalize-package-bin": "^1.0.1"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/npm/node_modules/read-package-json/node_modules/npm-normalize-package-bin": {
+			"version": "2.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/readable-stream": {
+			"version": "3.6.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"inherits": "^2.0.3",
+				"string_decoder": "^1.1.1",
+				"util-deprecate": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/npm/node_modules/readdir-scoped-modules": {
+			"version": "1.1.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"debuglog": "^1.0.1",
+				"dezalgo": "^1.0.0",
+				"graceful-fs": "^4.1.2",
+				"once": "^1.3.0"
 			}
 		},
 		"node_modules/npm/node_modules/retry": {
@@ -21771,6 +21525,83 @@
 				"node": ">= 4"
 			}
 		},
+		"node_modules/npm/node_modules/rimraf": {
+			"version": "3.0.2",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"glob": "^7.1.3"
+			},
+			"bin": {
+				"rimraf": "bin.js"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/npm/node_modules/rimraf/node_modules/brace-expansion": {
+			"version": "1.1.11",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"node_modules/npm/node_modules/rimraf/node_modules/glob": {
+			"version": "7.2.3",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.1.1",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
+			},
+			"engines": {
+				"node": "*"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/npm/node_modules/rimraf/node_modules/minimatch": {
+			"version": "3.1.2",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/npm/node_modules/safe-buffer": {
+			"version": "5.2.1",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"inBundle": true,
+			"license": "MIT"
+		},
 		"node_modules/npm/node_modules/safer-buffer": {
 			"version": "2.1.2",
 			"dev": true,
@@ -21779,10 +21610,13 @@
 			"optional": true
 		},
 		"node_modules/npm/node_modules/semver": {
-			"version": "7.7.2",
+			"version": "7.3.7",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
+			"dependencies": {
+				"lru-cache": "^6.0.0"
+			},
 			"bin": {
 				"semver": "bin/semver.js"
 			},
@@ -21790,107 +21624,29 @@
 				"node": ">=10"
 			}
 		},
-		"node_modules/npm/node_modules/shebang-command": {
-			"version": "2.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"shebang-regex": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/npm/node_modules/shebang-regex": {
-			"version": "3.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/npm/node_modules/signal-exit": {
-			"version": "4.1.0",
+		"node_modules/npm/node_modules/semver/node_modules/lru-cache": {
+			"version": "6.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
-			"engines": {
-				"node": ">=14"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/npm/node_modules/sigstore": {
-			"version": "3.1.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "Apache-2.0",
 			"dependencies": {
-				"@sigstore/bundle": "^3.1.0",
-				"@sigstore/core": "^2.0.0",
-				"@sigstore/protobuf-specs": "^0.4.0",
-				"@sigstore/sign": "^3.1.0",
-				"@sigstore/tuf": "^3.1.0",
-				"@sigstore/verify": "^2.1.0"
+				"yallist": "^4.0.0"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": ">=10"
 			}
 		},
-		"node_modules/npm/node_modules/sigstore/node_modules/@sigstore/bundle": {
-			"version": "3.1.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@sigstore/protobuf-specs": "^0.4.0"
-			},
-			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/npm/node_modules/sigstore/node_modules/@sigstore/core": {
+		"node_modules/npm/node_modules/set-blocking": {
 			"version": "2.0.0",
 			"dev": true,
 			"inBundle": true,
-			"license": "Apache-2.0",
-			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
+			"license": "ISC"
 		},
-		"node_modules/npm/node_modules/sigstore/node_modules/@sigstore/sign": {
-			"version": "3.1.0",
+		"node_modules/npm/node_modules/signal-exit": {
+			"version": "3.0.7",
 			"dev": true,
 			"inBundle": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@sigstore/bundle": "^3.1.0",
-				"@sigstore/core": "^2.0.0",
-				"@sigstore/protobuf-specs": "^0.4.0",
-				"make-fetch-happen": "^14.0.2",
-				"proc-log": "^5.0.0",
-				"promise-retry": "^2.0.1"
-			},
-			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/npm/node_modules/sigstore/node_modules/@sigstore/verify": {
-			"version": "2.1.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@sigstore/bundle": "^3.1.0",
-				"@sigstore/core": "^2.0.0",
-				"@sigstore/protobuf-specs": "^0.4.1"
-			},
-			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
+			"license": "ISC"
 		},
 		"node_modules/npm/node_modules/smart-buffer": {
 			"version": "4.2.0",
@@ -21903,35 +21659,35 @@
 			}
 		},
 		"node_modules/npm/node_modules/socks": {
-			"version": "2.8.5",
+			"version": "2.7.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
-				"ip-address": "^9.0.5",
+				"ip": "^2.0.0",
 				"smart-buffer": "^4.2.0"
 			},
 			"engines": {
-				"node": ">= 10.0.0",
+				"node": ">= 10.13.0",
 				"npm": ">= 3.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/socks-proxy-agent": {
-			"version": "8.0.5",
+			"version": "7.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
-				"agent-base": "^7.1.2",
-				"debug": "^4.3.4",
-				"socks": "^2.8.3"
+				"agent-base": "^6.0.2",
+				"debug": "^4.3.3",
+				"socks": "^2.6.2"
 			},
 			"engines": {
-				"node": ">= 14"
+				"node": ">= 10"
 			}
 		},
 		"node_modules/npm/node_modules/spdx-correct": {
-			"version": "3.2.0",
+			"version": "3.1.1",
 			"dev": true,
 			"inBundle": true,
 			"license": "Apache-2.0",
@@ -21940,7 +21696,13 @@
 				"spdx-license-ids": "^3.0.0"
 			}
 		},
-		"node_modules/npm/node_modules/spdx-correct/node_modules/spdx-expression-parse": {
+		"node_modules/npm/node_modules/spdx-exceptions": {
+			"version": "2.3.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "CC-BY-3.0"
+		},
+		"node_modules/npm/node_modules/spdx-expression-parse": {
 			"version": "3.0.1",
 			"dev": true,
 			"inBundle": true,
@@ -21950,62 +21712,34 @@
 				"spdx-license-ids": "^3.0.0"
 			}
 		},
-		"node_modules/npm/node_modules/spdx-exceptions": {
-			"version": "2.5.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "CC-BY-3.0"
-		},
-		"node_modules/npm/node_modules/spdx-expression-parse": {
-			"version": "4.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"spdx-exceptions": "^2.1.0",
-				"spdx-license-ids": "^3.0.0"
-			}
-		},
 		"node_modules/npm/node_modules/spdx-license-ids": {
-			"version": "3.0.21",
+			"version": "3.0.11",
 			"dev": true,
 			"inBundle": true,
 			"license": "CC0-1.0"
 		},
-		"node_modules/npm/node_modules/sprintf-js": {
-			"version": "1.1.3",
-			"dev": true,
-			"inBundle": true,
-			"license": "BSD-3-Clause"
-		},
 		"node_modules/npm/node_modules/ssri": {
-			"version": "12.0.0",
+			"version": "9.0.1",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"minipass": "^7.0.3"
+				"minipass": "^3.1.1"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
-		"node_modules/npm/node_modules/string-width": {
-			"version": "4.2.3",
+		"node_modules/npm/node_modules/string_decoder": {
+			"version": "1.3.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
-				"emoji-regex": "^8.0.0",
-				"is-fullwidth-code-point": "^3.0.0",
-				"strip-ansi": "^6.0.1"
-			},
-			"engines": {
-				"node": ">=8"
+				"safe-buffer": "~5.2.0"
 			}
 		},
-		"node_modules/npm/node_modules/string-width-cjs": {
-			"name": "string-width",
+		"node_modules/npm/node_modules/string-width": {
 			"version": "4.2.3",
 			"dev": true,
 			"inBundle": true,
@@ -22031,104 +21765,33 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/npm/node_modules/strip-ansi-cjs": {
-			"name": "strip-ansi",
-			"version": "6.0.1",
+		"node_modules/npm/node_modules/supports-color": {
+			"version": "7.2.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
-				"ansi-regex": "^5.0.1"
+				"has-flag": "^4.0.0"
 			},
 			"engines": {
 				"node": ">=8"
 			}
 		},
-		"node_modules/npm/node_modules/supports-color": {
-			"version": "9.4.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/supports-color?sponsor=1"
-			}
-		},
 		"node_modules/npm/node_modules/tar": {
-			"version": "6.2.1",
+			"version": "6.1.11",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
 				"chownr": "^2.0.0",
 				"fs-minipass": "^2.0.0",
-				"minipass": "^5.0.0",
+				"minipass": "^3.0.0",
 				"minizlib": "^2.1.1",
 				"mkdirp": "^1.0.3",
 				"yallist": "^4.0.0"
 			},
 			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/npm/node_modules/tar/node_modules/fs-minipass": {
-			"version": "2.1.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"minipass": "^3.0.0"
-			},
-			"engines": {
-				"node": ">= 8"
-			}
-		},
-		"node_modules/npm/node_modules/tar/node_modules/fs-minipass/node_modules/minipass": {
-			"version": "3.3.6",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/npm/node_modules/tar/node_modules/minipass": {
-			"version": "5.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/npm/node_modules/tar/node_modules/minizlib": {
-			"version": "2.1.2",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"minipass": "^3.0.0",
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">= 8"
-			}
-		},
-		"node_modules/npm/node_modules/tar/node_modules/minizlib/node_modules/minipass": {
-			"version": "3.3.6",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
+				"node": ">= 10"
 			}
 		},
 		"node_modules/npm/node_modules/text-table": {
@@ -22143,98 +21806,29 @@
 			"inBundle": true,
 			"license": "MIT"
 		},
-		"node_modules/npm/node_modules/tinyglobby": {
-			"version": "0.2.14",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"fdir": "^6.4.4",
-				"picomatch": "^4.0.2"
-			},
-			"engines": {
-				"node": ">=12.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/SuperchupuDev"
-			}
-		},
-		"node_modules/npm/node_modules/tinyglobby/node_modules/fdir": {
-			"version": "6.4.6",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"peerDependencies": {
-				"picomatch": "^3 || ^4"
-			},
-			"peerDependenciesMeta": {
-				"picomatch": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/npm/node_modules/tinyglobby/node_modules/picomatch": {
-			"version": "4.0.2",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
-			}
-		},
 		"node_modules/npm/node_modules/treeverse": {
-			"version": "3.0.0",
+			"version": "2.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/npm/node_modules/tuf-js": {
-			"version": "3.0.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"@tufjs/models": "3.0.1",
-				"debug": "^4.3.6",
-				"make-fetch-happen": "^14.0.1"
-			},
-			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/npm/node_modules/tuf-js/node_modules/@tufjs/models": {
-			"version": "3.0.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"@tufjs/canonical-json": "2.0.0",
-				"minimatch": "^9.0.5"
-			},
-			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/unique-filename": {
-			"version": "4.0.0",
+			"version": "2.0.1",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"unique-slug": "^5.0.0"
+				"unique-slug": "^3.0.0"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/unique-slug": {
-			"version": "5.0.0",
+			"version": "3.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
@@ -22242,7 +21836,7 @@
 				"imurmurhash": "^0.1.4"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/util-deprecate": {
@@ -22261,166 +21855,74 @@
 				"spdx-expression-parse": "^3.0.0"
 			}
 		},
-		"node_modules/npm/node_modules/validate-npm-package-license/node_modules/spdx-expression-parse": {
-			"version": "3.0.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"spdx-exceptions": "^2.1.0",
-				"spdx-license-ids": "^3.0.0"
-			}
-		},
 		"node_modules/npm/node_modules/validate-npm-package-name": {
-			"version": "6.0.1",
+			"version": "4.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
+			"dependencies": {
+				"builtins": "^5.0.0"
+			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/walk-up-path": {
-			"version": "3.0.1",
+			"version": "1.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC"
 		},
+		"node_modules/npm/node_modules/wcwidth": {
+			"version": "1.0.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"defaults": "^1.0.3"
+			}
+		},
 		"node_modules/npm/node_modules/which": {
-			"version": "5.0.0",
+			"version": "2.0.2",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"isexe": "^3.1.1"
+				"isexe": "^2.0.0"
 			},
 			"bin": {
-				"node-which": "bin/which.js"
+				"node-which": "bin/node-which"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": ">= 8"
 			}
 		},
-		"node_modules/npm/node_modules/which/node_modules/isexe": {
-			"version": "3.1.1",
+		"node_modules/npm/node_modules/wide-align": {
+			"version": "1.1.5",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
-			"engines": {
-				"node": ">=16"
-			}
-		},
-		"node_modules/npm/node_modules/wrap-ansi": {
-			"version": "8.1.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
 			"dependencies": {
-				"ansi-styles": "^6.1.0",
-				"string-width": "^5.0.1",
-				"strip-ansi": "^7.0.1"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+				"string-width": "^1.0.2 || 2 || 3 || 4"
 			}
 		},
-		"node_modules/npm/node_modules/wrap-ansi-cjs": {
-			"name": "wrap-ansi",
-			"version": "7.0.0",
+		"node_modules/npm/node_modules/wrappy": {
+			"version": "1.0.2",
 			"dev": true,
 			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-styles": "^4.0.0",
-				"string-width": "^4.1.0",
-				"strip-ansi": "^6.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-			}
-		},
-		"node_modules/npm/node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
-			"version": "4.3.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"color-convert": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"node_modules/npm/node_modules/wrap-ansi/node_modules/ansi-regex": {
-			"version": "6.1.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
-			}
-		},
-		"node_modules/npm/node_modules/wrap-ansi/node_modules/emoji-regex": {
-			"version": "9.2.2",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT"
-		},
-		"node_modules/npm/node_modules/wrap-ansi/node_modules/string-width": {
-			"version": "5.1.2",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"eastasianwidth": "^0.2.0",
-				"emoji-regex": "^9.2.2",
-				"strip-ansi": "^7.0.1"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/npm/node_modules/wrap-ansi/node_modules/strip-ansi": {
-			"version": "7.1.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^6.0.1"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
-			}
+			"license": "ISC"
 		},
 		"node_modules/npm/node_modules/write-file-atomic": {
-			"version": "6.0.0",
+			"version": "4.0.2",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
 				"imurmurhash": "^0.1.4",
-				"signal-exit": "^4.0.1"
+				"signal-exit": "^3.0.7"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/yallist": {
@@ -22787,45 +22289,27 @@
 			}
 		},
 		"node_modules/p-each-series": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-3.0.0.tgz",
-			"integrity": "sha512-lastgtAdoH9YaLyDa5i5z64q+kzOcQHsQ5SsZJD3q0VEyI8mq872S3geuNbRUQLVAE9siMfgKrpj7MloKFHruw==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-2.2.0.tgz",
+			"integrity": "sha512-ycIL2+1V32th+8scbpTvyHNaHe02z0sjgh91XXjAk+ZeXoPN4Z46DVUnzdso0aX4KckKw0FNNFHdjZ2UsZvxiA==",
 			"dev": true,
-			"license": "MIT",
 			"engines": {
-				"node": ">=12"
+				"node": ">=8"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/p-filter": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/p-filter/-/p-filter-4.1.0.tgz",
-			"integrity": "sha512-37/tPdZ3oJwHaS3gNJdenCDB3Tz26i9sjhnguBtvN0vYlRIiDNnvTWkuh+0hETV9rLPdJ3rlL3yVOYPIAnM8rw==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/p-filter/-/p-filter-2.1.0.tgz",
+			"integrity": "sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
-				"p-map": "^7.0.1"
+				"p-map": "^2.0.0"
 			},
 			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/p-filter/node_modules/p-map": {
-			"version": "7.0.3",
-			"resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.3.tgz",
-			"integrity": "sha512-VkndIv2fIB99swvQoA65bm+fsmt6UNdGeIB0oxBs+WhAhdh08QA04JXpI7rbB9r08/nkbysKoya9rtDERYOYMA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
+				"node": ">=8"
 			}
 		},
 		"node_modules/p-is-promise": {
@@ -22833,7 +22317,6 @@
 			"resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-3.0.0.tgz",
 			"integrity": "sha512-Wo8VsW4IRQSKVXsJCn7TomUaVtyfjVDn3nUP7kE967BQk0CwFpdbZs0X0uk5sW9mkBa9eNM7hCMaG93WUAwxYQ==",
 			"dev": true,
-			"license": "MIT",
 			"engines": {
 				"node": ">=8"
 			}
@@ -23127,10 +22610,9 @@
 			"dev": true
 		},
 		"node_modules/picocolors": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
-			"integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-			"license": "ISC"
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
+			"integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew=="
 		},
 		"node_modules/picomatch": {
 			"version": "2.3.1",
@@ -24154,8 +23636,7 @@
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
 			"integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
-			"dev": true,
-			"license": "ISC"
+			"dev": true
 		},
 		"node_modules/proxy-addr": {
 			"version": "2.0.7",
@@ -24377,6 +23858,17 @@
 				}
 			]
 		},
+		"node_modules/q": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+			"integrity": "sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==",
+			"deprecated": "You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.\n\n(For a CapTP with native promises, see @endo/eventual-send and @endo/captp)",
+			"dev": true,
+			"engines": {
+				"node": ">=0.6.0",
+				"teleport": ">=0.2.0"
+			}
+		},
 		"node_modules/qs": {
 			"version": "6.14.0",
 			"resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
@@ -24492,7 +23984,6 @@
 			"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
 			"integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
 			"dev": true,
-			"license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
 			"dependencies": {
 				"deep-extend": "^0.6.0",
 				"ini": "~1.3.0",
@@ -24508,7 +23999,6 @@
 			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
 			"integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
 			"dev": true,
-			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -24962,7 +24452,6 @@
 			"resolved": "https://registry.npmjs.org/redeyed/-/redeyed-2.1.1.tgz",
 			"integrity": "sha512-FNpGGo1DycYAdnrKFxCMmKYgo/mILAqtRYbkdQD8Ep/Hk2PQ5+aEAEx+IU713RTDmuBaH0c8P5ZozurNu5ObRQ==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"esprima": "~4.0.0"
 			}
@@ -25064,11 +24553,10 @@
 			}
 		},
 		"node_modules/registry-auth-token": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-5.1.0.tgz",
-			"integrity": "sha512-GdekYuwLXLxMuFTwAPg5UKGLW/UXzQrZvH/Zj791BQif5T05T0RsaLfHc9q3ZOKi7n+BoprPD9mJ0O0k4xzUlw==",
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-5.0.2.tgz",
+			"integrity": "sha512-o/3ikDxtXaA59BmZuZrJZDJv8NMDGSj+6j6XaeBmHw8eY1i1qd9+6H+LjVvQXx3HN6aRCGa1cUdJ9RaJZUugnQ==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"@pnpm/npm-conf": "^2.1.0"
 			},
@@ -25604,47 +25092,45 @@
 			}
 		},
 		"node_modules/semantic-release": {
-			"version": "22.0.12",
-			"resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-22.0.12.tgz",
-			"integrity": "sha512-0mhiCR/4sZb00RVFJIUlMuiBkW3NMpVIW2Gse7noqEMoFGkvfPPAImEQbkBV8xga4KOPP4FdTRYuLLy32R1fPw==",
+			"version": "19.0.5",
+			"resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-19.0.5.tgz",
+			"integrity": "sha512-NMPKdfpXTnPn49FDogMBi36SiBfXkSOJqCkk0E4iWOY1tusvvgBwqUmxTX1kmlT6kIYed9YwNKD1sfPpqa5yaA==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
-				"@semantic-release/commit-analyzer": "^11.0.0",
-				"@semantic-release/error": "^4.0.0",
-				"@semantic-release/github": "^9.0.0",
-				"@semantic-release/npm": "^11.0.0",
-				"@semantic-release/release-notes-generator": "^12.0.0",
-				"aggregate-error": "^5.0.0",
-				"cosmiconfig": "^8.0.0",
+				"@semantic-release/commit-analyzer": "^9.0.2",
+				"@semantic-release/error": "^3.0.0",
+				"@semantic-release/github": "^8.0.0",
+				"@semantic-release/npm": "^9.0.0",
+				"@semantic-release/release-notes-generator": "^10.0.0",
+				"aggregate-error": "^3.0.0",
+				"cosmiconfig": "^7.0.0",
 				"debug": "^4.0.0",
-				"env-ci": "^10.0.0",
-				"execa": "^8.0.0",
-				"figures": "^6.0.0",
-				"find-versions": "^5.1.0",
+				"env-ci": "^5.0.0",
+				"execa": "^5.0.0",
+				"figures": "^3.0.0",
+				"find-versions": "^4.0.0",
 				"get-stream": "^6.0.0",
 				"git-log-parser": "^1.2.0",
-				"hook-std": "^3.0.0",
-				"hosted-git-info": "^7.0.0",
-				"import-from-esm": "^1.3.1",
-				"lodash-es": "^4.17.21",
-				"marked": "^9.0.0",
-				"marked-terminal": "^6.0.0",
+				"hook-std": "^2.0.0",
+				"hosted-git-info": "^4.0.0",
+				"lodash": "^4.17.21",
+				"marked": "^4.0.10",
+				"marked-terminal": "^5.0.0",
 				"micromatch": "^4.0.2",
-				"p-each-series": "^3.0.0",
-				"p-reduce": "^3.0.0",
-				"read-pkg-up": "^11.0.0",
+				"p-each-series": "^2.1.0",
+				"p-reduce": "^2.0.0",
+				"read-pkg-up": "^7.0.0",
 				"resolve-from": "^5.0.0",
 				"semver": "^7.3.2",
-				"semver-diff": "^4.0.0",
+				"semver-diff": "^3.1.1",
 				"signale": "^1.2.1",
-				"yargs": "^17.5.1"
+				"yargs": "^16.2.0"
 			},
 			"bin": {
 				"semantic-release": "bin/semantic-release.js"
 			},
 			"engines": {
-				"node": "^18.17 || >=20.6.1"
+				"node": ">=16 || ^14.17"
 			}
 		},
 		"node_modules/semantic-release-version-bump": {
@@ -25656,103 +25142,44 @@
 				"glob": "^7.1.6"
 			}
 		},
-		"node_modules/semantic-release/node_modules/@semantic-release/error": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-4.0.0.tgz",
-			"integrity": "sha512-mgdxrHTLOjOddRVYIYDo0fR3/v61GNN1YGkfbrjuIKg/uMgCd+Qzo3UAXJ+woLQQpos4pl5Esuw5A7AoNlzjUQ==",
+		"node_modules/semantic-release/node_modules/cliui": {
+			"version": "7.0.4",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+			"integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
 			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/semantic-release/node_modules/aggregate-error": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-5.0.0.tgz",
-			"integrity": "sha512-gOsf2YwSlleG6IjRYG2A7k0HmBMEo6qVNk9Bp/EaLgAJT5ngH6PXbqa4ItvnEwCm/velL5jAnQgsHsWnjhGmvw==",
-			"dev": true,
-			"license": "MIT",
 			"dependencies": {
-				"clean-stack": "^5.2.0",
-				"indent-string": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
+				"string-width": "^4.2.0",
+				"strip-ansi": "^6.0.0",
+				"wrap-ansi": "^7.0.0"
 			}
 		},
-		"node_modules/semantic-release/node_modules/clean-stack": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-5.3.0.tgz",
-			"integrity": "sha512-9ngPTOhYGQqNVSfeJkYXHmF7AGWp4/nN5D/QqNQs3Dvxd1Kk/WpjHfNujKHYUQ/5CoGyOyFNoWSPk5afzP0QVg==",
+		"node_modules/semantic-release/node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"dev": true
+		},
+		"node_modules/semantic-release/node_modules/execa": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+			"integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
-				"escape-string-regexp": "5.0.0"
+				"cross-spawn": "^7.0.3",
+				"get-stream": "^6.0.0",
+				"human-signals": "^2.1.0",
+				"is-stream": "^2.0.0",
+				"merge-stream": "^2.0.0",
+				"npm-run-path": "^4.0.1",
+				"onetime": "^5.1.2",
+				"signal-exit": "^3.0.3",
+				"strip-final-newline": "^2.0.0"
 			},
 			"engines": {
-				"node": ">=14.16"
+				"node": ">=10"
 			},
 			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/semantic-release/node_modules/cosmiconfig": {
-			"version": "8.3.6",
-			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.3.6.tgz",
-			"integrity": "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"import-fresh": "^3.3.0",
-				"js-yaml": "^4.1.0",
-				"parse-json": "^5.2.0",
-				"path-type": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=14"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/d-fischer"
-			},
-			"peerDependencies": {
-				"typescript": ">=4.9.5"
-			},
-			"peerDependenciesMeta": {
-				"typescript": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/semantic-release/node_modules/escape-string-regexp": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
-			"integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/semantic-release/node_modules/figures": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
-			"integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"is-unicode-supported": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
+				"url": "https://github.com/sindresorhus/execa?sponsor=1"
 			}
 		},
 		"node_modules/semantic-release/node_modules/get-stream": {
@@ -25760,7 +25187,6 @@
 			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
 			"integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
 			"dev": true,
-			"license": "MIT",
 			"engines": {
 				"node": ">=10"
 			},
@@ -25768,132 +25194,67 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/semantic-release/node_modules/hosted-git-info": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
-			"integrity": "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"lru-cache": "^10.0.1"
-			},
-			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
-			}
-		},
-		"node_modules/semantic-release/node_modules/indent-string": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
-			"integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/semantic-release/node_modules/is-unicode-supported": {
+		"node_modules/semantic-release/node_modules/human-signals": {
 			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
-			"integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+			"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+			"integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
 			"dev": true,
-			"license": "MIT",
 			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
+				"node": ">=10.17.0"
 			}
 		},
-		"node_modules/semantic-release/node_modules/lru-cache": {
-			"version": "10.4.3",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-			"dev": true,
-			"license": "ISC"
-		},
-		"node_modules/semantic-release/node_modules/normalize-package-data": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-6.0.2.tgz",
-			"integrity": "sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g==",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"dependencies": {
-				"hosted-git-info": "^7.0.0",
-				"semver": "^7.3.5",
-				"validate-npm-package-license": "^3.0.4"
-			},
-			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
-			}
-		},
-		"node_modules/semantic-release/node_modules/p-reduce": {
+		"node_modules/semantic-release/node_modules/is-fullwidth-code-point": {
 			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-3.0.0.tgz",
-			"integrity": "sha512-xsrIUgI0Kn6iyDYm9StOpOeK29XM1aboGji26+QEortiFST1hGZaUQOLhtEbqHErPpGW/aSz6allwK2qcptp0Q==",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
 			"dev": true,
-			"license": "MIT",
 			"engines": {
-				"node": ">=12"
+				"node": ">=8"
+			}
+		},
+		"node_modules/semantic-release/node_modules/is-stream": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+			"integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/semantic-release/node_modules/read-pkg": {
-			"version": "9.0.1",
-			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-9.0.1.tgz",
-			"integrity": "sha512-9viLL4/n1BJUCT1NXVTdS1jtm80yDEgR5T4yCelII49Mbj0v1rZdKqj7zCiYdbB0CuCgdrvHcNogAKTFPBocFA==",
+		"node_modules/semantic-release/node_modules/mimic-fn": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+			"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
 			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/normalize-package-data": "^2.4.3",
-				"normalize-package-data": "^6.0.0",
-				"parse-json": "^8.0.0",
-				"type-fest": "^4.6.0",
-				"unicorn-magic": "^0.1.0"
-			},
 			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
+				"node": ">=6"
 			}
 		},
-		"node_modules/semantic-release/node_modules/read-pkg-up": {
-			"version": "11.0.0",
-			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-11.0.0.tgz",
-			"integrity": "sha512-LOVbvF1Q0SZdjClSefZ0Nz5z8u+tIE7mV5NibzmE9VYmDe9CaBbAVtz1veOSZbofrdsilxuDAYnFenukZVp8/Q==",
-			"deprecated": "Renamed to read-package-up",
+		"node_modules/semantic-release/node_modules/npm-run-path": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+			"integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
-				"find-up-simple": "^1.0.0",
-				"read-pkg": "^9.0.0",
-				"type-fest": "^4.6.0"
+				"path-key": "^3.0.0"
 			},
 			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
+				"node": ">=8"
 			}
 		},
-		"node_modules/semantic-release/node_modules/read-pkg/node_modules/parse-json": {
-			"version": "8.3.0",
-			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-8.3.0.tgz",
-			"integrity": "sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==",
+		"node_modules/semantic-release/node_modules/onetime": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+			"integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
-				"@babel/code-frame": "^7.26.2",
-				"index-to-position": "^1.1.0",
-				"type-fest": "^4.39.1"
+				"mimic-fn": "^2.1.0"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=6"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -25908,30 +25269,77 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/semantic-release/node_modules/type-fest": {
-			"version": "4.41.0",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
-			"integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+		"node_modules/semantic-release/node_modules/signal-exit": {
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+			"dev": true
+		},
+		"node_modules/semantic-release/node_modules/string-width": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
 			"dev": true,
-			"license": "(MIT OR CC0-1.0)",
-			"engines": {
-				"node": ">=16"
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
 			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
+			"engines": {
+				"node": ">=8"
 			}
 		},
-		"node_modules/semantic-release/node_modules/unicorn-magic": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.1.0.tgz",
-			"integrity": "sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==",
+		"node_modules/semantic-release/node_modules/strip-final-newline": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+			"integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
 			"dev": true,
-			"license": "MIT",
 			"engines": {
-				"node": ">=18"
+				"node": ">=6"
+			}
+		},
+		"node_modules/semantic-release/node_modules/wrap-ansi": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+			"dev": true,
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=10"
 			},
 			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
+		"node_modules/semantic-release/node_modules/yargs": {
+			"version": "16.2.0",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+			"integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+			"dev": true,
+			"dependencies": {
+				"cliui": "^7.0.2",
+				"escalade": "^3.1.1",
+				"get-caller-file": "^2.0.5",
+				"require-directory": "^2.1.1",
+				"string-width": "^4.2.0",
+				"y18n": "^5.0.5",
+				"yargs-parser": "^20.2.2"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/semantic-release/node_modules/yargs-parser": {
+			"version": "20.2.9",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+			"integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/semver": {
@@ -25950,29 +25358,33 @@
 			}
 		},
 		"node_modules/semver-diff": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-4.0.0.tgz",
-			"integrity": "sha512-0Ju4+6A8iOnpL/Thra7dZsSlOHYAHIeMxfhWQRI1/VLcT3WDBZKKtQt/QkBOsiIN9ZpuvHE6cGZ0x4glCMmfiA==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-3.1.1.tgz",
+			"integrity": "sha512-GX0Ix/CJcHyB8c4ykpHGIAvLyOwOobtM/8d+TQkAd81/bEjgPHrfba41Vpesr7jX/t8Uh+R3EX9eAS5be+jQYg==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
-				"semver": "^7.3.5"
+				"semver": "^6.3.0"
 			},
 			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
+				"node": ">=8"
+			}
+		},
+		"node_modules/semver-diff/node_modules/semver": {
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+			"dev": true,
+			"bin": {
+				"semver": "bin/semver.js"
 			}
 		},
 		"node_modules/semver-regex": {
-			"version": "4.0.5",
-			"resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-4.0.5.tgz",
-			"integrity": "sha512-hunMQrEy1T6Jr2uEVjrAIqjwWcQTgOAcIM52C8MY1EZSD3DDNft04XzvYKPqjED65bNVVko0YI38nYeEHCX3yw==",
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-3.1.4.tgz",
+			"integrity": "sha512-6IiqeZNgq01qGf0TId0t3NvKzSvUsjcpdEO3AQNeIjR6A2+ckTnQlDpl4qu1bjRv0RzN3FP9hzFmws3lKqRWkA==",
 			"dev": true,
-			"license": "MIT",
 			"engines": {
-				"node": ">=12"
+				"node": ">=8"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -26754,19 +26166,6 @@
 			"integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
 			"dev": true
 		},
-		"node_modules/skin-tone": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/skin-tone/-/skin-tone-2.0.0.tgz",
-			"integrity": "sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"unicode-emoji-modifier-base": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/slash": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -27034,6 +26433,18 @@
 			},
 			"engines": {
 				"node": ">=8.0"
+			}
+		},
+		"node_modules/split": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+			"integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+			"dev": true,
+			"dependencies": {
+				"through": "2"
+			},
+			"engines": {
+				"node": "*"
 			}
 		},
 		"node_modules/split2": {
@@ -27863,56 +27274,75 @@
 			}
 		},
 		"node_modules/temp-dir": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-3.0.0.tgz",
-			"integrity": "sha512-nHc6S/bwIilKHNRgK/3jlhDoIHcp45YgyiwcAk46Tr0LfEqGBVpmiAyuiuxeVE44m3mXnEeVhaipLOEWmH+Njw==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-2.0.0.tgz",
+			"integrity": "sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==",
 			"dev": true,
-			"license": "MIT",
 			"engines": {
-				"node": ">=14.16"
+				"node": ">=8"
 			}
 		},
 		"node_modules/tempy": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/tempy/-/tempy-3.1.0.tgz",
-			"integrity": "sha512-7jDLIdD2Zp0bDe5r3D2qtkd1QOCacylBuL7oa4udvN6v2pqr4+LcCr67C8DR1zkpaZ8XosF5m1yQSabKAW6f2g==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/tempy/-/tempy-1.0.1.tgz",
+			"integrity": "sha512-biM9brNqxSc04Ee71hzFbryD11nX7VPhQQY32AdDmjFvodsRFz/3ufeoTZ6uYkRFfGo188tENcASNs3vTdsM0w==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
-				"is-stream": "^3.0.0",
-				"temp-dir": "^3.0.0",
-				"type-fest": "^2.12.2",
-				"unique-string": "^3.0.0"
+				"del": "^6.0.0",
+				"is-stream": "^2.0.0",
+				"temp-dir": "^2.0.0",
+				"type-fest": "^0.16.0",
+				"unique-string": "^2.0.0"
 			},
 			"engines": {
-				"node": ">=14.16"
+				"node": ">=10"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/tempy/node_modules/crypto-random-string": {
+		"node_modules/tempy/node_modules/del": {
+			"version": "6.1.1",
+			"resolved": "https://registry.npmjs.org/del/-/del-6.1.1.tgz",
+			"integrity": "sha512-ua8BhapfP0JUJKC/zV9yHHDW/rDoDxP4Zhn3AkA6/xT6gY7jYXJiaeyBZznYVujhZZET+UgcbZiQ7sN3WqcImg==",
+			"dev": true,
+			"dependencies": {
+				"globby": "^11.0.1",
+				"graceful-fs": "^4.2.4",
+				"is-glob": "^4.0.1",
+				"is-path-cwd": "^2.2.0",
+				"is-path-inside": "^3.0.2",
+				"p-map": "^4.0.0",
+				"rimraf": "^3.0.2",
+				"slash": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/tempy/node_modules/is-stream": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+			"integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/tempy/node_modules/p-map": {
 			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-4.0.0.tgz",
-			"integrity": "sha512-x8dy3RnvYdlUcPOjkEHqozhiwzKNSq7GcPuXFbnyMOCHxX8V3OgIg/pYuabl2sbUPfIJaeAQB7PMOK8DFIdoRA==",
+			"resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+			"integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
-				"type-fest": "^1.0.1"
+				"aggregate-error": "^3.0.0"
 			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/tempy/node_modules/crypto-random-string/node_modules/type-fest": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
-			"integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
-			"dev": true,
-			"license": "(MIT OR CC0-1.0)",
 			"engines": {
 				"node": ">=10"
 			},
@@ -27921,29 +27351,12 @@
 			}
 		},
 		"node_modules/tempy/node_modules/type-fest": {
-			"version": "2.19.0",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-			"integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+			"version": "0.16.0",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.16.0.tgz",
+			"integrity": "sha512-eaBzG6MxNzEn9kiwvtre90cXaNLkmadMWa1zQMs3XORCXNbsH/OewwbxC5ia9dCxIxnTAsSxXJaa/p5y8DlvJg==",
 			"dev": true,
-			"license": "(MIT OR CC0-1.0)",
 			"engines": {
-				"node": ">=12.20"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/tempy/node_modules/unique-string": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/unique-string/-/unique-string-3.0.0.tgz",
-			"integrity": "sha512-VGXBUVwxKMBUznyffQweQABPRRW1vHZAbadFZud4pLFAqRGvv/96vafgjWFqzourzr8YonlQiPgH0YCJfawoGQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"crypto-random-string": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=12"
+				"node": ">=10"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -28619,11 +28032,10 @@
 			"dev": true
 		},
 		"node_modules/uglify-js": {
-			"version": "3.19.3",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
-			"integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
+			"version": "3.18.0",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.18.0.tgz",
+			"integrity": "sha512-SyVVbcNBCk0dzr9XL/R/ySrmYf0s372K6/hFklzgcp2lBFyXtw4I7BOdDjlLhE1aVqaI/SHWXWmYdlZxuyF38A==",
 			"dev": true,
-			"license": "BSD-2-Clause",
 			"optional": true,
 			"bin": {
 				"uglifyjs": "bin/uglifyjs"
@@ -28666,16 +28078,6 @@
 				"node": ">=4"
 			}
 		},
-		"node_modules/unicode-emoji-modifier-base": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/unicode-emoji-modifier-base/-/unicode-emoji-modifier-base-1.0.0.tgz",
-			"integrity": "sha512-yLSH4py7oFH3oG/9K+XWrz1pSi3dfUrWEnInbxMfArOfc1+33BlGPQtLsOYwvdMy11AwUBetYuaRxSPqgkq+8g==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=4"
-			}
-		},
 		"node_modules/unicode-match-property-ecmascript": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-2.0.0.tgz",
@@ -28707,19 +28109,6 @@
 				"node": ">=4"
 			}
 		},
-		"node_modules/unicorn-magic": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
-			"integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/unique-string": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
@@ -28736,8 +28125,7 @@
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.1.tgz",
 			"integrity": "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ==",
-			"dev": true,
-			"license": "ISC"
+			"dev": true
 		},
 		"node_modules/universalify": {
 			"version": "2.0.1",
@@ -28813,14 +28201,10 @@
 			}
 		},
 		"node_modules/url-join": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/url-join/-/url-join-5.0.0.tgz",
-			"integrity": "sha512-n2huDr9h9yzd6exQVnH/jU5mr+Pfx08LRXXZhkLLetAMESRj+anQsTAh940iMrIetKAmry9coFuZQ2jY8/p3WA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-			}
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
+			"integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
+			"dev": true
 		},
 		"node_modules/url-loader": {
 			"version": "4.1.1",
@@ -29720,8 +29104,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
 			"integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
-			"dev": true,
-			"license": "MIT"
+			"dev": true
 		},
 		"node_modules/wrap-ansi": {
 			"version": "9.0.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
 		"@wordpress/browserslist-config": "^6.33.0",
 		"eslint": "^8.57.0",
 		"lint-staged": "^15.5.1",
-		"newspack-scripts": "^5.7.0",
+		"newspack-scripts": "^5.5.2",
 		"postcss-scss": "^4.0.9"
 	}
 }

--- a/src/blocks/custom-placement/edit.js
+++ b/src/blocks/custom-placement/edit.js
@@ -8,102 +8,111 @@ import { Fragment, useEffect, useState } from '@wordpress/element';
 import { addQueryArgs } from '@wordpress/url';
 import { megaphone } from '@wordpress/icons';
 
-export const CustomPlacementEditor = ({ attributes, setAttributes }) => {
-	const [loading, setLoading] = useState(false);
-	const [prompts, setPrompts] = useState(null);
-	const [error, setError] = useState(null);
+export const CustomPlacementEditor = ( { attributes, setAttributes } ) => {
+	const [ loading, setLoading ] = useState( false );
+	const [ prompts, setPrompts ] = useState( null );
+	const [ error, setError ] = useState( null );
 	const { customPlacement } = attributes;
 	const customPlacements = window.newspack_popups_blocks_data?.custom_placements || {};
 	const customPlacementOptions = [
 		{
-			label: __('Choose a custom placement', 'newspack-popups'),
+			label: __( 'Choose a custom placement', 'newspack-popups' ),
 			value: '',
 			disabled: true,
 		},
 	].concat(
-		Object.keys(customPlacements).map(key => ({
+		Object.keys( customPlacements ).map( key => ( {
 			value: key,
-			label: customPlacements[key],
-		}))
+			label: customPlacements[ key ],
+		} ) )
 	);
 
 	const getPrompts = async () => {
-		setError(null);
-		setLoading(true);
+		setError( null );
+		setLoading( true );
 
 		try {
-			const response = await apiFetch({
-				path: addQueryArgs('/newspack-popups/v1/custom-placement/', {
+			const response = await apiFetch( {
+				path: addQueryArgs( '/newspack-popups/v1/custom-placement/', {
 					custom_placement: customPlacement,
-				}),
+				} ),
 				method: 'GET',
-			});
+			} );
 
-			setPrompts(response);
-			setLoading(false);
-		} catch (e) {
-			setError(e.message || __('There was an error fetching prompts for this custom placement.', 'newspack-popups'));
-			setLoading(false);
+			setPrompts( response );
+			setLoading( false );
+		} catch ( e ) {
+			setError(
+				e.message ||
+					__( 'There was an error fetching prompts for this custom placement.', 'newspack-popups' )
+			);
+			setLoading( false );
 		}
 	};
 
-	useEffect(() => {
-		if (customPlacement) {
+	useEffect( () => {
+		if ( customPlacement ) {
 			getPrompts();
 		}
-	}, [customPlacement]);
+	}, [ customPlacement ] );
 
 	const segments = {};
 
-	if (prompts) {
-		prompts.forEach(prompt => {
+	if ( prompts ) {
+		prompts.forEach( prompt => {
 			const assignedSegments = prompt.segments || [];
 
-			assignedSegments.forEach(segment => {
+			assignedSegments.forEach( segment => {
 				const segmentName = segment?.name || 'Everyone else';
 
-				if (!segments[segmentName]) {
-					segments[segmentName] = {
+				if ( ! segments[ segmentName ] ) {
+					segments[ segmentName ] = {
 						id: segment.id || null,
 						prompts: [],
 					};
 				}
 
-				segments[segmentName].prompts.push({ id: prompt.id, title: prompt.title });
-			});
-		});
+				segments[ segmentName ].prompts.push( { id: prompt.id, title: prompt.title } );
+			} );
+		} );
 	}
 
 	return (
-		<Placeholder className="newspack-popups__custom-placement-placeholder" label={__('Custom Placement', 'newspack-popups')} icon={megaphone}>
+		<Placeholder
+			className="newspack-popups__custom-placement-placeholder"
+			label={ __( 'Custom Placement', 'newspack-popups' ) }
+			icon={ megaphone }
+		>
 			<SelectControl
 				id="newspack-popups__custom-placement-select"
-				onChange={_customPlacement => setAttributes({ customPlacement: _customPlacement })}
-				value={-1 < Object.keys(customPlacements).indexOf(customPlacement) ? customPlacement : ''}
-				options={customPlacementOptions}
+				onChange={ _customPlacement => setAttributes( { customPlacement: _customPlacement } ) }
+				value={
+					-1 < Object.keys( customPlacements ).indexOf( customPlacement ) ? customPlacement : ''
+				}
+				options={ customPlacementOptions }
 			/>
 
-			{loading && <Spinner />}
+			{ loading && <Spinner /> }
 
-			{error && (
+			{ error && (
 				<div className="newspack-popups__custom-placement-prompts">
-					<Notice status="error" isDismissible={false}>
-						{error}
+					<Notice status="error" isDismissible={ false }>
+						{ error }
 					</Notice>
 				</div>
-			)}
+			) }
 
-			{!loading && !error && Array.isArray(prompts) && (
+			{ ! loading && ! error && Array.isArray( prompts ) && (
 				<div className="newspack-popups__custom-placement-prompts">
-					{0 === prompts.length && (
-						<Notice status="warning" isDismissible={false}>
-							{__('No active prompts found for this custom placement.', 'newspack-popups')}
+					{ 0 === prompts.length && (
+						<Notice status="warning" isDismissible={ false }>
+							{ __( 'No active prompts found for this custom placement.', 'newspack-popups' ) }
 						</Notice>
-					)}
-					{0 < prompts.length && (
+					) }
+					{ 0 < prompts.length && (
 						<>
 							<p>
-								{sprintf(
+								{ sprintf(
 									// Translators: Max. number of popups displayed; plural modifier.
 									__(
 										'This custom placement will display at most %1$sthe following active prompt%2$s, depending on the reader’s top-priority segment:',
@@ -111,47 +120,51 @@ export const CustomPlacementEditor = ({ attributes, setAttributes }) => {
 									),
 									1 < prompts.length ? 'one of ' : '',
 									1 < prompts.length ? 's' : ''
-								)}
+								) }
 							</p>
-							{Object.keys(segments).map(segmentName => {
-								const segmentId = segments[segmentName].id;
+							{ Object.keys( segments ).map( segmentName => {
+								const segmentId = segments[ segmentName ].id;
 								return (
-									<Fragment key={segmentId}>
+									<Fragment key={ segmentId }>
 										<strong>
-											{segmentId ? (
-												<ExternalLink href={`/wp-admin/admin.php?page=newspack-audience-campaigns#/campaigns/${segmentId}`}>
-													{sprintf(
+											{ segmentId ? (
+												<ExternalLink
+													href={ `/wp-admin/admin.php?page=newspack-audience-campaigns#/campaigns/${ segmentId }` }
+												>
+													{ sprintf(
 														// Translators: Segment name.
-														__('Segment: %s', 'newspack-popups'),
+														__( 'Segment: %s', 'newspack-popups' ),
 														segmentName
-													)}
+													) }
 												</ExternalLink>
 											) : (
 												[
-													'Everyone' !== segmentName ? __('Segment: ', 'newspack-popups') : '',
+													'Everyone' !== segmentName ? __( 'Segment: ', 'newspack-popups' ) : '',
 													segmentName || '',
-													'Everyone' === segmentName && 1 < Object.keys(segments).length
-														? __(' else', 'newspack-popups')
+													'Everyone' === segmentName && 1 < Object.keys( segments ).length
+														? __( ' else', 'newspack-popups' )
 														: '',
 												]
-											)}
+											) }
 										</strong>
 										<ul>
-											{segments[segmentName].prompts.map(prompt => (
-												<li key={prompt.id}>
-													<ExternalLink href={`/wp-admin/post.php?post=${prompt.id}&action=edit`}>
-														{prompt.title}
+											{ segments[ segmentName ].prompts.map( prompt => (
+												<li key={ prompt.id }>
+													<ExternalLink
+														href={ `/wp-admin/post.php?post=${ prompt.id }&action=edit` }
+													>
+														{ prompt.title }
 													</ExternalLink>
 												</li>
-											))}
+											) ) }
 										</ul>
 									</Fragment>
 								);
-							})}
+							} ) }
 						</>
-					)}
+					) }
 				</div>
-			)}
+			) }
 		</Placeholder>
 	);
 };

--- a/src/blocks/custom-placement/index.js
+++ b/src/blocks/custom-placement/index.js
@@ -14,32 +14,32 @@ const { attributes, category, name } = metadata;
 import { CustomPlacementEditor } from './edit';
 
 export const registerCustomPlacementBlock = () => {
-	const isPrompt = Boolean(window.newspack_popups_blocks_data?.is_prompt);
+	const isPrompt = Boolean( window.newspack_popups_blocks_data?.is_prompt );
 
 	// No prompts inside prompts.
-	if (isPrompt) {
+	if ( isPrompt ) {
 		return null;
 	}
 
-	registerBlockType(name, {
-		title: __('Campaigns: Custom Placement', 'newspack-listing'),
+	registerBlockType( name, {
+		title: __( 'Campaigns: Custom Placement', 'newspack-listing' ),
 		icon: {
-			src: <Icon icon={megaphone} />,
+			src: <Icon icon={ megaphone } />,
 			foreground: '#406ebc',
 		},
 		category,
 		keywords: [
-			__('newspack', 'newspack-popups'),
-			__('campaigns', 'newspack-popups'),
-			__('campaign', 'newspack-popups'),
-			__('prompt', 'newspack-popups'),
-			__('custom', 'newspack-popups'),
-			__('placement', 'newspack-popups'),
+			__( 'newspack', 'newspack-popups' ),
+			__( 'campaigns', 'newspack-popups' ),
+			__( 'campaign', 'newspack-popups' ),
+			__( 'prompt', 'newspack-popups' ),
+			__( 'custom', 'newspack-popups' ),
+			__( 'placement', 'newspack-popups' ),
 		],
 
 		attributes,
 
 		edit: CustomPlacementEditor,
 		save: () => null, // uses view.php
-	});
+	} );
 };

--- a/src/blocks/single-prompt/edit.js
+++ b/src/blocks/single-prompt/edit.js
@@ -14,140 +14,155 @@ import { megaphone } from '@wordpress/icons';
  */
 import { AutocompleteWithSuggestions } from 'newspack-components';
 
-export const SinglePromptEditor = ({ attributes, setAttributes }) => {
-	const [loading, setLoading] = useState(false);
-	const [prompt, setPrompt] = useState(null);
-	const [error, setError] = useState(null);
+export const SinglePromptEditor = ( { attributes, setAttributes } ) => {
+	const [ loading, setLoading ] = useState( false );
+	const [ prompt, setPrompt ] = useState( null );
+	const [ error, setError ] = useState( null );
 	const { promptId } = attributes;
 	const { endpoint, post_type: postType } = window?.newspack_popups_blocks_data;
 
 	const getPrompt = async () => {
-		setError(null);
-		setLoading(true);
+		setError( null );
+		setLoading( true );
 
 		try {
-			const response = await apiFetch({
-				path: addQueryArgs(endpoint, {
+			const response = await apiFetch( {
+				path: addQueryArgs( endpoint, {
 					per_page: 1,
 					include: promptId,
-				}),
-			});
+				} ),
+			} );
 
-			if (0 === response.length) {
+			if ( 0 === response.length ) {
 				setError(
 					sprintf(
 						// Translators: An id of a popup.
-						__('No active prompts found with ID %s. Try choosing another prompt.', 'newspack-popups'),
+						__(
+							'No active prompts found with ID %s. Try choosing another prompt.',
+							'newspack-popups'
+						),
 						promptId
 					)
 				);
-				setLoading(false);
+				setLoading( false );
 			} else {
-				setPrompt(response.shift());
-				setLoading(false);
+				setPrompt( response.shift() );
+				setLoading( false );
 			}
-		} catch (e) {
+		} catch ( e ) {
 			setError(
 				e.message ||
 					sprintf(
 						// Translators: An id of a popup.
-						__('There was an error fetching prompt with ID %s.', 'newspack-popups'),
+						__( 'There was an error fetching prompt with ID %s.', 'newspack-popups' ),
 						promptId
 					)
 			);
-			setLoading(false);
+			setLoading( false );
 		}
 	};
 
-	useEffect(() => {
-		if (promptId) {
+	useEffect( () => {
+		if ( promptId ) {
 			getPrompt();
 		}
-	}, [promptId]);
+	}, [ promptId ] );
 
-	if (!loading && promptId && prompt) {
+	if ( ! loading && promptId && prompt ) {
 		return (
 			<div className="newspack-popups__single-prompt">
 				<h4 className="newspack-popups__single-prompt-title">
-					{prompt.title || __('(no title)', 'newspack-popups')}{' '}
-					<ExternalLink href={`/wp-admin/post.php?post=${promptId}&action=edit`}>{__('edit', 'newspack-popups')}</ExternalLink>
+					{ prompt.title || __( '(no title)', 'newspack-popups' ) }{ ' ' }
+					<ExternalLink href={ `/wp-admin/post.php?post=${ promptId }&action=edit` }>
+						{ __( 'edit', 'newspack-popups' ) }
+					</ExternalLink>
 				</h4>
-				<div className="newspack-popup newspack-inline-popup" dangerouslySetInnerHTML={{ __html: prompt.content }} />
+				<div
+					className="newspack-popup newspack-inline-popup"
+					dangerouslySetInnerHTML={ { __html: prompt.content } }
+				/>
 				<Button
 					isSecondary
-					onClick={() => {
-						setAttributes({ promptId: 0 });
-						setPrompt(null);
-					}}
+					onClick={ () => {
+						setAttributes( { promptId: 0 } );
+						setPrompt( null );
+					} }
 				>
-					{__('Clear prompt')}
+					{ __( 'Clear prompt' ) }
 				</Button>
 			</div>
 		);
 	}
 
 	return (
-		<Placeholder className="newspack-popups__single-prompt-placeholder" label={__('Single Prompt', 'newspack-popups')} icon={megaphone}>
-			{loading && (
+		<Placeholder
+			className="newspack-popups__single-prompt-placeholder"
+			label={ __( 'Single Prompt', 'newspack-popups' ) }
+			icon={ megaphone }
+		>
+			{ loading && (
 				<div className="is-loading">
-					{sprintf(
+					{ sprintf(
 						// Translators: An id of a popup.
-						__('Loading prompt with ID %s…', 'newspack-popups'),
+						__( 'Loading prompt with ID %s…', 'newspack-popups' ),
 						promptId
-					)}
+					) }
 					<Spinner />
 				</div>
-			)}
+			) }
 
-			{error && (
-				<Notice status="error" isDismissible={false}>
-					{error}
+			{ error && (
+				<Notice status="error" isDismissible={ false }>
+					{ error }
 				</Notice>
-			)}
+			) }
 
-			{!prompt && !loading && (
+			{ ! prompt && ! loading && (
 				<AutocompleteWithSuggestions
-					label={__('Search for an inline or manual-only prompt:', 'newspack')}
-					help={__('Begin typing prompt title, click autocomplete result to select.', 'newspack')}
-					fetchSavedPosts={async postIDs => {
-						const posts = await apiFetch({
-							path: addQueryArgs(endpoint, {
+					label={ __( 'Search for an inline or manual-only prompt:', 'newspack' ) }
+					help={ __(
+						'Begin typing prompt title, click autocomplete result to select.',
+						'newspack'
+					) }
+					fetchSavedPosts={ async postIDs => {
+						const posts = await apiFetch( {
+							path: addQueryArgs( endpoint, {
 								per_page: 100,
-								include: postIDs.join(','),
-							}),
-						});
+								include: postIDs.join( ',' ),
+							} ),
+						} );
 
-						return posts.map(post => ({
+						return posts.map( post => ( {
 							value: post.id,
-							label: decodeEntities(post.title) || __('(no title)', 'newspack'),
-						}));
-					}}
-					fetchSuggestions={async search => {
-						const posts = await apiFetch({
-							path: addQueryArgs(endpoint, {
+							label: decodeEntities( post.title ) || __( '(no title)', 'newspack' ),
+						} ) );
+					} }
+					fetchSuggestions={ async search => {
+						const posts = await apiFetch( {
+							path: addQueryArgs( endpoint, {
 								search,
 								per_page: 10,
-							}),
-						});
+							} ),
+						} );
 
 						// Format suggestions for FormTokenField display.
-						const result = posts.reduce((acc, post) => {
-							acc.push({
+						const result = posts.reduce( ( acc, post ) => {
+							acc.push( {
 								value: post.id,
-								label: decodeEntities(post.title) || __('(no title)', 'newspack'),
-							});
+								label: decodeEntities( post.title ) || __( '(no title)', 'newspack' ),
+							} );
 
 							return acc;
-						}, []);
+						}, [] );
 						return result;
-					}}
-					postType={postType}
-					postTypeLabel={'prompt'}
-					maxLength={1}
-					onChange={items => setAttributes({ promptId: parseInt(items.pop().value) })}
-					selectedPost={null}
+					} }
+					postType={ postType }
+					postTypeLabel={ 'prompt' }
+					maxLength={ 1 }
+					onChange={ items => setAttributes( { promptId: parseInt( items.pop().value ) } ) }
+					selectedPost={ null }
 				/>
-			)}
+			) }
 		</Placeholder>
 	);
 };

--- a/src/blocks/single-prompt/index.js
+++ b/src/blocks/single-prompt/index.js
@@ -14,31 +14,31 @@ const { attributes, category, name } = metadata;
 import { SinglePromptEditor } from './edit';
 
 export const registerSinglePromptBlock = () => {
-	const isPrompt = Boolean(window.newspack_popups_blocks_data?.is_prompt);
+	const isPrompt = Boolean( window.newspack_popups_blocks_data?.is_prompt );
 
 	// No prompts inside prompts.
-	if (isPrompt) {
+	if ( isPrompt ) {
 		return null;
 	}
 
-	registerBlockType(name, {
-		title: __('Campaigns: Single Prompt', 'newspack-popups'),
+	registerBlockType( name, {
+		title: __( 'Campaigns: Single Prompt', 'newspack-popups' ),
 		icon: {
-			src: <Icon icon={megaphone} />,
+			src: <Icon icon={ megaphone } />,
 			foreground: '#406ebc',
 		},
 		category,
 		keywords: [
-			__('newspack', 'newspack-popups'),
-			__('campaigns', 'newspack-popups'),
-			__('campaign', 'newspack-popups'),
-			__('single', 'newspack-popups'),
-			__('prompt', 'newspack-popups'),
+			__( 'newspack', 'newspack-popups' ),
+			__( 'campaigns', 'newspack-popups' ),
+			__( 'campaign', 'newspack-popups' ),
+			__( 'single', 'newspack-popups' ),
+			__( 'prompt', 'newspack-popups' ),
 		],
 
 		attributes,
 
 		edit: SinglePromptEditor,
 		save: () => null, // uses view.php
-	});
+	} );
 };

--- a/src/criteria/default/articles-read.js
+++ b/src/criteria/default/articles-read.js
@@ -1,25 +1,29 @@
 import { setMatchingAttribute } from '../utils';
 
-setMatchingAttribute('articles_read', ras => {
-	const views = ras.getUniqueActivitiesBy('article_view', 'post_id');
-	return views.filter(view => view.timestamp > Date.now() - 30 * 24 * 60 * 60 * 1000).length;
-});
+setMatchingAttribute( 'articles_read', ras => {
+	const views = ras.getUniqueActivitiesBy( 'article_view', 'post_id' );
+	return views.filter( view => view.timestamp > Date.now() - 30 * 24 * 60 * 60 * 1000 ).length;
+} );
 
-setMatchingAttribute('articles_read_in_session', ras => {
-	const views = ras.getUniqueActivitiesBy('article_view', 'post_id');
-	if (!views.length) {
+setMatchingAttribute( 'articles_read_in_session', ras => {
+	const views = ras.getUniqueActivitiesBy( 'article_view', 'post_id' );
+	if ( ! views.length ) {
 		return 0;
 	}
 	// Sort by descending timestamp.
-	views.sort((a, b) => b.timestamp - a.timestamp);
+	views.sort( ( a, b ) => b.timestamp - a.timestamp );
 	// Bail if the most recent view is older than 30 minutes.
-	if (views[0].timestamp < Date.now() - 30 * 60 * 1000) {
+	if ( views[ 0 ].timestamp < Date.now() - 30 * 60 * 1000 ) {
 		return 0;
 	}
 	// Increment until the gap between views is greater than 30 minutes.
 	let i = 0;
-	while (i < views.length && views[i + 1] && views[i].timestamp - views[i + 1].timestamp < 30 * 60 * 1000) {
+	while (
+		i < views.length &&
+		views[ i + 1 ] &&
+		views[ i ].timestamp - views[ i + 1 ].timestamp < 30 * 60 * 1000
+	) {
 		i++;
 	}
 	return 1 + i; // Add 1 to account for the most recent view.
-});
+} );

--- a/src/criteria/default/devices.js
+++ b/src/criteria/default/devices.js
@@ -1,6 +1,6 @@
-import { setMatchingFunction } from '../utils';
+import {setMatchingFunction} from '../utils';
 
-setMatchingFunction('devices', (config, ras, { optionParams }) => {
+setMatchingFunction('devices', ( config, ras, { optionParams } )  => {
 	const selectedDevices = Array.isArray(config.value) ? config.value : [];
 	if (selectedDevices.length === 0) {
 		return false;
@@ -16,4 +16,5 @@ setMatchingFunction('devices', (config, ras, { optionParams }) => {
 
 		return width >= device.min_width && width < device.max_width;
 	});
+
 });

--- a/src/criteria/default/donation.js
+++ b/src/criteria/default/donation.js
@@ -1,12 +1,12 @@
 import { setMatchingFunction } from '../utils';
 
-setMatchingFunction('donation', (config, { store }) => {
-	switch (config.value) {
+setMatchingFunction( 'donation', ( config, { store } ) => {
+	switch ( config.value ) {
 		case 'donors':
-			return store.get('is_donor');
+			return store.get( 'is_donor' );
 		case 'non-donors':
-			return !store.get('is_donor');
+			return ! store.get( 'is_donor' );
 		case 'formers-donors':
-			return store.get('is_former_donor');
+			return store.get( 'is_former_donor' );
 	}
-});
+} );

--- a/src/criteria/default/favorite-categories.js
+++ b/src/criteria/default/favorite-categories.js
@@ -1,36 +1,36 @@
 import { setMatchingFunction } from '../utils';
 
-setMatchingFunction('favorite_categories', (config, ras) => {
+setMatchingFunction( 'favorite_categories', ( config, ras ) => {
 	let match = false;
-	const views = ras.getUniqueActivitiesBy('article_view', 'post_id');
+	const views = ras.getUniqueActivitiesBy( 'article_view', 'post_id' );
 
-	if (1 >= views.length) {
+	if ( 1 >= views.length ) {
 		return match;
 	}
 
-	const categories = views.reduce((c, v) => {
-		if (v.data?.categories?.length) {
-			c.push(...v.data.categories);
+	const categories = views.reduce( ( c, v ) => {
+		if ( v.data?.categories?.length ) {
+			c.push( ...v.data.categories );
 		}
 		return c;
-	}, []);
-	const counts = categories.reduce((number, category) => {
-		number[category] = (number[category] || 0) + 1;
+	}, [] );
+	const counts = categories.reduce( ( number, category ) => {
+		number[ category ] = ( number[ category ] || 0 ) + 1;
 		return number;
-	}, {});
-	const countsArray = Object.entries(counts);
-	countsArray.sort((a, b) => b[1] - a[1]);
+	}, {} );
+	const countsArray = Object.entries( counts );
+	countsArray.sort( ( a, b ) => b[ 1 ] - a[ 1 ] );
 
-	if (!countsArray || !countsArray.length) {
+	if ( ! countsArray || ! countsArray.length ) {
 		return match;
 	}
 
 	// Must have viewed at least 2 categories or 2 posts within the same category in order to rank.
-	if (!countsArray[1] || countsArray[0][1] > countsArray[1][1]) {
-		if (-1 < config.value.indexOf(parseInt(countsArray[0][0]))) {
+	if ( ! countsArray[ 1 ] || countsArray[ 0 ][ 1 ] > countsArray[ 1 ][ 1 ] ) {
+		if ( -1 < config.value.indexOf( parseInt( countsArray[ 0 ][ 0 ] ) ) ) {
 			match = true;
 		}
 	}
 
 	return match;
-});
+} );

--- a/src/criteria/default/newsletter.js
+++ b/src/criteria/default/newsletter.js
@@ -1,10 +1,10 @@
 import { setMatchingFunction } from '../utils';
 
-setMatchingFunction('newsletter', (config, { store }) => {
-	switch (config.value) {
+setMatchingFunction( 'newsletter', ( config, { store } ) => {
+	switch ( config.value ) {
 		case 'subscribers':
-			return store.get('is_newsletter_subscriber');
+			return store.get( 'is_newsletter_subscriber' );
 		case 'non-subscribers':
-			return !store.get('is_newsletter_subscriber');
+			return ! store.get( 'is_newsletter_subscriber' );
 	}
-});
+} );

--- a/src/criteria/default/user-account.js
+++ b/src/criteria/default/user-account.js
@@ -1,11 +1,11 @@
 /* globals newspackPopupsCriteria */
 import { setMatchingFunction } from '../utils';
 
-setMatchingFunction('user_account', (config, { store }) => {
-	switch (config.value) {
+setMatchingFunction( 'user_account', ( config, { store } ) => {
+	switch ( config.value ) {
 		case 'with-account':
-			return newspackPopupsCriteria.is_non_preview_user || store.get('reader')?.email;
+			return newspackPopupsCriteria.is_non_preview_user || store.get( 'reader' )?.email;
 		case 'without-account':
-			return !newspackPopupsCriteria.is_non_preview_user && !store.get('reader')?.email;
+			return ! newspackPopupsCriteria.is_non_preview_user && ! store.get( 'reader' )?.email;
 	}
-});
+} );

--- a/src/criteria/index.js
+++ b/src/criteria/index.js
@@ -9,8 +9,8 @@ import './default';
 newspackPopupsCriteria.criteria = {};
 
 // Register criteria from the global newspackPopupsCriteria object.
-if (newspackPopupsCriteria?.config) {
-	for (const id in newspackPopupsCriteria.config) {
-		registerCriteria(id, newspackPopupsCriteria.config[id]);
+if ( newspackPopupsCriteria?.config ) {
+	for ( const id in newspackPopupsCriteria.config ) {
+		registerCriteria( id, newspackPopupsCriteria.config[ id ] );
 	}
 }

--- a/src/criteria/index.test.js
+++ b/src/criteria/index.test.js
@@ -2,18 +2,18 @@ import { registerCriteria, getCriteria, setMatchingAttribute, setMatchingFunctio
 
 const criteriaId = 'test_criteria';
 
-describe('criteria registration', () => {
-	beforeEach(() => {
+describe( 'criteria registration', () => {
+	beforeEach( () => {
 		window.newspackPopupsCriteria = { criteria: {} };
-	});
-	it('should register a criteria with default properties', () => {
-		registerCriteria(criteriaId);
-		const criteria = getCriteria(criteriaId);
-		expect(criteria).toBeDefined();
-		expect(criteria.id).toEqual(criteriaId);
-		expect(criteria.matchingFunction).toEqual('default');
-	});
-	it('should register a criteria with custom properties', () => {
+	} );
+	it( 'should register a criteria with default properties', () => {
+		registerCriteria( criteriaId );
+		const criteria = getCriteria( criteriaId );
+		expect( criteria ).toBeDefined();
+		expect( criteria.id ).toEqual( criteriaId );
+		expect( criteria.matchingFunction ).toEqual( 'default' );
+	} );
+	it( 'should register a criteria with custom properties', () => {
 		const id = criteriaId;
 		const config = {
 			matchingAttribute: 'my-custom-attribute',
@@ -21,168 +21,168 @@ describe('criteria registration', () => {
 				return true;
 			},
 		};
-		registerCriteria(id, config);
-		const criteria = getCriteria(id);
-		expect(criteria).toBeDefined();
-		expect(criteria.id).toEqual(id);
-		expect(criteria.matchingAttribute).toEqual(config.matchingAttribute);
-		expect(criteria.matchingFunction).toEqual(config.matchingFunction);
-	});
-	it('should set a matching attribute', () => {
+		registerCriteria( id, config );
+		const criteria = getCriteria( id );
+		expect( criteria ).toBeDefined();
+		expect( criteria.id ).toEqual( id );
+		expect( criteria.matchingAttribute ).toEqual( config.matchingAttribute );
+		expect( criteria.matchingFunction ).toEqual( config.matchingFunction );
+	} );
+	it( 'should set a matching attribute', () => {
 		const matchingAttribute = () => {
 			return 'foo';
 		};
-		registerCriteria(criteriaId);
-		setMatchingAttribute(criteriaId, matchingAttribute);
-		const criteria = getCriteria(criteriaId);
-		expect(criteria.matchingAttribute).toEqual(matchingAttribute);
-	});
-	it('should set a matching function', () => {
+		registerCriteria( criteriaId );
+		setMatchingAttribute( criteriaId, matchingAttribute );
+		const criteria = getCriteria( criteriaId );
+		expect( criteria.matchingAttribute ).toEqual( matchingAttribute );
+	} );
+	it( 'should set a matching function', () => {
 		const matchingFunction = () => {
 			return true;
 		};
-		registerCriteria(criteriaId);
-		setMatchingFunction(criteriaId, matchingFunction);
-		const criteria = getCriteria(criteriaId);
-		expect(criteria.matchingFunction).toEqual(matchingFunction);
-	});
-	it('should return undefined if criteria is not registered', () => {
-		expect(getCriteria('missing')).toBeUndefined();
-	});
-	it('should return all criteria if no id is passed', () => {
-		registerCriteria(criteriaId);
-		registerCriteria('my-other-criteria');
+		registerCriteria( criteriaId );
+		setMatchingFunction( criteriaId, matchingFunction );
+		const criteria = getCriteria( criteriaId );
+		expect( criteria.matchingFunction ).toEqual( matchingFunction );
+	} );
+	it( 'should return undefined if criteria is not registered', () => {
+		expect( getCriteria( 'missing' ) ).toBeUndefined();
+	} );
+	it( 'should return all criteria if no id is passed', () => {
+		registerCriteria( criteriaId );
+		registerCriteria( 'my-other-criteria' );
 		const criteria = getCriteria();
-		expect(criteria).toBeDefined();
-		expect(Object.keys(criteria).length).toEqual(2);
-	});
-});
+		expect( criteria ).toBeDefined();
+		expect( Object.keys( criteria ).length ).toEqual( 2 );
+	} );
+} );
 
-describe('criteria matching', () => {
-	beforeEach(() => {
+describe( 'criteria matching', () => {
+	beforeEach( () => {
 		// Ignore console.warn calls due to missing RAS library on these tests.
-		jest.spyOn(console, 'warn').mockImplementation(() => {});
+		jest.spyOn( console, 'warn' ).mockImplementation( () => {} );
 		window.newspackPopupsCriteria = { criteria: {} };
-		registerCriteria(criteriaId);
-	});
-	it('should match "default" matching function', () => {
-		setMatchingAttribute(criteriaId, () => 'foo');
-		setMatchingFunction(criteriaId, 'default');
-		const criteria = getCriteria(criteriaId);
-		expect(criteria.matches({ value: 'foo' })).toEqual(true);
-		expect(criteria.matches({ value: 'bar' })).toEqual(false);
-	});
-	it('should match "range" matching function', () => {
-		setMatchingAttribute(criteriaId, () => 5);
-		setMatchingFunction(criteriaId, 'range');
-		const criteria = getCriteria(criteriaId);
-		expect(criteria.matches({ value: { min: 1, max: 10 } })).toEqual(true);
-		expect(criteria.matches({ value: { min: 10 } })).toEqual(false);
-		expect(criteria.matches({ value: {} })).toEqual(true);
-	});
-	it('should match "list__in" matching function', () => {
-		setMatchingAttribute(criteriaId, () => 'bar');
-		setMatchingFunction(criteriaId, 'list__in');
-		const criteria = getCriteria(criteriaId);
-		expect(criteria.matches({ value: ['foo', 'bar'] })).toEqual(true);
-		expect(criteria.matches({ value: 'foo, bar' })).toEqual(true);
-		expect(criteria.matches({ value: 'bar' })).toEqual(true);
-		expect(criteria.matches({ value: 'foo' })).toEqual(false);
-		expect(criteria.matches({ value: ['foo', 'baz'] })).toEqual(false);
-		expect(criteria.matches({ value: '' })).toEqual(false);
-		expect(criteria.matches({ value: [] })).toEqual(false);
-	});
-	it('should match "list__in" matching function with array value', () => {
-		setMatchingAttribute(criteriaId, () => ['foo', 'bar']);
-		setMatchingFunction(criteriaId, 'list__in');
-		const criteria = getCriteria(criteriaId);
-		expect(criteria.matches({ value: ['foo', 'bar'] })).toEqual(true);
-		expect(criteria.matches({ value: 'foo, bar' })).toEqual(true);
-		expect(criteria.matches({ value: 'bar' })).toEqual(true);
-		expect(criteria.matches({ value: ['foo', 'baz'] })).toEqual(true);
-		expect(criteria.matches({ value: ['baz'] })).toEqual(false);
-		expect(criteria.matches({ value: '' })).toEqual(false);
-		expect(criteria.matches({ value: [] })).toEqual(false);
-	});
-	it('should match "list__in" matching function with loose type comparison', () => {
-		setMatchingAttribute(criteriaId, () => 2);
-		setMatchingFunction(criteriaId, 'list__in');
-		const criteria = getCriteria(criteriaId);
-		expect(criteria.matches({ value: ['1', '2'] })).toEqual(true);
-		expect(criteria.matches({ value: [1, 2] })).toEqual(true);
-		expect(criteria.matches({ value: '1, 2' })).toEqual(true);
-		expect(criteria.matches({ value: '2' })).toEqual(true);
-		expect(criteria.matches({ value: [1] })).toEqual(false);
-		expect(criteria.matches({ value: '1' })).toEqual(false);
-		expect(criteria.matches({ value: 1 })).toEqual(false);
-	});
-	it('should match "list__not_in" matching function', () => {
-		setMatchingAttribute(criteriaId, () => 'bar');
-		setMatchingFunction(criteriaId, 'list__not_in');
-		const criteria = getCriteria(criteriaId);
-		expect(criteria.matches({ value: ['foo', 'bar'] })).toEqual(false);
-		expect(criteria.matches({ value: 'foo, bar' })).toEqual(false);
-		expect(criteria.matches({ value: 'bar' })).toEqual(false);
-		expect(criteria.matches({ value: 'foo' })).toEqual(true);
-		expect(criteria.matches({ value: ['foo', 'baz'] })).toEqual(true);
-		expect(criteria.matches({ value: '' })).toEqual(true);
-		expect(criteria.matches({ value: [] })).toEqual(true);
-	});
-	it('should match "list__not_in" matching function with array value', () => {
-		setMatchingAttribute(criteriaId, () => ['foo', 'bar']);
-		setMatchingFunction(criteriaId, 'list__not_in');
-		const criteria = getCriteria(criteriaId);
-		expect(criteria.matches({ value: ['foo', 'bar'] })).toEqual(false);
-		expect(criteria.matches({ value: 'foo, bar' })).toEqual(false);
-		expect(criteria.matches({ value: 'bar' })).toEqual(false);
-		expect(criteria.matches({ value: 'baz' })).toEqual(true);
-		expect(criteria.matches({ value: ['fuu', 'baz'] })).toEqual(true);
-		expect(criteria.matches({ value: '' })).toEqual(true);
-		expect(criteria.matches({ value: [] })).toEqual(true);
-	});
-	it('should match "list__not_in" matching function with loose type comparison', () => {
-		setMatchingAttribute(criteriaId, () => 2);
-		setMatchingFunction(criteriaId, 'list__not_in');
-		const criteria = getCriteria(criteriaId);
-		expect(criteria.matches({ value: ['1', '2'] })).toEqual(false);
-		expect(criteria.matches({ value: [1, 2] })).toEqual(false);
-		expect(criteria.matches({ value: '2' })).toEqual(false);
-		expect(criteria.matches({ value: [1] })).toEqual(true);
-		expect(criteria.matches({ value: '1' })).toEqual(true);
-		expect(criteria.matches({ value: 1 })).toEqual(true);
-	});
-	it('should match custom matching function', () => {
-		setMatchingFunction(criteriaId, segmentConfig => {
+		registerCriteria( criteriaId );
+	} );
+	it( 'should match "default" matching function', () => {
+		setMatchingAttribute( criteriaId, () => 'foo' );
+		setMatchingFunction( criteriaId, 'default' );
+		const criteria = getCriteria( criteriaId );
+		expect( criteria.matches( { value: 'foo' } ) ).toEqual( true );
+		expect( criteria.matches( { value: 'bar' } ) ).toEqual( false );
+	} );
+	it( 'should match "range" matching function', () => {
+		setMatchingAttribute( criteriaId, () => 5 );
+		setMatchingFunction( criteriaId, 'range' );
+		const criteria = getCriteria( criteriaId );
+		expect( criteria.matches( { value: { min: 1, max: 10 } } ) ).toEqual( true );
+		expect( criteria.matches( { value: { min: 10 } } ) ).toEqual( false );
+		expect( criteria.matches( { value: {} } ) ).toEqual( true );
+	} );
+	it( 'should match "list__in" matching function', () => {
+		setMatchingAttribute( criteriaId, () => 'bar' );
+		setMatchingFunction( criteriaId, 'list__in' );
+		const criteria = getCriteria( criteriaId );
+		expect( criteria.matches( { value: [ 'foo', 'bar' ] } ) ).toEqual( true );
+		expect( criteria.matches( { value: 'foo, bar' } ) ).toEqual( true );
+		expect( criteria.matches( { value: 'bar' } ) ).toEqual( true );
+		expect( criteria.matches( { value: 'foo' } ) ).toEqual( false );
+		expect( criteria.matches( { value: [ 'foo', 'baz' ] } ) ).toEqual( false );
+		expect( criteria.matches( { value: '' } ) ).toEqual( false );
+		expect( criteria.matches( { value: [] } ) ).toEqual( false );
+	} );
+	it( 'should match "list__in" matching function with array value', () => {
+		setMatchingAttribute( criteriaId, () => [ 'foo', 'bar' ] );
+		setMatchingFunction( criteriaId, 'list__in' );
+		const criteria = getCriteria( criteriaId );
+		expect( criteria.matches( { value: [ 'foo', 'bar' ] } ) ).toEqual( true );
+		expect( criteria.matches( { value: 'foo, bar' } ) ).toEqual( true );
+		expect( criteria.matches( { value: 'bar' } ) ).toEqual( true );
+		expect( criteria.matches( { value: [ 'foo', 'baz' ] } ) ).toEqual( true );
+		expect( criteria.matches( { value: [ 'baz' ] } ) ).toEqual( false );
+		expect( criteria.matches( { value: '' } ) ).toEqual( false );
+		expect( criteria.matches( { value: [] } ) ).toEqual( false );
+	} );
+	it( 'should match "list__in" matching function with loose type comparison', () => {
+		setMatchingAttribute( criteriaId, () => 2 );
+		setMatchingFunction( criteriaId, 'list__in' );
+		const criteria = getCriteria( criteriaId );
+		expect( criteria.matches( { value: [ '1', '2' ] } ) ).toEqual( true );
+		expect( criteria.matches( { value: [ 1, 2 ] } ) ).toEqual( true );
+		expect( criteria.matches( { value: '1, 2' } ) ).toEqual( true );
+		expect( criteria.matches( { value: '2' } ) ).toEqual( true );
+		expect( criteria.matches( { value: [ 1 ] } ) ).toEqual( false );
+		expect( criteria.matches( { value: '1' } ) ).toEqual( false );
+		expect( criteria.matches( { value: 1 } ) ).toEqual( false );
+	} );
+	it( 'should match "list__not_in" matching function', () => {
+		setMatchingAttribute( criteriaId, () => 'bar' );
+		setMatchingFunction( criteriaId, 'list__not_in' );
+		const criteria = getCriteria( criteriaId );
+		expect( criteria.matches( { value: [ 'foo', 'bar' ] } ) ).toEqual( false );
+		expect( criteria.matches( { value: 'foo, bar' } ) ).toEqual( false );
+		expect( criteria.matches( { value: 'bar' } ) ).toEqual( false );
+		expect( criteria.matches( { value: 'foo' } ) ).toEqual( true );
+		expect( criteria.matches( { value: [ 'foo', 'baz' ] } ) ).toEqual( true );
+		expect( criteria.matches( { value: '' } ) ).toEqual( true );
+		expect( criteria.matches( { value: [] } ) ).toEqual( true );
+	} );
+	it( 'should match "list__not_in" matching function with array value', () => {
+		setMatchingAttribute( criteriaId, () => [ 'foo', 'bar' ] );
+		setMatchingFunction( criteriaId, 'list__not_in' );
+		const criteria = getCriteria( criteriaId );
+		expect( criteria.matches( { value: [ 'foo', 'bar' ] } ) ).toEqual( false );
+		expect( criteria.matches( { value: 'foo, bar' } ) ).toEqual( false );
+		expect( criteria.matches( { value: 'bar' } ) ).toEqual( false );
+		expect( criteria.matches( { value: 'baz' } ) ).toEqual( true );
+		expect( criteria.matches( { value: [ 'fuu', 'baz' ] } ) ).toEqual( true );
+		expect( criteria.matches( { value: '' } ) ).toEqual( true );
+		expect( criteria.matches( { value: [] } ) ).toEqual( true );
+	} );
+	it( 'should match "list__not_in" matching function with loose type comparison', () => {
+		setMatchingAttribute( criteriaId, () => 2 );
+		setMatchingFunction( criteriaId, 'list__not_in' );
+		const criteria = getCriteria( criteriaId );
+		expect( criteria.matches( { value: [ '1', '2' ] } ) ).toEqual( false );
+		expect( criteria.matches( { value: [ 1, 2 ] } ) ).toEqual( false );
+		expect( criteria.matches( { value: '2' } ) ).toEqual( false );
+		expect( criteria.matches( { value: [ 1 ] } ) ).toEqual( true );
+		expect( criteria.matches( { value: '1' } ) ).toEqual( true );
+		expect( criteria.matches( { value: 1 } ) ).toEqual( true );
+	} );
+	it( 'should match custom matching function', () => {
+		setMatchingFunction( criteriaId, segmentConfig => {
 			return segmentConfig.value === 'foo';
-		});
-		const criteria = getCriteria(criteriaId);
-		expect(criteria.matches({ value: 'foo' })).toEqual(true);
-		expect(criteria.matches({ value: 'bar' })).toEqual(false);
-	});
-	it('should cache matching function results', () => {
-		const matchingFunction = jest.fn(() => true);
-		setMatchingFunction(criteriaId, matchingFunction);
-		const criteria = getCriteria(criteriaId);
-		expect(criteria.matches({ value: 'foo' })).toEqual(true);
-		expect(criteria.matches({ value: 'foo' })).toEqual(true);
-		expect(matchingFunction).toHaveBeenCalledTimes(1);
-		expect(criteria.matches({ value: 'bar' })).toEqual(true);
-		expect(matchingFunction).toHaveBeenCalledTimes(2);
-	});
-	it('should pass option params to matching function', () => {
-		registerCriteria(criteriaId, {
+		} );
+		const criteria = getCriteria( criteriaId );
+		expect( criteria.matches( { value: 'foo' } ) ).toEqual( true );
+		expect( criteria.matches( { value: 'bar' } ) ).toEqual( false );
+	} );
+	it( 'should cache matching function results', () => {
+		const matchingFunction = jest.fn( () => true );
+		setMatchingFunction( criteriaId, matchingFunction );
+		const criteria = getCriteria( criteriaId );
+		expect( criteria.matches( { value: 'foo' } ) ).toEqual( true );
+		expect( criteria.matches( { value: 'foo' } ) ).toEqual( true );
+		expect( matchingFunction ).toHaveBeenCalledTimes( 1 );
+		expect( criteria.matches( { value: 'bar' } ) ).toEqual( true );
+		expect( matchingFunction ).toHaveBeenCalledTimes( 2 );
+	} );
+	it( 'should pass option params to matching function', () => {
+		registerCriteria( criteriaId, {
 			matchingAttribute: 'my-custom-attribute',
-			matchingFunction: (config, ras, { optionParams }) => {
-				expect(optionParams).toBeDefined();
-				expect(optionParams[config.value]).toBeDefined();
+			matchingFunction: ( config, ras, { optionParams } ) => {
+				expect( optionParams ).toBeDefined();
+				expect( optionParams[ config.value ] ).toBeDefined();
 				return true;
 			},
 			optionParams: {
 				1: { foo: 'bar' },
 				2: { foo: 'baz' },
 			},
-		});
+		} );
 		// Trigger the matching function for assertions.
-		getCriteria(criteriaId).matches({ value: '1' });
-	});
-});
+		getCriteria( criteriaId ).matches( { value: '1' } );
+	} );
+} );

--- a/src/criteria/matching-functions.js
+++ b/src/criteria/matching-functions.js
@@ -7,7 +7,7 @@ export default {
 	/**
 	 * Matches the exact value of the criteria against the segment config.
 	 */
-	default: (criteria, config) => criteria.value === config.value,
+	default: ( criteria, config ) => criteria.value === config.value,
 	/**
 	 * Matches the criteria value against a list provided by the segment config,
 	 * returns true if the value is on the list.
@@ -15,18 +15,18 @@ export default {
 	 * If the criteria value is an array, it returns true if any of the values
 	 * are on the list.
 	 */
-	list__in: (criteria, config) => {
+	list__in: ( criteria, config ) => {
 		let list = config.value;
-		if (typeof list === 'string') {
-			list = config.value.split(',').map(item => item.trim());
+		if ( typeof list === 'string' ) {
+			list = config.value.split( ',' ).map( item => item.trim() );
 		}
-		if (!Array.isArray(list)) {
+		if ( ! Array.isArray( list ) ) {
 			return false;
 		}
-		if (Array.isArray(criteria.value)) {
-			return criteria.value.some(value => list.some(configValue => configValue == value));
+		if ( Array.isArray( criteria.value ) ) {
+			return criteria.value.some( value => list.some( configValue => configValue == value ) );
 		}
-		if (!criteria.value || !list.some(configValue => configValue == criteria.value)) {
+		if ( ! criteria.value || ! list.some( configValue => configValue == criteria.value ) ) {
 			return false;
 		}
 		return true;
@@ -38,18 +38,18 @@ export default {
 	 * If the criteria value is an array, it returns true if none of the values
 	 * are on the list.
 	 */
-	list__not_in: (criteria, config) => {
+	list__not_in: ( criteria, config ) => {
 		let list = config.value;
-		if (typeof list === 'string') {
-			list = config.value.split(',').map(item => item.trim());
+		if ( typeof list === 'string' ) {
+			list = config.value.split( ',' ).map( item => item.trim() );
 		}
-		if (!Array.isArray(list)) {
+		if ( ! Array.isArray( list ) ) {
 			return true;
 		}
-		if (Array.isArray(criteria.value)) {
-			return !criteria.value.some(value => list.some(configValue => configValue == value));
+		if ( Array.isArray( criteria.value ) ) {
+			return ! criteria.value.some( value => list.some( configValue => configValue == value ) );
 		}
-		if (!criteria.value || !list.some(configValue => configValue == criteria.value)) {
+		if ( ! criteria.value || ! list.some( configValue => configValue == criteria.value ) ) {
 			return true;
 		}
 		return false;
@@ -58,12 +58,12 @@ export default {
 	 * Matches the criteria value against a range of 'min' and 'max' provided by
 	 * the segment config.
 	 */
-	range: (criteria, config) => {
-		if (isNaN(criteria.value)) {
+	range: ( criteria, config ) => {
+		if ( isNaN( criteria.value ) ) {
 			return false;
 		}
 		const { min, max } = config.value;
-		if ((min && criteria.value < min) || (max && criteria.value > max)) {
+		if ( ( min && criteria.value < min ) || ( max && criteria.value > max ) ) {
 			return false;
 		}
 		return true;

--- a/src/criteria/utils.js
+++ b/src/criteria/utils.js
@@ -18,15 +18,15 @@ const pendingConfig = {};
  *
  * @throws {Error} If the criteria ID is not provided.
  */
-export function registerCriteria(id, config = {}) {
-	if (!id) {
-		throw new Error('Criteria must have an ID.');
+export function registerCriteria( id, config = {} ) {
+	if ( ! id ) {
+		throw new Error( 'Criteria must have an ID.' );
 	}
 	const criteria = {
 		id,
 		matchingFunction: 'default',
 		...config,
-		...pendingConfig[id],
+		...pendingConfig[ id ],
 	};
 
 	/**
@@ -34,71 +34,79 @@ export function registerCriteria(id, config = {}) {
 	 */
 	const setup = ras => {
 		// Run setup only once.
-		if (criteria._configured) {
+		if ( criteria._configured ) {
 			return;
 		}
 		criteria._configured = true;
 
 		// Default attribute to the criteria ID.
-		if (!criteria.matchingAttribute) {
+		if ( ! criteria.matchingAttribute ) {
 			criteria.matchingAttribute = criteria.id;
 		}
 
 		// Configure matching function.
-		if (typeof criteria.matchingFunction === 'string' && matchingFunctions[criteria.matchingFunction]) {
-			criteria.matchingFunction = matchingFunctions[criteria.matchingFunction].bind(null, criteria);
+		if (
+			typeof criteria.matchingFunction === 'string' &&
+			matchingFunctions[ criteria.matchingFunction ]
+		) {
+			criteria.matchingFunction = matchingFunctions[ criteria.matchingFunction ].bind(
+				null,
+				criteria
+			);
 		}
 
 		// Bail if unable to configure matching function.
-		if (typeof criteria.matchingFunction !== 'function') {
-			console.warn(`Unable to configure matching function for criteria ${criteria.id}.`); // eslint-disable-line no-console
+		if ( typeof criteria.matchingFunction !== 'function' ) {
+			console.warn( `Unable to configure matching function for criteria ${ criteria.id }.` ); // eslint-disable-line no-console
 			return;
 		}
 
 		// Clear matched cache when the reader data library store changes.
-		if (typeof ras?.on === 'function') {
-			ras.on('data', () => {
+		if ( typeof ras?.on === 'function' ) {
+			ras.on( 'data', () => {
 				criteria._matched = {};
-			});
+			} );
 		}
 
 		// Set criteria value.
-		criteria.value = criteria.getValue(ras);
+		criteria.value = criteria.getValue( ras );
 	};
 
 	criteria.getValue = ras => {
-		if (typeof criteria.matchingAttribute === 'function') {
-			return criteria.matchingAttribute(ras);
+		if ( typeof criteria.matchingAttribute === 'function' ) {
+			return criteria.matchingAttribute( ras );
 		}
-		if (typeof criteria.matchingAttribute === 'string') {
-			if (typeof ras?.store?.get === 'function') {
-				return ras.store.get(criteria.matchingAttribute);
+		if ( typeof criteria.matchingAttribute === 'string' ) {
+			if ( typeof ras?.store?.get === 'function' ) {
+				return ras.store.get( criteria.matchingAttribute );
 			}
 			// eslint-disable-next-line no-console
-			console.warn(`Reader data library not loaded. Unable to fetch value for '${criteria.id}'`);
+			console.warn(
+				`Reader data library not loaded. Unable to fetch value for '${ criteria.id }'`
+			);
 		}
 		return criteria.value;
-	};
+	}
 
 	// Check if the criteria matches the segment config.
 	criteria._matched = {}; // Cache results.
 	criteria.matches = segmentConfig => {
-		const configString = JSON.stringify(segmentConfig);
-		if (criteria._matched[configString] !== undefined) {
-			return criteria._matched[configString];
+		const configString = JSON.stringify( segmentConfig );
+		if ( criteria._matched[ configString ] !== undefined ) {
+			return criteria._matched[ configString ];
 		}
 		const ras = window.newspackReaderActivation;
-		if (!ras) {
-			console.warn('Reader activation script not loaded.'); // eslint-disable-line no-console
+		if ( ! ras ) {
+			console.warn( 'Reader activation script not loaded.' ); // eslint-disable-line no-console
 		}
-		setup(ras);
-		criteria._matched[configString] = criteria.matchingFunction(segmentConfig, ras, criteria);
-		return criteria._matched[configString];
+		setup( ras );
+		criteria._matched[ configString ] = criteria.matchingFunction( segmentConfig, ras, criteria );
+		return criteria._matched[ configString ];
 	};
-	if (!window.newspackPopupsCriteria.criteria) {
+	if ( ! window.newspackPopupsCriteria.criteria ) {
 		window.newspackPopupsCriteria.criteria = {};
 	}
-	window.newspackPopupsCriteria.criteria[id] = criteria;
+	window.newspackPopupsCriteria.criteria[ id ] = criteria;
 
 	return criteria;
 }
@@ -111,9 +119,9 @@ export function registerCriteria(id, config = {}) {
  * @return {Object|undefined} The criteria object or an object of all criteria.
  *                            undefined if the criteria ID is not found.
  */
-export function getCriteria(id) {
-	if (id) {
-		return window.newspackPopupsCriteria.criteria[id];
+export function getCriteria( id ) {
+	if ( id ) {
+		return window.newspackPopupsCriteria.criteria[ id ];
 	}
 	return window.newspackPopupsCriteria.criteria;
 }
@@ -127,11 +135,11 @@ export function getCriteria(id) {
  *
  * @throws {Error} If the criteria ID is not found.
  */
-export function setMatchingAttribute(id, matchingAttribute) {
-	let criteria = getCriteria(id);
-	if (!criteria) {
-		pendingConfig[id] = pendingConfig[id] || {};
-		criteria = pendingConfig[id];
+export function setMatchingAttribute( id, matchingAttribute ) {
+	let criteria = getCriteria( id );
+	if ( ! criteria ) {
+		pendingConfig[ id ] = pendingConfig[ id ] || {};
+		criteria = pendingConfig[ id ];
 	}
 	criteria._matched = {}; // Clear matched cache.
 	criteria.matchingAttribute = matchingAttribute;
@@ -145,11 +153,11 @@ export function setMatchingAttribute(id, matchingAttribute) {
  *
  * @throws {Error} If the criteria ID is not found.
  */
-export function setMatchingFunction(id, matchingFunction) {
-	let criteria = getCriteria(id);
-	if (!criteria) {
-		pendingConfig[id] = pendingConfig[id] || {};
-		criteria = pendingConfig[id];
+export function setMatchingFunction( id, matchingFunction ) {
+	let criteria = getCriteria( id );
+	if ( ! criteria ) {
+		pendingConfig[ id ] = pendingConfig[ id ] || {};
+		criteria = pendingConfig[ id ];
 	}
 	criteria._matched = {}; // Clear matched cache.
 	criteria.matchingFunction = matchingFunction;

--- a/src/document-settings/index.js
+++ b/src/document-settings/index.js
@@ -8,33 +8,36 @@ import { PluginDocumentSettingPanel } from '@wordpress/edit-post';
 import { registerPlugin } from '@wordpress/plugins';
 import { ToggleControl } from '@wordpress/components';
 
-const PopupsSettingsPanel = ({ hasDisabledPopups, onChange }) => (
-	<PluginDocumentSettingPanel name="newsletters-popups-settings-panel" title={__('Newspack Campaigns Settings', 'newspack-popups')}>
+const PopupsSettingsPanel = ( { hasDisabledPopups, onChange } ) => (
+	<PluginDocumentSettingPanel
+		name="newsletters-popups-settings-panel"
+		title={ __( 'Newspack Campaigns Settings', 'newspack-popups' ) }
+	>
 		<ToggleControl
-			checked={hasDisabledPopups}
-			onChange={() => onChange(!hasDisabledPopups)}
-			label={__('Disable prompts on this post or page', 'newspack-popups')}
+			checked={ hasDisabledPopups }
+			onChange={ () => onChange( ! hasDisabledPopups ) }
+			label={ __( 'Disable prompts on this post or page', 'newspack-popups' ) }
 		/>
 	</PluginDocumentSettingPanel>
 );
 
-const PopupsSettingsPanelWithSelect = compose([
-	withSelect(select => {
-		const { getEditedPostAttribute } = select('core/editor');
-		const meta = getEditedPostAttribute('meta');
+const PopupsSettingsPanelWithSelect = compose( [
+	withSelect( select => {
+		const { getEditedPostAttribute } = select( 'core/editor' );
+		const meta = getEditedPostAttribute( 'meta' );
 		return { hasDisabledPopups: meta && meta.newspack_popups_has_disabled_popups };
-	}),
-	withDispatch(dispatch => {
-		const { editPost } = dispatch('core/editor');
+	} ),
+	withDispatch( dispatch => {
+		const { editPost } = dispatch( 'core/editor' );
 		return {
 			onChange: hasDisabledPopups => {
-				editPost({ meta: { newspack_popups_has_disabled_popups: hasDisabledPopups } });
+				editPost( { meta: { newspack_popups_has_disabled_popups: hasDisabledPopups } } );
 			},
 		};
-	}),
-])(PopupsSettingsPanel);
+	} ),
+] )( PopupsSettingsPanel );
 
-registerPlugin('newspack-popups-post-status-info', {
+registerPlugin( 'newspack-popups-post-status-info', {
 	render: PopupsSettingsPanelWithSelect,
 	icon: false,
-});
+} );

--- a/src/editor/AdvancedSidebar.js
+++ b/src/editor/AdvancedSidebar.js
@@ -14,41 +14,52 @@ import { BaseControl } from '@wordpress/components';
  */
 import { CategoryAutocomplete, TextControl } from 'newspack-components';
 
-const AdvancedSidebar = ({ onMetaFieldChange, excluded_categories = [], excluded_tags = [], additional_classes = '' }) => {
+const AdvancedSidebar = ( {
+	onMetaFieldChange,
+	excluded_categories = [],
+	excluded_tags = [],
+	additional_classes = '',
+} ) => {
 	return (
 		<Fragment>
 			<BaseControl>
 				<TextControl
-					label={__('Additional CSS class(es)', 'newspack-popups')}
-					help={__('Separate multiple classes with spaces.', 'newspack-popups')}
-					value={additional_classes}
-					onChange={value =>
-						onMetaFieldChange({
+					label={ __( 'Additional CSS class(es)', 'newspack-popups' ) }
+					help={ __( 'Separate multiple classes with spaces.', 'newspack-popups' ) }
+					value={ additional_classes }
+					onChange={ value =>
+						onMetaFieldChange( {
 							additional_classes: value,
-						})
+						} )
 					}
 				/>
 				<hr />
 				<CategoryAutocomplete
-					label={__('Excluded Categories', 'newspack-popups')}
-					description={__('The prompt will not be shown on posts that have any these categories.', 'newspack-popups')}
-					value={excluded_categories}
-					onChange={tokens =>
-						onMetaFieldChange({
-							excluded_categories: tokens.map(token => parseInt(token.id)),
-						})
+					label={ __( 'Excluded Categories', 'newspack-popups' ) }
+					description={ __(
+						'The prompt will not be shown on posts that have any these categories.',
+						'newspack-popups'
+					) }
+					value={ excluded_categories }
+					onChange={ tokens =>
+						onMetaFieldChange( {
+							excluded_categories: tokens.map( token => parseInt( token.id ) ),
+						} )
 					}
 				/>
 				<hr />
 				<CategoryAutocomplete
-					label={__('Excluded Tags', 'newspack-popups')}
-					description={__('The prompt will not be shown on posts that have any these tags.', 'newspack-popups')}
+					label={ __( 'Excluded Tags', 'newspack-popups' ) }
+					description={ __(
+						'The prompt will not be shown on posts that have any these tags.',
+						'newspack-popups'
+					) }
 					taxonomy="tags"
-					value={excluded_tags}
-					onChange={tokens =>
-						onMetaFieldChange({
-							excluded_tags: tokens.map(token => parseInt(token.id)),
-						})
+					value={ excluded_tags }
+					onChange={ tokens =>
+						onMetaFieldChange( {
+							excluded_tags: tokens.map( token => parseInt( token.id ) ),
+						} )
 					}
 				/>
 			</BaseControl>

--- a/src/editor/ColorsSidebar.js
+++ b/src/editor/ColorsSidebar.js
@@ -10,7 +10,7 @@ import { Fragment } from '@wordpress/element';
 import { RangeControl, ToggleControl } from '@wordpress/components';
 import { ColorPaletteControl } from '@wordpress/block-editor';
 
-const ColorsSidebar = ({
+const ColorsSidebar = ( {
 	background_color,
 	close_button_background_color,
 	enable_close_button_background,
@@ -19,56 +19,54 @@ const ColorsSidebar = ({
 	overlay_color,
 	no_overlay_background,
 	isOverlay,
-}) => (
+} ) => (
 	<Fragment>
 		<ColorPaletteControl
-			value={background_color}
-			onChange={value => onMetaFieldChange({ background_color: value || '#FFFFFF' })}
-			label={__('Content Background Color', 'newspack-popups')}
+			value={ background_color }
+			onChange={ value => onMetaFieldChange( { background_color: value || '#FFFFFF' } ) }
+			label={ __( 'Content Background Color', 'newspack-popups' ) }
 		/>
-		{isOverlay && (
+		{ isOverlay && (
 			<Fragment>
-				<ToggleControl
-					className="newspack-popups__color-toggle"
-					label={__('Customize close button background', 'newspack-popups')}
-					checked={enable_close_button_background}
-					value={enable_close_button_background}
-					onChange={value => onMetaFieldChange({ enable_close_button_background: value })}
+				<ToggleControl className="newspack-popups__color-toggle"
+					label={ __( 'Customize close button background', 'newspack-popups' ) }
+					checked={ enable_close_button_background }
+					value={ enable_close_button_background}
+					onChange={ value => onMetaFieldChange( { enable_close_button_background: value } ) }
 				/>
-				{enable_close_button_background && (
+				{ enable_close_button_background && (
 					<ColorPaletteControl
-						value={close_button_background_color}
-						onChange={value => onMetaFieldChange({ close_button_background_color: value || '#00000000' })}
-						label={__('Close Button Background Color', 'newspack-popups')}
-						enableAlpha={true}
+						value={ close_button_background_color }
+						onChange={ value => onMetaFieldChange( { close_button_background_color: value || '#00000000' } ) }
+						label={ __( 'Close Button Background Color', 'newspack-popups' ) }
+						enableAlpha={ true }
 					/>
-				)}
+				) }
 
-				<ToggleControl
-					className="newspack-popups__color-toggle"
-					label={__('Display overlay background', 'newspack-popups')}
-					checked={!no_overlay_background}
-					value={!no_overlay_background}
-					onChange={value => onMetaFieldChange({ no_overlay_background: !value })}
+				<ToggleControl className="newspack-popups__color-toggle"
+					label={ __( 'Display overlay background', 'newspack-popups' ) }
+					checked={ ! no_overlay_background }
+					value={ ! no_overlay_background }
+					onChange={ value => onMetaFieldChange( { no_overlay_background: ! value } ) }
 				/>
-				{!no_overlay_background && (
+				{ ! no_overlay_background && (
 					<>
 						<ColorPaletteControl
-							value={overlay_color}
-							onChange={value => onMetaFieldChange({ overlay_color: value || '#000000' })}
-							label={__('Overlay Background Color', 'newspack-popups')}
+							value={ overlay_color }
+							onChange={ value => onMetaFieldChange( { overlay_color: value || '#000000' } ) }
+							label={ __( 'Overlay Background Color', 'newspack-popups' ) }
 						/>
 						<RangeControl
-							label={__('Overlay Background Opacity', 'newspack-popups')}
-							value={overlay_opacity}
-							onChange={value => onMetaFieldChange({ overlay_opacity: value })}
-							min={0}
-							max={100}
+							label={ __( 'Overlay Background Opacity', 'newspack-popups' ) }
+							value={ overlay_opacity }
+							onChange={ value => onMetaFieldChange( { overlay_opacity: value } ) }
+							min={ 0 }
+							max={ 100 }
 						/>
 					</>
-				)}
+				) }
 			</Fragment>
-		)}
+		) }
 	</Fragment>
 );
 

--- a/src/editor/Duplicate.js
+++ b/src/editor/Duplicate.js
@@ -9,158 +9,174 @@ import { useEffect, useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 
-const DuplicateButton = ({ autosave, campaignGroups, duplicateOf, isSavingPost, postId, title }) => {
-	const [error, setError] = useState(null);
-	const [modalVisible, setModalVisible] = useState(false);
-	const [duplicateTitle, setDuplicateTitle] = useState(null);
-	const [duplicated, setDuplicated] = useState(null);
+const DuplicateButton = ( {
+	autosave,
+	campaignGroups,
+	duplicateOf,
+	isSavingPost,
+	postId,
+	title,
+} ) => {
+	const [ error, setError ] = useState( null );
+	const [ modalVisible, setModalVisible ] = useState( false );
+	const [ duplicateTitle, setDuplicateTitle ] = useState( null );
+	const [ duplicated, setDuplicated ] = useState( null );
 
-	useEffect(() => {
-		setError(null);
-		if (modalVisible && !duplicateTitle) {
+	useEffect( () => {
+		setError( null );
+		if ( modalVisible && ! duplicateTitle ) {
 			getDefaultDupicateTitle();
 		}
-		if (!modalVisible) {
-			setDuplicated(null);
-			setDuplicateTitle(null);
+		if ( ! modalVisible ) {
+			setDuplicated( null );
+			setDuplicateTitle( null );
 		}
-	}, [modalVisible]);
+	}, [ modalVisible ] );
 
 	const getDefaultDupicateTitle = async () => {
-		const promptToDuplicate = parseInt(duplicateOf || postId);
+		const promptToDuplicate = parseInt( duplicateOf || postId );
 		try {
-			const defaultTitle = await apiFetch({
-				path: `/newspack-popups/v1/${promptToDuplicate}/${postId}/duplicate`,
-			});
+			const defaultTitle = await apiFetch( {
+				path: `/newspack-popups/v1/${ promptToDuplicate }/${ postId }/duplicate`,
+			} );
 
-			setDuplicateTitle(defaultTitle);
-		} catch (e) {
-			setDuplicateTitle(title + __(' copy', 'newspack-popups'));
+			setDuplicateTitle( defaultTitle );
+		} catch ( e ) {
+			setDuplicateTitle( title + __( ' copy', 'newspack-popups' ) );
 		}
 	};
 
-	const duplicatePrompt = async (popupId, titleForDuplicate) => {
-		setError(null);
+	const duplicatePrompt = async ( popupId, titleForDuplicate ) => {
+		setError( null );
 		try {
-			const newId = await apiFetch({
-				path: addQueryArgs(`/newspack-popups/v1/${popupId}/duplicate`, {
+			const newId = await apiFetch( {
+				path: addQueryArgs( `/newspack-popups/v1/${ popupId }/duplicate`, {
 					title: titleForDuplicate,
-				}),
+				} ),
 				method: 'POST',
-			});
+			} );
 
-			if (isNaN(newId)) {
-				throw new Error(__('Error duplicating prompt.', 'newspack-popups'));
+			if ( isNaN( newId ) ) {
+				throw new Error( __( 'Error duplicating prompt.', 'newspack-popups' ) );
 			}
 
 			// Redirect to edit page for the copy.
-			setDuplicated(newId);
-		} catch (e) {
-			setError(e?.message || __('Error duplicating prompt.', 'newspack-popups'));
+			setDuplicated( newId );
+		} catch ( e ) {
+			setError( e?.message || __( 'Error duplicating prompt.', 'newspack-popups' ) );
 		}
 	};
 
 	return (
 		<>
-			<Button isSecondary isBusy={isSavingPost} disabled={isSavingPost} onClick={() => setModalVisible(true)}>
-				{__('Duplicate', 'newspack-popups')}
+			<Button
+				isSecondary
+				isBusy={ isSavingPost }
+				disabled={ isSavingPost }
+				onClick={ () => setModalVisible( true ) }
+			>
+				{ __( 'Duplicate', 'newspack-popups' ) }
 			</Button>
-			{modalVisible && (
+			{ modalVisible && (
 				<Modal
 					className="newspack-popups__duplicate-modal"
 					// Translators: Title of the duplicated popup.
-					title={sprintf(__('Duplicate “%s”', 'newspack-popups'), title)}
-					onRequestClose={() => setModalVisible(false)}
+					title={ sprintf( __( 'Duplicate “%s”', 'newspack-popups' ), title ) }
+					onRequestClose={ () => setModalVisible( false ) }
 				>
-					{error && (
-						<Notice isDismissible={false} status="error">
-							{error}
+					{ error && (
+						<Notice isDismissible={ false } status="error">
+							{ error }
 						</Notice>
-					)}
-					{duplicated ? (
+					) }
+					{ duplicated ? (
 						<>
-							<Notice status="success" isDismissible={false}>
-								{sprintf(
+							<Notice status="success" isDismissible={ false }>
+								{ sprintf(
 									// Translators: Title of the duplicated popup.
-									__('Duplicate of “%s” created as a draft.', 'newspack-popups'),
+									__( 'Duplicate of “%s” created as a draft.', 'newspack-popups' ),
 									title
-								)}
+								) }
 							</Notice>
-							{(!campaignGroups || 0 === campaignGroups.length) && (
-								<Notice status="warning" isDismissible={false}>
-									{__('This prompt is currently not assigned to any campaign.', 'newspack-popups')}
+							{ ( ! campaignGroups || 0 === campaignGroups.length ) && (
+								<Notice status="warning" isDismissible={ false }>
+									{ __(
+										'This prompt is currently not assigned to any campaign.',
+										'newspack-popups'
+									) }
 								</Notice>
-							)}
+							) }
 							<Flex justify="flex-end">
-								<Button isSecondary onClick={() => setModalVisible(false)}>
-									{__('Close', 'newspack-popups')}
+								<Button isSecondary onClick={ () => setModalVisible( false ) }>
+									{ __( 'Close', 'newspack-popups' ) }
 								</Button>
-								<Button isPrimary href={`/wp-admin/post.php?post=${duplicated}&action=edit`}>
-									{__('Edit', 'newspack-popups')}
+								<Button isPrimary href={ `/wp-admin/post.php?post=${ duplicated }&action=edit` }>
+									{ __( 'Edit', 'newspack-popups' ) }
 								</Button>
 							</Flex>
 						</>
 					) : (
 						<>
-							{(!campaignGroups || 0 === campaignGroups.length) && (
-								<Notice status="warning" isDismissible={false}>
-									{__('This prompt will not be assigned to any campaign.', 'newspack-popups')}
+							{ ( ! campaignGroups || 0 === campaignGroups.length ) && (
+								<Notice status="warning" isDismissible={ false }>
+									{ __( 'This prompt will not be assigned to any campaign.', 'newspack-popups' ) }
 								</Notice>
-							)}
+							) }
 							<TextControl
-								disabled={isSavingPost || null === duplicateTitle}
-								label={__('Title', 'newspack-popups')}
-								value={duplicateTitle}
-								onChange={value => setDuplicateTitle(value)}
+								disabled={ isSavingPost || null === duplicateTitle }
+								label={ __( 'Title', 'newspack-popups' ) }
+								value={ duplicateTitle }
+								onChange={ value => setDuplicateTitle( value ) }
 							/>
 							<Flex justify="flex-end">
 								<Button
-									isBusy={isSavingPost}
+									isBusy={ isSavingPost }
 									isSecondary
-									onClick={() => {
-										setModalVisible(false);
-									}}
+									onClick={ () => {
+										setModalVisible( false );
+									} }
 								>
-									{__('Cancel', 'newspack-popups')}
+									{ __( 'Cancel', 'newspack-popups' ) }
 								</Button>
 								<Button
-									isBusy={isSavingPost}
-									disabled={null === duplicateTitle}
+									isBusy={ isSavingPost }
+									disabled={ null === duplicateTitle }
 									isPrimary
-									onClick={() => {
-										const titleForDuplicate = duplicateTitle.trim() || title + __(' copy', 'newspack-popups');
-										autosave().then(duplicatePrompt(postId, titleForDuplicate));
-									}}
+									onClick={ () => {
+										const titleForDuplicate =
+											duplicateTitle.trim() || title + __( ' copy', 'newspack-popups' );
+										autosave().then( duplicatePrompt( postId, titleForDuplicate ) );
+									} }
 								>
-									{__('Duplicate', 'newspack-popups')}
+									{ __( 'Duplicate', 'newspack-popups' ) }
 								</Button>
 							</Flex>
 						</>
-					)}
+					) }
 				</Modal>
-			)}
+			) }
 		</>
 	);
 };
 
-export default compose([
-	withSelect(select => {
-		const { isSavingPost, getCurrentPostId, getEditedPostAttribute } = select('core/editor');
-		const { duplicate_of: duplicateOf } = getEditedPostAttribute('meta');
+export default compose( [
+	withSelect( select => {
+		const { isSavingPost, getCurrentPostId, getEditedPostAttribute } = select( 'core/editor' );
+		const { duplicate_of: duplicateOf } = getEditedPostAttribute( 'meta' );
 		return {
 			postId: getCurrentPostId(),
 			isSavingPost: isSavingPost(),
-			title: getEditedPostAttribute('title'),
-			campaignGroups: getEditedPostAttribute('newspack_popups_taxonomy'),
+			title: getEditedPostAttribute( 'title' ),
+			campaignGroups: getEditedPostAttribute( 'newspack_popups_taxonomy' ),
 			duplicateOf,
 		};
-	}),
-	withDispatch(dispatch => {
-		const { autosave } = dispatch('core/editor');
-		const { createNotice } = dispatch('core/notices');
+	} ),
+	withDispatch( dispatch => {
+		const { autosave } = dispatch( 'core/editor' );
+		const { createNotice } = dispatch( 'core/notices' );
 		return {
 			autosave,
 			createNotice,
 		};
-	}),
-])(DuplicateButton);
+	} ),
+] )( DuplicateButton );

--- a/src/editor/EditorAdditions.js
+++ b/src/editor/EditorAdditions.js
@@ -14,29 +14,29 @@ import { useEffect } from '@wordpress/element';
 import { isOverlayPlacement, updateEditorColors } from './utils';
 
 const EditorAdditions = () => {
-	const meta = useSelect(select => select('core/editor').getEditedPostAttribute('meta'));
+	const meta = useSelect( select => select( 'core/editor' ).getEditedPostAttribute( 'meta' ) );
 	const { background_color, overlay_size, placement } = meta;
 
 	// Update editor colors to match popup colors.
-	useEffect(() => {
-		updateEditorColors(background_color);
-	}, [background_color]);
+	useEffect( () => {
+		updateEditorColors( background_color );
+	}, [ background_color ] );
 
 	// Setting editor size as per the popup size.
-	useEffect(() => {
-		const blockEditor = document.querySelector('.block-editor-block-list__layout');
-		if (blockEditor) {
-			blockEditor.classList.forEach(className => {
-				if (className.startsWith('is-size-')) {
-					blockEditor.classList.remove(className);
+	useEffect( () => {
+		const blockEditor = document.querySelector( '.block-editor-block-list__layout' );
+		if ( blockEditor ) {
+			blockEditor.classList.forEach( className => {
+				if ( className.startsWith( 'is-size-' ) ) {
+					blockEditor.classList.remove( className );
 				}
-			});
+			} );
 
-			if (isOverlayPlacement(placement)) {
-				blockEditor.classList.add(`is-size-${overlay_size}`);
+			if ( isOverlayPlacement( placement ) ) {
+				blockEditor.classList.add( `is-size-${ overlay_size }` );
 			}
 		}
-	}, [overlay_size, placement]);
+	}, [ overlay_size, placement ] );
 	return null;
 };
 

--- a/src/editor/ExpirationPanel.js
+++ b/src/editor/ExpirationPanel.js
@@ -11,11 +11,17 @@ import { useEffect, useState, useMemo } from '@wordpress/element';
  */
 import { convertDateToString } from './utils';
 
-const ExpirationPanel = ({ expiration_date = null, postStatus, onMetaFieldChange, createNotice, removeNotice }) => {
-	const [noticeId, setNoticeId] = useState(false);
-	useEffect(() => {
-		if (expiration_date && !isInTheFuture(expiration_date)) {
-			if (noticeId) {
+const ExpirationPanel = ( {
+	expiration_date = null,
+	postStatus,
+	onMetaFieldChange,
+	createNotice,
+	removeNotice,
+} ) => {
+	const [ noticeId, setNoticeId ] = useState( false );
+	useEffect( () => {
+		if ( expiration_date && ! isInTheFuture( expiration_date ) ) {
+			if ( noticeId ) {
 				return;
 			}
 			createNotice(
@@ -26,53 +32,63 @@ const ExpirationPanel = ({ expiration_date = null, postStatus, onMetaFieldChange
 						'This prompt has expired on %s and has been reverted to draft. Publishing it will reset the expiration date.',
 						'newspack-plugin'
 					),
-					new Date(expiration_date).toLocaleDateString()
+					new Date( expiration_date ).toLocaleDateString()
 				),
 				{
 					id: 'newspack-popups__expired',
 					isDismissible: false,
 				}
-			).then(({ notice }) => {
-				setNoticeId(notice.id);
-			});
+			).then( ( { notice } ) => {
+				setNoticeId( notice.id );
+			} );
 		}
-	}, [expiration_date]);
+	}, [ expiration_date ] );
 
-	useEffect(() => {
-		if (postStatus === 'publish' && noticeId) {
-			removeNotice(noticeId);
-			createNotice('info', __('This prompt has been published. The expiration date has been removed.', 'newspack-plugin'), {
-				id: 'newspack-popups__expiration-date-removed',
-			});
+	useEffect( () => {
+		if ( postStatus === 'publish' && noticeId ) {
+			removeNotice( noticeId );
+			createNotice(
+				'info',
+				__(
+					'This prompt has been published. The expiration date has been removed.',
+					'newspack-plugin'
+				),
+				{
+					id: 'newspack-popups__expiration-date-removed',
+				}
+			);
 			// This is just for quicked feedback, the actual meta field deletion will
 			// happen on the backend.
-			onMetaFieldChange({ expiration_date: null });
+			onMetaFieldChange( { expiration_date: null } );
 		}
-	}, [postStatus]);
+	}, [ postStatus ] );
 
-	const defaultExpirationDate = useMemo(() => {
+	const defaultExpirationDate = useMemo( () => {
 		const date = new Date();
-		date.setHours(date.getHours() + 24);
-		return convertDateToString(date);
-	}, []);
+		date.setHours( date.getHours() + 24 );
+		return convertDateToString( date );
+	}, [] );
 
 	return (
 		<>
 			<ToggleControl
-				label={__('Expiration Date', 'newspack-newsletters')}
-				checked={!!expiration_date}
-				onChange={() => {
-					onMetaFieldChange({ expiration_date: expiration_date ? null : defaultExpirationDate });
-				}}
-				help={__('If set, the prompt will be automatically unpublished at midnight on this date.', 'newspack-popups')}
+				label={ __( 'Expiration Date', 'newspack-newsletters' ) }
+				checked={ !! expiration_date }
+				onChange={ () => {
+					onMetaFieldChange( { expiration_date: expiration_date ? null : defaultExpirationDate } );
+				} }
+				help={ __(
+					'If set, the prompt will be automatically unpublished at midnight on this date.',
+					'newspack-popups'
+				) }
 			/>
-			{expiration_date ? (
+			{ expiration_date ? (
 				<DatePicker
-					currentDate={expiration_date}
-					onChange={value => onMetaFieldChange({ expiration_date: convertDateToString(new Date(value)) })}
-					isInvalidDate={date => !isInTheFuture(date)}
+					currentDate={ expiration_date }
+					onChange={ value => onMetaFieldChange( { expiration_date: convertDateToString( new Date( value ) ) } ) }
+					isInvalidDate={ date => ! isInTheFuture( date ) }
 				/>
-			) : null}
+			) : null }
 		</>
 	);
 };

--- a/src/editor/FrequencySidebar.js
+++ b/src/editor/FrequencySidebar.js
@@ -16,110 +16,120 @@ import {
 } from '@wordpress/components';
 
 const frequencyOptions = [
-	{ value: 'once', label: __('Once a month', 'newspack-popups') },
-	{ value: 'weekly', label: __('Once a week', 'newspack-popups') },
-	{ value: 'daily', label: __('Once a day', 'newspack-popups') },
+	{ value: 'once', label: __( 'Once a month', 'newspack-popups' ) },
+	{ value: 'weekly', label: __( 'Once a week', 'newspack-popups' ) },
+	{ value: 'daily', label: __( 'Once a day', 'newspack-popups' ) },
 	{
 		value: 'always',
-		label: __('Every pageview', 'newspack-popups'),
+		label: __( 'Every pageview', 'newspack-popups' ),
 	},
-	{ value: 'custom', label: __('Custom', 'newspack-popups') },
+	{ value: 'custom', label: __( 'Custom', 'newspack-popups' ) },
 ];
 
-const FrequencySidebar = ({ frequency, frequency_max, frequency_start, frequency_between, frequency_reset, onMetaFieldChange, utm_suppression }) => {
+const FrequencySidebar = ( {
+	frequency,
+	frequency_max,
+	frequency_start,
+	frequency_between,
+	frequency_reset,
+	onMetaFieldChange,
+	utm_suppression,
+} ) => {
 	return (
 		<Fragment>
 			<SelectControl
-				label={__('Frequency')}
-				value={frequency}
-				onChange={value => {
+				label={ __( 'Frequency' ) }
+				value={ frequency }
+				onChange={ value => {
 					const metaToUpdate = {
 						frequency: value,
 					};
 
-					if ('once' === value) {
+					if ( 'once' === value ) {
 						metaToUpdate.frequency_max = 1;
 						metaToUpdate.frequency_start = 0;
 						metaToUpdate.frequency_between = 0;
 						metaToUpdate.frequency_reset = 'month';
 					}
 
-					if ('daily' === value) {
+					if ( 'daily' === value ) {
 						metaToUpdate.frequency_max = 1;
 						metaToUpdate.frequency_start = 0;
 						metaToUpdate.frequency_between = 0;
 						metaToUpdate.frequency_reset = 'day';
 					}
 
-					if ('weekly' === value) {
+					if ( 'weekly' === value ) {
 						metaToUpdate.frequency_max = 1;
 						metaToUpdate.frequency_start = 0;
 						metaToUpdate.frequency_between = 0;
 						metaToUpdate.frequency_reset = 'week';
 					}
 
-					if ('always' === value) {
+					if ( 'always' === value ) {
 						metaToUpdate.frequency_max = 0;
 						metaToUpdate.frequency_start = 0;
 						metaToUpdate.frequency_between = 0;
 						metaToUpdate.frequency_reset = 'month';
 					}
 
-					onMetaFieldChange(metaToUpdate);
-				}}
-				options={frequencyOptions}
+					onMetaFieldChange( metaToUpdate );
+				} }
+				options={ frequencyOptions }
 			/>
-			{'custom' === frequency && (
+			{ 'custom' === frequency && (
 				<>
 					<NumberControl
 						className="newspack-popups__frequency-number-control"
-						label={__('Start at pageview', 'newspack-popups')}
-						value={frequency_start + 1}
-						min={1}
-						onChange={value => onMetaFieldChange({ frequency_start: value - 1 })}
+						label={ __( 'Start at pageview', 'newspack-popups' ) }
+						value={ frequency_start + 1 }
+						min={ 1 }
+						onChange={ value => onMetaFieldChange( { frequency_start: value - 1 } ) }
 					/>
 					<NumberControl
 						className="newspack-popups__frequency-number-control"
-						label={__('Display every n pageviews', 'newspack-popups')}
-						value={frequency_between + 1}
-						min={1}
-						onChange={value => onMetaFieldChange({ frequency_between: value - 1 })}
+						label={ __( 'Display every n pageviews', 'newspack-popups' ) }
+						value={ frequency_between + 1 }
+						min={ 1 }
+						onChange={ value => onMetaFieldChange( { frequency_between: value - 1 } ) }
 					/>
 					<ToggleControl
 						className="newspack-popups__frequency-toggle-control"
-						label={__('Limit number of displays', 'newspack-popups')}
-						checked={0 < frequency_max}
-						onChange={value => onMetaFieldChange({ frequency_max: value ? 1 : 0 })}
+						label={ __( 'Limit number of displays', 'newspack-popups' ) }
+						checked={ 0 < frequency_max }
+						onChange={ value => onMetaFieldChange( { frequency_max: value ? 1 : 0 } ) }
 					/>
-					{0 < frequency_max && (
+					{ 0 < frequency_max && (
 						<NumberControl
 							className="newspack-popups__frequency-number-control"
-							disabled={0 === frequency_max}
-							label={__('Max number of displays', 'newspack-popups')}
-							value={frequency_max}
-							min={0}
-							onChange={value => onMetaFieldChange({ frequency_max: value })}
+							disabled={ 0 === frequency_max }
+							label={ __( 'Max number of displays', 'newspack-popups' ) }
+							value={ frequency_max }
+							min={ 0 }
+							onChange={ value => onMetaFieldChange( { frequency_max: value } ) }
 						/>
-					)}
+					) }
 					<SelectControl
-						label={__('Reset counter per:', 'newspack-popups')}
-						value={frequency_reset}
-						options={[
-							{ value: 'month', label: __('Month', 'newspack-popups') },
-							{ value: 'week', label: __('Week', 'newspack-popups') },
-							{ value: 'day', label: __('Day', 'newspack-popups') },
-						]}
-						onChange={value => onMetaFieldChange({ frequency_reset: value })}
+						label={ __( 'Reset counter per:', 'newspack-popups' ) }
+						value={ frequency_reset }
+						options={ [
+							{ value: 'month', label: __( 'Month', 'newspack-popups' ) },
+							{ value: 'week', label: __( 'Week', 'newspack-popups' ) },
+							{ value: 'day', label: __( 'Day', 'newspack-popups' ) },
+						] }
+						onChange={ value => onMetaFieldChange( { frequency_reset: value } ) }
 					/>
 				</>
-			)}
+			) }
 			<hr />
 			<TextControl
-				label={__('UTM Suppression')}
-				help={__('Readers arriving at the site via URLs with this utm_source parameter will never be shown the prompt.')}
-				value={utm_suppression}
-				placeholder={__('utm_campaign_name', 'newspack')}
-				onChange={value => onMetaFieldChange({ utm_suppression: value })}
+				label={ __( 'UTM Suppression' ) }
+				help={ __(
+					'Readers arriving at the site via URLs with this utm_source parameter will never be shown the prompt.'
+				) }
+				value={ utm_suppression }
+				placeholder={ __( 'utm_campaign_name', 'newspack' ) }
+				onChange={ value => onMetaFieldChange( { utm_suppression: value } ) }
 			/>
 		</Fragment>
 	);

--- a/src/editor/MergeTagsBlockControl.js
+++ b/src/editor/MergeTagsBlockControl.js
@@ -10,19 +10,19 @@ const icon = () => (
 	<SVG width="24" height="24" viewBox="0 0 24 24">
 		<path d="M9.16601 4H10V5.5H9.16601C8.74401 5.5 8.25901 5.86 8.14001 6.543L7.63601 9.443C7.54684 9.96776 7.31701 10.4585 6.97101 10.863L6.00001 12L6.97301 13.138C7.31601 13.536 7.54301 14.028 7.63601 14.557L8.14001 17.457C8.25901 18.141 8.74401 18.5 9.16601 18.5H10V20H9.16601C7.87201 20 6.87901 18.965 6.66201 17.714L6.15801 14.815C6.11566 14.5585 6.00514 14.3181 5.83801 14.119L5.83701 14.118L3.99701 12L5.83901 9.88C5.99401 9.701 6.10901 9.46 6.15901 9.185L6.66201 6.287C6.87901 5.035 7.87201 4 9.16601 4ZM17.838 9.185L17.334 6.287C17.117 5.035 16.124 4 14.83 4H13.996V5.5H14.83C15.252 5.5 15.738 5.86 15.856 6.543L16.36 9.443C16.452 9.967 16.679 10.465 17.025 10.863L17.996 12L17.023 13.138C16.6782 13.5426 16.4491 14.0329 16.36 14.557L15.856 17.457C15.738 18.141 15.252 18.5 14.83 18.5H13.996V20H14.83C16.125 20 17.117 18.965 17.334 17.714L17.838 14.815C17.886 14.542 18.002 14.301 18.158 14.119L18.159 14.118L20 12L18.157 9.88C17.9902 9.68121 17.88 9.44113 17.838 9.185Z" />
 	</SVG>
-);
+)
 
-const MergeTagsBlockControl = ({ tags, attributes, setAttributes }) => {
-	const { clientId, selectionStart, selectionEnd } = useSelect(select => ({
-		clientId: select('core/block-editor').getSelectedBlockClientId(),
-		selectionStart: select('core/block-editor').getSelectionStart(),
-		selectionEnd: select('core/block-editor').getSelectionEnd(),
-	}));
+const MergeTagsBlockControl = ( { tags, attributes, setAttributes } ) => {
+	const { clientId, selectionStart, selectionEnd } = useSelect( select => ( {
+		clientId: select( 'core/block-editor' ).getSelectedBlockClientId(),
+		selectionStart: select( 'core/block-editor' ).getSelectionStart(),
+		selectionEnd: select( 'core/block-editor' ).getSelectionEnd(),
+	} ) );
 
 	const { selectionChange } = useDispatch('core/block-editor');
 
 	// Bail if it's a multi-block selection.
-	if (selectionStart.clientId !== selectionEnd.clientId) {
+	if ( selectionStart.clientId !== selectionEnd.clientId ) {
 		return null;
 	}
 
@@ -30,26 +30,30 @@ const MergeTagsBlockControl = ({ tags, attributes, setAttributes }) => {
 		<BlockControls>
 			<ToolbarGroup>
 				<ToolbarDropdownMenu
-					icon={icon}
-					label={__('Merge tags', 'newspack-popups')}
-					menuProps={{ className: 'newspack-popups__merge-tags-menu' }}
-					controls={tags.map(tag => ({
-						title: tag.description,
-						onClick: () => {
-							const text = `{{${tag.name.toUpperCase()}}}`;
-							const newContent =
-								attributes.content.slice(0, selectionStart.offset) + text + attributes.content.slice(selectionEnd.offset);
+					icon={ icon }
+					label={ __( 'Merge tags', 'newspack-popups' ) }
+					menuProps={ { className: "newspack-popups__merge-tags-menu" } }
+					controls={ tags.map( ( tag ) => (
+						{
+							title: tag.description,
+							onClick: () => {
+								const text = `{{${tag.name.toUpperCase()}}}`;
+								const newContent =
+									attributes.content.slice( 0, selectionStart.offset ) +
+									text +
+									attributes.content.slice( selectionEnd.offset );
 
-							const cursorPosition = selectionStart.offset + text.length;
+								const cursorPosition = selectionStart.offset + text.length;
 
-							setAttributes({ content: newContent });
-							selectionChange(clientId, 'content', cursorPosition, cursorPosition);
-						},
-					}))}
+								setAttributes( { content: newContent } );
+								selectionChange( clientId, 'content', cursorPosition, cursorPosition );
+							},
+						}
+					) ) }
 				/>
 			</ToolbarGroup>
 		</BlockControls>
-	);
+	)
 };
 
 export default MergeTagsBlockControl;

--- a/src/editor/PositionPlacementControl.js
+++ b/src/editor/PositionPlacementControl.js
@@ -9,98 +9,97 @@ import { ButtonGroup, Button, Tooltip } from '@wordpress/components';
  */
 import classnames from 'classnames';
 
-const PositionPlacementControl = ({ layout, label, help, onChange, size, ...props }) => {
+const PositionPlacementControl = ( { layout, label, help, onChange, size, ...props } ) => {
 	/**
 	 * Set layout options
 	 */
 	const layoutOptions =
 		size === 'full-width'
 			? [
-					{
-						value: 'top',
-						/* translators: Overlay Prompt Position */
-						label: __('Top', 'newspack-popups'),
-					},
-					{
-						value: 'center',
-						/* translators: Overlay Prompt Position */
-						label: __('Center', 'newspack-popups'),
-					},
-					{
-						value: 'bottom',
-						/* translators: Overlay Prompt Position */
-						label: __('Bottom', 'newspack-popups'),
-					},
-				]
-			: [
-					{
-						value: 'top_left',
-						/* translators: Overlay Prompt Position */
-						label: __('Top Left', 'newspack-popups'),
-					},
-					{
-						value: 'top',
-						/* translators: Overlay Prompt Position */
-						label: __('Top Center', 'newspack-popups'),
-					},
-					{
-						value: 'top_right',
-						/* translators: Overlay Prompt Position */
-						label: __('Top Right', 'newspack-popups'),
-					},
-					{
-						value: 'center_left',
-						/* translators: Overlay Prompt Position */
-						label: __('Center Left', 'newspack-popups'),
-					},
-					{
-						value: 'center',
-						/* translators: Overlay Prompt Position */
-						label: __('Center', 'newspack-popups'),
-					},
-					{
-						value: 'center_right',
-						/* translators: Overlay Prompt Position */
-						label: __('Center Right', 'newspack-popups'),
-					},
-					{
-						value: 'bottom_left',
-						/* translators: Overlay Prompt Position */
-						label: __('Bottom Left', 'newspack-popups'),
-					},
-					{
-						value: 'bottom',
-						/* translators: Overlay Prompt Position */
-						label: __('Bottom Center', 'newspack-popups'),
-					},
-					{
-						value: 'bottom_right',
-						/* translators: Overlay Prompt Position */
-						label: __('Bottom Right', 'newspack-popups'),
-					},
-				];
+				{
+					value: 'top',
+					/* translators: Overlay Prompt Position */
+					label: __( 'Top', 'newspack-popups' ),
+				},
+				{
+					value: 'center',
+					/* translators: Overlay Prompt Position */
+					label: __( 'Center', 'newspack-popups' ),
+				},
+				{
+					value: 'bottom',
+					/* translators: Overlay Prompt Position */
+					label: __( 'Bottom', 'newspack-popups' ),
+				},
+			] : [
+				{
+					value: 'top_left',
+					/* translators: Overlay Prompt Position */
+					label: __( 'Top Left', 'newspack-popups' ),
+				},
+				{
+					value: 'top',
+					/* translators: Overlay Prompt Position */
+					label: __( 'Top Center', 'newspack-popups' ),
+				},
+				{
+					value: 'top_right',
+					/* translators: Overlay Prompt Position */
+					label: __( 'Top Right', 'newspack-popups' ),
+				},
+				{
+					value: 'center_left',
+					/* translators: Overlay Prompt Position */
+					label: __( 'Center Left', 'newspack-popups' ),
+				},
+				{
+					value: 'center',
+					/* translators: Overlay Prompt Position */
+					label: __( 'Center', 'newspack-popups' ),
+				},
+				{
+					value: 'center_right',
+					/* translators: Overlay Prompt Position */
+					label: __( 'Center Right', 'newspack-popups' ),
+				},
+				{
+					value: 'bottom_left',
+					/* translators: Overlay Prompt Position */
+					label: __( 'Bottom Left', 'newspack-popups' ),
+				},
+				{
+					value: 'bottom',
+					/* translators: Overlay Prompt Position */
+					label: __( 'Bottom Center', 'newspack-popups' ),
+				},
+				{
+					value: 'bottom_right',
+					/* translators: Overlay Prompt Position */
+					label: __( 'Bottom Right', 'newspack-popups' ),
+				},
+			];
 	return (
-		<div className={classnames('newspack-popups-css-grid-selector', 'size-' + size)}>
-			<p className="components-base-control__label">{label}</p>
-			<ButtonGroup aria-label={__('Select Position', 'newspack-popups')} {...props}>
-				{layoutOptions.map(({ label: layoutLabel, value }, index) => {
+		<div className={ classnames( 'newspack-popups-css-grid-selector', 'size-' + size ) }>
+			<p className="components-base-control__label">{ label }</p>
+			<ButtonGroup aria-label={ __( 'Select Position', 'newspack-popups' ) } { ...props }>
+				{ layoutOptions.map( ( { label: layoutLabel, value }, index ) => {
 					return (
-						<Tooltip text={layoutLabel} key={`grid-tooltip-${index}`}>
-							<div className={value === layout ? 'is-selected' : null}>
+						<Tooltip text={ layoutLabel } key={ `grid-tooltip-${ index }` }>
+							<div className={ value === layout ? 'is-selected' : null }>
 								<Button
 									isSmall
-									isSecondary={value !== layout}
-									isPrimary={value === layout}
-									onClick={() => {
-										onChange(value);
-									}}
+									isSecondary={ value !== layout }
+									isPrimary={ value === layout }
+									onClick={ () => {
+										onChange( value );
+									} }
 								/>
 							</div>
 						</Tooltip>
 					);
-				})}
+				} ) }
 			</ButtonGroup>
-			<p className="components-base-control__help">{help}</p>
+			<p className="components-base-control__help">{ help }</p>
 		</div>
 	);
 };

--- a/src/editor/PostTypesPanel.js
+++ b/src/editor/PostTypesPanel.js
@@ -8,26 +8,26 @@ import { without } from 'lodash';
  */
 import { PanelRow, CheckboxControl } from '@wordpress/components';
 
-const PostTypesPanel = ({ post_types = [], onMetaFieldChange }) => {
+const PostTypesPanel = ( { post_types = [], onMetaFieldChange } ) => {
 	const availablePostTypes = [
 		{ name: 'post', label: 'Posts' },
 		{ name: 'page', label: 'Pages' },
 		...window.newspack_popups_data.available_post_types,
 	];
 
-	return availablePostTypes.map(({ name, label }) => (
-		<PanelRow key={name}>
+	return availablePostTypes.map( ( { name, label } ) => (
+		<PanelRow key={ name }>
 			<CheckboxControl
-				label={label}
-				checked={post_types.indexOf(name) > -1}
-				onChange={isIncluded => {
-					onMetaFieldChange({
-						post_types: isIncluded ? [...post_types, name] : without(post_types, name),
-					});
-				}}
+				label={ label }
+				checked={ post_types.indexOf( name ) > -1 }
+				onChange={ isIncluded => {
+					onMetaFieldChange( {
+						post_types: isIncluded ? [ ...post_types, name ] : without( post_types, name ),
+					} );
+				} }
 			/>
 		</PanelRow>
-	));
+	) );
 };
 
 export default PostTypesPanel;

--- a/src/editor/Preview.js
+++ b/src/editor/Preview.js
@@ -12,15 +12,15 @@ import { addQueryArgs } from '@wordpress/url';
  */
 import { WebPreview } from 'newspack-components';
 
-const PreviewSetting = ({ autosavePost, isSavingPost, postId, metaFields }) => {
+const PreviewSetting = ( { autosavePost, isSavingPost, postId, metaFields } ) => {
 	const previewQueryKeys = window.newspack_popups_data?.preview_query_keys || {};
 	const frontendUrl = window?.newspack_popups_data?.frontend_url || '/';
 	const abbreviatedKeys = {};
-	Object.keys(metaFields).forEach(key => {
-		if (previewQueryKeys.hasOwnProperty(key)) {
-			abbreviatedKeys[previewQueryKeys[key]] = metaFields[key];
+	Object.keys( metaFields ).forEach( key => {
+		if ( previewQueryKeys.hasOwnProperty( key ) ) {
+			abbreviatedKeys[ previewQueryKeys[ key ] ] = metaFields[ key ];
 		}
-	});
+	} );
 
 	const query = {
 		pid: postId,
@@ -29,43 +29,51 @@ const PreviewSetting = ({ autosavePost, isSavingPost, postId, metaFields }) => {
 	};
 
 	const isArchivePagesPrompt = metaFields.placement === 'archives';
-	const previewURL = window.newspack_popups_data[isArchivePagesPrompt ? 'preview_archive' : 'preview_post'] || '/';
+	const previewURL =
+		window.newspack_popups_data[ isArchivePagesPrompt ? 'preview_archive' : 'preview_post' ] || '/';
 
 	const onWebPreviewLoad = iframeEl => {
-		if (iframeEl) {
-			[...iframeEl.contentWindow.document.querySelectorAll('a[href^="' + frontendUrl + '"]')].forEach(anchor => {
-				anchor.setAttribute('href', addQueryArgs(anchor.getAttribute('href'), query));
-			});
+		if ( iframeEl ) {
+			[
+				...iframeEl.contentWindow.document.querySelectorAll( 'a[href^="' + frontendUrl + '"]' ),
+			].forEach( anchor => {
+				anchor.setAttribute( 'href', addQueryArgs( anchor.getAttribute( 'href' ), query ) );
+			} );
 		}
 	};
 
 	return (
 		<WebPreview
-			url={addQueryArgs(previewURL, query)}
-			onLoad={onWebPreviewLoad}
-			renderButton={({ showPreview }) => (
-				<Button isPrimary isBusy={isSavingPost} disabled={isSavingPost} onClick={() => autosavePost().then(showPreview)}>
-					{__('Preview', 'newspack-popups')}
+			url={ addQueryArgs( previewURL, query ) }
+			onLoad={ onWebPreviewLoad }
+			renderButton={ ( { showPreview } ) => (
+				<Button
+					isPrimary
+					isBusy={ isSavingPost }
+					disabled={ isSavingPost }
+					onClick={ () => autosavePost().then( showPreview ) }
+				>
+					{ __( 'Preview', 'newspack-popups' ) }
 				</Button>
-			)}
+			) }
 		/>
 	);
 };
 
-const connectPreviewSetting = compose([
-	withSelect(select => {
-		const { isSavingPost, getCurrentPostId, getEditedPostAttribute } = select('core/editor');
+const connectPreviewSetting = compose( [
+	withSelect( select => {
+		const { isSavingPost, getCurrentPostId, getEditedPostAttribute } = select( 'core/editor' );
 		return {
 			postId: getCurrentPostId(),
-			metaFields: getEditedPostAttribute('meta'),
+			metaFields: getEditedPostAttribute( 'meta' ),
 			isSavingPost: isSavingPost(),
 		};
-	}),
-	withDispatch(dispatch => {
+	} ),
+	withDispatch( dispatch => {
 		return {
-			autosavePost: () => dispatch('core/editor').autosave(),
+			autosavePost: () => dispatch( 'core/editor' ).autosave(),
 		};
-	}),
-]);
+	} ),
+] );
 
-export default connectPreviewSetting(PreviewSetting);
+export default connectPreviewSetting( PreviewSetting );

--- a/src/editor/Sidebar.js
+++ b/src/editor/Sidebar.js
@@ -7,7 +7,13 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Fragment } from '@wordpress/element';
-import { RadioControl, RangeControl, SelectControl, ToggleControl, CheckboxControl } from '@wordpress/components';
+import {
+	RadioControl,
+	RangeControl,
+	SelectControl,
+	ToggleControl,
+	CheckboxControl,
+} from '@wordpress/components';
 
 /**
  * External dependencies
@@ -35,27 +41,27 @@ const Sidebar = props => {
 		archive_page_types = [],
 	} = props;
 	const updatePlacement = value => {
-		onMetaFieldChange({ placement: value });
+		onMetaFieldChange( { placement: value } );
 	};
 	const updatePlacementWhenPopupIsFullWidth = () => {
-		switch (placement) {
+		switch ( placement ) {
 			case 'top_left':
 			case 'top_right':
-				onMetaFieldChange({ placement: 'top' });
+				onMetaFieldChange( { placement: 'top' } );
 				break;
 			case 'center_left':
 			case 'center_right':
-				onMetaFieldChange({ placement: 'center' });
+				onMetaFieldChange( { placement: 'center' } );
 				break;
 			case 'bottom_left':
 			case 'bottom_right':
-				onMetaFieldChange({ placement: 'bottom' });
+				onMetaFieldChange( { placement: 'bottom' } );
 				break;
 		}
 	};
 	const updateSize = size => {
-		onMetaFieldChange({ overlay_size: size });
-		if ('full-width' === size) {
+		onMetaFieldChange( { overlay_size: size } );
+		if ( 'full-width' === size ) {
 			updatePlacementWhenPopupIsFullWidth();
 		}
 	};
@@ -63,146 +69,155 @@ const Sidebar = props => {
 	const popupSizeOptions = window.newspack_popups_data?.popup_size_options || {};
 	const availableArchivePageTypes = window.newspack_popups_data?.available_archive_page_types || [];
 
-	const helpMessage = getPlacementHelpMessage(props);
+	const helpMessage = getPlacementHelpMessage( props );
 
 	return (
 		<>
 			<RadioControl
 				className="newspack-popups__prompt-type-control"
-				label={__('Prompt type', 'newspack-popups')}
-				selected={isOverlay ? 'center' : 'inline'}
-				options={[
-					{ label: __('Inline', 'newspack-popups'), value: 'inline' },
-					{ label: __('Overlay', 'newspack-popups'), value: 'center' },
-				]}
-				onChange={updatePlacement}
+				label={ __( 'Prompt type', 'newspack-popups' ) }
+				selected={ isOverlay ? 'center' : 'inline' }
+				options={ [
+					{ label: __( 'Inline', 'newspack-popups' ), value: 'inline' },
+					{ label: __( 'Overlay', 'newspack-popups' ), value: 'center' },
+				] }
+				onChange={ updatePlacement }
 			/>
-			{isOverlay ? (
+			{ isOverlay ? (
 				<>
-					<SelectControl label={__('Size', 'newspack-popups')} value={overlay_size} onChange={updateSize} options={popupSizeOptions} />
+					<SelectControl
+						label={ __( 'Size', 'newspack-popups' ) }
+						value={ overlay_size }
+						onChange={ updateSize }
+						options={ popupSizeOptions }
+					/>
 					<PositionPlacementControl
-						layout={placement}
-						label={__('Position', 'newspack-popups')}
-						help={helpMessage}
-						value={placement}
-						onChange={updatePlacement}
-						size={overlay_size}
+						layout={ placement }
+						label={ __( 'Position', 'newspack-popups' ) }
+						help={ helpMessage }
+						value={ placement }
+						onChange={ updatePlacement }
+						size={ overlay_size }
 					/>
 				</>
 			) : (
 				<SelectControl
-					label={__('Placement')}
-					help={helpMessage}
-					value={placement}
-					onChange={updatePlacement}
-					options={[
-						{ value: 'inline', label: __('In article content', 'newspack-popups') },
-						{ value: 'archives', label: __('In archive pages') },
-						{ value: 'above_header', label: __('Above site header', 'newspack-popups') },
-						{ value: 'manual', label: __('Manual only', 'newspack-popups') },
+					label={ __( 'Placement' ) }
+					help={ helpMessage }
+					value={ placement }
+					onChange={ updatePlacement }
+					options={ [
+						{ value: 'inline', label: __( 'In article content', 'newspack-popups' ) },
+						{ value: 'archives', label: __( 'In archive pages' ) },
+						{ value: 'above_header', label: __( 'Above site header', 'newspack-popups' ) },
+						{ value: 'manual', label: __( 'Manual only', 'newspack-popups' ) },
 					].concat(
-						Object.keys(customPlacements).map(key => ({
+						Object.keys( customPlacements ).map( key => ( {
 							value: key,
-							label: customPlacements[key],
-						}))
-					)}
+							label: customPlacements[ key ],
+						} ) )
+					) }
 				/>
-			)}
+			) }
 
-			{isOverlay && (
+			{ isOverlay && (
 				<>
 					<SelectControl
-						label={__('Trigger', 'newspack-popups')}
-						help={__('The event to trigger the prompt.', 'newspack-popups')}
-						value={trigger_type}
-						options={[
-							{ label: __('Timer', 'newspack-popups'), value: 'time' },
-							{ label: __('Scroll Progress', 'newspack-popups'), value: 'scroll' },
-						]}
-						onChange={value => onMetaFieldChange({ trigger_type: value })}
+						label={ __( 'Trigger', 'newspack-popups' ) }
+						help={ __( 'The event to trigger the prompt.', 'newspack-popups' ) }
+						value={ trigger_type }
+						options={ [
+							{ label: __( 'Timer', 'newspack-popups' ), value: 'time' },
+							{ label: __( 'Scroll Progress', 'newspack-popups' ), value: 'scroll' },
+						] }
+						onChange={ value => onMetaFieldChange( { trigger_type: value } ) }
 					/>
-					{'scroll' === trigger_type ? (
+					{ 'scroll' === trigger_type ? (
 						<RangeControl
-							label={__('Scroll Progress (percent)', 'newspack-popups')}
-							value={trigger_scroll_progress}
-							onChange={value => onMetaFieldChange({ trigger_scroll_progress: value })}
-							min={1}
-							max={100}
+							label={ __( 'Scroll Progress (percent)', 'newspack-popups' ) }
+							value={ trigger_scroll_progress }
+							onChange={ value => onMetaFieldChange( { trigger_scroll_progress: value } ) }
+							min={ 1 }
+							max={ 100 }
 						/>
 					) : (
 						<RangeControl
-							label={__('Delay (seconds)', 'newspack-popups')}
-							value={trigger_delay}
-							onChange={value => onMetaFieldChange({ trigger_delay: value })}
-							min={0}
-							max={60}
+							label={ __( 'Delay (seconds)', 'newspack-popups' ) }
+							value={ trigger_delay }
+							onChange={ value => onMetaFieldChange( { trigger_delay: value } ) }
+							min={ 0 }
+							max={ 60 }
 						/>
-					)}
+					) }
 				</>
-			)}
-			{placement === 'inline' && (
+			) }
+			{ placement === 'inline' && (
 				<>
 					<SelectControl
-						label={__('Insertion position', 'newspack-popups')}
-						help={__('The position at which to insert the prompt.', 'newspack-popups')}
-						value={trigger_type}
-						options={[
-							{ label: __('Percentage', 'newspack-popups'), value: 'scroll' },
-							{ label: __('Blocks Count', 'newspack-popups'), value: 'blocks_count' },
-						]}
-						onChange={value => onMetaFieldChange({ trigger_type: value })}
+						label={ __( 'Insertion position', 'newspack-popups' ) }
+						help={ __( 'The position at which to insert the prompt.', 'newspack-popups' ) }
+						value={ trigger_type }
+						options={ [
+							{ label: __( 'Percentage', 'newspack-popups' ), value: 'scroll' },
+							{ label: __( 'Blocks Count', 'newspack-popups' ), value: 'blocks_count' },
+						] }
+						onChange={ value => onMetaFieldChange( { trigger_type: value } ) }
 					/>
-					{'blocks_count' === trigger_type ? (
+					{ 'blocks_count' === trigger_type ? (
 						<RangeControl
-							label={__('Number of blocks before the prompt', 'newspack-popups')}
-							value={trigger_blocks_count}
-							onChange={value => onMetaFieldChange({ trigger_blocks_count: value })}
-							min={0}
+							label={ __( 'Number of blocks before the prompt', 'newspack-popups' ) }
+							value={ trigger_blocks_count }
+							onChange={ value => onMetaFieldChange( { trigger_blocks_count: value } ) }
+							min={ 0 }
 						/>
 					) : (
 						<RangeControl
-							label={__('Approximate Position (in percent)', 'newspack-popups')}
-							value={trigger_scroll_progress}
-							onChange={value => onMetaFieldChange({ trigger_scroll_progress: value })}
-							min={0}
-							max={100}
+							label={ __( 'Approximate Position (in percent)', 'newspack-popups' ) }
+							value={ trigger_scroll_progress }
+							onChange={ value => onMetaFieldChange( { trigger_scroll_progress: value } ) }
+							min={ 0 }
+							max={ 100 }
 						/>
-					)}
+					) }
 				</>
-			)}
-			{placement === 'archives' && (
+			) }
+			{ placement === 'archives' && (
 				<Fragment>
 					<RangeControl
-						label={__('Number of articles before prompt', 'newspack-popups')}
-						value={archive_insertion_posts_count}
-						onChange={value => onMetaFieldChange({ archive_insertion_posts_count: value })}
-						min={1}
-						max={20}
+						label={ __( 'Number of articles before prompt', 'newspack-popups' ) }
+						value={ archive_insertion_posts_count }
+						onChange={ value => onMetaFieldChange( { archive_insertion_posts_count: value } ) }
+						min={ 1 }
+						max={ 20 }
 					/>
 
 					<div className="newspack-popups__prompt-type-control">
-						<legend className="components-base-control__legend">{__('Archive Page Types', 'newspack-popups')}</legend>
-						{availableArchivePageTypes.map(({ name, label }) => (
+						<legend className="components-base-control__legend">
+							{ __( 'Archive Page Types', 'newspack-popups' ) }
+						</legend>
+						{ availableArchivePageTypes.map( ( { name, label } ) => (
 							<CheckboxControl
-								key={name}
-								label={label}
-								checked={archive_page_types.indexOf(name) > -1}
-								onChange={isIncluded => {
-									onMetaFieldChange({
-										archive_page_types: isIncluded ? [...archive_page_types, name] : without(archive_page_types, name),
-									});
-								}}
+								key={ name }
+								label={ label }
+								checked={ archive_page_types.indexOf( name ) > -1 }
+								onChange={ isIncluded => {
+									onMetaFieldChange( {
+										archive_page_types: isIncluded
+											? [ ...archive_page_types, name ]
+											: without( archive_page_types, name ),
+									} );
+								} }
 							/>
-						))}
+						) ) }
 					</div>
 
 					<ToggleControl
-						label={__('Repeat prompt', 'newspack-popups')}
-						checked={archive_insertion_is_repeating}
-						onChange={value => onMetaFieldChange({ archive_insertion_is_repeating: value })}
+						label={ __( 'Repeat prompt', 'newspack-popups' ) }
+						checked={ archive_insertion_is_repeating }
+						onChange={ value => onMetaFieldChange( { archive_insertion_is_repeating: value } ) }
 					/>
 				</Fragment>
-			)}
+			) }
 		</>
 	);
 };

--- a/src/editor/StylesSidebar.js
+++ b/src/editor/StylesSidebar.js
@@ -12,52 +12,52 @@ import { useEffect } from '@wordpress/element';
 const StylesSidebar = props => {
 	const { onMetaFieldChange, hide_border, large_border, no_padding, isOverlay } = props;
 
-	useEffect(() => {
-		if (!isOverlay && no_padding) {
-			onMetaFieldChange({ hide_border: false, large_border: false, no_padding: false });
+	useEffect( () => {
+		if ( ! isOverlay && no_padding ) {
+			onMetaFieldChange( { hide_border: false, large_border: false, no_padding: false } )
 		}
-	}, [isOverlay]);
+	}, [ isOverlay ] );
 
 	return (
 		<div className="newspack-popups-style-selector">
 			<Button
-				variant={!hide_border && !large_border && !no_padding ? 'primary' : 'secondary'}
-				isPressed={!hide_border && !large_border && !no_padding}
-				onClick={() => onMetaFieldChange({ hide_border: false, large_border: false, no_padding: false })}
-				aria-current={!hide_border && !large_border && !no_padding}
+				variant={ ! hide_border && ! large_border && ! no_padding ? 'primary' : 'secondary' }
+				isPressed={ ! hide_border && ! large_border && ! no_padding }
+				onClick={ () => onMetaFieldChange( { hide_border: false, large_border: false, no_padding: false } ) }
+				aria-current={ ! hide_border && ! large_border && ! no_padding }
 			>
-				{__('Default', 'newspack-popups')}
+				{ __( 'Default', 'newspack-popups' ) }
 			</Button>
 			<Button
-				variant={hide_border ? 'primary' : 'secondary'}
-				isPressed={hide_border}
-				onClick={() => onMetaFieldChange({ hide_border: true, large_border: false, no_padding: false })}
-				aria-current={hide_border}
+				variant={ hide_border ? 'primary' : 'secondary' }
+				isPressed={ hide_border }
+				onClick={ () => onMetaFieldChange( { hide_border: true, large_border: false, no_padding: false } ) }
+				aria-current={ hide_border }
 			>
-				{isOverlay ? __('Small Padding', 'newspack-popups') : __('Hide Border', 'newspack-popups')}
+				{ isOverlay ? __( 'Small Padding', 'newspack-popups' ) : __( 'Hide Border', 'newspack-popups' ) }
 			</Button>
 			<Button
-				variant={large_border ? 'primary' : 'secondary'}
-				isPressed={large_border}
-				onClick={() => onMetaFieldChange({ hide_border: false, large_border: true, no_padding: false })}
-				aria-current={large_border}
+				variant={ large_border ? 'primary' : 'secondary' }
+				isPressed={ large_border }
+				onClick={ () => onMetaFieldChange( { hide_border: false, large_border: true, no_padding: false } ) }
+				aria-current={ large_border }
 			>
-				{sprintf(
+				{ sprintf(
 					// Translators: %s is "padding" if the prompt is inline, or "border" if not
-					__('Large %s', 'newspack-popups'),
-					isOverlay ? __('Padding', 'newspack-popups') : __('Border', 'newspack-popups')
-				)}
+					__( 'Large %s', 'newspack-popups' ),
+					isOverlay ? __( 'Padding', 'newspack-popups' ) : __( 'Border', 'newspack-popups' )
+				) }
 			</Button>
-			{isOverlay && (
+			{ isOverlay && (
 				<Button
-					variant={no_padding ? 'primary' : 'secondary'}
-					isPressed={no_padding}
-					onClick={() => onMetaFieldChange({ hide_border: false, large_border: false, no_padding: true })}
-					aria-current={no_padding}
+					variant={ no_padding ? 'primary' : 'secondary' }
+					isPressed={ no_padding }
+					onClick={ () => onMetaFieldChange( { hide_border: false, large_border: false, no_padding: true } ) }
+					aria-current={ no_padding }
 				>
-					{__('No Padding', 'newspack-popups')}
+					{ __( 'No Padding', 'newspack-popups' ) }
 				</Button>
-			)}
+			) }
 		</div>
 	);
 };

--- a/src/editor/index.js
+++ b/src/editor/index.js
@@ -42,11 +42,11 @@ const TAXONOMY_SLUG = newspack_popups_data.segments_taxonomy;
 
 // Action dispatchers for the sidebar components.
 const mapDispatchToProps = dispatch => {
-	const { createNotice, removeNotice } = dispatch('core/notices');
+	const { createNotice, removeNotice } = dispatch( 'core/notices' );
 	return {
-		onMetaFieldChange: (metaToUpdate = {}) => {
-			if (0 < Object.keys(metaToUpdate).length) {
-				dispatch('core/editor').editPost({ meta: metaToUpdate });
+		onMetaFieldChange: ( metaToUpdate = {} ) => {
+			if ( 0 < Object.keys( metaToUpdate ).length ) {
+				dispatch( 'core/editor' ).editPost( { meta: metaToUpdate } );
 			}
 		},
 		createNotice,
@@ -54,119 +54,156 @@ const mapDispatchToProps = dispatch => {
 	};
 };
 
-const connectData = compose([withSelect(promptEditorPropsSelector), withDispatch(mapDispatchToProps)]);
+const connectData = compose( [
+	withSelect( promptEditorPropsSelector ),
+	withDispatch( mapDispatchToProps ),
+] );
 
 // Connect data to components.
-const SidebarWithData = connectData(Sidebar);
-const StylesSidebarWithData = connectData(StylesSidebar);
-const FrequencySidebarWithData = connectData(FrequencySidebar);
-const ColorsSidebarWithData = connectData(ColorsSidebar);
-const PostTypesPanelWithData = connectData(PostTypesPanel);
-const ExpirationPanelWithData = connectData(ExpirationPanel);
-const AdvancedSidebarWithData = connectData(AdvancedSidebar);
+const SidebarWithData = connectData( Sidebar );
+const StylesSidebarWithData = connectData( StylesSidebar );
+const FrequencySidebarWithData = connectData( FrequencySidebar );
+const ColorsSidebarWithData = connectData( ColorsSidebar );
+const PostTypesPanelWithData = connectData( PostTypesPanel );
+const ExpirationPanelWithData = connectData( ExpirationPanel );
+const AdvancedSidebarWithData = connectData( AdvancedSidebar );
 
 // Register components.
-registerPlugin('newspack-popups-styles', {
+registerPlugin( 'newspack-popups-styles', {
 	render: () => (
-		<PluginDocumentSettingPanel name="popup-styles-panel" title={__('Styles', 'newspack-popups')}>
+		<PluginDocumentSettingPanel
+			name="popup-styles-panel"
+			title={ __( 'Styles', 'newspack-popups' ) }
+		>
 			<StylesSidebarWithData />
 		</PluginDocumentSettingPanel>
 	),
 	icon: null,
-});
+} );
 
-registerPlugin('newspack-popups', {
+registerPlugin( 'newspack-popups', {
 	render: () => (
-		<PluginDocumentSettingPanel name="popup-settings-panel" title={__('Settings', 'newspack-popups')}>
+		<PluginDocumentSettingPanel
+			name="popup-settings-panel"
+			title={ __( 'Settings', 'newspack-popups' ) }
+		>
 			<SidebarWithData />
 		</PluginDocumentSettingPanel>
 	),
 	icon: null,
-});
+} );
 
-if (window?.newspack_popups_data?.segmentation_enabled) {
-	registerPlugin('newspack-popups-frequency', {
+if ( window?.newspack_popups_data?.segmentation_enabled ) {
+	registerPlugin( 'newspack-popups-frequency', {
 		render: () => (
-			<PluginDocumentSettingPanel name="-frequency-panel" title={__('Frequency', 'newspack-popups')}>
+			<PluginDocumentSettingPanel
+				name="-frequency-panel"
+				title={ __( 'Frequency', 'newspack-popups' ) }
+			>
 				<FrequencySidebarWithData />
 			</PluginDocumentSettingPanel>
 		),
 		icon: null,
-	});
+	} );
 }
 
-registerPlugin('newspack-popups-colors', {
+registerPlugin( 'newspack-popups-colors', {
 	render: () => (
-		<PluginDocumentSettingPanel name="popup-colors-panel" title={__('Color', 'newspack-popups')}>
+		<PluginDocumentSettingPanel
+			name="popup-colors-panel"
+			title={ __( 'Color', 'newspack-popups' ) }
+		>
 			<ColorsSidebarWithData />
 		</PluginDocumentSettingPanel>
 	),
 	icon: null,
-});
+} );
 
-registerPlugin('newspack-popups-post-types', {
+registerPlugin( 'newspack-popups-post-types', {
 	render: () => (
-		<PluginDocumentSettingPanel name="post-types-panel" title={__('Post Types', 'newspack-popups')}>
+		<PluginDocumentSettingPanel
+			name="post-types-panel"
+			title={ __( 'Post Types', 'newspack-popups' ) }
+		>
 			<PostTypesPanelWithData />
 		</PluginDocumentSettingPanel>
 	),
 	icon: null,
-});
+} );
 
-registerPlugin('newspack-popups-expiration', {
+registerPlugin( 'newspack-popups-expiration', {
 	render: () => (
-		<PluginDocumentSettingPanel name="expiration-panel" title={__('Expiration', 'newspack-popups')}>
+		<PluginDocumentSettingPanel
+			name="expiration-panel"
+			title={ __( 'Expiration', 'newspack-popups' ) }
+		>
 			<ExpirationPanelWithData />
 		</PluginDocumentSettingPanel>
 	),
 	icon: null,
-});
+} );
 
-if (window.newspack_popups_merge_tags?.tags?.length) {
-	wp.hooks.addFilter('editor.BlockEdit', 'newspack-popups/merge-tags-block-control', BlockEdit => props => {
-		const blocks = ['core/paragraph', 'core/heading', 'core/list-item', 'core/quote', 'core/pullquote', 'core/verse', 'core/preformatted'];
-		if (blocks.includes(props.name)) {
-			return (
-				<>
-					<BlockEdit {...props} />
-					<MergeTagsBlockControl tags={window.newspack_popups_merge_tags.tags} {...props} />
-				</>
-			);
+if ( window.newspack_popups_merge_tags?.tags?.length ) {
+	wp.hooks.addFilter(
+		'editor.BlockEdit',
+		'newspack-popups/merge-tags-block-control',
+		BlockEdit => props => {
+			const blocks = [
+				'core/paragraph',
+				'core/heading',
+				'core/list-item',
+				'core/quote',
+				'core/pullquote',
+				'core/verse',
+				'core/preformatted',
+			];
+			if ( blocks.includes( props.name ) ) {
+				return (
+					<>
+						<BlockEdit { ...props } />
+						<MergeTagsBlockControl tags={ window.newspack_popups_merge_tags.tags } { ...props } />
+					</>
+				);
+			}
+			return <BlockEdit { ...props } />;
 		}
-		return <BlockEdit {...props} />;
-	});
+	)
 }
 
-registerPlugin('newspack-popups-advanced', {
+
+registerPlugin( 'newspack-popups-advanced', {
 	render: () => (
-		<PluginDocumentSettingPanel name="popup-advanced-panel" title={__('Advanced Settings', 'newspack-popups')}>
+		<PluginDocumentSettingPanel
+			name="popup-advanced-panel"
+			title={ __( 'Advanced Settings', 'newspack-popups' ) }
+		>
 			<AdvancedSidebarWithData />
 		</PluginDocumentSettingPanel>
 	),
 	icon: null,
-});
+} );
 
-registerPlugin('newspack-popups-editor', {
+registerPlugin( 'newspack-popups-editor', {
 	render: EditorAdditions,
 	icon: null,
-});
+} );
 
 // Hide Newspack's Homepage Posts block deduplication toggle when the popup is an overlay.
-registerPlugin('newspack-popups-disable-newspack-blocks-deduplication', {
+registerPlugin( 'newspack-popups-disable-newspack-blocks-deduplication', {
 	render: function HideDeduplicationToggle() {
-		const { placement } = useSelect(select => {
-			const { getEditedPostAttribute } = select('core/editor');
+		const { placement } = useSelect( select => {
+			const { getEditedPostAttribute } = select( 'core/editor' );
 			return {
-				placement: getEditedPostAttribute('meta')?.placement,
+				placement: getEditedPostAttribute( 'meta' )?.placement,
 			};
-		});
-		if (!isOverlayPlacement(placement)) {
+		} );
+		if ( ! isOverlayPlacement( placement ) ) {
 			return null;
 		}
-		return <style>{'.newspack-blocks-deduplication-toggle {display: none;}'}</style>;
+		return <style>{ '.newspack-blocks-deduplication-toggle {display: none;}' }</style>;
 	},
 	icon: null,
-});
+} );
 
 // Add a button in post status section
 const PluginPostStatusInfoTest = () => (
@@ -175,67 +212,87 @@ const PluginPostStatusInfoTest = () => (
 		<Duplicate />
 	</PluginPostStatusInfo>
 );
-registerPlugin('newspack-popups-preview', { render: PluginPostStatusInfoTest });
+registerPlugin( 'newspack-popups-preview', { render: PluginPostStatusInfoTest } );
 
 let updatedWithGetParam = false;
 
 /**
  * Adds a help message to the Segment selector
  */
-const NewspackPopupsSegmentsHelper = ({ slug }) => {
-	const { editPost } = useDispatch(editorStore);
+const NewspackPopupsSegmentsHelper = ( { slug } ) => {
+	const { editPost } = useDispatch( editorStore );
 	const { terms, taxonomy } = useSelect(
 		select => {
-			const { getEditedPostAttribute } = select('core/editor');
-			const { getTaxonomy } = select(coreStore);
-			const _taxonomy = getTaxonomy(slug);
+			const { getEditedPostAttribute } = select( 'core/editor' );
+			const { getTaxonomy } = select( coreStore );
+			const _taxonomy = getTaxonomy( slug );
 
 			return {
-				terms: _taxonomy ? getEditedPostAttribute(_taxonomy.rest_base) : EMPTY_ARRAY,
+				terms: _taxonomy ? getEditedPostAttribute( _taxonomy.rest_base ) : EMPTY_ARRAY,
 				taxonomy: _taxonomy,
 			};
 		},
-		[slug]
+		[ slug ]
 	);
 
 	// Auto-fill the Segment selector if the segment is passed in the URL.
-	useEffect(() => {
-		const currentURL = new URL(window.location);
+	useEffect( () => {
+		const currentURL = new URL( window.location );
 		const searchParams = currentURL.searchParams;
-		const initialSegment = searchParams.get('segment');
-		if (!updatedWithGetParam && initialSegment) {
-			editPost({ [taxonomy.rest_base]: [parseInt(initialSegment)] });
+		const initialSegment = searchParams.get( 'segment' );
+		if ( ! updatedWithGetParam && initialSegment ) {
+			editPost( { [ taxonomy.rest_base ]: [ parseInt( initialSegment ) ] } );
 			updatedWithGetParam = true;
 		}
-	}, []);
+	}, [] );
 
 	return (
 		<Flex direction="column" gap="4">
 			<div className="newspack-popups-segments-tax-control-helper">
-				{terms.length === 0 && <p>{__('The prompt will be shown to all readers.', 'newspack-popups')}</p>}
-				{terms.length === 1 && <p>{__('The prompt will be shown only to readers who match the selected segment.', 'newspack-popups')}</p>}
-				{terms.length > 1 && <p>{__('The prompt will be shown only to readers who match the selected segments.', 'newspack-popups')}</p>}
+				{ terms.length === 0 && (
+					<p>{ __( 'The prompt will be shown to all readers.', 'newspack-popups' ) }</p>
+				) }
+				{ terms.length === 1 && (
+					<p>
+						{ __(
+							'The prompt will be shown only to readers who match the selected segment.',
+							'newspack-popups'
+						) }
+					</p>
+				) }
+				{ terms.length > 1 && (
+					<p>
+						{ __(
+							'The prompt will be shown only to readers who match the selected segments.',
+							'newspack-popups'
+						) }
+					</p>
+				) }
 			</div>
 
-			<ExternalLink href={ADMIN_URL} key="segmentation-link">
-				{__('Manage segments', 'newspack-popups')}
+			<ExternalLink href={ ADMIN_URL } key="segmentation-link">
+				{ __( 'Manage segments', 'newspack-popups' ) }
 			</ExternalLink>
 		</Flex>
 	);
 };
 
-function customizeSelector(OriginalComponent) {
-	return function NewComponent(props) {
-		if (props.slug === TAXONOMY_SLUG) {
+function customizeSelector( OriginalComponent ) {
+	return function NewComponent( props ) {
+		if ( props.slug === TAXONOMY_SLUG ) {
 			return (
 				<div className="newspack-popups-segments-tax-control">
-					<OriginalComponent {...props} />
-					<NewspackPopupsSegmentsHelper {...props} />
+					<OriginalComponent { ...props } />
+					<NewspackPopupsSegmentsHelper { ...props } />
 				</div>
 			);
 		}
-		return <OriginalComponent {...props} />;
+		return <OriginalComponent { ...props } />;
 	};
 }
 
-wp.hooks.addFilter('editor.PostTaxonomyType', 'newspack/multibranded-site/brand-selector-filter', customizeSelector);
+wp.hooks.addFilter(
+	'editor.PostTaxonomyType',
+	'newspack/multibranded-site/brand-selector-filter',
+	customizeSelector
+);

--- a/src/editor/utils.js
+++ b/src/editor/utils.js
@@ -6,8 +6,8 @@ import { __, sprintf, _n } from '@wordpress/i18n';
  * @param {Function} select Select function
  */
 export const promptEditorPropsSelector = select => {
-	const { getEditedPostAttribute } = select('core/editor');
-	const meta = getEditedPostAttribute('meta');
+	const { getEditedPostAttribute } = select( 'core/editor' );
+	const meta = getEditedPostAttribute( 'meta' );
 	const {
 		background_color,
 		frequency,
@@ -40,9 +40,9 @@ export const promptEditorPropsSelector = select => {
 		expiration_date,
 	} = meta || {};
 
-	const isOverlay = isOverlayPlacement(placement);
-	const postStatus = select('core/editor').getEditedPostAttribute('status');
-	const featured_image_id = getEditedPostAttribute('featured_media');
+	const isOverlay = isOverlayPlacement( placement );
+	const postStatus = select( 'core/editor' ).getEditedPostAttribute( 'status' );
+	const featured_image_id = getEditedPostAttribute( 'featured_media' );
 
 	return {
 		background_color,
@@ -88,10 +88,10 @@ export const promptEditorPropsSelector = select => {
  */
 const hexToRGB = hex =>
 	hex
-		.replace(/^#?([a-f\d])([a-f\d])([a-f\d])$/i, (m, r, g, b) => '#' + r + r + g + g + b + b)
-		.substring(1)
-		.match(/.{2}/g)
-		.map(x => parseInt(x, 16));
+		.replace( /^#?([a-f\d])([a-f\d])([a-f\d])$/i, ( m, r, g, b ) => '#' + r + r + g + g + b + b )
+		.substring( 1 )
+		.match( /.{2}/g )
+		.map( x => parseInt( x, 16 ) );
 
 /**
  * Set the background color meta field.
@@ -100,34 +100,43 @@ const hexToRGB = hex =>
  * @param {string} backgroundColor color string
  */
 export const updateEditorColors = backgroundColor => {
-	if (!backgroundColor) {
+	if ( ! backgroundColor ) {
 		return;
 	}
 	const blackColor = '#000000';
 	const whiteColor = '#ffffff';
 
-	const backgroundColorRGB = hexToRGB(backgroundColor);
-	const blackRGB = hexToRGB(blackColor);
+	const backgroundColorRGB = hexToRGB( backgroundColor );
+	const blackRGB = hexToRGB( blackColor );
 
 	const l1 =
-		0.2126 * Math.pow(backgroundColorRGB[0] / 255, 2.2) +
-		0.7152 * Math.pow(backgroundColorRGB[1] / 255, 2.2) +
-		0.0722 * Math.pow(backgroundColorRGB[2] / 255, 2.2);
-	const l2 = 0.2126 * Math.pow(blackRGB[0] / 255, 2.2) + 0.7152 * Math.pow(blackRGB[1] / 255, 2.2) + 0.0722 * Math.pow(blackRGB[2] / 255, 2.2);
+		0.2126 * Math.pow( backgroundColorRGB[ 0 ] / 255, 2.2 ) +
+		0.7152 * Math.pow( backgroundColorRGB[ 1 ] / 255, 2.2 ) +
+		0.0722 * Math.pow( backgroundColorRGB[ 2 ] / 255, 2.2 );
+	const l2 =
+		0.2126 * Math.pow( blackRGB[ 0 ] / 255, 2.2 ) +
+		0.7152 * Math.pow( blackRGB[ 1 ] / 255, 2.2 ) +
+		0.0722 * Math.pow( blackRGB[ 2 ] / 255, 2.2 );
 
-	const contrastRatio = l1 > l2 ? parseInt((l1 + 0.05) / (l2 + 0.05)) : parseInt((l2 + 0.05) / (l1 + 0.05));
+	const contrastRatio =
+		l1 > l2 ? parseInt( ( l1 + 0.05 ) / ( l2 + 0.05 ) ) : parseInt( ( l2 + 0.05 ) / ( l1 + 0.05 ) );
 
 	const foregroundColor = contrastRatio > 5 ? blackColor : whiteColor;
 
-	const editorStylesEl = document.querySelector('.editor-styles-wrapper');
-	const editorPostTitleEl = document.querySelector('.wp-block.editor-post-title__block .editor-post-title__input');
-	if (editorStylesEl) {
+	const editorStylesEl = document.querySelector( '.editor-styles-wrapper' );
+	const editorPostTitleEl = document.querySelector(
+		'.wp-block.editor-post-title__block .editor-post-title__input'
+	);
+	if ( editorStylesEl ) {
 		editorStylesEl.style.backgroundColor = backgroundColor;
 		editorStylesEl.style.color = foregroundColor;
 	}
-	if (editorPostTitleEl) {
+	if ( editorPostTitleEl ) {
 		editorPostTitleEl.style.color = foregroundColor;
-		editorPostTitleEl.style.setProperty('--newspack-popups-editor-placeholder-color', `${foregroundColor}80`);
+		editorPostTitleEl.style.setProperty(
+			'--newspack-popups-editor-placeholder-color',
+			`${ foregroundColor }80`
+		);
 	}
 };
 
@@ -139,7 +148,7 @@ export const updateEditorColors = backgroundColor => {
  */
 export const isOverlayPlacement = placementValue => {
 	const overlayPlacements = window.newspack_popups_data?.overlay_placements || [];
-	return -1 < overlayPlacements.indexOf(placementValue);
+	return -1 < overlayPlacements.indexOf( placementValue );
 };
 
 /**
@@ -149,7 +158,8 @@ export const isOverlayPlacement = placementValue => {
  * @param {string} placementValue Placement value of the prompt.
  * @return {boolean} True if placementValue is an inline placement.
  */
-export const isInlinePlacement = placementValue => -1 < ['inline', 'above_header', 'archives'].indexOf(placementValue);
+export const isInlinePlacement = placementValue =>
+	-1 < [ 'inline', 'above_header', 'archives' ].indexOf( placementValue );
 
 /**
  * Is the given placement value a custom placement?
@@ -159,7 +169,7 @@ export const isInlinePlacement = placementValue => -1 < ['inline', 'above_header
  */
 export const isCustomPlacement = placementValue => {
 	const customPlacements = window.newspack_popups_data?.custom_placements || {};
-	return -1 < Object.keys(customPlacements).indexOf(placementValue);
+	return -1 < Object.keys( customPlacements ).indexOf( placementValue );
 };
 
 /**
@@ -176,69 +186,113 @@ export const isManualOnlyPlacement = placementValue => 'manual' === placementVal
  * @return {string} An appropriate help message.
  */
 export const getPlacementHelpMessage = props => {
-	if (isCustomPlacement(props.placement)) {
+	if ( isCustomPlacement( props.placement ) ) {
 		const customPlacements = window.newspack_popups_data?.custom_placements || {};
 		return sprintf(
 			// Translators: Custom placement name.
-			__('The prompt will appear where %s is inserted using the Custom Placement block.', 'newspack-popups'),
-			customPlacements[props.placement] || __('this custom placement', 'newspack-popups')
+			__(
+				'The prompt will appear where %s is inserted using the Custom Placement block.',
+				'newspack-popups'
+			),
+			customPlacements[ props.placement ] || __( 'this custom placement', 'newspack-popups' )
 		);
 	}
 
-	switch (props.placement) {
+	switch ( props.placement ) {
 		case 'center':
-			return __('The prompt will be displayed as an overlay at the center of the viewport.', 'newspack-popups');
+			return __(
+				'The prompt will be displayed as an overlay at the center of the viewport.',
+				'newspack-popups'
+			);
 		case 'center_left':
-			return __('The prompt will be displayed as an overlay at the center left of the viewport.', 'newspack-popups');
+			return __(
+				'The prompt will be displayed as an overlay at the center left of the viewport.',
+				'newspack-popups'
+			);
 		case 'center_right':
-			return __('The prompt will be displayed as an overlay at the center right of the viewport.', 'newspack-popups');
+			return __(
+				'The prompt will be displayed as an overlay at the center right of the viewport.',
+				'newspack-popups'
+			);
 		case 'top':
-			return __('The prompt will be displayed as an overlay at the top of the viewport.', 'newspack-popups');
+			return __(
+				'The prompt will be displayed as an overlay at the top of the viewport.',
+				'newspack-popups'
+			);
 		case 'top_left':
-			return __('The prompt will be displayed as an overlay at the top left of the viewport.', 'newspack-popups');
+			return __(
+				'The prompt will be displayed as an overlay at the top left of the viewport.',
+				'newspack-popups'
+			);
 		case 'top_right':
-			return __('The prompt will be displayed as an overlay at the top right of the viewport.', 'newspack-popups');
+			return __(
+				'The prompt will be displayed as an overlay at the top right of the viewport.',
+				'newspack-popups'
+			);
 		case 'bottom':
-			return __('The prompt will be displayed as an overlay at the bottom of the viewport.', 'newspack-popups');
+			return __(
+				'The prompt will be displayed as an overlay at the bottom of the viewport.',
+				'newspack-popups'
+			);
 		case 'bottom_left':
-			return __('The prompt will be displayed as an overlay at the bottom left of the viewport.', 'newspack-popups');
+			return __(
+				'The prompt will be displayed as an overlay at the bottom left of the viewport.',
+				'newspack-popups'
+			);
 		case 'bottom_right':
-			return __('The prompt will be displayed as an overlay at the bottom right of the viewport.', 'newspack-popups');
+			return __(
+				'The prompt will be displayed as an overlay at the bottom right of the viewport.',
+				'newspack-popups'
+			);
 		case 'above_header':
-			return __('The prompt will be automatically inserted at the very top of the page, above the header.', 'newspack-popups');
+			return __(
+				'The prompt will be automatically inserted at the very top of the page, above the header.',
+				'newspack-popups'
+			);
 		case 'inline':
 			return props.trigger_type === 'blocks_count'
 				? sprintf(
-						// Translators: Blocks count until insertion.
-						_n(
-							'The prompt will be automatically inserted after %s block of content.',
-							'The prompt will be automatically inserted after %s blocks of content.',
-							props.trigger_blocks_count,
-							'newspack-popups'
-						),
-						props.trigger_blocks_count
-					)
-				: sprintf(
-						// Translators: Article percentage count until insertion.
-						__('The prompt will be automatically inserted about %s into article content.', 'newspack-popups'),
-						props.trigger_scroll_progress + '%'
-					);
+					// Translators: Blocks count until insertion.
+					_n(
+						'The prompt will be automatically inserted after %s block of content.',
+						'The prompt will be automatically inserted after %s blocks of content.',
+						props.trigger_blocks_count,
+						'newspack-popups'
+					),
+					props.trigger_blocks_count
+				) : sprintf(
+					// Translators: Article percentage count until insertion.
+					__(
+						'The prompt will be automatically inserted about %s into article content.',
+						'newspack-popups'
+					),
+					props.trigger_scroll_progress + '%'
+				);
 		case 'archives':
 			return props.archive_insertion_is_repeating
 				? sprintf(
-						// Translators: Insertion period.
-						__('The prompt will be automatically inserted every %d articles in the archive pages.', 'newspack-popups'),
-						props.archive_insertion_posts_count
-					)
+					// Translators: Insertion period.
+					__(
+						'The prompt will be automatically inserted every %d articles in the archive pages.',
+						'newspack-popups'
+					),
+					props.archive_insertion_posts_count
+				)
 				: sprintf(
-						// Translators: Insertion period articles count.
-						__('The prompt will be automatically inserted after %d articles in the archive pages.', 'newspack-popups'),
-						props.archive_insertion_posts_count
-					);
+					// Translators: Insertion period articles count.
+					__(
+						'The prompt will be automatically inserted after %d articles in the archive pages.',
+						'newspack-popups'
+					),
+					props.archive_insertion_posts_count
+				);
 		case 'manual':
-			return __('The prompt will appear only where inserted using the Single Prompt block or a shortcode.', 'newspack-popups');
+			return __(
+				'The prompt will appear only where inserted using the Single Prompt block or a shortcode.',
+				'newspack-popups'
+			);
 		default:
-			return __('The placement where the prompt can appear.', 'newspack-popups');
+			return __( 'The placement where the prompt can appear.', 'newspack-popups' );
 	}
 };
 
@@ -249,15 +303,15 @@ export const getPlacementHelpMessage = props => {
  * @return {string} Date string in Y-m-d H:i:s format or empty string if the given date can't be parsed.
  */
 export const convertDateToString = date => {
-	if (!(date instanceof Date)) {
+	if ( ! ( date instanceof Date ) ) {
 		return '';
 	}
 
 	// Format the date string
 	const year = date.getFullYear();
-	const month = String(date.getMonth() + 1).padStart(2, '0');
-	const day = String(date.getDate()).padStart(2, '0');
+	const month = String( date.getMonth() + 1 ).padStart( 2, '0' );
+	const day = String( date.getDate() ).padStart( 2, '0' );
 	const time = 'T23:59:59'; // Set to the very end of the day.
 
-	return `${year}-${month}-${day}${time}`;
+	return `${ year }-${ month }-${ day }${ time }`;
 };

--- a/src/settings/index.js
+++ b/src/settings/index.js
@@ -7,7 +7,17 @@ import { render, useState } from '@wordpress/element';
 import domReady from '@wordpress/dom-ready';
 import { __ } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
-import { Button, Card, CardBody, CardHeader, CheckboxControl, FlexBlock, Notice, SelectControl, TextControl } from '@wordpress/components';
+import {
+	Button,
+	Card,
+	CardBody,
+	CardHeader,
+	CheckboxControl,
+	FlexBlock,
+	Notice,
+	SelectControl,
+	TextControl,
+} from '@wordpress/components';
 
 /**
  * Newspack dependencies.
@@ -20,65 +30,77 @@ import { NewspackLogo } from 'newspack-components';
 import './style.scss';
 
 const App = () => {
-	const [inFlight, setInFlight] = useState(false);
-	const [settings, setSettings] = useState(newspack_popups_settings);
-	const [settingsToUpdate, setSettingsToUpdate] = useState({});
-	const [error, setError] = useState(null);
+	const [ inFlight, setInFlight ] = useState( false );
+	const [ settings, setSettings ] = useState( newspack_popups_settings );
+	const [ settingsToUpdate, setSettingsToUpdate ] = useState( {} );
+	const [ error, setError ] = useState( null );
 	const handleSettingChange = option_name => option_value => {
 		const newSettings = { ...settingsToUpdate };
-		newSettings[option_name] = option_value;
-		setSettingsToUpdate(newSettings);
+		newSettings[ option_name ] = option_value;
+		setSettingsToUpdate( newSettings );
 	};
 	const handleSave = () => {
-		setError(null);
-		setInFlight(true);
-		apiFetch({
+		setError( null );
+		setInFlight( true );
+		apiFetch( {
 			path: '/newspack-popups/v1/settings/',
 			method: 'POST',
 			data: { settingsToUpdate },
-		})
-			.then(response => {
-				setSettingsToUpdate({});
-				setSettings(response);
-			})
-			.catch(e => {
-				setError(e.message || __('Error updating settings.', 'newspack-popups'));
-			})
-			.finally(() => {
-				setInFlight(false);
-			});
+		} )
+			.then( response => {
+				setSettingsToUpdate( {} );
+				setSettings( response );
+			} )
+			.catch( e => {
+				setError( e.message || __( 'Error updating settings.', 'newspack-popups' ) );
+			} )
+			.finally( () => {
+				setInFlight( false );
+			} );
 	};
 
 	const renderSetting = setting => {
-		if (setting.description && 'active' !== setting.key) {
+		if ( setting.description && 'active' !== setting.key ) {
 			const props = {
 				key: setting.key,
 				label: setting.description,
 				help: setting.help,
 				disabled: inFlight,
-				onChange: handleSettingChange(setting.key),
+				onChange: handleSettingChange( setting.key ),
 			};
-			switch (setting.type) {
+			switch ( setting.type ) {
 				case 'string':
 					return (
 						<TextControl
-							{...props}
-							value={settingsToUpdate.hasOwnProperty(setting.key) ? settingsToUpdate[setting.key] : setting.value}
+							{ ...props }
+							value={
+								settingsToUpdate.hasOwnProperty( setting.key )
+									? settingsToUpdate[ setting.key ]
+									: setting.value
+							}
 						/>
 					);
 				case 'select':
 					return (
 						<SelectControl
-							{...props}
-							value={settingsToUpdate.hasOwnProperty(setting.key) ? settingsToUpdate[setting.key] : setting.value}
-							options={setting.options}
+							{ ...props }
+							value={
+								settingsToUpdate.hasOwnProperty( setting.key )
+									? settingsToUpdate[ setting.key ]
+									: setting.value
+							}
+							options={ setting.options }
 						/>
 					);
 				default:
 					return (
 						<CheckboxControl
-							{...props}
-							checked={settingsToUpdate.hasOwnProperty(setting.key) ? settingsToUpdate[setting.key] : !!setting.value}
+							{ ...props }
+							checked={
+								settingsToUpdate.hasOwnProperty( setting.key )
+									? settingsToUpdate[ setting.key ]
+									: !! setting.value
+							}
 						/>
 					);
 			}
@@ -89,26 +111,34 @@ const App = () => {
 	return (
 		<div className="newspack-campaigns__wrapper">
 			<div className="newspack-logo__wrapper">
-				<Button className="newspack-logo-button" href="https://newspack.pub/" target="_blank" label={__('By Newspack')}>
-					<NewspackLogo height={32} />
+				<Button
+					className="newspack-logo-button"
+					href="https://newspack.pub/"
+					target="_blank"
+					label={ __( 'By Newspack' ) }
+				>
+					<NewspackLogo height={ 32 } />
 				</Button>
 			</div>
 			<Card>
 				<CardHeader isShady>
 					<FlexBlock>
-						<h2>{__('Settings', 'newspack-popups')}</h2>
+						<h2>{ __( 'Settings', 'newspack-popups' ) }</h2>
 					</FlexBlock>
 				</CardHeader>
 				<CardBody>
-					{settings.map(renderSetting)}
-					{error && (
-						<Notice status="error" isDismissible={false}>
-							{error}
+					{ settings.map( renderSetting ) }
+					{ error && (
+						<Notice status="error" isDismissible={ false }>
+							{ error }
 						</Notice>
-					)}
+					) }
 					<div className="newspack-popups-save">
-						<Button disabled={inFlight || 0 === Object.keys(settingsToUpdate).length} onClick={handleSave}>
-							{__('Save', 'newspack-popups')}
+						<Button
+							disabled={ inFlight || 0 === Object.keys( settingsToUpdate ).length }
+							onClick={ handleSave }
+						>
+							{ __( 'Save', 'newspack-popups' ) }
 						</Button>
 					</div>
 				</CardBody>
@@ -117,7 +147,7 @@ const App = () => {
 	);
 };
 
-domReady(() => {
-	const element = document.getElementById('newspack-popups-settings-root');
-	render(<App />, element);
-});
+domReady( () => {
+	const element = document.getElementById( 'newspack-popups-settings-root' );
+	render( <App />, element );
+} );

--- a/src/view/admin.js
+++ b/src/view/admin.js
@@ -5,28 +5,28 @@
  */
 import './admin.scss';
 
-const toggle = document.querySelectorAll('.newspack-campaigns-preview-toggle a');
+const toggle = document.querySelectorAll( '.newspack-campaigns-preview-toggle a' );
 const { label_visible: labelVisible, label_hidden: labelHidden } = newspack_popups_admin;
-let isHidden = parseInt(localStorage.getItem('newspackPopupsHide'));
+let isHidden = parseInt( localStorage.getItem( 'newspackPopupsHide' ) );
 
-if (isHidden) {
-	document.body.classList.add('newspack-popups-hide-prompts');
+if ( isHidden ) {
+	document.body.classList.add( 'newspack-popups-hide-prompts' );
 }
 
 const toggleHandler = e => {
 	e.preventDefault();
-	isHidden = !isHidden;
-	document.body.classList.toggle('newspack-popups-hide-prompts');
-	localStorage.setItem('newspackPopupsHide', isHidden ? 1 : 0);
+	isHidden = ! isHidden;
+	document.body.classList.toggle( 'newspack-popups-hide-prompts' );
+	localStorage.setItem( 'newspackPopupsHide', isHidden ? 1 : 0 );
 
 	e.currentTarget.textContent = isHidden ? labelHidden : labelVisible;
 };
 
-for (let i = 0; i < toggle.length; i++) {
-	const thisToggle = toggle[i];
-	thisToggle.addEventListener('click', toggleHandler);
+for ( let i = 0; i < toggle.length; i++ ) {
+	const thisToggle = toggle[ i ];
+	thisToggle.addEventListener( 'click', toggleHandler );
 
-	if (isHidden) {
+	if ( isHidden ) {
 		thisToggle.textContent = labelHidden;
 	}
 }

--- a/src/view/analytics/clicked.js
+++ b/src/view/analytics/clicked.js
@@ -7,19 +7,23 @@ import { getEventPayload, getRawId, sendEvent } from '../utils';
  */
 
 export const manageClickedEvents = prompts => {
-	prompts.forEach(prompt => {
-		const anchorLinks = [...prompt.querySelectorAll('.newspack-popup-container a')];
+	prompts.forEach( prompt => {
+		const anchorLinks = [ ...prompt.querySelectorAll( '.newspack-popup-container a' ) ];
 		const handleEvent = e => {
 			const extraParams = {};
 
-			if (e.currentTarget?.href && '#' !== e.currentTarget?.href) {
-				extraParams.action_value = e.currentTarget.getAttribute('href');
+			if ( e.currentTarget?.href && '#' !== e.currentTarget?.href ) {
+				extraParams.action_value = e.currentTarget.getAttribute( 'href' );
 			}
 
-			const payload = getEventPayload('clicked', getRawId(prompt.getAttribute('id')), extraParams);
-			sendEvent(payload);
+			const payload = getEventPayload(
+				'clicked',
+				getRawId( prompt.getAttribute( 'id' ) ),
+				extraParams
+			);
+			sendEvent( payload );
 		};
 
-		anchorLinks.forEach(link => link.addEventListener('click', handleEvent));
-	});
+		anchorLinks.forEach( link => link.addEventListener( 'click', handleEvent ) );
+	} );
 };

--- a/src/view/analytics/dismissed.js
+++ b/src/view/analytics/dismissed.js
@@ -7,21 +7,23 @@ import { getEventPayload, getRawId, sendEvent } from '../utils';
  */
 
 export const manageDismissals = prompts => {
-	prompts.forEach(prompt => {
-		const closeButton = prompt.querySelector('.newspack-lightbox__close');
-		const forms = [...prompt.querySelectorAll('.newspack-popup-container form')];
-		if (closeButton) {
+	prompts.forEach( prompt => {
+		const closeButton = prompt.querySelector( '.newspack-lightbox__close' );
+		const forms = [ ...prompt.querySelectorAll( '.newspack-popup-container form' ) ];
+		if ( closeButton ) {
 			const handleEvent = () => {
-				const payload = getEventPayload('dismissed', getRawId(prompt.getAttribute('id')));
-				sendEvent(payload);
+				const payload = getEventPayload( 'dismissed', getRawId( prompt.getAttribute( 'id' ) ) );
+				sendEvent( payload );
 			};
 
-			closeButton.addEventListener('click', handleEvent);
+			closeButton.addEventListener( 'click', handleEvent );
 
 			// If a form inside an overlay prompt is submitted, closing it should not result in a `dismissed` action.
-			forms.forEach(form => {
-				form.addEventListener('submit', () => closeButton.removeEventListener('click', handleEvent));
-			});
+			forms.forEach( form => {
+				form.addEventListener( 'submit', () =>
+					closeButton.removeEventListener( 'click', handleEvent )
+				);
+			} );
 		}
-	});
+	} );
 };

--- a/src/view/analytics/ga4.js
+++ b/src/view/analytics/ga4.js
@@ -8,11 +8,11 @@ import { manageFormSubmissions } from './submitted';
 
 export const handleAnalytics = prompts => {
 	// Must have a gtag instance to proceed.
-	if ('function' === typeof gtag) {
-		manageLoadedEvents(prompts);
+	if ( 'function' === typeof gtag ) {
+		manageLoadedEvents( prompts );
 		manageSeenEvents();
-		manageDismissals(prompts);
-		manageClickedEvents(prompts);
-		manageFormSubmissions(prompts);
+		manageDismissals( prompts );
+		manageClickedEvents( prompts );
+		manageFormSubmissions( prompts );
 	}
 };

--- a/src/view/analytics/loaded.js
+++ b/src/view/analytics/loaded.js
@@ -7,13 +7,17 @@ import { getEventPayload, getRawId, sendEvent } from '../utils';
  * @return {MutationObserver} Observer instance.
  */
 const getObserver = handleEvent => {
-	return new MutationObserver(mutations => {
-		mutations.forEach(mutation => {
-			if (mutation.attributeName === 'amp-access-hide' && mutation.type === 'attributes' && !mutation.target.hasAttribute('amp-access-hide')) {
+	return new MutationObserver( mutations => {
+		mutations.forEach( mutation => {
+			if (
+				mutation.attributeName === 'amp-access-hide' &&
+				mutation.type === 'attributes' &&
+				! mutation.target.hasAttribute( 'amp-access-hide' )
+			) {
 				handleEvent();
 			}
-		});
-	});
+		} );
+	} );
 };
 
 /**
@@ -22,12 +26,12 @@ const getObserver = handleEvent => {
  * @param {Array} prompts Array of prompts loaded in the DOM.
  */
 export const manageLoadedEvents = prompts => {
-	prompts.forEach(prompt => {
+	prompts.forEach( prompt => {
 		const handleEvent = () => {
-			const payload = getEventPayload('loaded', getRawId(prompt.getAttribute('id')));
-			sendEvent(payload);
+			const payload = getEventPayload( 'loaded', getRawId( prompt.getAttribute( 'id' ) ) );
+			sendEvent( payload );
 		};
 
-		getObserver(handleEvent).observe(prompt, { attributes: true });
-	});
+		getObserver( handleEvent ).observe( prompt, { attributes: true } );
+	} );
 };

--- a/src/view/analytics/seen.js
+++ b/src/view/analytics/seen.js
@@ -5,13 +5,13 @@ import { getEventPayload, sendEvent } from '../utils';
  */
 export const manageSeenEvents = () => {
 	window.newspackRAS = window.newspackRAS || [];
-	window.newspackRAS.push(ras => {
-		ras.on('activity', ({ detail: { action, data } }) => {
-			if (action === 'prompt_seen') {
+	window.newspackRAS.push( ras => {
+		ras.on( 'activity', ( { detail: { action, data } } ) => {
+			if ( action === 'prompt_seen' ) {
 				const { prompt_id: promptId } = data;
-				const payload = getEventPayload('seen', promptId);
-				sendEvent(payload);
+				const payload = getEventPayload( 'seen', promptId );
+				sendEvent( payload );
 			}
-		});
-	});
+		} );
+	} );
 };

--- a/src/view/analytics/submitted.js
+++ b/src/view/analytics/submitted.js
@@ -7,13 +7,13 @@ import { getEventPayload, getRawId, sendEvent } from '../utils';
  */
 
 export const manageFormSubmissions = prompts => {
-	prompts.forEach(prompt => {
-		const forms = [...prompt.querySelectorAll('.newspack-popup-container form')];
+	prompts.forEach( prompt => {
+		const forms = [ ...prompt.querySelectorAll( '.newspack-popup-container form' ) ];
 		const handleEvent = () => {
-			const payload = getEventPayload('form_submission', getRawId(prompt.getAttribute('id')));
-			sendEvent(payload);
+			const payload = getEventPayload( 'form_submission', getRawId( prompt.getAttribute( 'id' ) ) );
+			sendEvent( payload );
 		};
 
-		forms.forEach(form => form.addEventListener('submit', handleEvent));
-	});
+		forms.forEach( form => form.addEventListener( 'submit', handleEvent ) );
+	} );
 };

--- a/src/view/index.js
+++ b/src/view/index.js
@@ -11,15 +11,15 @@ import { domReady, logPageview, getPrompts } from './utils';
 
 import './merge-tags';
 
-domReady(() => {
+domReady( () => {
 	window.newspackRAS = window.newspackRAS || [];
-	window.newspackRAS.push(logPageview); // Pageviews should be logged whether or not prompts are enabled.
+	window.newspackRAS.push( logPageview ); // Pageviews should be logged whether or not prompts are enabled.
 
-	if (!newspack_popups_view?.has_disabled_prompts) {
+	if ( ! newspack_popups_view?.has_disabled_prompts ) {
 		// Fetch all prompts on the page just once.
 		const prompts = getPrompts();
 
-		handleSegmentation(prompts);
-		handleAnalytics(prompts);
+		handleSegmentation( prompts );
+		handleAnalytics( prompts );
 	}
-});
+} );

--- a/src/view/merge-tags/index.js
+++ b/src/view/merge-tags/index.js
@@ -2,28 +2,30 @@ import { domReady } from '../utils';
 import { getCriteria } from '../../criteria/utils';
 
 window.newspackRAS = window.newspackRAS || [];
-window.newspackRAS.push(ras => {
-	function attachCriteria(mergeTag) {
-		const criteria = getCriteria(mergeTag.dataset.criteria);
-		if (!criteria) {
+window.newspackRAS.push( ras => {
+
+	function attachCriteria( mergeTag ) {
+		const criteria = getCriteria( mergeTag.dataset.criteria );
+		if ( ! criteria ) {
 			return;
 		}
-		mergeTag.innerHTML = criteria.getValue(ras);
-		ras.on('data', () => {
-			mergeTag.innerHTML = criteria.getValue(ras);
-		});
+		mergeTag.innerHTML = criteria.getValue( ras );
+		ras.on( 'data', () => {
+			mergeTag.innerHTML = criteria.getValue( ras );
+		} );
 	}
 
-	domReady(() => {
-		const mergeTags = document.querySelectorAll('.merge-tag');
-		if (!mergeTags.length) {
+	domReady( () => {
+		const mergeTags = document.querySelectorAll( '.merge-tag' );
+		if ( ! mergeTags.length ) {
 			return;
 		}
-		for (const mergeTag of mergeTags) {
-			if (!mergeTag.dataset.criteria) {
+		for ( const mergeTag of mergeTags ) {
+			if ( ! mergeTag.dataset.criteria ) {
 				continue;
 			}
-			attachCriteria(mergeTag);
+			attachCriteria( mergeTag );
 		}
-	});
-});
+	} );
+
+} );

--- a/src/view/segmentation.js
+++ b/src/view/segmentation.js
@@ -15,74 +15,76 @@ import {
  * Match reader to segments.
  */
 export const handleSegmentation = prompts => {
-	const maybeDisplayPrompts = (ras = null) => {
+	const maybeDisplayPrompts = ( ras = null ) => {
 		// Don't display prompts if the content is locked.
-		if (document.body.classList.contains('newspack-content-locked')) {
+		if ( document.body.classList.contains( 'newspack-content-locked' ) ) {
 			return;
 		}
 		const segments = newspack_popups_view?.segments || {};
-		const matchingSegment = getBestPrioritySegment(segments);
-		debug('matchingSegment', matchingSegment);
+		const matchingSegment = getBestPrioritySegment( segments );
+		debug( 'matchingSegment', matchingSegment );
 		let overlayDisplayed;
 
-		prompts.forEach(prompt => {
-			const promptId = prompt.getAttribute('id');
-			const isOverlay = prompt.classList.contains('newspack-lightbox');
-			const override = getOverride(getRawId(promptId), isOverlay, overlayDisplayed);
+		prompts.forEach( prompt => {
+			const promptId = prompt.getAttribute( 'id' );
+			const isOverlay = prompt.classList.contains( 'newspack-lightbox' );
+			const override = getOverride( getRawId( promptId ), isOverlay, overlayDisplayed );
 
 			// Attach event listeners to overlay close buttons.
-			const closeButtons = [...prompt.querySelectorAll('.newspack-lightbox__close, button.newspack-lightbox-overlay')];
-			closeButtons.forEach(closeButton => {
-				closeButton.addEventListener('click', closeOverlay);
-			});
+			const closeButtons = [
+				...prompt.querySelectorAll( '.newspack-lightbox__close, button.newspack-lightbox-overlay' ),
+			];
+			closeButtons.forEach( closeButton => {
+				closeButton.addEventListener( 'click', closeOverlay );
+			} );
 			// Check segmentation.
-			const shouldDisplay = shouldPromptBeDisplayed(prompt, matchingSegment, ras, override);
+			const shouldDisplay = shouldPromptBeDisplayed( prompt, matchingSegment, ras, override );
 
 			// Only show one overlay at a time.
-			if (!overlayDisplayed && isOverlay && shouldDisplay) {
+			if ( ! overlayDisplayed && isOverlay && shouldDisplay ) {
 				overlayDisplayed = true;
 			}
 
 			// Unhide the prompt.
-			if (shouldDisplay) {
+			if ( shouldDisplay ) {
 				const delayPrompt = () => {
 					// By delay.
-					const delay = prompt.getAttribute('data-delay') || 0;
-					setTimeout(unhide, delay);
-				};
+					const delay = prompt.getAttribute( 'data-delay' ) || 0;
+					setTimeout( unhide, delay );
+				}
 				const unhide = () => {
 					// Conditions may have changed since the prompt was delayed.
 					// Verify whether the prompt can still be displayed.
-					const updatedMatchingSegment = getBestPrioritySegment(segments);
-					if (!shouldPromptBeDisplayed(prompt, updatedMatchingSegment, ras, override)) {
+					const updatedMatchingSegment = getBestPrioritySegment( segments );
+					if ( ! shouldPromptBeDisplayed( prompt, updatedMatchingSegment, ras, override ) ) {
 						return;
 					}
 					// Prioritize RAS overlays. If there are any reinitiate the delay and return early.
-					if (ras?.overlays && ras.overlays.get().length) {
+					if ( ras?.overlays && ras.overlays.get().length ) {
 						delayPrompt();
 						return;
 					}
-					prompt.classList.remove('hidden');
+					prompt.classList.remove( 'hidden' );
 
 					// Log a "prompt_seen" activity when the prompt becomes visible.
-					if (ras) {
-						handleSeen(prompt, ras);
+					if ( ras ) {
+						handleSeen( prompt, ras );
 					}
 
 					// Register the overlay in RAS.
-					if (isOverlay && ras?.overlays) {
-						if (!document.body.classList.contains('newspack-content-locked')) {
-							prompt.overlayId = ras.overlays.add(`prompt_${promptId}`);
+					if ( isOverlay && ras?.overlays ) {
+						if ( ! document.body.classList.contains( 'newspack-content-locked' ) ) {
+							prompt.overlayId = ras.overlays.add( `prompt_${ promptId }` );
 						}
 					}
 				};
-				if (isOverlay) {
-					const scroll = prompt.getAttribute('data-scroll');
-					if (scroll) {
+				if ( isOverlay ) {
+					const scroll = prompt.getAttribute( 'data-scroll' );
+					if ( scroll ) {
 						// By scroll trigger.
-						const marker = document.getElementById(`page-position-marker_${promptId}`);
-						if (marker) {
-							getIntersectionObserver(unhide).observe(marker);
+						const marker = document.getElementById( `page-position-marker_${ promptId }` );
+						if ( marker ) {
+							getIntersectionObserver( unhide ).observe( marker );
 						}
 					} else {
 						delayPrompt();
@@ -91,14 +93,14 @@ export const handleSegmentation = prompts => {
 					unhide();
 				}
 			}
-		});
+		} );
 	};
 
 	// If no segments to handle.
-	if (!newspack_popups_view.segments) {
+	if ( ! newspack_popups_view.segments ) {
 		maybeDisplayPrompts();
 	} else {
 		window.newspackRAS = window.newspackRAS || [];
-		window.newspackRAS.push(maybeDisplayPrompts);
+		window.newspackRAS.push( maybeDisplayPrompts );
 	}
 };

--- a/src/view/utils/analytics.js
+++ b/src/view/utils/analytics.js
@@ -9,12 +9,12 @@
  *
  * @return {Object} Event payload.
  */
-export const getEventPayload = (action, promptId, extraParams = {}) => {
-	if (!newspackPopupsData || !newspackPopupsData[promptId]) {
+export const getEventPayload = ( action, promptId, extraParams = {} ) => {
+	if ( ! newspackPopupsData || ! newspackPopupsData[ promptId ] ) {
 		return false;
 	}
 
-	return { ...newspackPopupsData[promptId], ...extraParams, action };
+	return { ...newspackPopupsData[ promptId ], ...extraParams, action };
 };
 
 /**
@@ -23,8 +23,8 @@ export const getEventPayload = (action, promptId, extraParams = {}) => {
  * @param {Object} payload   Event payload.
  * @param {string} eventName Name of the event. Defaults to `np_prompt_interaction` but can be overriden if necessary.
  */
-export const sendEvent = (payload, eventName = 'np_prompt_interaction') => {
-	if ('function' === typeof gtag && payload) {
-		gtag('event', eventName, payload);
+export const sendEvent = ( payload, eventName = 'np_prompt_interaction' ) => {
+	if ( 'function' === typeof gtag && payload ) {
+		gtag( 'event', eventName, payload );
 	}
 };

--- a/src/view/utils/index.js
+++ b/src/view/utils/index.js
@@ -23,19 +23,19 @@ export const getIntersectionObserver = handleEvent => {
 	let timer;
 	const observer = new IntersectionObserver(
 		entries => {
-			entries.forEach(observerEntry => {
-				if (observerEntry.isIntersecting) {
-					if (!timer) {
-						timer = setTimeout(() => {
+			entries.forEach( observerEntry => {
+				if ( observerEntry.isIntersecting ) {
+					if ( ! timer ) {
+						timer = setTimeout( () => {
 							handleEvent();
-							observer.unobserve(observerEntry.target);
-						}, MINIMUM_VISIBLE_TIME || 0);
+							observer.unobserve( observerEntry.target );
+						}, MINIMUM_VISIBLE_TIME || 0 );
 					}
-				} else if (timer) {
-					clearTimeout(timer);
+				} else if ( timer ) {
+					clearTimeout( timer );
 					timer = false;
 				}
-			});
+			} );
 		},
 		{
 			threshold: MINIMUM_VISIBLE_PERCENTAGE,
@@ -53,8 +53,8 @@ export const getIntersectionObserver = handleEvent => {
  * @param {Function} callback A function to execute after the DOM is ready.
  * @return {void}
  */
-export function domReady(callback) {
-	if (typeof document === 'undefined') {
+export function domReady( callback ) {
+	if ( typeof document === 'undefined' ) {
 		return;
 	}
 	if (
@@ -64,7 +64,7 @@ export function domReady(callback) {
 		return void callback();
 	}
 	// DOMContentLoaded has not fired yet, delay callback until then.
-	document.addEventListener('DOMContentLoaded', callback);
+	document.addEventListener( 'DOMContentLoaded', callback );
 }
 
 /**
@@ -73,9 +73,10 @@ export function domReady(callback) {
  * @param {HTMLElement} prompt HTML element for prompt.
  * @param {Object}      ras    Reader Data Library object.
  */
-export const handleSeen = (prompt, ras) => {
-	const handleEvent = () => ras.dispatchActivity('prompt_seen', { prompt_id: getRawId(prompt.getAttribute('id')) });
-	getIntersectionObserver(handleEvent).observe(prompt, { attributes: true });
+export const handleSeen = ( prompt, ras ) => {
+	const handleEvent = () =>
+		ras.dispatchActivity( 'prompt_seen', { prompt_id: getRawId( prompt.getAttribute( 'id' ) ) } );
+	getIntersectionObserver( handleEvent ).observe( prompt, { attributes: true } );
 };
 
 /**
@@ -102,32 +103,32 @@ export const logPageview = ras => {
 		},
 	};
 
-	const priorPageviews = ras.store.get('pageviews') || {};
+	const priorPageviews = ras.store.get( 'pageviews' ) || {};
 	const pageviews = { ...pageviewTemplate, ...priorPageviews };
 
 	// If the current page is the donor landing page, mark the reader as a donor.
 	let pageId;
-	document.body.classList.forEach(className => {
-		if (0 === className.indexOf('page-id-')) {
-			pageId = parseInt(className.replace('page-id-', ''));
+	document.body.classList.forEach( className => {
+		if ( 0 === className.indexOf( 'page-id-' ) ) {
+			pageId = parseInt( className.replace( 'page-id-', '' ) );
 		}
-	});
-	if (pageId && parseInt(newspack_popups_view?.donor_landing_page) === pageId) {
-		ras.store.set('is_donor', true);
+	} );
+	if ( pageId && parseInt( newspack_popups_view?.donor_landing_page ) === pageId ) {
+		ras.store.set( 'is_donor', true );
 	}
 
-	for (const period in pageviews) {
+	for ( const period in pageviews ) {
 		// If the period has elapsed, reset the count.
-		if (periods[period] < now - pageviews[period].start) {
-			pageviews[period].count = 0;
-			pageviews[period].start = now;
+		if ( periods[ period ] < now - pageviews[ period ].start ) {
+			pageviews[ period ].count = 0;
+			pageviews[ period ].start = now;
 		}
 
 		// Increment the count.
-		pageviews[period].count++;
+		pageviews[ period ].count++;
 	}
 
 	// Persist to the Reader Data Library store.
-	ras.store.set('pageviews', pageviews);
+	ras.store.set( 'pageviews', pageviews );
 	return pageviews;
 };

--- a/src/view/utils/prompts.js
+++ b/src/view/utils/prompts.js
@@ -6,7 +6,7 @@
  * @return {Array} Array of prompt elements.
  */
 export const getPrompts = () => {
-	return [...document.querySelectorAll('.newspack-popup-container')];
+	return [ ...document.querySelectorAll( '.newspack-popup-container' ) ];
 };
 
 /**
@@ -17,8 +17,8 @@ export const getPrompts = () => {
  * @return {number} Raw ID number from the element ID.
  */
 export const getRawId = id => {
-	const parts = id.split('_');
-	return parseInt(parts[parts.length - 1]);
+	const parts = id.split( '_' );
+	return parseInt( parts[ parts.length - 1 ] );
 };
 
 /**
@@ -27,15 +27,15 @@ export const getRawId = id => {
  * @param {Event} event Dispatched click event.
  */
 export const closeOverlay = event => {
-	const parent = event.currentTarget.closest('.newspack-lightbox');
+	const parent = event.currentTarget.closest( '.newspack-lightbox' );
 
-	if (parent && parent.contains(event.currentTarget)) {
+	if ( parent && parent.contains( event.currentTarget ) ) {
 		parent.style.display = 'none';
 	}
 
 	// Remove the overlay from RAS.
-	if (parent.overlayId && window.newspackReaderActivation?.overlays) {
-		window.newspackReaderActivation.overlays.remove(parent.overlayId);
+	if ( parent.overlayId && window.newspackReaderActivation?.overlays ) {
+		window.newspackReaderActivation.overlays.remove( parent.overlayId );
 	}
 
 	event.preventDefault();
@@ -47,11 +47,11 @@ export const closeOverlay = event => {
  * @param {string} key  Key name for debug data.
  * @param {any}    data Data to log.
  */
-export const debug = (key, data) => {
-	if (!newspack_popups_view.debug) {
+export const debug = ( key, data ) => {
+	if ( ! newspack_popups_view.debug ) {
 		return;
 	}
 
 	window.newspack_popups_debug = window.newspack_popups_debug || {};
-	window.newspack_popups_debug[key] = data;
+	window.newspack_popups_debug[ key ] = data;
 };

--- a/src/view/utils/segments.js
+++ b/src/view/utils/segments.js
@@ -15,24 +15,24 @@ export const periods = {
  *
  * @return {Object|null} View_as object or null.
  */
-const parseViewAs = (queryString = null) => {
-	if (!queryString) {
+const parseViewAs = ( queryString = null ) => {
+	if ( ! queryString ) {
 		queryString = window.location.search;
 	}
-	const params = new URLSearchParams(queryString);
-	if (params.get('view_as')) {
+	const params = new URLSearchParams( queryString );
+	if ( params.get( 'view_as' ) ) {
 		const viewAs = params
-			.get('view_as')
-			.split(';')
-			.reduce((acc, item) => {
-				const parts = item.split(':');
-				if (1 === parts.length) {
-					acc[parts[0]] = true;
+			.get( 'view_as' )
+			.split( ';' )
+			.reduce( ( acc, item ) => {
+				const parts = item.split( ':' );
+				if ( 1 === parts.length ) {
+					acc[ parts[ 0 ] ] = true;
 				} else {
-					acc[parts[0]] = parts[1];
+					acc[ parts[ 0 ] ] = parts[ 1 ];
 				}
 				return acc;
-			}, {});
+			}, {} );
 		return viewAs;
 	}
 
@@ -46,13 +46,13 @@ const parseViewAs = (queryString = null) => {
  *
  * @return {number|null} Prompt ID, or null.
  */
-export const getPreviewedPromptId = (queryString = null) => {
-	if (!queryString) {
+export const getPreviewedPromptId = ( queryString = null ) => {
+	if ( ! queryString ) {
 		queryString = window.location.search;
 	}
-	const params = new URLSearchParams(queryString);
-	if (params.get('pid')) {
-		return parseInt(params.get('pid'));
+	const params = new URLSearchParams( queryString );
+	if ( params.get( 'pid' ) ) {
+		return parseInt( params.get( 'pid' ) );
 	}
 	return null;
 };
@@ -65,12 +65,12 @@ export const getPreviewedPromptId = (queryString = null) => {
  * @return {boolean} True if the reader matches all of the segment's criteria, false if not.
  */
 const match = segmentCriteria => {
-	for (const item of segmentCriteria) {
-		const criteria = getCriteria(item.criteria_id);
-		if (!criteria) {
+	for ( const item of segmentCriteria ) {
+		const criteria = getCriteria( item.criteria_id );
+		if ( ! criteria ) {
 			continue;
 		}
-		if (!criteria.matches(item)) {
+		if ( ! criteria.matches( item ) ) {
 			return false;
 		}
 	}
@@ -85,30 +85,30 @@ const match = segmentCriteria => {
  *
  * @return {string|null} Segment ID, or null.
  */
-export const getBestPrioritySegment = (segments, viewAsString = null) => {
+export const getBestPrioritySegment = ( segments, viewAsString = null ) => {
 	// If previewing as a specific segment.
-	const viewAs = parseViewAs(viewAsString);
-	if (viewAs?.segment) {
+	const viewAs = parseViewAs( viewAsString );
+	if ( viewAs?.segment ) {
 		return viewAs.segment;
 	}
 
 	const matchingSegments = [];
-	for (const segmentId in segments) {
-		if (match(segments[segmentId].criteria)) {
-			matchingSegments.push({
+	for ( const segmentId in segments ) {
+		if ( match( segments[ segmentId ].criteria ) ) {
+			matchingSegments.push( {
 				id: segmentId,
-				priority: segments[segmentId].priority,
-			});
+				priority: segments[ segmentId ].priority,
+			} );
 		}
 	}
 
-	if (!matchingSegments.length) {
+	if ( ! matchingSegments.length ) {
 		return null;
 	}
 
-	matchingSegments.sort((a, b) => a.priority - b.priority);
+	matchingSegments.sort( ( a, b ) => a.priority - b.priority );
 
-	return matchingSegments[0].id;
+	return matchingSegments[ 0 ].id;
 };
 
 /**
@@ -120,8 +120,8 @@ export const getBestPrioritySegment = (segments, viewAsString = null) => {
  * @param {null|boolean} override        If true or false, force the value.
  * @return {boolean} True if the prompt should be displayed, false if not.
  */
-export const shouldPromptBeDisplayed = (prompt, matchingSegment, ras, override = null) => {
-	const id = prompt.getAttribute('id');
+export const shouldPromptBeDisplayed = ( prompt, matchingSegment, ras, override = null ) => {
+	const id = prompt.getAttribute( 'id' );
 	const suppression = [];
 	const debugInfo = {
 		element: prompt,
@@ -129,76 +129,85 @@ export const shouldPromptBeDisplayed = (prompt, matchingSegment, ras, override =
 
 	const shouldDisplay = () => {
 		// By override.
-		if (true === override || false === override) {
+		if ( true === override || false === override ) {
 			debugInfo.override = true;
-			if (!override) {
-				suppression.push('Prompt suppressed by override.');
+			if ( ! override ) {
+				suppression.push( 'Prompt suppressed by override.' );
 			}
 			return override;
 		}
 
 		// If RAS is not available, the prompt should not be displayed.
-		if (!ras) {
-			suppression.push('Prompt not displayed because RAS is not available.');
+		if ( ! ras ) {
+			suppression.push( 'Prompt not displayed because RAS is not available.' );
 			return false;
 		}
 
 		// eslint-disable-next-line @wordpress/no-unused-vars-before-return
-		const [start, between, max, reset] = prompt.getAttribute('data-frequency').split(',');
-		const pageviews = ras.store.get('pageviews');
-		if (pageviews[reset]) {
-			const views = pageviews[reset].count || 0;
+		const [ start, between, max, reset ] = prompt.getAttribute( 'data-frequency' ).split( ',' );
+		const pageviews = ras.store.get( 'pageviews' );
+		if ( pageviews[ reset ] ) {
+			const views = pageviews[ reset ].count || 0;
 
 			// If reader hasn't amassed enough pageviews yet.
-			if (views <= parseInt(start)) {
-				suppression.push(`Prompt displayed starting at pageview ${parseInt(start) + 1}. Reader has only ${views} pageviews.`);
+			if ( views <= parseInt( start ) ) {
+				suppression.push(
+					`Prompt displayed starting at pageview ${
+						parseInt( start ) + 1
+					}. Reader has only ${ views } pageviews.`
+				);
 				return false;
 			}
 
 			// If not displaying every pageview.
-			if (0 < between) {
-				const viewsAfterStart = Math.max(0, views - (parseInt(start) + 1));
-				if (0 < viewsAfterStart % (parseInt(between) + 1)) {
-					suppression.push(`Prompt displayed once every ${parseInt(between) + 1} pageviews.`);
+			if ( 0 < between ) {
+				const viewsAfterStart = Math.max( 0, views - ( parseInt( start ) + 1 ) );
+				if ( 0 < viewsAfterStart % ( parseInt( between ) + 1 ) ) {
+					suppression.push( `Prompt displayed once every ${ parseInt( between ) + 1 } pageviews.` );
 					return false;
 				}
 			}
 
 			// If there's a max frequency.
-			const promptId = getRawId(id);
-			const seenEvents = (ras.getActivities('prompt_seen') || []).filter(activity => {
-				return activity.data?.prompt_id === promptId && periods[reset] > Date.now() - activity.timestamp;
-			});
-			if (0 < parseInt(max) && seenEvents.length >= parseInt(max)) {
-				suppression.push(`Prompt already displayed the max of ${max} times.`);
+			const promptId = getRawId( id );
+			const seenEvents = ( ras.getActivities( 'prompt_seen' ) || [] ).filter( activity => {
+				return (
+					activity.data?.prompt_id === promptId &&
+					periods[ reset ] > Date.now() - activity.timestamp
+				);
+			} );
+			if ( 0 < parseInt( max ) && seenEvents.length >= parseInt( max ) ) {
+				suppression.push( `Prompt already displayed the max of ${ max } times.` );
 				return false;
 			}
 		}
 
 		// Handle UTM suppression.
-		const suppressByUTM = prompt.getAttribute('data-suppression');
-		if (suppressByUTM) {
-			const suppressionValues = ras.store.get('utm_source') || [];
-			const params = new URLSearchParams(window.location.search);
-			const currentUTM = params.get('utm_source');
+		const suppressByUTM = prompt.getAttribute( 'data-suppression' );
+		if ( suppressByUTM ) {
+			const suppressionValues = ras.store.get( 'utm_source' ) || [];
+			const params = new URLSearchParams( window.location.search );
+			const currentUTM = params.get( 'utm_source' )
 			let suppressedByUTM = false;
-			if (-1 < suppressionValues.indexOf(suppressByUTM)) {
+			if ( -1 < suppressionValues.indexOf( suppressByUTM ) ) {
 				suppressedByUTM = true;
 			}
-			if (!suppressedByUTM && suppressByUTM === currentUTM) {
+			if ( ! suppressedByUTM && suppressByUTM === currentUTM ) {
 				suppressedByUTM = true;
-				ras.store.set('utm_source', [...suppressionValues, currentUTM]);
+				ras.store.set( 'utm_source', [ ...suppressionValues, currentUTM ] );
 			}
-			if (suppressedByUTM) {
-				suppression.push(`Prompt suppressed by utm_source=${suppressByUTM}.`);
+			if ( suppressedByUTM ) {
+				suppression.push( `Prompt suppressed by utm_source=${ suppressByUTM }.` );
 				return false;
 			}
 		}
 
 		// By assigned segments.
-		const assignedSegments = prompt.getAttribute('data-segments') ? prompt.getAttribute('data-segments').split(',') : null;
-		if (assignedSegments && 0 > assignedSegments.indexOf(matchingSegment)) {
-			suppression.push('Reader does not match prompt’s assigned segments.');
+		const assignedSegments = prompt.getAttribute( 'data-segments' )
+			? prompt.getAttribute( 'data-segments' ).split( ',' )
+			: null;
+		if ( assignedSegments && 0 > assignedSegments.indexOf( matchingSegment ) ) {
+			suppression.push( 'Reader does not match prompt’s assigned segments.' );
 			return false;
 		}
 
@@ -207,10 +216,10 @@ export const shouldPromptBeDisplayed = (prompt, matchingSegment, ras, override =
 
 	const display = shouldDisplay();
 	debugInfo.displayed = display;
-	if (0 < suppression.length) {
+	if ( 0 < suppression.length ) {
 		debugInfo.suppression = suppression;
 	}
-	debug(id, debugInfo);
+	debug( id, debugInfo );
 
 	return display;
 };
@@ -228,14 +237,19 @@ export const shouldPromptBeDisplayed = (prompt, matchingSegment, ras, override =
  *
  * @return {boolean|null} The override value to pass to the shouldPromptBeDisplayed function.
  */
-export const getOverride = (promptId, isOverlay = false, overlayDisplayed = false, pidString = null) => {
+export const getOverride = (
+	promptId,
+	isOverlay = false,
+	overlayDisplayed = false,
+	pidString = null
+) => {
 	// If previewing a single prompt, it should always be displayed.
-	if (promptId === getPreviewedPromptId(pidString)) {
+	if ( promptId === getPreviewedPromptId( pidString ) ) {
 		return true;
 	}
 
 	// If an overlay and another overlay has already been displayed, it should not be displaeyd.
-	if (isOverlay && overlayDisplayed) {
+	if ( isOverlay && overlayDisplayed ) {
 		return false;
 	}
 

--- a/src/view/utils/segments.test.js
+++ b/src/view/utils/segments.test.js
@@ -2,9 +2,9 @@ import { registerCriteria } from '../../criteria/utils';
 import { getBestPrioritySegment, getOverride, shouldPromptBeDisplayed, periods } from './index.js';
 
 // Mock the window.location object. See: https://developer.mozilla.org/en-US/docs/Web/API/Location
-const setWindowLocation = (domain = 'example.com', search = '') => {
+const setWindowLocation = ( domain = 'example.com', search = '' ) => {
 	delete global.window.location;
-	global.window = Object.create(window);
+	global.window = Object.create( window );
 	global.window.location = {
 		ancestorOrigins: null,
 		hash: null,
@@ -67,7 +67,7 @@ const segments = {
 		criteria: [
 			{
 				criteria_id: 'list__in',
-				value: ['list-value', 'list-value-2'],
+				value: [ 'list-value', 'list-value-2' ],
 			},
 		],
 		priority: 2,
@@ -79,23 +79,23 @@ const now = Date.now();
 window.newspack_popups_view = {};
 window.newspackReaderActivation = {
 	store: {
-		set(matchingAttribute, value) {
-			if (!this.values) {
+		set( matchingAttribute, value ) {
+			if ( ! this.values ) {
 				this.values = {};
 			}
-			this.values[matchingAttribute] = value;
+			this.values[ matchingAttribute ] = value;
 		},
-		get(matchingAttribute) {
-			if (!this.values) {
+		get( matchingAttribute ) {
+			if ( ! this.values ) {
 				this.values = {};
 			}
-			return this.values[matchingAttribute];
+			return this.values[ matchingAttribute ];
 		},
 		clear() {
 			this.values = {};
 		},
 	},
-	getActivities(action = null) {
+	getActivities( action = null ) {
 		const testActivities = [
 			{
 				action: 'article_view',
@@ -116,45 +116,51 @@ window.newspackReaderActivation = {
 			},
 		];
 
-		if (!action) {
+		if ( ! action ) {
 			return testActivities;
 		}
 
-		return testActivities.filter(activity => activity.action === action);
+		return testActivities.filter( activity => activity.action === action );
 	},
 	on() {},
 };
 
 const ras = window.newspackReaderActivation;
 
-const createPrompt = (assignedSegments = [], frequency = '0,0,0,month', id = '1', type = 'inline', utmSuppression = '') => {
-	const prompt = document.createElement('div');
-	prompt.setAttribute('id', 'id_' + id);
-	prompt.setAttribute('data-segments', assignedSegments.join(','));
-	prompt.setAttribute('data-frequency', frequency);
+const createPrompt = (
+	assignedSegments = [],
+	frequency = '0,0,0,month',
+	id = '1',
+	type = 'inline',
+	utmSuppression = ''
+) => {
+	const prompt = document.createElement( 'div' );
+	prompt.setAttribute( 'id', 'id_' + id );
+	prompt.setAttribute( 'data-segments', assignedSegments.join( ',' ) );
+	prompt.setAttribute( 'data-frequency', frequency );
 
-	if (utmSuppression) {
-		prompt.setAttribute('data-suppression', utmSuppression);
+	if ( utmSuppression ) {
+		prompt.setAttribute( 'data-suppression', utmSuppression );
 	}
 
-	if ('inline' === type) {
-		prompt.classList.add('newspack-inline-popup');
-	} else if ('overlay' === type) {
-		prompt.classList.add('newspack-lightbox');
+	if ( 'inline' === type ) {
+		prompt.classList.add( 'newspack-inline-popup' );
+	} else if ( 'overlay' === type ) {
+		prompt.classList.add( 'newspack-lightbox' );
 	}
 
 	return prompt;
 };
 
-describe('segmentation API', () => {
-	beforeEach(() => {
+describe( 'segmentation API', () => {
+	beforeEach( () => {
 		setWindowLocation();
 		window.newspackPopupsCriteria = { criteria: {} };
-		for (const criteriaId in criteria) {
-			registerCriteria(criteriaId, criteria[criteriaId]);
+		for ( const criteriaId in criteria ) {
+			registerCriteria( criteriaId, criteria[ criteriaId ] );
 		}
 		ras.store.clear();
-		ras.store.set('pageviews', {
+		ras.store.set( 'pageviews', {
 			day: {
 				count: 1,
 				start: now,
@@ -167,87 +173,95 @@ describe('segmentation API', () => {
 				count: 1,
 				start: now,
 			},
-		});
-	});
+		} );
+	} );
 
-	it('should return null if the reader matches no segment', () => {
+	it( 'should return null if the reader matches no segment', () => {
 		// Set an initial value.
-		ras.store.set('simple', 'initial-value');
-		expect(getBestPrioritySegment(segments)).toEqual(null);
-	});
+		ras.store.set( 'simple', 'initial-value' );
+		expect( getBestPrioritySegment( segments ) ).toEqual( null );
+	} );
 
-	it('should return the segment ID of the matching segment with the highest priority', () => {
-		ras.store.set('simple', 'simple-match');
-		expect(getBestPrioritySegment(segments)).toEqual('segment2');
-	});
+	it( 'should return the segment ID of the matching segment with the highest priority', () => {
+		ras.store.set( 'simple', 'simple-match' );
+		expect( getBestPrioritySegment( segments ) ).toEqual( 'segment2' );
+	} );
 
-	it('should return the segment ID of the segment in the view_as query string', () => {
+	it( 'should return the segment ID of the segment in the view_as query string', () => {
 		const queryString = '?view_as=segment:segment1;all;session_id:1';
-		expect(getBestPrioritySegment(segments, queryString)).toEqual('segment1');
+		expect( getBestPrioritySegment( segments, queryString ) ).toEqual( 'segment1' );
 
 		const queryString2 = '?view_as=segment:segment2;all;session_id:2';
-		expect(getBestPrioritySegment(segments, queryString2)).toEqual('segment2');
-	});
+		expect( getBestPrioritySegment( segments, queryString2 ) ).toEqual( 'segment2' );
+	} );
 
-	it('should return false if the reader doesn’t match the prompt’s segments', () => {
-		const prompt = createPrompt(['segment4']);
-		expect(shouldPromptBeDisplayed(prompt, getBestPrioritySegment(segments), ras)).toBeFalsy();
-	});
+	it( 'should return false if the reader doesn’t match the prompt’s segments', () => {
+		const prompt = createPrompt( [ 'segment4' ] );
+		expect(
+			shouldPromptBeDisplayed( prompt, getBestPrioritySegment( segments ), ras )
+		).toBeFalsy();
+	} );
 
-	it('should return true if the reader matches the prompt’s segments', () => {
-		const prompt = createPrompt(['segment4']);
-		ras.store.set('list__in', 'list-value');
-		expect(shouldPromptBeDisplayed(prompt, getBestPrioritySegment(segments), ras)).toBeTruthy();
-	});
+	it( 'should return true if the reader matches the prompt’s segments', () => {
+		const prompt = createPrompt( [ 'segment4' ] );
+		ras.store.set( 'list__in', 'list-value' );
+		expect(
+			shouldPromptBeDisplayed( prompt, getBestPrioritySegment( segments ), ras )
+		).toBeTruthy();
+	} );
 
-	it('should return true if the prompt has no assigned segments', () => {
+	it( 'should return true if the prompt has no assigned segments', () => {
 		const prompt = createPrompt();
-		expect(shouldPromptBeDisplayed(prompt, null, ras)).toBeTruthy();
-	});
+		expect( shouldPromptBeDisplayed( prompt, null, ras ) ).toBeTruthy();
+	} );
 
-	it('should return false if the reader hasn’t amassed enough pageviews', () => {
-		const prompt = createPrompt([], '2,0,0,month');
-		expect(shouldPromptBeDisplayed(prompt, getBestPrioritySegment(segments), ras)).toBeFalsy();
-	});
+	it( 'should return false if the reader hasn’t amassed enough pageviews', () => {
+		const prompt = createPrompt( [], '2,0,0,month' );
+		expect(
+			shouldPromptBeDisplayed( prompt, getBestPrioritySegment( segments ), ras )
+		).toBeFalsy();
+	} );
 
-	it('should return false if the reader has already viewed the prompt the max number of times', () => {
-		const prompt = createPrompt([], '0,0,1,month');
-		expect(shouldPromptBeDisplayed(prompt, getBestPrioritySegment(segments), ras)).toBeFalsy();
-	});
+	it( 'should return false if the reader has already viewed the prompt the max number of times', () => {
+		const prompt = createPrompt( [], '0,0,1,month' );
+		expect(
+			shouldPromptBeDisplayed( prompt, getBestPrioritySegment( segments ), ras )
+		).toBeFalsy();
+	} );
 
-	it('should only show one overlay prompt per request', () => {
-		const prompt1 = createPrompt([], '0,0,0,month', '1', 'overlay');
-		const prompt2 = createPrompt([], '0,0,0,month', '2', 'overlay');
+	it( 'should only show one overlay prompt per request', () => {
+		const prompt1 = createPrompt( [], '0,0,0,month', '1', 'overlay' );
+		const prompt2 = createPrompt( [], '0,0,0,month', '2', 'overlay' );
 
-		const shouldPrompt1BeDisplayed = shouldPromptBeDisplayed(prompt1, null, ras);
+		const shouldPrompt1BeDisplayed = shouldPromptBeDisplayed( prompt1, null, ras );
 
 		// First overlay prompt should be displayed.
-		expect(shouldPrompt1BeDisplayed).toBeTruthy();
+		expect( shouldPrompt1BeDisplayed ).toBeTruthy();
 
 		// Force the second overlay prompt to not be displayed even though all other criteria are met.
-		const overlayOverride = getOverride(2, true, shouldPrompt1BeDisplayed);
-		expect(shouldPromptBeDisplayed(prompt2, null, ras, overlayOverride)).toBeFalsy();
-	});
+		const overlayOverride = getOverride( 2, true, shouldPrompt1BeDisplayed );
+		expect( shouldPromptBeDisplayed( prompt2, null, ras, overlayOverride ) ).toBeFalsy();
+	} );
 
-	it('should allow a specific prompt to be always displayed', () => {
+	it( 'should allow a specific prompt to be always displayed', () => {
 		// Force specific prompt to always be displayed.
-		const prompt = createPrompt([], '0,0,0,month', '123');
-		const pidOverride = getOverride(123, false, false, '?pid=123');
-		expect(shouldPromptBeDisplayed(prompt, null, ras, pidOverride)).toBeTruthy();
-	});
+		const prompt = createPrompt( [], '0,0,0,month', '123' );
+		const pidOverride = getOverride( 123, false, false, '?pid=123' );
+		expect( shouldPromptBeDisplayed( prompt, null, ras, pidOverride ) ).toBeTruthy();
+	} );
 
-	it('should return false if the reader has or had the UTM Suppression value in utm_source params', () => {
-		const prompt = createPrompt([], '0,0,0,month', '1', 'inline', 'suppress_this');
+	it ( 'should return false if the reader has or had the UTM Suppression value in utm_source params', () => {
+		const prompt = createPrompt( [], '0,0,0,month', '1', 'inline', 'suppress_this' );
 
 		// If the URL does not contain the prompt's UTM suppression value in utm_source, the prompt should be displayed.
-		expect(shouldPromptBeDisplayed(prompt, null, ras)).toBeTruthy();
+		expect( shouldPromptBeDisplayed( prompt, null, ras ) ).toBeTruthy();
 
 		// If the URL has the prompt's UTM suppression value in utm_source, the prompt should not be displayed.
-		setWindowLocation('example.com', '?utm_source=suppress_this');
-		expect(shouldPromptBeDisplayed(prompt, null, ras)).toBeFalsy();
+		setWindowLocation( 'example.com', '?utm_source=suppress_this' );
+		expect( shouldPromptBeDisplayed( prompt, null, ras ) ).toBeFalsy();
 
 		// Once the reader has had the UTM suppression value, the prompt should no longer be displayed.
-		setWindowLocation('example.com', '');
-		expect(shouldPromptBeDisplayed(prompt, null, ras)).toBeFalsy();
-	});
-});
+		setWindowLocation( 'example.com', '' );
+		expect( shouldPromptBeDisplayed( prompt, null, ras ) ).toBeFalsy();
+	} );
+} );

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,24 +7,26 @@
 /**
  * External dependencies
  */
-const getBaseWebpackConfig = require('newspack-scripts/config/getWebpackConfig');
-const path = require('path');
+const getBaseWebpackConfig = require( 'newspack-scripts/config/getWebpackConfig' );
+const path = require( 'path' );
 
 /**
  * Internal variables
  */
 const entry = {
-	editor: path.join(__dirname, 'src', 'editor'),
-	view: path.join(__dirname, 'src', 'view'),
-	admin: path.join(__dirname, 'src', 'view', 'admin'),
-	documentSettings: path.join(__dirname, 'src', 'document-settings'),
-	settings: path.join(__dirname, 'src', 'settings'),
-	blocks: path.join(__dirname, 'src', 'blocks'),
-	criteria: path.join(__dirname, 'src', 'criteria'),
+	editor: path.join( __dirname, 'src', 'editor' ),
+	view: path.join( __dirname, 'src', 'view' ),
+	admin: path.join( __dirname, 'src', 'view', 'admin' ),
+	documentSettings: path.join( __dirname, 'src', 'document-settings' ),
+	settings: path.join( __dirname, 'src', 'settings' ),
+	blocks: path.join( __dirname, 'src', 'blocks' ),
+	criteria: path.join( __dirname, 'src', 'criteria' ),
 };
 
-const webpackConfig = getBaseWebpackConfig({
-	entry,
-});
+const webpackConfig = getBaseWebpackConfig(
+	{
+		entry,
+	}
+);
 
 module.exports = webpackConfig;


### PR DESCRIPTION
I'm not sure why the bump to `@newspack-scripts` v5.7.0 forces new Prettier rules that differ from those in `newspack-plugin` with the same version of `@newspack-scripts`. We should hold off on updating to v5.7.0 until we resolve this