### PR TITLE
chore: bump newspack-components from v3.1.0 to v4.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
 				"classnames": "^2.5.1",
 				"intersection-observer": "^0.12.2",
 				"js-cookie": "^3.0.5",
-				"newspack-components": "^3.1.0",
+				"newspack-components": "^4.1.0",
 				"qs": "^6.14.0"
 			},
 			"devDependencies": {
@@ -3786,22 +3786,6 @@
 			},
 			"funding": {
 				"url": "https://opencollective.com/unts"
-			}
-		},
-		"node_modules/@playwright/test": {
-			"version": "1.45.3",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.45.3.tgz",
-			"integrity": "sha512-UKF4XsBfy+u3MFWEH44hva1Q8Da28G6RFtR2+5saw+jgAFQV5yYnB1fu68Mz7fO+5GJF3wgwAIs0UelU8TxFrA==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"playwright": "1.45.3"
-			},
-			"bin": {
-				"playwright": "cli.js"
-			},
-			"engines": {
-				"node": ">=18"
 			}
 		},
 		"node_modules/@pmmmwh/react-refresh-webpack-plugin": {
@@ -18788,9 +18772,10 @@
 			}
 		},
 		"node_modules/newspack-components": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/newspack-components/-/newspack-components-3.1.0.tgz",
-			"integrity": "sha512-jQjFWmO3Z52a57ZFwKPV/rMpoUKSeNHPGrCHDTziJpRclapidqJyk9pIp4FKbks8Xc8g0zP4hH397Bk/treTJQ==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/newspack-components/-/newspack-components-4.1.0.tgz",
+			"integrity": "sha512-o4/IfGBV4Ydp4bSCJIr29JNckMO73MhIO/X+pForwzqhOscesFspoKNh1OIhioWt17fgGLmjC1RofU9AwftQOg==",
+			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/base-styles": "^5.0.0",
 				"@wordpress/components": "^28.0.0",
@@ -22819,53 +22804,6 @@
 			},
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/playwright": {
-			"version": "1.45.3",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.45.3.tgz",
-			"integrity": "sha512-QhVaS+lpluxCaioejDZ95l4Y4jSFCsBvl2UZkpeXlzxmqS+aABr5c82YmfMHrL6x27nvrvykJAFpkzT2eWdJww==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"playwright-core": "1.45.3"
-			},
-			"bin": {
-				"playwright": "cli.js"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"optionalDependencies": {
-				"fsevents": "2.3.2"
-			}
-		},
-		"node_modules/playwright-core": {
-			"version": "1.45.3",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.45.3.tgz",
-			"integrity": "sha512-+ym0jNbcjikaOwwSZycFbwkWgfruWvYlJfThKYAlImbxUgdWFO2oW70ojPm4OpE4t6TAo2FY/smM+hpVTtkhDA==",
-			"dev": true,
-			"peer": true,
-			"bin": {
-				"playwright-core": "cli.js"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/playwright/node_modules/fsevents": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-			"dev": true,
-			"hasInstallScript": true,
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"peer": true,
-			"engines": {
-				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
 			}
 		},
 		"node_modules/plur": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
 		"classnames": "^2.5.1",
 		"intersection-observer": "^0.12.2",
 		"js-cookie": "^3.0.5",
-		"newspack-components": "^3.1.0",
+		"newspack-components": "^4.1.0",
 		"qs": "^6.14.0"
 	},
 	"devDependencies": {

--- a/src/settings/index.js
+++ b/src/settings/index.js
@@ -22,7 +22,7 @@ import {
 /**
  * Newspack dependencies.
  */
-import { NewspackLogo } from 'newspack-components';
+import { NewspackIcon } from 'newspack-components';
 
 /**
  * Internal dependencies
@@ -117,7 +117,7 @@ const App = () => {
 					target="_blank"
 					label={ __( 'By Newspack' ) }
 				>
-					<NewspackLogo height={ 32 } />
+					<NewspackIcon height={ 32 } />
 				</Button>
 			</div>
 			<Card>

--- a/src/settings/style.scss
+++ b/src/settings/style.scss
@@ -1,4 +1,4 @@
-@use "~newspack-components/shared/scss/colors";
+@use "~newspack-components/colors/colors.module";
 
 .components-card {
 	margin: 2rem auto;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Bump `newspack-components` to v4.1.0 and resolve build errors due to changed paths/export names in that version. See https://github.com/Automattic/newspack-plugin/pull/4259#issuecomment-3457029247 for more details

### How to test the changes in this Pull Request:

1. Check out this branch and run `npm start` to reinstall all dependencies
2. Confirm that `npm run watch` and `npm run build` compile JS/SCSS assets successfully
3. Smoke test Campaigns functionality that uses JS and SCSS in both WP admin and on the front-end

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
