### PR TITLE
fix(apple-news): disable prompts when exporting to apple news

### DIFF
--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -31,13 +31,6 @@ final class Newspack_Popups_Inserter {
 	protected static $segments = [];
 
 	/**
-	 * Whether we're exporting to Apple News.
-	 *
-	 * @var boolean
-	 */
-	private static $is_apple_news_exporting = false;
-
-	/**
 	 * Whether we've already inserted prompts into the content.
 	 * If we've already inserted popups into the content, don't try to do it again.
 	 *
@@ -46,50 +39,11 @@ final class Newspack_Popups_Inserter {
 	public static $the_content_has_rendered = false;
 
 	/**
-	 * Retrieve the appropriate popups for the current post.
+	 * Whether we're exporting to Apple News.
 	 *
-	 * @return array Popup objects.
+	 * @var boolean
 	 */
-	public static function popups_for_post() {
-		if ( ! empty( self::$popups ) ) {
-			return self::$popups;
-		}
-
-		// Get the previewed popup and return early.
-		if ( Newspack_Popups::previewed_popup_id() ) {
-			$preview_popup = Newspack_Popups_Model::retrieve_preview_popup( Newspack_Popups::previewed_popup_id() );
-			return [ $preview_popup ];
-		}
-		if ( Newspack_Popups::preset_popup_id() ) {
-			$preset_popup = Newspack_Popups_Presets::retrieve_preset_popup( Newspack_Popups::preset_popup_id() );
-			return [ $preset_popup ];
-		}
-
-		// Popups disabled for this page.
-		if ( self::assess_has_disabled_popups() ) {
-			return [];
-		}
-
-		$view_as_spec        = Newspack_Popups_View_As::parse_view_as();
-		$campaign_id         = isset( $view_as_spec['campaign'] ) ? $view_as_spec['campaign'] : false;
-		$include_unpublished = isset( $view_as_spec['show_unpublished'] ) && 'true' === $view_as_spec['show_unpublished'] ? true : false;
-
-		// Retrieve all prompts eligible for display.
-		$popups_to_maybe_display = Newspack_Popups_Model::retrieve_eligible_popups( $include_unpublished, $campaign_id );
-		$popups_to_display       = array_filter(
-			$popups_to_maybe_display,
-			function( $popup ) {
-				return self::should_display( $popup, true );
-			}
-		);
-
-		// Cache results so we don't have to query again.
-		if ( ! defined( 'IS_TEST_ENV' ) || ! IS_TEST_ENV ) {
-			self::$popups = $popups_to_display;
-		}
-
-		return $popups_to_display;
-	}
+	private static $is_apple_news_exporting = false;
 
 	/**
 	 * Constructor.
@@ -147,6 +101,52 @@ final class Newspack_Popups_Inserter {
 			return true;
 		}
 		return $disabled;
+	}
+
+	/**
+	 * Retrieve the appropriate popups for the current post.
+	 *
+	 * @return array Popup objects.
+	 */
+	public static function popups_for_post() {
+		if ( ! empty( self::$popups ) ) {
+			return self::$popups;
+		}
+
+		// Get the previewed popup and return early.
+		if ( Newspack_Popups::previewed_popup_id() ) {
+			$preview_popup = Newspack_Popups_Model::retrieve_preview_popup( Newspack_Popups::previewed_popup_id() );
+			return [ $preview_popup ];
+		}
+		if ( Newspack_Popups::preset_popup_id() ) {
+			$preset_popup = Newspack_Popups_Presets::retrieve_preset_popup( Newspack_Popups::preset_popup_id() );
+			return [ $preset_popup ];
+		}
+
+		// Popups disabled for this page.
+		if ( self::assess_has_disabled_popups() ) {
+			return [];
+		}
+
+		$view_as_spec        = Newspack_Popups_View_As::parse_view_as();
+		$campaign_id         = isset( $view_as_spec['campaign'] ) ? $view_as_spec['campaign'] : false;
+		$include_unpublished = isset( $view_as_spec['show_unpublished'] ) && 'true' === $view_as_spec['show_unpublished'] ? true : false;
+
+		// Retrieve all prompts eligible for display.
+		$popups_to_maybe_display = Newspack_Popups_Model::retrieve_eligible_popups( $include_unpublished, $campaign_id );
+		$popups_to_display       = array_filter(
+			$popups_to_maybe_display,
+			function( $popup ) {
+				return self::should_display( $popup, true );
+			}
+		);
+
+		// Cache results so we don't have to query again.
+		if ( ! defined( 'IS_TEST_ENV' ) || ! IS_TEST_ENV ) {
+			self::$popups = $popups_to_display;
+		}
+
+		return $popups_to_display;
 	}
 
 	/**
@@ -467,8 +467,10 @@ final class Newspack_Popups_Inserter {
 		$filtered_content = explode( "\n", $content );
 		$post_content     = explode( "\n", $post->post_content );
 		if (
+			// If prompts are disabled for this post.
+			self::assess_has_disabled_popups()
 			// Avoid duplicate execution.
-			true === self::$the_content_has_rendered
+			|| true === self::$the_content_has_rendered
 			// Not Frontend.
 			|| is_admin()
 			// Content is empty.

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -31,6 +31,13 @@ final class Newspack_Popups_Inserter {
 	protected static $segments = [];
 
 	/**
+	 * Whether we're exporting to Apple News.
+	 *
+	 * @var boolean
+	 */
+	private static $is_apple_news_exporting = false;
+
+	/**
 	 * Whether we've already inserted prompts into the content.
 	 * If we've already inserted popups into the content, don't try to do it again.
 	 *
@@ -97,42 +104,8 @@ final class Newspack_Popups_Inserter {
 
 		// Always enqueue scripts, since this plugin's scripts are handling pageview sending via GTAG.
 		add_action( 'wp_enqueue_scripts', [ $this, 'enqueue_scripts' ] );
-
-		add_filter(
-			'newspack_popups_assess_has_disabled_popups',
-			function ( $disabled ) {
-				if ( get_post_meta( get_the_ID(), 'newspack_popups_has_disabled_popups', true ) ) {
-					return true;
-				}
-
-				return $disabled;
-			}
-		);
-
-		// Suppress popups on product pages.
-		// Until the popups non-AMP refactoring happens, they will break Add to Cart buttons.
-		add_filter(
-			'newspack_popups_assess_has_disabled_popups',
-			function( $disabled ) {
-				if ( function_exists( 'is_product' ) && is_product() ) {
-					return true;
-				}
-				return $disabled;
-			}
-		);
-
-		// The suppress filter used to be named 'newspack_newsletters_assess_has_disabled_popups'.
-		// Maintain that filter for backwards compatibility.
-		add_filter(
-			'newspack_popups_assess_has_disabled_popups',
-			function( $disabled ) {
-				if ( apply_filters( 'newspack_newsletters_assess_has_disabled_popups', false ) ) {
-					return true;
-				}
-
-				return $disabled;
-			}
-		);
+		add_action( 'apple_news_do_fetch_exporter', [ __CLASS__, 'apple_news_do_fetch_exporter' ] );
+		add_filter( 'newspack_popups_assess_has_disabled_popups', [ __CLASS__, 'disable_prompts' ] );
 
 		// These hooks are fired before and after rendering posts in the Homepage Posts block.
 		// By removing the the_content filter before rendering, we avoid incorrectly injecting popup content into excerpts in the block.
@@ -149,6 +122,31 @@ final class Newspack_Popups_Inserter {
 				add_filter( 'the_content', [ $this, 'insert_popups_in_content' ], 1 );
 			}
 		);
+	}
+
+	/**
+	 * Disable prompts for specific conditions.
+	 *
+	 * @param bool $disabled Whether prompts are disabled.
+	 * @return bool Whether prompts are disabled.
+	 */
+	public static function disable_prompts( $disabled ) {
+		// If the post has been set to disable prompts.
+		if ( get_post_meta( get_the_ID(), 'newspack_popups_has_disabled_popups', true ) ) {
+			return true;
+		}
+
+		// The suppress filter used to be named 'newspack_newsletters_assess_has_disabled_popups'.
+		// Maintain that filter for backwards compatibility.
+		if ( apply_filters( 'newspack_newsletters_assess_has_disabled_popups', false ) ) {
+			return true;
+		}
+
+		// If exporting to Apple News.
+		if ( self::$is_apple_news_exporting ) {
+			return true;
+		}
+		return $disabled;
 	}
 
 	/**
@@ -952,6 +950,13 @@ final class Newspack_Popups_Inserter {
 				],
 			]
 		);
+	}
+
+	/**
+	 * Mark this request as an Apple News exporter request.
+	 */
+	public static function apple_news_do_fetch_exporter() {
+		self::$is_apple_news_exporting = true;
 	}
 }
 $newspack_popups_inserter = new Newspack_Popups_Inserter();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Prevents prompts from being injected into post content while the [Apple News plugin](https://github.com/alleyinteractive/apple-news) is exporting posts. Segmentation behavior and prompt styles won't carry over gracefully to Apple News.

Also does a little reorganization to consolidate several callbacks on the `newspack_popups_assess_has_disabled_popups` to a single callback.

Also allows prompts to appear on Product pages, since the original reason for disabling prompts on all Product pages (AMP) is no longer a factor.

### How to test the changes in this Pull Request:

If you have an Apple News publishing account, you can test this by [downloading Apple News JSON for a post](https://github.com/alleyinteractive/apple-news/wiki/Usage#downloading-posts) and confirming that prompts that would otherwise be rendered in post content never appear in these exports.

You can also run this code via WP CLI to view the export JSON—just replace `1234` with a post ID to test with (h/t @adekbadek):

```
wp eval "echo (new \Apple_Actions\Index\Export((new Admin_Apple_Settings())->fetch_settings(), 1234))->fetch_exporter()->export();" | jq '.'
```

Additionally:

1. Smoke test the conditions that have been consolidated into the `disable_prompts` method. Prompts should be disabled when:

  - The "Disable prompts on this post or page" toggle is ON for specific posts and pages
  - The `newspack_newsletters_assess_has_disabled_popups` filter returns `true` (temporarily add a filter callback to set this value)

2. View a single product page and confirm that prompts CAN now appear on these pages. Smoke test adding the product to your cart and checkout out via normal Woo checkout.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
