### PR TITLE
fix: make sure custom placements follow post type restrictions

### DIFF
--- a/includes/class-newspack-popups-custom-placements.php
+++ b/includes/class-newspack-popups-custom-placements.php
@@ -258,7 +258,7 @@ final class Newspack_Popups_Custom_Placements {
 	 */
 	public static function is_custom_placement_or_manual( $prompt ) {
 		return (
-			'manual' === $prompt['options']['frequency'] ||
+			'manual' === $prompt['options']['placement'] ||
 			in_array( $prompt['options']['placement'], self::get_custom_placement_values() )
 		);
 	}

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -913,7 +913,6 @@ final class Newspack_Popups_Inserter {
 			// Popup's post types are *set* - different than defaults. These should override the global post types.
 			$supported_post_types = $popup_post_types;
 		}
-
 		$is_post_context_matching = $is_taxonomy_matching && in_array( $post_type, $supported_post_types );
 
 		/**

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -895,10 +895,6 @@ final class Newspack_Popups_Inserter {
 		if ( Newspack_Popups::is_account_related_post( get_post() ) ) {
 			return false;
 		}
-		// Custom and manual placements should override context conditions, since they are placed arbitrarily.
-		if ( Newspack_Popups_Custom_Placements::is_custom_placement_or_manual( $popup ) ) {
-			return true;
-		}
 
 		// Context in which the popup appears.
 		// 1. the taxonomy of the post.
@@ -917,6 +913,7 @@ final class Newspack_Popups_Inserter {
 			// Popup's post types are *set* - different than defaults. These should override the global post types.
 			$supported_post_types = $popup_post_types;
 		}
+
 		$is_post_context_matching = $is_taxonomy_matching && in_array( $post_type, $supported_post_types );
 
 		/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR makes the the Manual and Custom prompt placements treat the post type restrictions the same way, but I'm less sure that this is the way it was designed to work 😅 

Prior to this change, the Manual placement respected the post type setting, and the Custom placement did not. This PR fixes an error in the _Manual_ placement code to make them act the same way, and removes a check for either in the `should_display()` function. This implies to me that the Custom Placements were acting correctly, but given how both Custom and Manual placements can be added to widget areas, it's helpful to be able to control their visibility like this.

(Widget visibility would also work with the classic theme, but not if we wanted to do a similar quasi-in-template placement in the block theme, since they wouldn't be widgets there).

Note that if you limit these prompts to just posts, they show up on the archives; the same thing happens with other placements, like above header. It's not a post type, but should we add an additional option to that list for archive pages?

See NPPM-2314.

### How to test the changes in this Pull Request:

1. Set up three prompts: a Custom placement, Manual placement, and Inline (to be placed in the above-header spot for comparison).
2. Set all three prompts to only show for Posts.
3. Set up the Custom placement and Manual placement prompts in the Above footer widget area.
4. View on the front-end; note that the Manual placement and Above Header prompts only show on posts (and archives), but the Custom placement ignores this setting.
5. Apply this PR.
6. Repeat step 4; confirm all the prompts are only showing up for the same post type. 
7. Change the criteria of all three prompts (to a different post type, or to a particular tag or category, or add to a segment), and confirm they still respect it.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
