### PR TITLE
fix(prompt-expiration): evaluate expiration timestamp in site timezone

### DIFF
--- a/includes/class-newspack-popups-expiry.php
+++ b/includes/class-newspack-popups-expiry.php
@@ -81,7 +81,7 @@ final class Newspack_Popups_Expiry {
 		$now      = current_datetime(); // Site timezone aware.
 		$tomorrow = $now->setTime( 0, 0 )->modify( '+1 day' ); // Next occurring midnight in the site's timezone.
 
-		return $expiration_date <= $tomorrow;
+		return $expiration_date < $tomorrow;
 	}
 
 	/**

--- a/includes/class-newspack-popups-expiry.php
+++ b/includes/class-newspack-popups-expiry.php
@@ -70,11 +70,18 @@ final class Newspack_Popups_Expiry {
 	 * @return bool True if the date is expired, false otherwise.
 	 */
 	public static function is_expired( $date ) {
-		$expiration_date = strtotime( $date );
-		if ( $expiration_date && $expiration_date <= strtotime( 'tomorrow' ) ) {
-			return true;
+		if ( ! $date ) {
+			return false;
 		}
-		return false;
+		$expiration_date = date_create_immutable( $date, wp_timezone() );
+		if ( false === $expiration_date ) {
+			return false;
+		}
+
+		$now      = current_datetime(); // Site timezone aware.
+		$tomorrow = $now->setTime( 0, 0 )->modify( '+1 day' ); // Next occurring midnight in the site's timezone.
+
+		return $expiration_date <= $tomorrow;
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Ensures that when evaluating whether a prompt's `expiration_date` timestamp has passed, the comparison is done with the next occurring midnight in the site's timezone, rather than in UTC. This should prevent premature prompt expiration for sites west of UTC, and delays in expiration for sites in timezones east of UTC.

Closes NPPM-2503.

### How to test the changes in this Pull Request:

Kind of hard to test this without waiting 24 hours, but for clarity's sake:

1. In Settings > General, set your site's timezone to a large difference from UTC, such as UTC-8.
2. Publish a prompt with an expiration date set to tomorrow.
3. Wait until UTC midnight has passed, but it's still the prior day in your site's timezone. On `release`, observe that the prompt is unpublished even though there are still 8 hours left in the day in your site's timezone.
4. Check out this branch, repeat, and confirm that the prompt isn't unpublished until midnight of the site's timezone, not UTC.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
