### PR TITLE
feat: make prompt_title available to modal checkout data events 

### DIFF
--- a/includes/class-newspack-popups-data-api.php
+++ b/includes/class-newspack-popups-data-api.php
@@ -189,6 +189,9 @@ final class Newspack_Popups_Data_Api {
 		if ( ! empty( $data['prompt_id'] ) ) {
 			self::$popups[ $data['prompt_id'] ] = $data;
 		}
+		if ( ! empty( $data['prompt_title'] ) ) {
+			self::$popups[ $data['prompt_title'] ] = $data;
+		}
 	}
 
 	/**
@@ -256,6 +259,10 @@ final class Newspack_Popups_Data_Api {
 		if ( ! empty( $popup_id ) ) {
 			$cart_item_data['newspack_popup_id'] = $popup_id;
 		}
+		$prompt_title = filter_input( INPUT_GET, 'prompt_title', FILTER_SANITIZE_SPECIAL_CHARS );
+		if ( ! empty( $prompt_title ) ) {
+			$cart_item_data['prompt_title'] = $prompt_title;
+		}
 		return $cart_item_data;
 	}
 
@@ -271,6 +278,9 @@ final class Newspack_Popups_Data_Api {
 	public static function checkout_create_order_line_item( $item, $cart_item_key, $values, $order ) {
 		if ( ! empty( $values['newspack_popup_id'] ) ) {
 			$order->add_meta_data( '_newspack_popup_id', $values['newspack_popup_id'] );
+		}
+		if ( ! empty( $values['prompt_title'] ) ) {
+			$order->add_meta_data( '_prompt_title', $values['prompt_title'] );
 		}
 	}
 

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -906,6 +906,11 @@ final class Newspack_Popups_Model {
 				type="hidden"
 				value="<?php echo esc_attr( self::$form_hooks_popup_id ); ?>"
 			/>
+			<input
+				name="prompt_title"
+				type="hidden"
+				value="<?php echo esc_attr( get_the_title( self::$form_hooks_popup_id ) ); ?>"
+			/>
 		<?php
 	}
 


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR, along with https://github.com/Automattic/newspack-blocks/pull/2271 and https://github.com/Automattic/newspack-plugin/pull/4377, adds the prompt_title to the modal checkout data events.

See https://github.com/Automattic/newspack-blocks/pull/2271 for testing steps.

Closes # .

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
