### PR TITLE
fix: rename prompt_id to newspack_popup_id for consistency

### DIFF
--- a/includes/class-newspack-popups-data-api.php
+++ b/includes/class-newspack-popups-data-api.php
@@ -105,8 +105,8 @@ final class Newspack_Popups_Data_Api {
 			return $data;
 		}
 
-		$data['prompt_id']    = $popup['id'];
-		$data['prompt_title'] = $popup['title'];
+		$data['newspack_popup_id'] = $popup['id'];
+		$data['prompt_title']      = $popup['title'];
 
 		if ( isset( $popup['options'] ) ) {
 			$data['prompt_frequency'] = self::get_frequency_summary( $popup );
@@ -186,8 +186,8 @@ final class Newspack_Popups_Data_Api {
 	 */
 	public static function get_rendered_popups( $popup ) {
 		$data = self::get_popup_metadata( $popup );
-		if ( ! empty( $data['prompt_id'] ) ) {
-			self::$popups[ $data['prompt_id'] ] = $data;
+		if ( ! empty( $data['newspack_popup_id'] ) ) {
+			self::$popups[ $data['newspack_popup_id'] ] = $data;
 		}
 	}
 
@@ -203,7 +203,7 @@ final class Newspack_Popups_Data_Api {
 	 */
 	public static function prepare_popup_params_for_ga( $popup_params ) {
 		// Invalid input.
-		if ( ! is_array( $popup_params ) || ! isset( $popup_params['prompt_id'] ) ) {
+		if ( ! is_array( $popup_params ) || ! isset( $popup_params['newspack_popup_id'] ) ) {
 			return [];
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Along with https://github.com/Automattic/newspack-plugin/pull/4378, this PR renames `prompt_id` to `newspack_popup_id` in Data Events for consistency based on feedback.

Question (I'll ask this in Linear, too!): do we need to do anything to make sure existing data that's been captured in GA4 "understands" this change? Or is it basically a breaking change?

See NPPM-2486

### How to test the changes in this Pull Request:

1. Apply this PR and https://github.com/Automattic/newspack-plugin/pull/4378 (it's just a readme update, but both PRs need to go together)
2. Set up some prompts (inline and popup).
3. Either using GA4 or an extension like [this](https://chromewebstore.google.com/detail/google-analytics-debugger/jnkmfdileelhofjcijamephohjechhna), check the information coming with the `np_prompt_interaction` event as you interact with the site. Ensure the prompt's ID is being tracked as `newspack_popup_id`.
4. Confirm whether the readme change in https://github.com/Automattic/newspack-plugin/pull/4378 looks okay.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
