### PR TITLE
fix: ignore corrections when validating content for inline prompts

### DIFF
--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -466,7 +466,7 @@ final class Newspack_Popups_Inserter {
 			return $content;
 		}
 
-		$filtered_content = explode( "\n", $content );
+		$filtered_content = explode( "\n", self::filter_content( $content ) );
 		$post_content     = explode( "\n", $post->post_content );
 		if (
 			// Avoid duplicate execution.
@@ -604,6 +604,34 @@ final class Newspack_Popups_Inserter {
 		$is_amp_plus = $is_amp && self::is_amp_plus();
 
 		return Newspack_Popups_Segmentation::is_admin_user() && ( ! $is_amp || $is_amp_plus ) && ! is_admin();
+	}
+
+	/**
+	 * Filter specific blocks to be ignored when validating content.
+	 *
+	 * @param string $content The content.
+	 *
+	 * @return string Filtered content.
+	 */
+	private static function filter_content( $content ) {
+		$blocks       = parse_blocks( $content );
+		$filtered     = array_filter(
+			$blocks,
+			function ( $block ) {
+				$excluded_blocks = [
+					// Corrections are always added to the start or end of the content, so we can ignore them.
+					'newspack/correction-box',
+					'newspack/correction-item',
+				];
+				return ! in_array( $block['blockName'], $excluded_blocks, true );
+			}
+		);
+
+		$filtered_html = '';
+		foreach ( $filtered as $block ) {
+			$filtered_html .= serialize_block( $block );
+		}
+		return trim( $filtered_html );
 	}
 
 	/**

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -466,7 +466,7 @@ final class Newspack_Popups_Inserter {
 			return $content;
 		}
 
-		$filtered_content = explode( "\n", self::filter_content( $content ) );
+		$filtered_content = explode( "\n", self::get_validation_content( $content ) );
 		$post_content     = explode( "\n", $post->post_content );
 		if (
 			// Avoid duplicate execution.
@@ -613,9 +613,9 @@ final class Newspack_Popups_Inserter {
 	 *
 	 * @return string Filtered content.
 	 */
-	private static function filter_content( $content ) {
-		$blocks       = parse_blocks( $content );
-		$filtered     = array_filter(
+	private static function get_validation_content( $content ) {
+		$blocks   = parse_blocks( $content );
+		$filtered = array_filter(
 			$blocks,
 			function ( $block ) {
 				$excluded_blocks = [


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes # https://linear.app/a8c/issue/NPPM-2507/high-priority-corrections-hide-inline-campaign-prompts

This PR also requires https://github.com/Automattic/newspack-plugin/pull/4385

This PR ignores corrections when validating content before rendering inline prompts. This is because corrections are always added to the start or end of the content and should not impact whether an inline prompt renders.

![Screenshot 2026-01-08 at 15 10 07](https://github.com/user-attachments/assets/0be64aac-6f83-4e30-989f-8b636ed33f2b)


![Screenshot 2026-01-08 at 15 10 12](https://github.com/user-attachments/assets/aa197927-e2fe-4025-a01c-e7160b963ffc)


### How to test the changes in this Pull Request:

1. Create an inline campaign prompt set to display at 0% of article content (top)
2. Create another inline campaign prompt set to display at 100% of article content (bottom)
3. Create a post and observe that both display on the frontend
4. Add a correction to the post and set Priority to "High" (top)
5. Add another correction to the post and set Priority to "Low" (bottom)
6. On `release`, observe that the inline prompts don't render on the frontend 
7. On this branch, observe that the top inline prompt appears BEFORE the top correction and the bottom inline prompt appears AFTER the bottom correction (Be sure to also check out https://github.com/Automattic/newspack-plugin/pull/4385)


### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
