### PR TITLE
fix: iframe Editor Compatibility

### DIFF
--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -690,9 +690,7 @@ final class Newspack_Popups {
 	 * Load up common JS/CSS for the editor.
 	 */
 	public static function enqueue_block_assets() {
-		if ( ! is_admin() ) {
-			return;
-		}
+		$screen = get_current_screen();
 
 		// Block assets for Custom Placement and Prompt blocks.
 		\wp_enqueue_script(
@@ -723,7 +721,6 @@ final class Newspack_Popups {
 		wp_style_add_data( 'newspack-popups-blocks', 'rtl', 'replace' );
 		wp_enqueue_style( 'newspack-popups-blocks' );
 
-		$screen = get_current_screen();
 		// Don't enqueue Prompt editor files if we don't have a valid post type or ID (e.g. on the Widget Blocks screen).
 		if ( empty( $screen->post_type ) || empty( get_the_ID() ) ) {
 			return;

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -88,7 +88,7 @@ final class Newspack_Popups {
 		add_action( 'init', [ __CLASS__, 'register_taxonomy' ] );
 		add_action( 'init', [ __CLASS__, 'disable_prompts_for_protected_pages' ] );
 		add_action( 'init', [ __CLASS__, 'maybe_create_temp_reader_session' ] );
-		add_action( 'enqueue_block_editor_assets', [ __CLASS__, 'enqueue_block_editor_assets' ] );
+		add_action( 'enqueue_block_assets', [ __CLASS__, 'enqueue_block_assets' ] );
 		add_filter( 'display_post_states', [ __CLASS__, 'display_post_states' ], 10, 2 );
 		add_action( 'save_post_' . self::NEWSPACK_POPUPS_CPT, [ __CLASS__, 'popup_default_fields' ], 10, 3 );
 		add_action( 'transition_post_status', [ __CLASS__, 'prevent_default_category_on_publish' ], 10, 3 );
@@ -689,8 +689,10 @@ final class Newspack_Popups {
 	/**
 	 * Load up common JS/CSS for the editor.
 	 */
-	public static function enqueue_block_editor_assets() {
-		$screen = get_current_screen();
+	public static function enqueue_block_assets() {
+		if ( ! is_admin() ) {
+			return;
+		}
 
 		// Block assets for Custom Placement and Prompt blocks.
 		\wp_enqueue_script(
@@ -721,6 +723,7 @@ final class Newspack_Popups {
 		wp_style_add_data( 'newspack-popups-blocks', 'rtl', 'replace' );
 		wp_enqueue_style( 'newspack-popups-blocks' );
 
+		$screen = get_current_screen();
 		// Don't enqueue Prompt editor files if we don't have a valid post type or ID (e.g. on the Widget Blocks screen).
 		if ( empty( $screen->post_type ) || empty( get_the_ID() ) ) {
 			return;

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -690,6 +690,9 @@ final class Newspack_Popups {
 	 * Load up common JS/CSS for the editor.
 	 */
 	public static function enqueue_block_assets() {
+		if ( ! is_admin() ) {
+			return;
+		}
 		$screen = get_current_screen();
 
 		// Block assets for Custom Placement and Prompt blocks.

--- a/src/blocks/custom-placement/block.json
+++ b/src/blocks/custom-placement/block.json
@@ -1,4 +1,6 @@
 {
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
 	"name": "newspack-popups/custom-placement",
 	"category": "newspack",
 	"attributes": {

--- a/src/blocks/custom-placement/edit.js
+++ b/src/blocks/custom-placement/edit.js
@@ -2,6 +2,7 @@
  * WordPress dependencies.
  */
 import apiFetch from '@wordpress/api-fetch';
+import { useBlockProps } from '@wordpress/block-editor';
 import { __, sprintf } from '@wordpress/i18n';
 import { ExternalLink, Notice, Placeholder, SelectControl, Spinner } from '@wordpress/components';
 import { Fragment, useEffect, useState } from '@wordpress/element';
@@ -26,6 +27,7 @@ export const CustomPlacementEditor = ( { attributes, setAttributes } ) => {
 			label: customPlacements[ key ],
 		} ) )
 	);
+	const blockProps = useBlockProps();
 
 	const getPrompts = async () => {
 		setError( null );
@@ -75,89 +77,91 @@ export const CustomPlacementEditor = ( { attributes, setAttributes } ) => {
 	}
 
 	return (
-		<Placeholder
-			className="newspack-popups__custom-placement-placeholder"
-			label={ __( 'Custom Placement', 'newspack-popups' ) }
-			icon={ megaphone }
-		>
-			<SelectControl
-				id="newspack-popups__custom-placement-select"
-				onChange={ _customPlacement => setAttributes( { customPlacement: _customPlacement } ) }
-				value={ -1 < Object.keys( customPlacements ).indexOf( customPlacement ) ? customPlacement : '' }
-				options={ customPlacementOptions }
-			/>
+		<div { ...blockProps }>
+			<Placeholder
+				className="newspack-popups__custom-placement-placeholder"
+				label={ __( 'Custom Placement', 'newspack-popups' ) }
+				icon={ megaphone }
+			>
+				<SelectControl
+					id="newspack-popups__custom-placement-select"
+					onChange={ _customPlacement => setAttributes( { customPlacement: _customPlacement } ) }
+					value={ -1 < Object.keys( customPlacements ).indexOf( customPlacement ) ? customPlacement : '' }
+					options={ customPlacementOptions }
+				/>
 
-			{ loading && <Spinner /> }
+				{ loading && <Spinner /> }
 
-			{ error && (
-				<div className="newspack-popups__custom-placement-prompts">
-					<Notice status="error" isDismissible={ false }>
-						{ error }
-					</Notice>
-				</div>
-			) }
-
-			{ ! loading && ! error && Array.isArray( prompts ) && (
-				<div className="newspack-popups__custom-placement-prompts">
-					{ 0 === prompts.length && (
-						<Notice status="warning" isDismissible={ false }>
-							{ __( 'No active prompts found for this custom placement.', 'newspack-popups' ) }
+				{ error && (
+					<div className="newspack-popups__custom-placement-prompts">
+						<Notice status="error" isDismissible={ false }>
+							{ error }
 						</Notice>
-					) }
-					{ 0 < prompts.length && (
-						<>
-							<p>
-								{ sprintf(
-									// translators: %1$s: max number of popups displayed. %2$s: plural modifier.
-									__(
-										'This custom placement will display at most %1$sthe following active prompt%2$s, depending on the reader’s top-priority segment:',
-										'newspack-popups'
-									),
-									1 < prompts.length ? 'one of ' : '',
-									1 < prompts.length ? 's' : ''
-								) }
-							</p>
-							{ Object.keys( segments ).map( segmentName => {
-								const segmentId = segments[ segmentName ].id;
-								return (
-									<Fragment key={ segmentId }>
-										<strong>
-											{ segmentId ? (
-												<ExternalLink
-													href={ `/wp-admin/admin.php?page=newspack-audience-campaigns#/campaigns/${ segmentId }` }
-												>
-													{ sprintf(
-														// translators: %s: segment name.
-														__( 'Segment: %s', 'newspack-popups' ),
-														segmentName
-													) }
-												</ExternalLink>
-											) : (
-												[
-													'Everyone' !== segmentName ? __( 'Segment:', 'newspack-popups' ) : '',
-													segmentName || '',
-													'Everyone' === segmentName && 1 < Object.keys( segments ).length
-														? __( 'else', 'newspack-popups' )
-														: '',
-												]
-											) }
-										</strong>
-										<ul>
-											{ segments[ segmentName ].prompts.map( prompt => (
-												<li key={ prompt.id }>
-													<ExternalLink href={ `/wp-admin/post.php?post=${ prompt.id }&action=edit` }>
-														{ prompt.title }
+					</div>
+				) }
+
+				{ ! loading && ! error && Array.isArray( prompts ) && (
+					<div className="newspack-popups__custom-placement-prompts">
+						{ 0 === prompts.length && (
+							<Notice status="warning" isDismissible={ false }>
+								{ __( 'No active prompts found for this custom placement.', 'newspack-popups' ) }
+							</Notice>
+						) }
+						{ 0 < prompts.length && (
+							<>
+								<p>
+									{ sprintf(
+										// translators: %1$s: max number of popups displayed. %2$s: plural modifier.
+										__(
+											'This custom placement will display at most %1$sthe following active prompt%2$s, depending on the reader’s top-priority segment:',
+											'newspack-popups'
+										),
+										1 < prompts.length ? 'one of ' : '',
+										1 < prompts.length ? 's' : ''
+									) }
+								</p>
+								{ Object.keys( segments ).map( segmentName => {
+									const segmentId = segments[ segmentName ].id;
+									return (
+										<Fragment key={ segmentId }>
+											<strong>
+												{ segmentId ? (
+													<ExternalLink
+														href={ `/wp-admin/admin.php?page=newspack-audience-campaigns#/campaigns/${ segmentId }` }
+													>
+														{ sprintf(
+															// translators: %s: segment name.
+															__( 'Segment: %s', 'newspack-popups' ),
+															segmentName
+														) }
 													</ExternalLink>
-												</li>
-											) ) }
-										</ul>
-									</Fragment>
-								);
-							} ) }
-						</>
-					) }
-				</div>
-			) }
-		</Placeholder>
+												) : (
+													[
+														'Everyone' !== segmentName ? __( 'Segment:', 'newspack-popups' ) : '',
+														segmentName || '',
+														'Everyone' === segmentName && 1 < Object.keys( segments ).length
+															? __( 'else', 'newspack-popups' )
+															: '',
+													]
+												) }
+											</strong>
+											<ul>
+												{ segments[ segmentName ].prompts.map( prompt => (
+													<li key={ prompt.id }>
+														<ExternalLink href={ `/wp-admin/post.php?post=${ prompt.id }&action=edit` }>
+															{ prompt.title }
+														</ExternalLink>
+													</li>
+												) ) }
+											</ul>
+										</Fragment>
+									);
+								} ) }
+							</>
+						) }
+					</div>
+				) }
+			</Placeholder>
+		</div>
 	);
 };

--- a/src/blocks/custom-placement/index.js
+++ b/src/blocks/custom-placement/index.js
@@ -22,6 +22,7 @@ export const registerCustomPlacementBlock = () => {
 	}
 
 	registerBlockType( name, {
+		...metadata,
 		title: __( 'Campaigns: Custom Placement', 'newspack-listing' ),
 		icon: {
 			src: <Icon icon={ megaphone } />,

--- a/src/blocks/custom-placement/view.php
+++ b/src/blocks/custom-placement/view.php
@@ -20,6 +20,7 @@ function register_block() {
 	register_block_type(
 		$block_json['name'],
 		[
+			'api_version'     => $block_json['apiVersion'],
 			'attributes'      => $block_json['attributes'],
 			'render_callback' => __NAMESPACE__ . '\render_block',
 		]

--- a/src/blocks/single-prompt/block.json
+++ b/src/blocks/single-prompt/block.json
@@ -1,4 +1,6 @@
 {
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
 	"name": "newspack-popups/single-prompt",
 	"category": "newspack",
 	"attributes": {

--- a/src/blocks/single-prompt/edit.js
+++ b/src/blocks/single-prompt/edit.js
@@ -2,6 +2,7 @@
  * WordPress dependencies.
  */
 import apiFetch from '@wordpress/api-fetch';
+import { useBlockProps } from '@wordpress/block-editor';
 import { __, sprintf } from '@wordpress/i18n';
 import { Button, ExternalLink, Notice, Placeholder, Spinner } from '@wordpress/components';
 import { useEffect, useState } from '@wordpress/element';
@@ -20,6 +21,7 @@ export const SinglePromptEditor = ( { attributes, setAttributes } ) => {
 	const [ error, setError ] = useState( null );
 	const { promptId } = attributes;
 	const { endpoint, post_type: postType } = window?.newspack_popups_blocks_data;
+	const blockProps = useBlockProps();
 
 	const getPrompt = async () => {
 		setError( null );
@@ -67,7 +69,7 @@ export const SinglePromptEditor = ( { attributes, setAttributes } ) => {
 
 	if ( ! loading && promptId && prompt ) {
 		return (
-			<div className="newspack-popups__single-prompt">
+			<div className="newspack-popups__single-prompt" { ...blockProps }>
 				<h4 className="newspack-popups__single-prompt-title">
 					{ prompt.title || __( '(no title)', 'newspack-popups' ) }{ ' ' }
 					<ExternalLink href={ `/wp-admin/post.php?post=${ promptId }&action=edit` }>{ __( 'edit', 'newspack-popups' ) }</ExternalLink>
@@ -87,67 +89,69 @@ export const SinglePromptEditor = ( { attributes, setAttributes } ) => {
 	}
 
 	return (
-		<Placeholder className="newspack-popups__single-prompt-placeholder" label={ __( 'Single Prompt', 'newspack-popups' ) } icon={ megaphone }>
-			{ loading && (
-				<div className="is-loading">
-					{ sprintf(
-						// translators: %s: an id of a popup.
-						__( 'Loading prompt with ID %s…', 'newspack-popups' ),
-						promptId
-					) }
-					<Spinner />
-				</div>
-			) }
+		<div { ...blockProps }>
+			<Placeholder className="newspack-popups__single-prompt-placeholder" label={ __( 'Single Prompt', 'newspack-popups' ) } icon={ megaphone }>
+				{ loading && (
+					<div className="is-loading">
+						{ sprintf(
+							// translators: %s: an id of a popup.
+							__( 'Loading prompt with ID %s…', 'newspack-popups' ),
+							promptId
+						) }
+						<Spinner />
+					</div>
+				) }
 
-			{ error && (
-				<Notice status="error" isDismissible={ false }>
-					{ error }
-				</Notice>
-			) }
+				{ error && (
+					<Notice status="error" isDismissible={ false }>
+						{ error }
+					</Notice>
+				) }
 
-			{ ! prompt && ! loading && (
-				<AutocompleteWithSuggestions
-					label={ __( 'Search for an inline or manual-only prompt:', 'newspack' ) }
-					help={ __( 'Begin typing prompt title, click autocomplete result to select.', 'newspack' ) }
-					fetchSavedPosts={ async postIDs => {
-						const posts = await apiFetch( {
-							path: addQueryArgs( endpoint, {
-								per_page: 100,
-								include: postIDs.join( ',' ),
-							} ),
-						} );
-
-						return posts.map( post => ( {
-							value: post.id,
-							label: decodeEntities( post.title ) || __( '(no title)', 'newspack' ),
-						} ) );
-					} }
-					fetchSuggestions={ async search => {
-						const posts = await apiFetch( {
-							path: addQueryArgs( endpoint, {
-								search,
-								per_page: 10,
-							} ),
-						} );
-
-						// Format suggestions for FormTokenField display.
-						const result = posts.reduce( ( acc, post ) => {
-							acc.push( {
-								value: post.id,
-								label: decodeEntities( post.title ) || __( '(no title)', 'newspack' ),
+				{ ! prompt && ! loading && (
+					<AutocompleteWithSuggestions
+						label={ __( 'Search for an inline or manual-only prompt:', 'newspack' ) }
+						help={ __( 'Begin typing prompt title, click autocomplete result to select.', 'newspack' ) }
+						fetchSavedPosts={ async postIDs => {
+							const posts = await apiFetch( {
+								path: addQueryArgs( endpoint, {
+									per_page: 100,
+									include: postIDs.join( ',' ),
+								} ),
 							} );
 
-							return acc;
-						}, [] );
-						return result;
-					} }
-					postType={ postType }
-					postTypeLabel={ 'prompt' }
-					maxLength={ 1 }
-					onChange={ items => setAttributes( { promptId: parseInt( items.pop().value ) } ) }
-					selectedPost={ null }
-				/>
-			) }
-		</Placeholder>
+							return posts.map( post => ( {
+								value: post.id,
+								label: decodeEntities( post.title ) || __( '(no title)', 'newspack' ),
+							} ) );
+						} }
+						fetchSuggestions={ async search => {
+							const posts = await apiFetch( {
+								path: addQueryArgs( endpoint, {
+									search,
+									per_page: 10,
+								} ),
+							} );
+
+							// Format suggestions for FormTokenField display.
+							const result = posts.reduce( ( acc, post ) => {
+								acc.push( {
+									value: post.id,
+									label: decodeEntities( post.title ) || __( '(no title)', 'newspack' ),
+								} );
+
+								return acc;
+							}, [] );
+							return result;
+						} }
+						postType={ postType }
+						postTypeLabel={ 'prompt' }
+						maxLength={ 1 }
+						onChange={ items => setAttributes( { promptId: parseInt( items.pop().value ) } ) }
+						selectedPost={ null }
+					/>
+				) }
+			</Placeholder>
+		</div>
 	);
 };

--- a/src/blocks/single-prompt/edit.js
+++ b/src/blocks/single-prompt/edit.js
@@ -21,7 +21,6 @@ export const SinglePromptEditor = ( { attributes, setAttributes } ) => {
 	const [ error, setError ] = useState( null );
 	const { promptId } = attributes;
 	const { endpoint, post_type: postType } = window?.newspack_popups_blocks_data;
-	const blockProps = useBlockProps();
 
 	const getPrompt = async () => {
 		setError( null );
@@ -67,91 +66,99 @@ export const SinglePromptEditor = ( { attributes, setAttributes } ) => {
 		}
 	}, [ promptId ] );
 
-	if ( ! loading && promptId && prompt ) {
+	const shouldRenderPlaceholder = loading || ! promptId || ! prompt;
+	const blockProps = useBlockProps( {
+		className: shouldRenderPlaceholder ? '' : 'newspack-popups__single-prompt',
+	} );
+	if ( shouldRenderPlaceholder ) {
 		return (
-			<div className="newspack-popups__single-prompt" { ...blockProps }>
-				<h4 className="newspack-popups__single-prompt-title">
-					{ prompt.title || __( '(no title)', 'newspack-popups' ) }{ ' ' }
-					<ExternalLink href={ `/wp-admin/post.php?post=${ promptId }&action=edit` }>{ __( 'edit', 'newspack-popups' ) }</ExternalLink>
-				</h4>
-				<div className="newspack-popup newspack-inline-popup" dangerouslySetInnerHTML={ { __html: prompt.content } } />
-				<Button
-					isSecondary
-					onClick={ () => {
-						setAttributes( { promptId: 0 } );
-						setPrompt( null );
-					} }
+			<div { ...blockProps }>
+				<Placeholder
+					className="newspack-popups__single-prompt-placeholder"
+					label={ __( 'Single Prompt', 'newspack-popups' ) }
+					icon={ megaphone }
 				>
-					{ __( 'Clear prompt' ) }
-				</Button>
+					{ loading && (
+						<div className="is-loading">
+							{ sprintf(
+								// translators: %s: an id of a popup.
+								__( 'Loading prompt with ID %s…', 'newspack-popups' ),
+								promptId
+							) }
+							<Spinner />
+						</div>
+					) }
+
+					{ error && (
+						<Notice status="error" isDismissible={ false }>
+							{ error }
+						</Notice>
+					) }
+
+					{ ! prompt && ! loading && (
+						<AutocompleteWithSuggestions
+							label={ __( 'Search for an inline or manual-only prompt:', 'newspack' ) }
+							help={ __( 'Begin typing prompt title, click autocomplete result to select.', 'newspack' ) }
+							fetchSavedPosts={ async postIDs => {
+								const posts = await apiFetch( {
+									path: addQueryArgs( endpoint, {
+										per_page: 100,
+										include: postIDs.join( ',' ),
+									} ),
+								} );
+
+								return posts.map( post => ( {
+									value: post.id,
+									label: decodeEntities( post.title ) || __( '(no title)', 'newspack' ),
+								} ) );
+							} }
+							fetchSuggestions={ async search => {
+								const posts = await apiFetch( {
+									path: addQueryArgs( endpoint, {
+										search,
+										per_page: 10,
+									} ),
+								} );
+
+								// Format suggestions for FormTokenField display.
+								const result = posts.reduce( ( acc, post ) => {
+									acc.push( {
+										value: post.id,
+										label: decodeEntities( post.title ) || __( '(no title)', 'newspack' ),
+									} );
+
+									return acc;
+								}, [] );
+								return result;
+							} }
+							postType={ postType }
+							postTypeLabel={ 'prompt' }
+							maxLength={ 1 }
+							onChange={ items => setAttributes( { promptId: parseInt( items.pop().value ) } ) }
+							selectedPost={ null }
+						/>
+					) }
+				</Placeholder>
 			</div>
 		);
 	}
 
 	return (
 		<div { ...blockProps }>
-			<Placeholder className="newspack-popups__single-prompt-placeholder" label={ __( 'Single Prompt', 'newspack-popups' ) } icon={ megaphone }>
-				{ loading && (
-					<div className="is-loading">
-						{ sprintf(
-							// translators: %s: an id of a popup.
-							__( 'Loading prompt with ID %s…', 'newspack-popups' ),
-							promptId
-						) }
-						<Spinner />
-					</div>
-				) }
-
-				{ error && (
-					<Notice status="error" isDismissible={ false }>
-						{ error }
-					</Notice>
-				) }
-
-				{ ! prompt && ! loading && (
-					<AutocompleteWithSuggestions
-						label={ __( 'Search for an inline or manual-only prompt:', 'newspack' ) }
-						help={ __( 'Begin typing prompt title, click autocomplete result to select.', 'newspack' ) }
-						fetchSavedPosts={ async postIDs => {
-							const posts = await apiFetch( {
-								path: addQueryArgs( endpoint, {
-									per_page: 100,
-									include: postIDs.join( ',' ),
-								} ),
-							} );
-
-							return posts.map( post => ( {
-								value: post.id,
-								label: decodeEntities( post.title ) || __( '(no title)', 'newspack' ),
-							} ) );
-						} }
-						fetchSuggestions={ async search => {
-							const posts = await apiFetch( {
-								path: addQueryArgs( endpoint, {
-									search,
-									per_page: 10,
-								} ),
-							} );
-
-							// Format suggestions for FormTokenField display.
-							const result = posts.reduce( ( acc, post ) => {
-								acc.push( {
-									value: post.id,
-									label: decodeEntities( post.title ) || __( '(no title)', 'newspack' ),
-								} );
-
-								return acc;
-							}, [] );
-							return result;
-						} }
-						postType={ postType }
-						postTypeLabel={ 'prompt' }
-						maxLength={ 1 }
-						onChange={ items => setAttributes( { promptId: parseInt( items.pop().value ) } ) }
-						selectedPost={ null }
-					/>
-				) }
-			</Placeholder>
+			<h4 className="newspack-popups__single-prompt-title">
+				{ prompt.title || __( '(no title)', 'newspack-popups' ) }{ ' ' }
+				<ExternalLink href={ `/wp-admin/post.php?post=${ promptId }&action=edit` }>{ __( 'edit', 'newspack-popups' ) }</ExternalLink>
+			</h4>
+			<div className="newspack-popup newspack-inline-popup" dangerouslySetInnerHTML={ { __html: prompt.content } } />
+			<Button
+				isSecondary
+				onClick={ () => {
+					setAttributes( { promptId: 0 } );
+					setPrompt( null );
+				} }
+			>
+				{ __( 'Clear prompt' ) }
+			</Button>
 		</div>
 	);
 };

--- a/src/blocks/single-prompt/index.js
+++ b/src/blocks/single-prompt/index.js
@@ -22,6 +22,7 @@ export const registerSinglePromptBlock = () => {
 	}
 
 	registerBlockType( name, {
+		...metadata,
 		title: __( 'Campaigns: Single Prompt', 'newspack-popups' ),
 		icon: {
 			src: <Icon icon={ megaphone } />,

--- a/src/blocks/single-prompt/view.php
+++ b/src/blocks/single-prompt/view.php
@@ -20,6 +20,7 @@ function register_block() {
 	register_block_type(
 		$block_json['name'],
 		[
+			'api_version'     => $block_json['apiVersion'],
 			'attributes'      => $block_json['attributes'],
 			'render_callback' => __NAMESPACE__ . '\render_block',
 		]


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://linear.app/a8c/issue/NPPM-2585/newspack-popups-iframe-editor-compatibility

### How to test the changes in this Pull Request:

1. Ensure ONLY the main plugin, blocks, newsletters, and popups are the only Newspack extensions active and are all on the fix/iframe-editor-compatibility branch.
2. Smoke test blocks in the editor + frontend (You can find a list in the linked linear issue)


### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
