### PR TITLE
fix: add is-layout-constrained and is-layout-flow CSS classes for block themes

### DIFF
--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -1135,7 +1135,7 @@ final class Newspack_Popups_Model {
 							<?php echo ! empty( $popup['options']['featured_image_id'] ) ? wp_get_attachment_image( $popup['options']['featured_image_id'], 'large' ) : get_the_post_thumbnail( $popup['id'], 'large' ); ?>
 						</div>
 					<?php endif; ?>
-					<div class="newspack-popup__content <?php echo self::is_block_theme() ? 'is-layout-flow' : ''; ?>">
+					<div class="newspack-popup__content <?php echo esc_attr( self::is_block_theme() ? 'is-layout-flow' : '' ); ?>">
 						<?php echo do_shortcode( $body ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 					</div>
 					<button class="newspack-lightbox__close" style="<?php echo esc_attr( $close_button_styles ); ?>" aria-label="<?php esc_html_e( 'Close Pop-up', 'newspack-popups' ); // phpcs:ignore WordPressVIPMinimum.Security.ProperEscapingFunction.htmlAttrNotByEscHTML ?>">

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -52,6 +52,13 @@ final class Newspack_Popups_Model {
 	protected static $current_popup = null;
 
 	/**
+	 * Override for block theme detection (used in tests).
+	 *
+	 * @var boolean|null
+	 */
+	protected static $block_theme_override = null;
+
+	/**
 	 * Retrieve all Popups (first 100).
 	 *
 	 * @param  boolean $include_unpublished Whether to include unpublished posts.
@@ -958,7 +965,20 @@ final class Newspack_Popups_Model {
 	 * @return boolean True if the current theme is a block theme.
 	 */
 	private static function is_block_theme() {
+		if ( null !== self::$block_theme_override ) {
+			return self::$block_theme_override;
+		}
+
 		return function_exists( 'wp_is_block_theme' ) && wp_is_block_theme();
+	}
+
+	/**
+	 * Override block theme detection (intended for tests).
+	 *
+	 * @param boolean|null $is_block_theme Override value; null resets.
+	 */
+	public static function set_block_theme_override( $is_block_theme ) {
+		self::$block_theme_override = $is_block_theme;
 	}
 
 	/**

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -1135,7 +1135,7 @@ final class Newspack_Popups_Model {
 							<?php echo ! empty( $popup['options']['featured_image_id'] ) ? wp_get_attachment_image( $popup['options']['featured_image_id'], 'large' ) : get_the_post_thumbnail( $popup['id'], 'large' ); ?>
 						</div>
 					<?php endif; ?>
-					<div class="newspack-popup__content <?php echo self::is_block_theme() ? 'is-layout-constrained' : ''; ?>">
+					<div class="newspack-popup__content <?php echo self::is_block_theme() ? 'is-layout-flow' : ''; ?>">
 						<?php echo do_shortcode( $body ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 					</div>
 					<button class="newspack-lightbox__close" style="<?php echo esc_attr( $close_button_styles ); ?>" aria-label="<?php esc_html_e( 'Close Pop-up', 'newspack-popups' ); // phpcs:ignore WordPressVIPMinimum.Security.ProperEscapingFunction.htmlAttrNotByEscHTML ?>">

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -953,6 +953,15 @@ final class Newspack_Popups_Model {
 	}
 
 	/**
+	 * Check if the current theme is a block theme.
+	 *
+	 * @return boolean True if the current theme is a block theme.
+	 */
+	private static function is_block_theme() {
+		return function_exists( 'wp_is_block_theme' ) && wp_is_block_theme();
+	}
+
+	/**
 	 * Generate markup for an inline popup.
 	 *
 	 * @param string $popup The popup object.
@@ -983,6 +992,7 @@ final class Newspack_Popups_Model {
 		$classes[]            = $large_border ? 'newspack-lightbox-large-border' : null;
 		$classes[]            = $no_padding ? 'newspack-lightbox-no-padding' : null;
 		$classes[]            = $is_newsletter_prompt ? 'newspack-newsletter-prompt-inline' : null;
+		$classes[]            = self::is_block_theme() ? 'is-layout-constrained' : null;
 		$classes              = array_merge( $classes, explode( ' ', $popup['options']['additional_classes'] ) );
 		$assigned_segments    = Newspack_Segments_Model::get_popup_segments_ids_string( $popup['id'] );
 		$frequency_config     = self::get_frequency_config( $popup );
@@ -1125,7 +1135,7 @@ final class Newspack_Popups_Model {
 							<?php echo ! empty( $popup['options']['featured_image_id'] ) ? wp_get_attachment_image( $popup['options']['featured_image_id'], 'large' ) : get_the_post_thumbnail( $popup['id'], 'large' ); ?>
 						</div>
 					<?php endif; ?>
-					<div class="newspack-popup__content">
+					<div class="newspack-popup__content <?php echo self::is_block_theme() ? 'is-layout-constrained' : ''; ?>">
 						<?php echo do_shortcode( $body ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 					</div>
 					<button class="newspack-lightbox__close" style="<?php echo esc_attr( $close_button_styles ); ?>" aria-label="<?php esc_html_e( 'Close Pop-up', 'newspack-popups' ); // phpcs:ignore WordPressVIPMinimum.Security.ProperEscapingFunction.htmlAttrNotByEscHTML ?>">

--- a/tests/test-model.php
+++ b/tests/test-model.php
@@ -152,6 +152,59 @@ class ModelTest extends WP_UnitTestCase {
 			$xpath->query( '//*[starts-with(@id,"page-position-marker")]' )->item( 0 )->getAttribute( 'style' ),
 			'The position marker is set at position passed in options.'
 		);
+
+		Newspack_Popups_Model::set_block_theme_override( true );
+		try {
+			$popup_object_inline_block_theme = Newspack_Popups_Model::create_popup_object(
+				get_post( self::$popup_id ),
+				false,
+				[
+					'placement'    => 'inline',
+					'trigger_type' => 'time',
+				]
+			);
+
+			$dom = new DomDocument();
+			@$dom->loadHTML( Newspack_Popups_Model::generate_popup( $popup_object_inline_block_theme ) ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+			$xpath = new DOMXpath( $dom );
+
+			$inline_container = $xpath->query( '//*[contains(concat(" ", normalize-space(@class), " "), " newspack-inline-popup ")]' )->item( 0 );
+			self::assertNotNull(
+				$inline_container,
+				'Inline popup container is present for block theme.'
+			);
+			self::assertStringContainsString(
+				'is-layout-constrained',
+				$inline_container->getAttribute( 'class' ),
+				'Inline popups receive block theme layout class.'
+			);
+
+			$popup_object_overlay_block_theme = Newspack_Popups_Model::create_popup_object(
+				get_post( self::$popup_id ),
+				false,
+				[
+					'placement'    => 'center',
+					'trigger_type' => 'time',
+				]
+			);
+
+			$dom = new DomDocument();
+			@$dom->loadHTML( Newspack_Popups_Model::generate_popup( $popup_object_overlay_block_theme ) ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+			$xpath = new DOMXpath( $dom );
+
+			$content = $xpath->query( '//*[contains(concat(" ", normalize-space(@class), " "), " newspack-popup__content ")]' )->item( 0 );
+			self::assertNotNull(
+				$content,
+				'Overlay popup content container is present for block theme.'
+			);
+			self::assertStringContainsString(
+				'is-layout-flow',
+				$content->getAttribute( 'class' ),
+				'Overlay popup content receives block theme layout class.'
+			);
+		} finally {
+			Newspack_Popups_Model::set_block_theme_override( null );
+		}
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds a couple standard block layout classes to the Campaign containers:
* For inline campaigns, it adds the `is-layout-constrained` class, which will fixes an issue with vertical spacing within the block - it means the inner blocks will pick up the right vertical spacing, and remove the top margin for the first element, and bottom element from the last element. 
* For overlay campaigns, it adds the `is-layout-flow` class - this also fixes the vertical spacing, but doesn't include styles that constrain the width of the inner blocks (so the blocks will fill the inner space). Otherwise with `is-layout-constrained`, the inner blocks don't get wider than 632px

Note: this doesn't address how inline campaigns always display at the narrower content width, even in wider templates. We need some way to set them wide; I'm not sure what that is yet (maybe a block theme-specific control?)

Closes NPPD-1192 
Closes NPPD-1193

### How to test the changes in this Pull Request:

1. Using the block theme, set up an inline campaign with a few blocks in it (preferably leading with a paragraph or heading), and view it on the front end. Note the extra space at the top, and lack of space between some blocks (non-paragraph and non-heading). 

<img width="1368" height="752" alt="CleanShot 2026-02-04 at 11 52 06@2x" src="https://github.com/user-attachments/assets/8f08a37b-793c-4b97-8d35-9a6eb00b4808" />

2. Switch it to an overlay campaign, and make it Large or Full width (just to make sure the block widths don't change in trunk vs. this branch); view on the front-end and note the same spacing issues:
<img width="2622" height="828" alt="CleanShot 2026-02-04 at 11 55 02@2x" src="https://github.com/user-attachments/assets/ef0bd313-0a72-4013-bd53-7a9860dc9e76" />

3. Apply the PR and repeat testing the campaign as inline and overlay - the vertical spacing should be fixed:

<img width="1330" height="730" alt="CleanShot 2026-02-04 at 11 57 29@2x" src="https://github.com/user-attachments/assets/eb05ad66-250a-453b-b236-c8e6d272c8f7" />

<img width="2588" height="904" alt="CleanShot 2026-02-04 at 11 56 26@2x" src="https://github.com/user-attachments/assets/ad3de07a-d9b6-425e-9af8-3c43b8014b5e" />

4. Try switching the campaign to the inline above-header placement - the block inside the campaign should be `632px`.
5. Try making at least one block in the campaign 'wide' or 'full'; view on the front-end and confirm it respects the width.

<img width="3082" height="566" alt="CleanShot 2026-02-04 at 12 05 47@2x" src="https://github.com/user-attachments/assets/3c15a381-4fe9-4a85-81d3-6fd599612e0c" />

(Note: there will be a lack of padding in this layout, but that's also present in the classic theme. Flex blocks like row also seem to be missing styles for alignment. I'll dig into those in a separate PR 😅 ). 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
