### PR TITLE
feat: reorganise editor sidebar to use tabs and new components

### DIFF
--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -504,32 +504,38 @@ final class Newspack_Popups_Model {
 		 *
 		 * @param array Array of possible popup sizes.
 		 *     $params = [
-		 *          'value' => (string) size value.
-		 *          'label' => (string) size label to be displayed.
+		 *          'value'     => (string) size value.
+		 *          'label'     => (string) size label to be displayed.
+		 *          'shortname' => (string) short size label for compact UIs.
 		 *     ]
 		 */
 		return apply_filters(
 			'newspack_popups_size_options',
 			[
 				[
-					'value' => 'x-small',
-					'label' => __( 'Extra Small', 'newspack-popups' ),
+					'value'     => 'x-small',
+					'label'     => __( 'Extra small', 'newspack-popups' ),
+					'shortname' => _x( 'XS', 'prompt size label', 'newspack-popups' ),
 				],
 				[
-					'value' => 'small',
-					'label' => __( 'Small', 'newspack-popups' ),
+					'value'     => 'small',
+					'label'     => __( 'Small', 'newspack-popups' ),
+					'shortname' => _x( 'S', 'prompt size label', 'newspack-popups' ),
 				],
 				[
-					'value' => 'medium',
-					'label' => __( 'Medium', 'newspack-popups' ),
+					'value'     => 'medium',
+					'label'     => __( 'Medium', 'newspack-popups' ),
+					'shortname' => _x( 'M', 'prompt size label', 'newspack-popups' ),
 				],
 				[
-					'value' => 'large',
-					'label' => __( 'Large', 'newspack-popups' ),
+					'value'     => 'large',
+					'label'     => __( 'Large', 'newspack-popups' ),
+					'shortname' => _x( 'L', 'prompt size label', 'newspack-popups' ),
 				],
 				[
-					'value' => 'full-width',
-					'label' => __( 'Full-Width', 'newspack-popups' ),
+					'value'     => 'full-width',
+					'label'     => __( 'Full width', 'newspack-popups' ),
+					'shortname' => _x( 'Full width', 'prompt size label', 'newspack-popups' ),
 				],
 			]
 		);

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -507,7 +507,8 @@ final class Newspack_Popups_Model {
 		 *          'value'     => (string) size value.
 		 *          'label'     => (string) size label to be displayed.
 		 *          'shortname' => (string) short size label for compact UIs.
-		 *     ]
+		 *          'help'      => (string) descriptive help text for the size.
+		 *     ].
 		 */
 		return apply_filters(
 			'newspack_popups_size_options',
@@ -516,26 +517,31 @@ final class Newspack_Popups_Model {
 					'value'     => 'x-small',
 					'label'     => __( 'Extra small', 'newspack-popups' ),
 					'shortname' => _x( 'XS', 'prompt size label', 'newspack-popups' ),
+					'help'      => __( 'Narrowest overlay, best for concise prompts (380px wide).', 'newspack-popups' ),
 				],
 				[
 					'value'     => 'small',
 					'label'     => __( 'Small', 'newspack-popups' ),
 					'shortname' => _x( 'S', 'prompt size label', 'newspack-popups' ),
+					'help'      => __( 'Compact overlay for short messages (544px wide).', 'newspack-popups' ),
 				],
 				[
 					'value'     => 'medium',
 					'label'     => __( 'Medium', 'newspack-popups' ),
 					'shortname' => _x( 'M', 'prompt size label', 'newspack-popups' ),
+					'help'      => __( 'Balanced size for most prompts (784px wide).', 'newspack-popups' ),
 				],
 				[
 					'value'     => 'large',
 					'label'     => __( 'Large', 'newspack-popups' ),
 					'shortname' => _x( 'L', 'prompt size label', 'newspack-popups' ),
+					'help'      => __( 'Larger overlay for richer content (1264px wide).', 'newspack-popups' ),
 				],
 				[
 					'value'     => 'full-width',
 					'label'     => __( 'Full width', 'newspack-popups' ),
-					'shortname' => _x( 'Full width', 'prompt size label', 'newspack-popups' ),
+					'shortname' => _x( 'FW', 'prompt size label', 'newspack-popups' ),
+					'help'      => __( 'Spans the full width of the viewport (100%).', 'newspack-popups' ),
 				],
 			]
 		);

--- a/package-lock.json
+++ b/package-lock.json
@@ -2621,6 +2621,13 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@date-fns/utc": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@date-fns/utc/-/utc-2.1.1.tgz",
+			"integrity": "sha512-SlJDfG6RPeEX8wEVv6ZB3kak4MmbtyiI2qX/5zuKdordbrhB/iaJ58GVMZgJ6P1sJaM1gMgENFYYeg1JWrCFrA==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@discoveryjs/json-ext": {
 			"version": "0.5.7",
 			"resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
@@ -7456,13 +7463,13 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/react": {
-			"version": "18.3.26",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.26.tgz",
-			"integrity": "sha512-RFA/bURkcKzx/X9oumPG9Vp3D3JUgus/d0b67KB0t5S/raciymilkOa66olh78MUI92QLbEJevO7rvqU/kjwKA==",
+			"version": "18.3.28",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+			"integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
 			"license": "MIT",
 			"dependencies": {
 				"@types/prop-types": "*",
-				"csstype": "^3.0.2"
+				"csstype": "^3.2.2"
 			}
 		},
 		"node_modules/@types/react-dom": {
@@ -8253,13 +8260,13 @@
 			}
 		},
 		"node_modules/@wordpress/a11y": {
-			"version": "4.34.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.34.0.tgz",
-			"integrity": "sha512-l4/Q1nnLMi1nQJWl4y3Rdr9zQnxYgGqL0ZJwz1vOI8qqSO2Uug8wVCrVIsKIuUQHuD+ya/Q5hqQIedXKAdTvsQ==",
+			"version": "4.39.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.39.0.tgz",
+			"integrity": "sha512-uFy3FIF6MOo67tTVC2SaNyBQbFafu+DRirt2/IUQlY7w2MOiXWPaQFi3Oyy81gc8TfsooSFBlK4lrujd7O4gEw==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/dom-ready": "^4.34.0",
-				"@wordpress/i18n": "^6.7.0"
+				"@wordpress/dom-ready": "^4.39.0",
+				"@wordpress/i18n": "^6.12.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -8267,13 +8274,13 @@
 			}
 		},
 		"node_modules/@wordpress/a11y/node_modules/@wordpress/i18n": {
-			"version": "6.7.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.7.0.tgz",
-			"integrity": "sha512-156R15kz17WkFJ0mtoVt9ByFvt4i9zcstFiXC1HjMKr3zV1DZSplvcJeNJTENJBRX8sE+Be0NPevaC8LCodjgw==",
+			"version": "6.12.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.12.0.tgz",
+			"integrity": "sha512-KMleg8p/HtnoX1d/WoRDI51VTZsA4RGNUvBYn+Cc3avaeeNKROb91+viMcOc8NHuLplEzl7zH9/mrOSs9aY3rg==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@tannin/sprintf": "^1.3.2",
-				"@wordpress/hooks": "^4.34.0",
+				"@wordpress/hooks": "^4.39.0",
 				"gettext-parser": "^1.3.1",
 				"memize": "^2.1.0",
 				"tannin": "^1.2.0"
@@ -8325,9 +8332,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@wordpress/admin-ui/node_modules/@wordpress/base-styles": {
-			"version": "6.10.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-6.10.0.tgz",
-			"integrity": "sha512-Dw/1Om7Kv9YXvN6RaSOmzq2id1MrHZ+rUS2uHNkadeF3Jv+W0Zewl9iCBJarB6Nf72GMkktPwpaRrwhc6zPLIg==",
+			"version": "6.15.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-6.15.0.tgz",
+			"integrity": "sha512-AJ569cP6WqG0/RWx+x7MDNFxnCrZ5Pz1dHCLSE+7B0lLMXh3RGC1+Fj0YIZtUQ2ULLf2I3LRn6kuHdwyWNGiNA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -8336,13 +8343,14 @@
 			}
 		},
 		"node_modules/@wordpress/admin-ui/node_modules/@wordpress/components": {
-			"version": "30.7.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-30.7.0.tgz",
-			"integrity": "sha512-LlXjicK7zXnwmFSTnxByVwL+Muh4QGcqunxlBg3+Ni8yLtQyTKb6yS8wGUCE7USGEMOlEX1NYvp6i3DOZk1tiw==",
+			"version": "30.9.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-30.9.0.tgz",
+			"integrity": "sha512-mx0df0TjChmpCtqQn3iFHphqaLQVNk5Yprs+3NJSfm1kWuZPKfVys6AtmhfBgXs/VrrJk34Z+1N+nqXovHuXnw==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@ariakit/react": "^0.4.15",
+				"@date-fns/utc": "^2.1.1",
 				"@emotion/cache": "^11.7.1",
 				"@emotion/css": "^11.7.1",
 				"@emotion/react": "^11.7.1",
@@ -8353,24 +8361,24 @@
 				"@types/gradient-parser": "1.1.0",
 				"@types/highlight-words-core": "1.2.1",
 				"@use-gesture/react": "^10.3.1",
-				"@wordpress/a11y": "^4.34.0",
-				"@wordpress/base-styles": "^6.10.0",
-				"@wordpress/compose": "^7.34.0",
-				"@wordpress/date": "^5.34.0",
-				"@wordpress/deprecated": "^4.34.0",
-				"@wordpress/dom": "^4.34.0",
-				"@wordpress/element": "^6.34.0",
-				"@wordpress/escape-html": "^3.34.0",
-				"@wordpress/hooks": "^4.34.0",
-				"@wordpress/html-entities": "^4.34.0",
-				"@wordpress/i18n": "^6.7.0",
-				"@wordpress/icons": "^11.1.0",
-				"@wordpress/is-shallow-equal": "^5.34.0",
-				"@wordpress/keycodes": "^4.34.0",
-				"@wordpress/primitives": "^4.34.0",
-				"@wordpress/private-apis": "^1.34.0",
-				"@wordpress/rich-text": "^7.34.0",
-				"@wordpress/warning": "^3.34.0",
+				"@wordpress/a11y": "^4.36.0",
+				"@wordpress/base-styles": "^6.12.0",
+				"@wordpress/compose": "^7.36.0",
+				"@wordpress/date": "^5.36.0",
+				"@wordpress/deprecated": "^4.36.0",
+				"@wordpress/dom": "^4.36.0",
+				"@wordpress/element": "^6.36.0",
+				"@wordpress/escape-html": "^3.36.0",
+				"@wordpress/hooks": "^4.36.0",
+				"@wordpress/html-entities": "^4.36.0",
+				"@wordpress/i18n": "^6.9.0",
+				"@wordpress/icons": "^11.3.0",
+				"@wordpress/is-shallow-equal": "^5.36.0",
+				"@wordpress/keycodes": "^4.36.0",
+				"@wordpress/primitives": "^4.36.0",
+				"@wordpress/private-apis": "^1.36.0",
+				"@wordpress/rich-text": "^7.36.0",
+				"@wordpress/warning": "^3.36.0",
 				"change-case": "^4.1.2",
 				"clsx": "^2.1.1",
 				"colord": "^2.7.0",
@@ -8399,14 +8407,14 @@
 			}
 		},
 		"node_modules/@wordpress/admin-ui/node_modules/@wordpress/i18n": {
-			"version": "6.7.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.7.0.tgz",
-			"integrity": "sha512-156R15kz17WkFJ0mtoVt9ByFvt4i9zcstFiXC1HjMKr3zV1DZSplvcJeNJTENJBRX8sE+Be0NPevaC8LCodjgw==",
+			"version": "6.12.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.12.0.tgz",
+			"integrity": "sha512-KMleg8p/HtnoX1d/WoRDI51VTZsA4RGNUvBYn+Cc3avaeeNKROb91+viMcOc8NHuLplEzl7zH9/mrOSs9aY3rg==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@tannin/sprintf": "^1.3.2",
-				"@wordpress/hooks": "^4.34.0",
+				"@wordpress/hooks": "^4.39.0",
 				"gettext-parser": "^1.3.1",
 				"memize": "^2.1.0",
 				"tannin": "^1.2.0"
@@ -8420,18 +8428,21 @@
 			}
 		},
 		"node_modules/@wordpress/admin-ui/node_modules/@wordpress/icons": {
-			"version": "11.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-11.1.0.tgz",
-			"integrity": "sha512-N61MEoI9dU3fDQu7tdY1/kUSOhERyAnKHcVDWl3KWNFDuNuelnoUCMSckNV4T1Jz/M+2Mkov/J39Mroqo782zQ==",
+			"version": "11.6.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-11.6.0.tgz",
+			"integrity": "sha512-X3Tp3ARJWRokFOTJ1SJQef3J+bykyZHuHL6NSaMnEtbQzs7Tre+3HEghP5S5K/AGnLr+RvpGnwEN0uNy53uIiA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/element": "^6.34.0",
-				"@wordpress/primitives": "^4.34.0"
+				"@wordpress/element": "^6.39.0",
+				"@wordpress/primitives": "^4.39.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
 			}
 		},
 		"node_modules/@wordpress/admin-ui/node_modules/gradient-parser": {
@@ -8663,9 +8674,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@wordpress/block-editor/node_modules/@wordpress/base-styles": {
-			"version": "6.10.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-6.10.0.tgz",
-			"integrity": "sha512-Dw/1Om7Kv9YXvN6RaSOmzq2id1MrHZ+rUS2uHNkadeF3Jv+W0Zewl9iCBJarB6Nf72GMkktPwpaRrwhc6zPLIg==",
+			"version": "6.15.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-6.15.0.tgz",
+			"integrity": "sha512-AJ569cP6WqG0/RWx+x7MDNFxnCrZ5Pz1dHCLSE+7B0lLMXh3RGC1+Fj0YIZtUQ2ULLf2I3LRn6kuHdwyWNGiNA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -8674,13 +8685,14 @@
 			}
 		},
 		"node_modules/@wordpress/block-editor/node_modules/@wordpress/components": {
-			"version": "30.7.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-30.7.0.tgz",
-			"integrity": "sha512-LlXjicK7zXnwmFSTnxByVwL+Muh4QGcqunxlBg3+Ni8yLtQyTKb6yS8wGUCE7USGEMOlEX1NYvp6i3DOZk1tiw==",
+			"version": "30.9.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-30.9.0.tgz",
+			"integrity": "sha512-mx0df0TjChmpCtqQn3iFHphqaLQVNk5Yprs+3NJSfm1kWuZPKfVys6AtmhfBgXs/VrrJk34Z+1N+nqXovHuXnw==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@ariakit/react": "^0.4.15",
+				"@date-fns/utc": "^2.1.1",
 				"@emotion/cache": "^11.7.1",
 				"@emotion/css": "^11.7.1",
 				"@emotion/react": "^11.7.1",
@@ -8691,24 +8703,24 @@
 				"@types/gradient-parser": "1.1.0",
 				"@types/highlight-words-core": "1.2.1",
 				"@use-gesture/react": "^10.3.1",
-				"@wordpress/a11y": "^4.34.0",
-				"@wordpress/base-styles": "^6.10.0",
-				"@wordpress/compose": "^7.34.0",
-				"@wordpress/date": "^5.34.0",
-				"@wordpress/deprecated": "^4.34.0",
-				"@wordpress/dom": "^4.34.0",
-				"@wordpress/element": "^6.34.0",
-				"@wordpress/escape-html": "^3.34.0",
-				"@wordpress/hooks": "^4.34.0",
-				"@wordpress/html-entities": "^4.34.0",
-				"@wordpress/i18n": "^6.7.0",
-				"@wordpress/icons": "^11.1.0",
-				"@wordpress/is-shallow-equal": "^5.34.0",
-				"@wordpress/keycodes": "^4.34.0",
-				"@wordpress/primitives": "^4.34.0",
-				"@wordpress/private-apis": "^1.34.0",
-				"@wordpress/rich-text": "^7.34.0",
-				"@wordpress/warning": "^3.34.0",
+				"@wordpress/a11y": "^4.36.0",
+				"@wordpress/base-styles": "^6.12.0",
+				"@wordpress/compose": "^7.36.0",
+				"@wordpress/date": "^5.36.0",
+				"@wordpress/deprecated": "^4.36.0",
+				"@wordpress/dom": "^4.36.0",
+				"@wordpress/element": "^6.36.0",
+				"@wordpress/escape-html": "^3.36.0",
+				"@wordpress/hooks": "^4.36.0",
+				"@wordpress/html-entities": "^4.36.0",
+				"@wordpress/i18n": "^6.9.0",
+				"@wordpress/icons": "^11.3.0",
+				"@wordpress/is-shallow-equal": "^5.36.0",
+				"@wordpress/keycodes": "^4.36.0",
+				"@wordpress/primitives": "^4.36.0",
+				"@wordpress/private-apis": "^1.36.0",
+				"@wordpress/rich-text": "^7.36.0",
+				"@wordpress/warning": "^3.36.0",
 				"change-case": "^4.1.2",
 				"clsx": "^2.1.1",
 				"colord": "^2.7.0",
@@ -8737,14 +8749,14 @@
 			}
 		},
 		"node_modules/@wordpress/block-editor/node_modules/@wordpress/i18n": {
-			"version": "6.7.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.7.0.tgz",
-			"integrity": "sha512-156R15kz17WkFJ0mtoVt9ByFvt4i9zcstFiXC1HjMKr3zV1DZSplvcJeNJTENJBRX8sE+Be0NPevaC8LCodjgw==",
+			"version": "6.12.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.12.0.tgz",
+			"integrity": "sha512-KMleg8p/HtnoX1d/WoRDI51VTZsA4RGNUvBYn+Cc3avaeeNKROb91+viMcOc8NHuLplEzl7zH9/mrOSs9aY3rg==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@tannin/sprintf": "^1.3.2",
-				"@wordpress/hooks": "^4.34.0",
+				"@wordpress/hooks": "^4.39.0",
 				"gettext-parser": "^1.3.1",
 				"memize": "^2.1.0",
 				"tannin": "^1.2.0"
@@ -8758,18 +8770,21 @@
 			}
 		},
 		"node_modules/@wordpress/block-editor/node_modules/@wordpress/icons": {
-			"version": "11.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-11.1.0.tgz",
-			"integrity": "sha512-N61MEoI9dU3fDQu7tdY1/kUSOhERyAnKHcVDWl3KWNFDuNuelnoUCMSckNV4T1Jz/M+2Mkov/J39Mroqo782zQ==",
+			"version": "11.6.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-11.6.0.tgz",
+			"integrity": "sha512-X3Tp3ARJWRokFOTJ1SJQef3J+bykyZHuHL6NSaMnEtbQzs7Tre+3HEghP5S5K/AGnLr+RvpGnwEN0uNy53uIiA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/element": "^6.34.0",
-				"@wordpress/primitives": "^4.34.0"
+				"@wordpress/element": "^6.39.0",
+				"@wordpress/primitives": "^4.39.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
 			}
 		},
 		"node_modules/@wordpress/block-editor/node_modules/gradient-parser": {
@@ -8864,9 +8879,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@wordpress/block-library/node_modules/@wordpress/base-styles": {
-			"version": "6.10.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-6.10.0.tgz",
-			"integrity": "sha512-Dw/1Om7Kv9YXvN6RaSOmzq2id1MrHZ+rUS2uHNkadeF3Jv+W0Zewl9iCBJarB6Nf72GMkktPwpaRrwhc6zPLIg==",
+			"version": "6.15.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-6.15.0.tgz",
+			"integrity": "sha512-AJ569cP6WqG0/RWx+x7MDNFxnCrZ5Pz1dHCLSE+7B0lLMXh3RGC1+Fj0YIZtUQ2ULLf2I3LRn6kuHdwyWNGiNA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -8875,13 +8890,14 @@
 			}
 		},
 		"node_modules/@wordpress/block-library/node_modules/@wordpress/components": {
-			"version": "30.7.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-30.7.0.tgz",
-			"integrity": "sha512-LlXjicK7zXnwmFSTnxByVwL+Muh4QGcqunxlBg3+Ni8yLtQyTKb6yS8wGUCE7USGEMOlEX1NYvp6i3DOZk1tiw==",
+			"version": "30.9.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-30.9.0.tgz",
+			"integrity": "sha512-mx0df0TjChmpCtqQn3iFHphqaLQVNk5Yprs+3NJSfm1kWuZPKfVys6AtmhfBgXs/VrrJk34Z+1N+nqXovHuXnw==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@ariakit/react": "^0.4.15",
+				"@date-fns/utc": "^2.1.1",
 				"@emotion/cache": "^11.7.1",
 				"@emotion/css": "^11.7.1",
 				"@emotion/react": "^11.7.1",
@@ -8892,24 +8908,24 @@
 				"@types/gradient-parser": "1.1.0",
 				"@types/highlight-words-core": "1.2.1",
 				"@use-gesture/react": "^10.3.1",
-				"@wordpress/a11y": "^4.34.0",
-				"@wordpress/base-styles": "^6.10.0",
-				"@wordpress/compose": "^7.34.0",
-				"@wordpress/date": "^5.34.0",
-				"@wordpress/deprecated": "^4.34.0",
-				"@wordpress/dom": "^4.34.0",
-				"@wordpress/element": "^6.34.0",
-				"@wordpress/escape-html": "^3.34.0",
-				"@wordpress/hooks": "^4.34.0",
-				"@wordpress/html-entities": "^4.34.0",
-				"@wordpress/i18n": "^6.7.0",
-				"@wordpress/icons": "^11.1.0",
-				"@wordpress/is-shallow-equal": "^5.34.0",
-				"@wordpress/keycodes": "^4.34.0",
-				"@wordpress/primitives": "^4.34.0",
-				"@wordpress/private-apis": "^1.34.0",
-				"@wordpress/rich-text": "^7.34.0",
-				"@wordpress/warning": "^3.34.0",
+				"@wordpress/a11y": "^4.36.0",
+				"@wordpress/base-styles": "^6.12.0",
+				"@wordpress/compose": "^7.36.0",
+				"@wordpress/date": "^5.36.0",
+				"@wordpress/deprecated": "^4.36.0",
+				"@wordpress/dom": "^4.36.0",
+				"@wordpress/element": "^6.36.0",
+				"@wordpress/escape-html": "^3.36.0",
+				"@wordpress/hooks": "^4.36.0",
+				"@wordpress/html-entities": "^4.36.0",
+				"@wordpress/i18n": "^6.9.0",
+				"@wordpress/icons": "^11.3.0",
+				"@wordpress/is-shallow-equal": "^5.36.0",
+				"@wordpress/keycodes": "^4.36.0",
+				"@wordpress/primitives": "^4.36.0",
+				"@wordpress/private-apis": "^1.36.0",
+				"@wordpress/rich-text": "^7.36.0",
+				"@wordpress/warning": "^3.36.0",
 				"change-case": "^4.1.2",
 				"clsx": "^2.1.1",
 				"colord": "^2.7.0",
@@ -8938,14 +8954,14 @@
 			}
 		},
 		"node_modules/@wordpress/block-library/node_modules/@wordpress/i18n": {
-			"version": "6.7.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.7.0.tgz",
-			"integrity": "sha512-156R15kz17WkFJ0mtoVt9ByFvt4i9zcstFiXC1HjMKr3zV1DZSplvcJeNJTENJBRX8sE+Be0NPevaC8LCodjgw==",
+			"version": "6.12.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.12.0.tgz",
+			"integrity": "sha512-KMleg8p/HtnoX1d/WoRDI51VTZsA4RGNUvBYn+Cc3avaeeNKROb91+viMcOc8NHuLplEzl7zH9/mrOSs9aY3rg==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@tannin/sprintf": "^1.3.2",
-				"@wordpress/hooks": "^4.34.0",
+				"@wordpress/hooks": "^4.39.0",
 				"gettext-parser": "^1.3.1",
 				"memize": "^2.1.0",
 				"tannin": "^1.2.0"
@@ -8959,18 +8975,21 @@
 			}
 		},
 		"node_modules/@wordpress/block-library/node_modules/@wordpress/icons": {
-			"version": "11.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-11.1.0.tgz",
-			"integrity": "sha512-N61MEoI9dU3fDQu7tdY1/kUSOhERyAnKHcVDWl3KWNFDuNuelnoUCMSckNV4T1Jz/M+2Mkov/J39Mroqo782zQ==",
+			"version": "11.6.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-11.6.0.tgz",
+			"integrity": "sha512-X3Tp3ARJWRokFOTJ1SJQef3J+bykyZHuHL6NSaMnEtbQzs7Tre+3HEghP5S5K/AGnLr+RvpGnwEN0uNy53uIiA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/element": "^6.34.0",
-				"@wordpress/primitives": "^4.34.0"
+				"@wordpress/element": "^6.39.0",
+				"@wordpress/primitives": "^4.39.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
 			}
 		},
 		"node_modules/@wordpress/block-library/node_modules/gradient-parser": {
@@ -9123,9 +9142,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@wordpress/commands/node_modules/@wordpress/base-styles": {
-			"version": "6.10.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-6.10.0.tgz",
-			"integrity": "sha512-Dw/1Om7Kv9YXvN6RaSOmzq2id1MrHZ+rUS2uHNkadeF3Jv+W0Zewl9iCBJarB6Nf72GMkktPwpaRrwhc6zPLIg==",
+			"version": "6.15.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-6.15.0.tgz",
+			"integrity": "sha512-AJ569cP6WqG0/RWx+x7MDNFxnCrZ5Pz1dHCLSE+7B0lLMXh3RGC1+Fj0YIZtUQ2ULLf2I3LRn6kuHdwyWNGiNA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -9134,13 +9153,14 @@
 			}
 		},
 		"node_modules/@wordpress/commands/node_modules/@wordpress/components": {
-			"version": "30.7.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-30.7.0.tgz",
-			"integrity": "sha512-LlXjicK7zXnwmFSTnxByVwL+Muh4QGcqunxlBg3+Ni8yLtQyTKb6yS8wGUCE7USGEMOlEX1NYvp6i3DOZk1tiw==",
+			"version": "30.9.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-30.9.0.tgz",
+			"integrity": "sha512-mx0df0TjChmpCtqQn3iFHphqaLQVNk5Yprs+3NJSfm1kWuZPKfVys6AtmhfBgXs/VrrJk34Z+1N+nqXovHuXnw==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@ariakit/react": "^0.4.15",
+				"@date-fns/utc": "^2.1.1",
 				"@emotion/cache": "^11.7.1",
 				"@emotion/css": "^11.7.1",
 				"@emotion/react": "^11.7.1",
@@ -9151,24 +9171,24 @@
 				"@types/gradient-parser": "1.1.0",
 				"@types/highlight-words-core": "1.2.1",
 				"@use-gesture/react": "^10.3.1",
-				"@wordpress/a11y": "^4.34.0",
-				"@wordpress/base-styles": "^6.10.0",
-				"@wordpress/compose": "^7.34.0",
-				"@wordpress/date": "^5.34.0",
-				"@wordpress/deprecated": "^4.34.0",
-				"@wordpress/dom": "^4.34.0",
-				"@wordpress/element": "^6.34.0",
-				"@wordpress/escape-html": "^3.34.0",
-				"@wordpress/hooks": "^4.34.0",
-				"@wordpress/html-entities": "^4.34.0",
-				"@wordpress/i18n": "^6.7.0",
-				"@wordpress/icons": "^11.1.0",
-				"@wordpress/is-shallow-equal": "^5.34.0",
-				"@wordpress/keycodes": "^4.34.0",
-				"@wordpress/primitives": "^4.34.0",
-				"@wordpress/private-apis": "^1.34.0",
-				"@wordpress/rich-text": "^7.34.0",
-				"@wordpress/warning": "^3.34.0",
+				"@wordpress/a11y": "^4.36.0",
+				"@wordpress/base-styles": "^6.12.0",
+				"@wordpress/compose": "^7.36.0",
+				"@wordpress/date": "^5.36.0",
+				"@wordpress/deprecated": "^4.36.0",
+				"@wordpress/dom": "^4.36.0",
+				"@wordpress/element": "^6.36.0",
+				"@wordpress/escape-html": "^3.36.0",
+				"@wordpress/hooks": "^4.36.0",
+				"@wordpress/html-entities": "^4.36.0",
+				"@wordpress/i18n": "^6.9.0",
+				"@wordpress/icons": "^11.3.0",
+				"@wordpress/is-shallow-equal": "^5.36.0",
+				"@wordpress/keycodes": "^4.36.0",
+				"@wordpress/primitives": "^4.36.0",
+				"@wordpress/private-apis": "^1.36.0",
+				"@wordpress/rich-text": "^7.36.0",
+				"@wordpress/warning": "^3.36.0",
 				"change-case": "^4.1.2",
 				"clsx": "^2.1.1",
 				"colord": "^2.7.0",
@@ -9197,14 +9217,14 @@
 			}
 		},
 		"node_modules/@wordpress/commands/node_modules/@wordpress/i18n": {
-			"version": "6.7.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.7.0.tgz",
-			"integrity": "sha512-156R15kz17WkFJ0mtoVt9ByFvt4i9zcstFiXC1HjMKr3zV1DZSplvcJeNJTENJBRX8sE+Be0NPevaC8LCodjgw==",
+			"version": "6.12.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.12.0.tgz",
+			"integrity": "sha512-KMleg8p/HtnoX1d/WoRDI51VTZsA4RGNUvBYn+Cc3avaeeNKROb91+viMcOc8NHuLplEzl7zH9/mrOSs9aY3rg==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@tannin/sprintf": "^1.3.2",
-				"@wordpress/hooks": "^4.34.0",
+				"@wordpress/hooks": "^4.39.0",
 				"gettext-parser": "^1.3.1",
 				"memize": "^2.1.0",
 				"tannin": "^1.2.0"
@@ -9218,18 +9238,21 @@
 			}
 		},
 		"node_modules/@wordpress/commands/node_modules/@wordpress/icons": {
-			"version": "11.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-11.1.0.tgz",
-			"integrity": "sha512-N61MEoI9dU3fDQu7tdY1/kUSOhERyAnKHcVDWl3KWNFDuNuelnoUCMSckNV4T1Jz/M+2Mkov/J39Mroqo782zQ==",
+			"version": "11.6.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-11.6.0.tgz",
+			"integrity": "sha512-X3Tp3ARJWRokFOTJ1SJQef3J+bykyZHuHL6NSaMnEtbQzs7Tre+3HEghP5S5K/AGnLr+RvpGnwEN0uNy53uIiA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/element": "^6.34.0",
-				"@wordpress/primitives": "^4.34.0"
+				"@wordpress/element": "^6.39.0",
+				"@wordpress/primitives": "^4.39.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
 			}
 		},
 		"node_modules/@wordpress/commands/node_modules/gradient-parser": {
@@ -9303,19 +9326,19 @@
 			}
 		},
 		"node_modules/@wordpress/compose": {
-			"version": "7.34.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.34.0.tgz",
-			"integrity": "sha512-gCgsU/VB8mvP9WqzOJLpd9p6ErTBC9qMhP9HQWnmW/SiYm0mhmNaknyr1viu4QYDlMeTVsCycNiP+MacUDCUzg==",
+			"version": "7.39.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.39.0.tgz",
+			"integrity": "sha512-9VyaqEDojUEnXKVxNamamEyYrWuI9vc2r33iV7hAe+8W0ISujRAFXp/baDiSOlYAcsbauRD4yAkEXuM0C4Vyhg==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@types/mousetrap": "^1.6.8",
-				"@wordpress/deprecated": "^4.34.0",
-				"@wordpress/dom": "^4.34.0",
-				"@wordpress/element": "^6.34.0",
-				"@wordpress/is-shallow-equal": "^5.34.0",
-				"@wordpress/keycodes": "^4.34.0",
-				"@wordpress/priority-queue": "^3.34.0",
-				"@wordpress/undo-manager": "^1.34.0",
+				"@wordpress/deprecated": "^4.39.0",
+				"@wordpress/dom": "^4.39.0",
+				"@wordpress/element": "^6.39.0",
+				"@wordpress/is-shallow-equal": "^5.39.0",
+				"@wordpress/keycodes": "^4.39.0",
+				"@wordpress/priority-queue": "^3.39.0",
+				"@wordpress/undo-manager": "^1.39.0",
 				"change-case": "^4.1.2",
 				"clipboard": "^2.0.11",
 				"mousetrap": "^1.6.5",
@@ -9389,18 +9412,18 @@
 			}
 		},
 		"node_modules/@wordpress/data": {
-			"version": "10.34.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.34.0.tgz",
-			"integrity": "sha512-3xk2NHweks8TLHyhTnMuIXTV2IVBCcejpGMTJeAayLoh0i/G+285EMz7O1t6fIu3u5uXCd/vQdJ2ewLTiIqXiQ==",
+			"version": "10.39.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.39.0.tgz",
+			"integrity": "sha512-L04X/Vawzx6RgvvSQga8JhvPxr1A6seBrWJoRBBP7+1zdCV7nmmR8339yTEPRnCH6m70qb0xSwTByUmTzWYzLg==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/compose": "^7.34.0",
-				"@wordpress/deprecated": "^4.34.0",
-				"@wordpress/element": "^6.34.0",
-				"@wordpress/is-shallow-equal": "^5.34.0",
-				"@wordpress/priority-queue": "^3.34.0",
-				"@wordpress/private-apis": "^1.34.0",
-				"@wordpress/redux-routine": "^5.34.0",
+				"@wordpress/compose": "^7.39.0",
+				"@wordpress/deprecated": "^4.39.0",
+				"@wordpress/element": "^6.39.0",
+				"@wordpress/is-shallow-equal": "^5.39.0",
+				"@wordpress/priority-queue": "^3.39.0",
+				"@wordpress/private-apis": "^1.39.0",
+				"@wordpress/redux-routine": "^5.39.0",
 				"deepmerge": "^4.3.0",
 				"equivalent-key-map": "^0.2.2",
 				"is-plain-object": "^5.0.0",
@@ -9476,9 +9499,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@wordpress/dataviews/node_modules/@wordpress/base-styles": {
-			"version": "6.10.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-6.10.0.tgz",
-			"integrity": "sha512-Dw/1Om7Kv9YXvN6RaSOmzq2id1MrHZ+rUS2uHNkadeF3Jv+W0Zewl9iCBJarB6Nf72GMkktPwpaRrwhc6zPLIg==",
+			"version": "6.15.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-6.15.0.tgz",
+			"integrity": "sha512-AJ569cP6WqG0/RWx+x7MDNFxnCrZ5Pz1dHCLSE+7B0lLMXh3RGC1+Fj0YIZtUQ2ULLf2I3LRn6kuHdwyWNGiNA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -9487,13 +9510,14 @@
 			}
 		},
 		"node_modules/@wordpress/dataviews/node_modules/@wordpress/components": {
-			"version": "30.7.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-30.7.0.tgz",
-			"integrity": "sha512-LlXjicK7zXnwmFSTnxByVwL+Muh4QGcqunxlBg3+Ni8yLtQyTKb6yS8wGUCE7USGEMOlEX1NYvp6i3DOZk1tiw==",
+			"version": "30.9.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-30.9.0.tgz",
+			"integrity": "sha512-mx0df0TjChmpCtqQn3iFHphqaLQVNk5Yprs+3NJSfm1kWuZPKfVys6AtmhfBgXs/VrrJk34Z+1N+nqXovHuXnw==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@ariakit/react": "^0.4.15",
+				"@date-fns/utc": "^2.1.1",
 				"@emotion/cache": "^11.7.1",
 				"@emotion/css": "^11.7.1",
 				"@emotion/react": "^11.7.1",
@@ -9504,24 +9528,24 @@
 				"@types/gradient-parser": "1.1.0",
 				"@types/highlight-words-core": "1.2.1",
 				"@use-gesture/react": "^10.3.1",
-				"@wordpress/a11y": "^4.34.0",
-				"@wordpress/base-styles": "^6.10.0",
-				"@wordpress/compose": "^7.34.0",
-				"@wordpress/date": "^5.34.0",
-				"@wordpress/deprecated": "^4.34.0",
-				"@wordpress/dom": "^4.34.0",
-				"@wordpress/element": "^6.34.0",
-				"@wordpress/escape-html": "^3.34.0",
-				"@wordpress/hooks": "^4.34.0",
-				"@wordpress/html-entities": "^4.34.0",
-				"@wordpress/i18n": "^6.7.0",
-				"@wordpress/icons": "^11.1.0",
-				"@wordpress/is-shallow-equal": "^5.34.0",
-				"@wordpress/keycodes": "^4.34.0",
-				"@wordpress/primitives": "^4.34.0",
-				"@wordpress/private-apis": "^1.34.0",
-				"@wordpress/rich-text": "^7.34.0",
-				"@wordpress/warning": "^3.34.0",
+				"@wordpress/a11y": "^4.36.0",
+				"@wordpress/base-styles": "^6.12.0",
+				"@wordpress/compose": "^7.36.0",
+				"@wordpress/date": "^5.36.0",
+				"@wordpress/deprecated": "^4.36.0",
+				"@wordpress/dom": "^4.36.0",
+				"@wordpress/element": "^6.36.0",
+				"@wordpress/escape-html": "^3.36.0",
+				"@wordpress/hooks": "^4.36.0",
+				"@wordpress/html-entities": "^4.36.0",
+				"@wordpress/i18n": "^6.9.0",
+				"@wordpress/icons": "^11.3.0",
+				"@wordpress/is-shallow-equal": "^5.36.0",
+				"@wordpress/keycodes": "^4.36.0",
+				"@wordpress/primitives": "^4.36.0",
+				"@wordpress/private-apis": "^1.36.0",
+				"@wordpress/rich-text": "^7.36.0",
+				"@wordpress/warning": "^3.36.0",
 				"change-case": "^4.1.2",
 				"clsx": "^2.1.1",
 				"colord": "^2.7.0",
@@ -9561,14 +9585,14 @@
 			}
 		},
 		"node_modules/@wordpress/dataviews/node_modules/@wordpress/i18n": {
-			"version": "6.7.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.7.0.tgz",
-			"integrity": "sha512-156R15kz17WkFJ0mtoVt9ByFvt4i9zcstFiXC1HjMKr3zV1DZSplvcJeNJTENJBRX8sE+Be0NPevaC8LCodjgw==",
+			"version": "6.12.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.12.0.tgz",
+			"integrity": "sha512-KMleg8p/HtnoX1d/WoRDI51VTZsA4RGNUvBYn+Cc3avaeeNKROb91+viMcOc8NHuLplEzl7zH9/mrOSs9aY3rg==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@tannin/sprintf": "^1.3.2",
-				"@wordpress/hooks": "^4.34.0",
+				"@wordpress/hooks": "^4.39.0",
 				"gettext-parser": "^1.3.1",
 				"memize": "^2.1.0",
 				"tannin": "^1.2.0"
@@ -9582,18 +9606,21 @@
 			}
 		},
 		"node_modules/@wordpress/dataviews/node_modules/@wordpress/icons": {
-			"version": "11.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-11.1.0.tgz",
-			"integrity": "sha512-N61MEoI9dU3fDQu7tdY1/kUSOhERyAnKHcVDWl3KWNFDuNuelnoUCMSckNV4T1Jz/M+2Mkov/J39Mroqo782zQ==",
+			"version": "11.6.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-11.6.0.tgz",
+			"integrity": "sha512-X3Tp3ARJWRokFOTJ1SJQef3J+bykyZHuHL6NSaMnEtbQzs7Tre+3HEghP5S5K/AGnLr+RvpGnwEN0uNy53uIiA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/element": "^6.34.0",
-				"@wordpress/primitives": "^4.34.0"
+				"@wordpress/element": "^6.39.0",
+				"@wordpress/primitives": "^4.39.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
 			}
 		},
 		"node_modules/@wordpress/dataviews/node_modules/date-fns": {
@@ -9617,12 +9644,12 @@
 			}
 		},
 		"node_modules/@wordpress/date": {
-			"version": "5.34.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/date/-/date-5.34.0.tgz",
-			"integrity": "sha512-0HbuRIL8b1KtpAU1ANG58iY07p9m0+jGUDpJCvJlPOQiCP0nDDLws9C5vTPrRiJnosxj6elyHtyt4LQnHAFJRA==",
+			"version": "5.39.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/date/-/date-5.39.0.tgz",
+			"integrity": "sha512-Wy8z+I0ZQjSTP/S4M9JqaDEUuucxGy70g+I8UCOFRgDFIO5v4hZVKo1uOH0NO5gGdlhmg4Scb9l9uzYVp8oqmg==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/deprecated": "^4.34.0",
+				"@wordpress/deprecated": "^4.39.0",
 				"moment": "^2.29.4",
 				"moment-timezone": "^0.5.40"
 			},
@@ -9656,12 +9683,12 @@
 			"license": "BSD"
 		},
 		"node_modules/@wordpress/deprecated": {
-			"version": "4.34.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.34.0.tgz",
-			"integrity": "sha512-SuQX1CX97dBVPmN33zdzdjkBHajkOpr1WUdLfiP5aR8xS9CAlyMJgfYygBxFZeMKmsbBYENDVJtrulw4lPvkKw==",
+			"version": "4.39.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.39.0.tgz",
+			"integrity": "sha512-/vTXUsh2MGOuh8nhzgpBKIKsbgdtgjE2hFiCPw8rP4wwEbKUlxhNdtZdqkaumNtZywfHbRUBWO9xTpAVX17XfA==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/hooks": "^4.34.0"
+				"@wordpress/hooks": "^4.39.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -9669,12 +9696,12 @@
 			}
 		},
 		"node_modules/@wordpress/dom": {
-			"version": "4.34.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.34.0.tgz",
-			"integrity": "sha512-W2gk4kkjhEHBLg/6nrJJ4QfvRguuzAx83S8UXS4tYtcYKh5vCzzcDPv8hN3cMS75R5nZBBzHgNfquS5iDhSXOA==",
+			"version": "4.39.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.39.0.tgz",
+			"integrity": "sha512-PCZVqTIV3V797rjWxZYoBJ+5g8girPZB0GzKZWxgsB6Y/+bS5OvBCJ70FgeZwO7oReo7ktXVNz/ZQMb5JsPosw==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/deprecated": "^4.34.0"
+				"@wordpress/deprecated": "^4.39.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -9682,9 +9709,9 @@
 			}
 		},
 		"node_modules/@wordpress/dom-ready": {
-			"version": "4.34.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-4.34.0.tgz",
-			"integrity": "sha512-LclbzuGRtDkF/NrygvnjtO+hcQsnq/iC+iEa78KvHJXQB8daWvrImgqhsD99K53e8AeUwtUFPFwLac5Co14jOg==",
+			"version": "4.39.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-4.39.0.tgz",
+			"integrity": "sha512-qHhRnlSK0E2GTMo1D2gOtcr9FW11HG8X8lZLkmf3N0zhjem+MP7G15jFB7wophpypL3plnBHMxiDD6qUHh9dSg==",
 			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",
@@ -9785,9 +9812,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@wordpress/edit-post/node_modules/@wordpress/base-styles": {
-			"version": "6.10.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-6.10.0.tgz",
-			"integrity": "sha512-Dw/1Om7Kv9YXvN6RaSOmzq2id1MrHZ+rUS2uHNkadeF3Jv+W0Zewl9iCBJarB6Nf72GMkktPwpaRrwhc6zPLIg==",
+			"version": "6.15.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-6.15.0.tgz",
+			"integrity": "sha512-AJ569cP6WqG0/RWx+x7MDNFxnCrZ5Pz1dHCLSE+7B0lLMXh3RGC1+Fj0YIZtUQ2ULLf2I3LRn6kuHdwyWNGiNA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -9796,13 +9823,14 @@
 			}
 		},
 		"node_modules/@wordpress/edit-post/node_modules/@wordpress/components": {
-			"version": "30.7.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-30.7.0.tgz",
-			"integrity": "sha512-LlXjicK7zXnwmFSTnxByVwL+Muh4QGcqunxlBg3+Ni8yLtQyTKb6yS8wGUCE7USGEMOlEX1NYvp6i3DOZk1tiw==",
+			"version": "30.9.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-30.9.0.tgz",
+			"integrity": "sha512-mx0df0TjChmpCtqQn3iFHphqaLQVNk5Yprs+3NJSfm1kWuZPKfVys6AtmhfBgXs/VrrJk34Z+1N+nqXovHuXnw==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@ariakit/react": "^0.4.15",
+				"@date-fns/utc": "^2.1.1",
 				"@emotion/cache": "^11.7.1",
 				"@emotion/css": "^11.7.1",
 				"@emotion/react": "^11.7.1",
@@ -9813,24 +9841,24 @@
 				"@types/gradient-parser": "1.1.0",
 				"@types/highlight-words-core": "1.2.1",
 				"@use-gesture/react": "^10.3.1",
-				"@wordpress/a11y": "^4.34.0",
-				"@wordpress/base-styles": "^6.10.0",
-				"@wordpress/compose": "^7.34.0",
-				"@wordpress/date": "^5.34.0",
-				"@wordpress/deprecated": "^4.34.0",
-				"@wordpress/dom": "^4.34.0",
-				"@wordpress/element": "^6.34.0",
-				"@wordpress/escape-html": "^3.34.0",
-				"@wordpress/hooks": "^4.34.0",
-				"@wordpress/html-entities": "^4.34.0",
-				"@wordpress/i18n": "^6.7.0",
-				"@wordpress/icons": "^11.1.0",
-				"@wordpress/is-shallow-equal": "^5.34.0",
-				"@wordpress/keycodes": "^4.34.0",
-				"@wordpress/primitives": "^4.34.0",
-				"@wordpress/private-apis": "^1.34.0",
-				"@wordpress/rich-text": "^7.34.0",
-				"@wordpress/warning": "^3.34.0",
+				"@wordpress/a11y": "^4.36.0",
+				"@wordpress/base-styles": "^6.12.0",
+				"@wordpress/compose": "^7.36.0",
+				"@wordpress/date": "^5.36.0",
+				"@wordpress/deprecated": "^4.36.0",
+				"@wordpress/dom": "^4.36.0",
+				"@wordpress/element": "^6.36.0",
+				"@wordpress/escape-html": "^3.36.0",
+				"@wordpress/hooks": "^4.36.0",
+				"@wordpress/html-entities": "^4.36.0",
+				"@wordpress/i18n": "^6.9.0",
+				"@wordpress/icons": "^11.3.0",
+				"@wordpress/is-shallow-equal": "^5.36.0",
+				"@wordpress/keycodes": "^4.36.0",
+				"@wordpress/primitives": "^4.36.0",
+				"@wordpress/private-apis": "^1.36.0",
+				"@wordpress/rich-text": "^7.36.0",
+				"@wordpress/warning": "^3.36.0",
 				"change-case": "^4.1.2",
 				"clsx": "^2.1.1",
 				"colord": "^2.7.0",
@@ -9859,14 +9887,14 @@
 			}
 		},
 		"node_modules/@wordpress/edit-post/node_modules/@wordpress/i18n": {
-			"version": "6.7.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.7.0.tgz",
-			"integrity": "sha512-156R15kz17WkFJ0mtoVt9ByFvt4i9zcstFiXC1HjMKr3zV1DZSplvcJeNJTENJBRX8sE+Be0NPevaC8LCodjgw==",
+			"version": "6.12.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.12.0.tgz",
+			"integrity": "sha512-KMleg8p/HtnoX1d/WoRDI51VTZsA4RGNUvBYn+Cc3avaeeNKROb91+viMcOc8NHuLplEzl7zH9/mrOSs9aY3rg==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@tannin/sprintf": "^1.3.2",
-				"@wordpress/hooks": "^4.34.0",
+				"@wordpress/hooks": "^4.39.0",
 				"gettext-parser": "^1.3.1",
 				"memize": "^2.1.0",
 				"tannin": "^1.2.0"
@@ -9880,18 +9908,21 @@
 			}
 		},
 		"node_modules/@wordpress/edit-post/node_modules/@wordpress/icons": {
-			"version": "11.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-11.1.0.tgz",
-			"integrity": "sha512-N61MEoI9dU3fDQu7tdY1/kUSOhERyAnKHcVDWl3KWNFDuNuelnoUCMSckNV4T1Jz/M+2Mkov/J39Mroqo782zQ==",
+			"version": "11.6.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-11.6.0.tgz",
+			"integrity": "sha512-X3Tp3ARJWRokFOTJ1SJQef3J+bykyZHuHL6NSaMnEtbQzs7Tre+3HEghP5S5K/AGnLr+RvpGnwEN0uNy53uIiA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/element": "^6.34.0",
-				"@wordpress/primitives": "^4.34.0"
+				"@wordpress/element": "^6.39.0",
+				"@wordpress/primitives": "^4.39.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
 			}
 		},
 		"node_modules/@wordpress/edit-post/node_modules/gradient-parser": {
@@ -9990,9 +10021,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@wordpress/editor/node_modules/@wordpress/base-styles": {
-			"version": "6.10.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-6.10.0.tgz",
-			"integrity": "sha512-Dw/1Om7Kv9YXvN6RaSOmzq2id1MrHZ+rUS2uHNkadeF3Jv+W0Zewl9iCBJarB6Nf72GMkktPwpaRrwhc6zPLIg==",
+			"version": "6.15.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-6.15.0.tgz",
+			"integrity": "sha512-AJ569cP6WqG0/RWx+x7MDNFxnCrZ5Pz1dHCLSE+7B0lLMXh3RGC1+Fj0YIZtUQ2ULLf2I3LRn6kuHdwyWNGiNA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -10001,13 +10032,14 @@
 			}
 		},
 		"node_modules/@wordpress/editor/node_modules/@wordpress/components": {
-			"version": "30.7.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-30.7.0.tgz",
-			"integrity": "sha512-LlXjicK7zXnwmFSTnxByVwL+Muh4QGcqunxlBg3+Ni8yLtQyTKb6yS8wGUCE7USGEMOlEX1NYvp6i3DOZk1tiw==",
+			"version": "30.9.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-30.9.0.tgz",
+			"integrity": "sha512-mx0df0TjChmpCtqQn3iFHphqaLQVNk5Yprs+3NJSfm1kWuZPKfVys6AtmhfBgXs/VrrJk34Z+1N+nqXovHuXnw==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@ariakit/react": "^0.4.15",
+				"@date-fns/utc": "^2.1.1",
 				"@emotion/cache": "^11.7.1",
 				"@emotion/css": "^11.7.1",
 				"@emotion/react": "^11.7.1",
@@ -10018,24 +10050,24 @@
 				"@types/gradient-parser": "1.1.0",
 				"@types/highlight-words-core": "1.2.1",
 				"@use-gesture/react": "^10.3.1",
-				"@wordpress/a11y": "^4.34.0",
-				"@wordpress/base-styles": "^6.10.0",
-				"@wordpress/compose": "^7.34.0",
-				"@wordpress/date": "^5.34.0",
-				"@wordpress/deprecated": "^4.34.0",
-				"@wordpress/dom": "^4.34.0",
-				"@wordpress/element": "^6.34.0",
-				"@wordpress/escape-html": "^3.34.0",
-				"@wordpress/hooks": "^4.34.0",
-				"@wordpress/html-entities": "^4.34.0",
-				"@wordpress/i18n": "^6.7.0",
-				"@wordpress/icons": "^11.1.0",
-				"@wordpress/is-shallow-equal": "^5.34.0",
-				"@wordpress/keycodes": "^4.34.0",
-				"@wordpress/primitives": "^4.34.0",
-				"@wordpress/private-apis": "^1.34.0",
-				"@wordpress/rich-text": "^7.34.0",
-				"@wordpress/warning": "^3.34.0",
+				"@wordpress/a11y": "^4.36.0",
+				"@wordpress/base-styles": "^6.12.0",
+				"@wordpress/compose": "^7.36.0",
+				"@wordpress/date": "^5.36.0",
+				"@wordpress/deprecated": "^4.36.0",
+				"@wordpress/dom": "^4.36.0",
+				"@wordpress/element": "^6.36.0",
+				"@wordpress/escape-html": "^3.36.0",
+				"@wordpress/hooks": "^4.36.0",
+				"@wordpress/html-entities": "^4.36.0",
+				"@wordpress/i18n": "^6.9.0",
+				"@wordpress/icons": "^11.3.0",
+				"@wordpress/is-shallow-equal": "^5.36.0",
+				"@wordpress/keycodes": "^4.36.0",
+				"@wordpress/primitives": "^4.36.0",
+				"@wordpress/private-apis": "^1.36.0",
+				"@wordpress/rich-text": "^7.36.0",
+				"@wordpress/warning": "^3.36.0",
 				"change-case": "^4.1.2",
 				"clsx": "^2.1.1",
 				"colord": "^2.7.0",
@@ -10064,14 +10096,14 @@
 			}
 		},
 		"node_modules/@wordpress/editor/node_modules/@wordpress/i18n": {
-			"version": "6.7.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.7.0.tgz",
-			"integrity": "sha512-156R15kz17WkFJ0mtoVt9ByFvt4i9zcstFiXC1HjMKr3zV1DZSplvcJeNJTENJBRX8sE+Be0NPevaC8LCodjgw==",
+			"version": "6.12.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.12.0.tgz",
+			"integrity": "sha512-KMleg8p/HtnoX1d/WoRDI51VTZsA4RGNUvBYn+Cc3avaeeNKROb91+viMcOc8NHuLplEzl7zH9/mrOSs9aY3rg==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@tannin/sprintf": "^1.3.2",
-				"@wordpress/hooks": "^4.34.0",
+				"@wordpress/hooks": "^4.39.0",
 				"gettext-parser": "^1.3.1",
 				"memize": "^2.1.0",
 				"tannin": "^1.2.0"
@@ -10085,18 +10117,21 @@
 			}
 		},
 		"node_modules/@wordpress/editor/node_modules/@wordpress/icons": {
-			"version": "11.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-11.1.0.tgz",
-			"integrity": "sha512-N61MEoI9dU3fDQu7tdY1/kUSOhERyAnKHcVDWl3KWNFDuNuelnoUCMSckNV4T1Jz/M+2Mkov/J39Mroqo782zQ==",
+			"version": "11.6.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-11.6.0.tgz",
+			"integrity": "sha512-X3Tp3ARJWRokFOTJ1SJQef3J+bykyZHuHL6NSaMnEtbQzs7Tre+3HEghP5S5K/AGnLr+RvpGnwEN0uNy53uIiA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/element": "^6.34.0",
-				"@wordpress/primitives": "^4.34.0"
+				"@wordpress/element": "^6.39.0",
+				"@wordpress/primitives": "^4.39.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
 			}
 		},
 		"node_modules/@wordpress/editor/node_modules/gradient-parser": {
@@ -10109,14 +10144,14 @@
 			}
 		},
 		"node_modules/@wordpress/element": {
-			"version": "6.34.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.34.0.tgz",
-			"integrity": "sha512-WoCBhGa7fTd9NB0B1XS+hF64vmglI90tEskQxxfqtgby1IiLj7TjG+zyVeW1UdrKja3zSAhZTqZc1wjpEtbcoQ==",
+			"version": "6.39.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.39.0.tgz",
+			"integrity": "sha512-yVEjTddIVEsYjwRCY1pEzav/dGVH9S1xfwYwRyGsUGOQw5hXtIVnTbCIfQ2t3OCOGgSIYEh2ZmsSt0eTxZvtBw==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@types/react": "^18.2.79",
-				"@types/react-dom": "^18.2.25",
-				"@wordpress/escape-html": "^3.34.0",
+				"@types/react": "^18.3.27",
+				"@types/react-dom": "^18.3.1",
+				"@wordpress/escape-html": "^3.39.0",
 				"change-case": "^4.1.2",
 				"is-plain-object": "^5.0.0",
 				"react": "^18.3.0",
@@ -10128,9 +10163,9 @@
 			}
 		},
 		"node_modules/@wordpress/escape-html": {
-			"version": "3.34.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.34.0.tgz",
-			"integrity": "sha512-uDkh9w970Lnh43GTw/8csw0BkWY08tzYo2gqIF1I26N7YnpwRbVnv1Swet8PFvv8YDxpfejWBFfA7so4nciKfw==",
+			"version": "3.39.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.39.0.tgz",
+			"integrity": "sha512-YhAmZYQsOnnfafMwInzy/M1AR77O59u4aaIVSqiQjvCLkY+BQABsU6AizDckCg57mF2SoDnARl6xQY/7FCwEmw==",
 			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",
@@ -10647,9 +10682,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@wordpress/fields/node_modules/@wordpress/base-styles": {
-			"version": "6.10.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-6.10.0.tgz",
-			"integrity": "sha512-Dw/1Om7Kv9YXvN6RaSOmzq2id1MrHZ+rUS2uHNkadeF3Jv+W0Zewl9iCBJarB6Nf72GMkktPwpaRrwhc6zPLIg==",
+			"version": "6.15.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-6.15.0.tgz",
+			"integrity": "sha512-AJ569cP6WqG0/RWx+x7MDNFxnCrZ5Pz1dHCLSE+7B0lLMXh3RGC1+Fj0YIZtUQ2ULLf2I3LRn6kuHdwyWNGiNA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -10658,13 +10693,14 @@
 			}
 		},
 		"node_modules/@wordpress/fields/node_modules/@wordpress/components": {
-			"version": "30.7.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-30.7.0.tgz",
-			"integrity": "sha512-LlXjicK7zXnwmFSTnxByVwL+Muh4QGcqunxlBg3+Ni8yLtQyTKb6yS8wGUCE7USGEMOlEX1NYvp6i3DOZk1tiw==",
+			"version": "30.9.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-30.9.0.tgz",
+			"integrity": "sha512-mx0df0TjChmpCtqQn3iFHphqaLQVNk5Yprs+3NJSfm1kWuZPKfVys6AtmhfBgXs/VrrJk34Z+1N+nqXovHuXnw==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@ariakit/react": "^0.4.15",
+				"@date-fns/utc": "^2.1.1",
 				"@emotion/cache": "^11.7.1",
 				"@emotion/css": "^11.7.1",
 				"@emotion/react": "^11.7.1",
@@ -10675,24 +10711,24 @@
 				"@types/gradient-parser": "1.1.0",
 				"@types/highlight-words-core": "1.2.1",
 				"@use-gesture/react": "^10.3.1",
-				"@wordpress/a11y": "^4.34.0",
-				"@wordpress/base-styles": "^6.10.0",
-				"@wordpress/compose": "^7.34.0",
-				"@wordpress/date": "^5.34.0",
-				"@wordpress/deprecated": "^4.34.0",
-				"@wordpress/dom": "^4.34.0",
-				"@wordpress/element": "^6.34.0",
-				"@wordpress/escape-html": "^3.34.0",
-				"@wordpress/hooks": "^4.34.0",
-				"@wordpress/html-entities": "^4.34.0",
-				"@wordpress/i18n": "^6.7.0",
-				"@wordpress/icons": "^11.1.0",
-				"@wordpress/is-shallow-equal": "^5.34.0",
-				"@wordpress/keycodes": "^4.34.0",
-				"@wordpress/primitives": "^4.34.0",
-				"@wordpress/private-apis": "^1.34.0",
-				"@wordpress/rich-text": "^7.34.0",
-				"@wordpress/warning": "^3.34.0",
+				"@wordpress/a11y": "^4.36.0",
+				"@wordpress/base-styles": "^6.12.0",
+				"@wordpress/compose": "^7.36.0",
+				"@wordpress/date": "^5.36.0",
+				"@wordpress/deprecated": "^4.36.0",
+				"@wordpress/dom": "^4.36.0",
+				"@wordpress/element": "^6.36.0",
+				"@wordpress/escape-html": "^3.36.0",
+				"@wordpress/hooks": "^4.36.0",
+				"@wordpress/html-entities": "^4.36.0",
+				"@wordpress/i18n": "^6.9.0",
+				"@wordpress/icons": "^11.3.0",
+				"@wordpress/is-shallow-equal": "^5.36.0",
+				"@wordpress/keycodes": "^4.36.0",
+				"@wordpress/primitives": "^4.36.0",
+				"@wordpress/private-apis": "^1.36.0",
+				"@wordpress/rich-text": "^7.36.0",
+				"@wordpress/warning": "^3.36.0",
 				"change-case": "^4.1.2",
 				"clsx": "^2.1.1",
 				"colord": "^2.7.0",
@@ -10721,14 +10757,14 @@
 			}
 		},
 		"node_modules/@wordpress/fields/node_modules/@wordpress/i18n": {
-			"version": "6.7.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.7.0.tgz",
-			"integrity": "sha512-156R15kz17WkFJ0mtoVt9ByFvt4i9zcstFiXC1HjMKr3zV1DZSplvcJeNJTENJBRX8sE+Be0NPevaC8LCodjgw==",
+			"version": "6.12.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.12.0.tgz",
+			"integrity": "sha512-KMleg8p/HtnoX1d/WoRDI51VTZsA4RGNUvBYn+Cc3avaeeNKROb91+viMcOc8NHuLplEzl7zH9/mrOSs9aY3rg==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@tannin/sprintf": "^1.3.2",
-				"@wordpress/hooks": "^4.34.0",
+				"@wordpress/hooks": "^4.39.0",
 				"gettext-parser": "^1.3.1",
 				"memize": "^2.1.0",
 				"tannin": "^1.2.0"
@@ -10742,18 +10778,21 @@
 			}
 		},
 		"node_modules/@wordpress/fields/node_modules/@wordpress/icons": {
-			"version": "11.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-11.1.0.tgz",
-			"integrity": "sha512-N61MEoI9dU3fDQu7tdY1/kUSOhERyAnKHcVDWl3KWNFDuNuelnoUCMSckNV4T1Jz/M+2Mkov/J39Mroqo782zQ==",
+			"version": "11.6.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-11.6.0.tgz",
+			"integrity": "sha512-X3Tp3ARJWRokFOTJ1SJQef3J+bykyZHuHL6NSaMnEtbQzs7Tre+3HEghP5S5K/AGnLr+RvpGnwEN0uNy53uIiA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/element": "^6.34.0",
-				"@wordpress/primitives": "^4.34.0"
+				"@wordpress/element": "^6.39.0",
+				"@wordpress/primitives": "^4.39.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
 			}
 		},
 		"node_modules/@wordpress/fields/node_modules/gradient-parser": {
@@ -10866,9 +10905,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@wordpress/global-styles-ui/node_modules/@wordpress/base-styles": {
-			"version": "6.10.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-6.10.0.tgz",
-			"integrity": "sha512-Dw/1Om7Kv9YXvN6RaSOmzq2id1MrHZ+rUS2uHNkadeF3Jv+W0Zewl9iCBJarB6Nf72GMkktPwpaRrwhc6zPLIg==",
+			"version": "6.15.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-6.15.0.tgz",
+			"integrity": "sha512-AJ569cP6WqG0/RWx+x7MDNFxnCrZ5Pz1dHCLSE+7B0lLMXh3RGC1+Fj0YIZtUQ2ULLf2I3LRn6kuHdwyWNGiNA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -10877,13 +10916,14 @@
 			}
 		},
 		"node_modules/@wordpress/global-styles-ui/node_modules/@wordpress/components": {
-			"version": "30.7.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-30.7.0.tgz",
-			"integrity": "sha512-LlXjicK7zXnwmFSTnxByVwL+Muh4QGcqunxlBg3+Ni8yLtQyTKb6yS8wGUCE7USGEMOlEX1NYvp6i3DOZk1tiw==",
+			"version": "30.9.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-30.9.0.tgz",
+			"integrity": "sha512-mx0df0TjChmpCtqQn3iFHphqaLQVNk5Yprs+3NJSfm1kWuZPKfVys6AtmhfBgXs/VrrJk34Z+1N+nqXovHuXnw==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@ariakit/react": "^0.4.15",
+				"@date-fns/utc": "^2.1.1",
 				"@emotion/cache": "^11.7.1",
 				"@emotion/css": "^11.7.1",
 				"@emotion/react": "^11.7.1",
@@ -10894,24 +10934,24 @@
 				"@types/gradient-parser": "1.1.0",
 				"@types/highlight-words-core": "1.2.1",
 				"@use-gesture/react": "^10.3.1",
-				"@wordpress/a11y": "^4.34.0",
-				"@wordpress/base-styles": "^6.10.0",
-				"@wordpress/compose": "^7.34.0",
-				"@wordpress/date": "^5.34.0",
-				"@wordpress/deprecated": "^4.34.0",
-				"@wordpress/dom": "^4.34.0",
-				"@wordpress/element": "^6.34.0",
-				"@wordpress/escape-html": "^3.34.0",
-				"@wordpress/hooks": "^4.34.0",
-				"@wordpress/html-entities": "^4.34.0",
-				"@wordpress/i18n": "^6.7.0",
-				"@wordpress/icons": "^11.1.0",
-				"@wordpress/is-shallow-equal": "^5.34.0",
-				"@wordpress/keycodes": "^4.34.0",
-				"@wordpress/primitives": "^4.34.0",
-				"@wordpress/private-apis": "^1.34.0",
-				"@wordpress/rich-text": "^7.34.0",
-				"@wordpress/warning": "^3.34.0",
+				"@wordpress/a11y": "^4.36.0",
+				"@wordpress/base-styles": "^6.12.0",
+				"@wordpress/compose": "^7.36.0",
+				"@wordpress/date": "^5.36.0",
+				"@wordpress/deprecated": "^4.36.0",
+				"@wordpress/dom": "^4.36.0",
+				"@wordpress/element": "^6.36.0",
+				"@wordpress/escape-html": "^3.36.0",
+				"@wordpress/hooks": "^4.36.0",
+				"@wordpress/html-entities": "^4.36.0",
+				"@wordpress/i18n": "^6.9.0",
+				"@wordpress/icons": "^11.3.0",
+				"@wordpress/is-shallow-equal": "^5.36.0",
+				"@wordpress/keycodes": "^4.36.0",
+				"@wordpress/primitives": "^4.36.0",
+				"@wordpress/private-apis": "^1.36.0",
+				"@wordpress/rich-text": "^7.36.0",
+				"@wordpress/warning": "^3.36.0",
 				"change-case": "^4.1.2",
 				"clsx": "^2.1.1",
 				"colord": "^2.7.0",
@@ -10940,14 +10980,14 @@
 			}
 		},
 		"node_modules/@wordpress/global-styles-ui/node_modules/@wordpress/i18n": {
-			"version": "6.7.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.7.0.tgz",
-			"integrity": "sha512-156R15kz17WkFJ0mtoVt9ByFvt4i9zcstFiXC1HjMKr3zV1DZSplvcJeNJTENJBRX8sE+Be0NPevaC8LCodjgw==",
+			"version": "6.12.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.12.0.tgz",
+			"integrity": "sha512-KMleg8p/HtnoX1d/WoRDI51VTZsA4RGNUvBYn+Cc3avaeeNKROb91+viMcOc8NHuLplEzl7zH9/mrOSs9aY3rg==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@tannin/sprintf": "^1.3.2",
-				"@wordpress/hooks": "^4.34.0",
+				"@wordpress/hooks": "^4.39.0",
 				"gettext-parser": "^1.3.1",
 				"memize": "^2.1.0",
 				"tannin": "^1.2.0"
@@ -10961,18 +11001,21 @@
 			}
 		},
 		"node_modules/@wordpress/global-styles-ui/node_modules/@wordpress/icons": {
-			"version": "11.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-11.1.0.tgz",
-			"integrity": "sha512-N61MEoI9dU3fDQu7tdY1/kUSOhERyAnKHcVDWl3KWNFDuNuelnoUCMSckNV4T1Jz/M+2Mkov/J39Mroqo782zQ==",
+			"version": "11.6.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-11.6.0.tgz",
+			"integrity": "sha512-X3Tp3ARJWRokFOTJ1SJQef3J+bykyZHuHL6NSaMnEtbQzs7Tre+3HEghP5S5K/AGnLr+RvpGnwEN0uNy53uIiA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/element": "^6.34.0",
-				"@wordpress/primitives": "^4.34.0"
+				"@wordpress/element": "^6.39.0",
+				"@wordpress/primitives": "^4.39.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
 			}
 		},
 		"node_modules/@wordpress/global-styles-ui/node_modules/gradient-parser": {
@@ -10985,9 +11028,9 @@
 			}
 		},
 		"node_modules/@wordpress/hooks": {
-			"version": "4.34.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.34.0.tgz",
-			"integrity": "sha512-uZcgAMDhf6OzYCUoDqq//wYsfC7yx+XUd2av07aROn8SKTkWRfu7zweJHsOBmK0TkCx976ELoL/SZZfHPcj3aw==",
+			"version": "4.39.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.39.0.tgz",
+			"integrity": "sha512-FTKdGF5jHHmC8GSO6/ATQqh1IFQeDwapRtlp7t4VaTGwZtX+uzawgq/7QDIhFi3cfg9hNsFF0CSFp/Ul3nEeUA==",
 			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",
@@ -10995,9 +11038,9 @@
 			}
 		},
 		"node_modules/@wordpress/html-entities": {
-			"version": "4.34.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-4.34.0.tgz",
-			"integrity": "sha512-TYYNhGbHEAuVH48Q5+Muy1Bc1G32yK+4btLhkiQOtRXfa/p7f+3bUMe1/t3wgdmU1hM//wS6dsJ2wvXa9rBCeA==",
+			"version": "4.39.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-4.39.0.tgz",
+			"integrity": "sha512-gKpDo9vXxws4L03x6JYal8zrv+HjtQ4KMicpUdsHY8hhH5Asid2UGOBkCA1pQ1j9KVSWWj+3RsF0Ay1lem06Fw==",
 			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",
@@ -11123,9 +11166,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@wordpress/interface/node_modules/@wordpress/base-styles": {
-			"version": "6.10.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-6.10.0.tgz",
-			"integrity": "sha512-Dw/1Om7Kv9YXvN6RaSOmzq2id1MrHZ+rUS2uHNkadeF3Jv+W0Zewl9iCBJarB6Nf72GMkktPwpaRrwhc6zPLIg==",
+			"version": "6.15.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-6.15.0.tgz",
+			"integrity": "sha512-AJ569cP6WqG0/RWx+x7MDNFxnCrZ5Pz1dHCLSE+7B0lLMXh3RGC1+Fj0YIZtUQ2ULLf2I3LRn6kuHdwyWNGiNA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -11134,13 +11177,14 @@
 			}
 		},
 		"node_modules/@wordpress/interface/node_modules/@wordpress/components": {
-			"version": "30.7.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-30.7.0.tgz",
-			"integrity": "sha512-LlXjicK7zXnwmFSTnxByVwL+Muh4QGcqunxlBg3+Ni8yLtQyTKb6yS8wGUCE7USGEMOlEX1NYvp6i3DOZk1tiw==",
+			"version": "30.9.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-30.9.0.tgz",
+			"integrity": "sha512-mx0df0TjChmpCtqQn3iFHphqaLQVNk5Yprs+3NJSfm1kWuZPKfVys6AtmhfBgXs/VrrJk34Z+1N+nqXovHuXnw==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@ariakit/react": "^0.4.15",
+				"@date-fns/utc": "^2.1.1",
 				"@emotion/cache": "^11.7.1",
 				"@emotion/css": "^11.7.1",
 				"@emotion/react": "^11.7.1",
@@ -11151,24 +11195,24 @@
 				"@types/gradient-parser": "1.1.0",
 				"@types/highlight-words-core": "1.2.1",
 				"@use-gesture/react": "^10.3.1",
-				"@wordpress/a11y": "^4.34.0",
-				"@wordpress/base-styles": "^6.10.0",
-				"@wordpress/compose": "^7.34.0",
-				"@wordpress/date": "^5.34.0",
-				"@wordpress/deprecated": "^4.34.0",
-				"@wordpress/dom": "^4.34.0",
-				"@wordpress/element": "^6.34.0",
-				"@wordpress/escape-html": "^3.34.0",
-				"@wordpress/hooks": "^4.34.0",
-				"@wordpress/html-entities": "^4.34.0",
-				"@wordpress/i18n": "^6.7.0",
-				"@wordpress/icons": "^11.1.0",
-				"@wordpress/is-shallow-equal": "^5.34.0",
-				"@wordpress/keycodes": "^4.34.0",
-				"@wordpress/primitives": "^4.34.0",
-				"@wordpress/private-apis": "^1.34.0",
-				"@wordpress/rich-text": "^7.34.0",
-				"@wordpress/warning": "^3.34.0",
+				"@wordpress/a11y": "^4.36.0",
+				"@wordpress/base-styles": "^6.12.0",
+				"@wordpress/compose": "^7.36.0",
+				"@wordpress/date": "^5.36.0",
+				"@wordpress/deprecated": "^4.36.0",
+				"@wordpress/dom": "^4.36.0",
+				"@wordpress/element": "^6.36.0",
+				"@wordpress/escape-html": "^3.36.0",
+				"@wordpress/hooks": "^4.36.0",
+				"@wordpress/html-entities": "^4.36.0",
+				"@wordpress/i18n": "^6.9.0",
+				"@wordpress/icons": "^11.3.0",
+				"@wordpress/is-shallow-equal": "^5.36.0",
+				"@wordpress/keycodes": "^4.36.0",
+				"@wordpress/primitives": "^4.36.0",
+				"@wordpress/private-apis": "^1.36.0",
+				"@wordpress/rich-text": "^7.36.0",
+				"@wordpress/warning": "^3.36.0",
 				"change-case": "^4.1.2",
 				"clsx": "^2.1.1",
 				"colord": "^2.7.0",
@@ -11197,14 +11241,14 @@
 			}
 		},
 		"node_modules/@wordpress/interface/node_modules/@wordpress/i18n": {
-			"version": "6.7.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.7.0.tgz",
-			"integrity": "sha512-156R15kz17WkFJ0mtoVt9ByFvt4i9zcstFiXC1HjMKr3zV1DZSplvcJeNJTENJBRX8sE+Be0NPevaC8LCodjgw==",
+			"version": "6.12.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.12.0.tgz",
+			"integrity": "sha512-KMleg8p/HtnoX1d/WoRDI51VTZsA4RGNUvBYn+Cc3avaeeNKROb91+viMcOc8NHuLplEzl7zH9/mrOSs9aY3rg==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@tannin/sprintf": "^1.3.2",
-				"@wordpress/hooks": "^4.34.0",
+				"@wordpress/hooks": "^4.39.0",
 				"gettext-parser": "^1.3.1",
 				"memize": "^2.1.0",
 				"tannin": "^1.2.0"
@@ -11218,18 +11262,21 @@
 			}
 		},
 		"node_modules/@wordpress/interface/node_modules/@wordpress/icons": {
-			"version": "11.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-11.1.0.tgz",
-			"integrity": "sha512-N61MEoI9dU3fDQu7tdY1/kUSOhERyAnKHcVDWl3KWNFDuNuelnoUCMSckNV4T1Jz/M+2Mkov/J39Mroqo782zQ==",
+			"version": "11.6.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-11.6.0.tgz",
+			"integrity": "sha512-X3Tp3ARJWRokFOTJ1SJQef3J+bykyZHuHL6NSaMnEtbQzs7Tre+3HEghP5S5K/AGnLr+RvpGnwEN0uNy53uIiA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/element": "^6.34.0",
-				"@wordpress/primitives": "^4.34.0"
+				"@wordpress/element": "^6.39.0",
+				"@wordpress/primitives": "^4.39.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
 			}
 		},
 		"node_modules/@wordpress/interface/node_modules/gradient-parser": {
@@ -11242,9 +11289,9 @@
 			}
 		},
 		"node_modules/@wordpress/is-shallow-equal": {
-			"version": "5.34.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.34.0.tgz",
-			"integrity": "sha512-p401k9SahwMOlmQq9DsKnfpHbax6QtE1hB6qTS/1VfhKLYy/DHc43OKafrwGB5G+rHntrsBNsO9r63DRcl4bbQ==",
+			"version": "5.39.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.39.0.tgz",
+			"integrity": "sha512-v/yDkQj/VpdR8y4b0xNTeuFkfdU2AYf/0YABbry6GB6zG+mkPgi2+cglQ681V621korKOX6JRAsMQuRX6D2UNA==",
 			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",
@@ -11307,12 +11354,12 @@
 			}
 		},
 		"node_modules/@wordpress/keycodes": {
-			"version": "4.34.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.34.0.tgz",
-			"integrity": "sha512-x/Z+tbcics353Kc1oymrWrnQ8BErpYk112yncli0VXYPGa1OYDoYiUs2Fh49wWXorlx3Dtw6mI+hbiJ14gGp7g==",
+			"version": "4.39.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.39.0.tgz",
+			"integrity": "sha512-RN7Py7vvvmBOGuRM8X4hHOvXXG57jWDW9pIXUnVGc33EvTrwtnr16f8Xt4nKWs8L/UNUdrrAtA2HAeqRkdxr+A==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/i18n": "^6.7.0"
+				"@wordpress/i18n": "^6.12.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -11320,13 +11367,13 @@
 			}
 		},
 		"node_modules/@wordpress/keycodes/node_modules/@wordpress/i18n": {
-			"version": "6.7.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.7.0.tgz",
-			"integrity": "sha512-156R15kz17WkFJ0mtoVt9ByFvt4i9zcstFiXC1HjMKr3zV1DZSplvcJeNJTENJBRX8sE+Be0NPevaC8LCodjgw==",
+			"version": "6.12.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.12.0.tgz",
+			"integrity": "sha512-KMleg8p/HtnoX1d/WoRDI51VTZsA4RGNUvBYn+Cc3avaeeNKROb91+viMcOc8NHuLplEzl7zH9/mrOSs9aY3rg==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@tannin/sprintf": "^1.3.2",
-				"@wordpress/hooks": "^4.34.0",
+				"@wordpress/hooks": "^4.39.0",
 				"gettext-parser": "^1.3.1",
 				"memize": "^2.1.0",
 				"tannin": "^1.2.0"
@@ -11397,9 +11444,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@wordpress/media-utils/node_modules/@wordpress/base-styles": {
-			"version": "6.10.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-6.10.0.tgz",
-			"integrity": "sha512-Dw/1Om7Kv9YXvN6RaSOmzq2id1MrHZ+rUS2uHNkadeF3Jv+W0Zewl9iCBJarB6Nf72GMkktPwpaRrwhc6zPLIg==",
+			"version": "6.15.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-6.15.0.tgz",
+			"integrity": "sha512-AJ569cP6WqG0/RWx+x7MDNFxnCrZ5Pz1dHCLSE+7B0lLMXh3RGC1+Fj0YIZtUQ2ULLf2I3LRn6kuHdwyWNGiNA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -11408,13 +11455,14 @@
 			}
 		},
 		"node_modules/@wordpress/media-utils/node_modules/@wordpress/components": {
-			"version": "30.7.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-30.7.0.tgz",
-			"integrity": "sha512-LlXjicK7zXnwmFSTnxByVwL+Muh4QGcqunxlBg3+Ni8yLtQyTKb6yS8wGUCE7USGEMOlEX1NYvp6i3DOZk1tiw==",
+			"version": "30.9.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-30.9.0.tgz",
+			"integrity": "sha512-mx0df0TjChmpCtqQn3iFHphqaLQVNk5Yprs+3NJSfm1kWuZPKfVys6AtmhfBgXs/VrrJk34Z+1N+nqXovHuXnw==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@ariakit/react": "^0.4.15",
+				"@date-fns/utc": "^2.1.1",
 				"@emotion/cache": "^11.7.1",
 				"@emotion/css": "^11.7.1",
 				"@emotion/react": "^11.7.1",
@@ -11425,24 +11473,24 @@
 				"@types/gradient-parser": "1.1.0",
 				"@types/highlight-words-core": "1.2.1",
 				"@use-gesture/react": "^10.3.1",
-				"@wordpress/a11y": "^4.34.0",
-				"@wordpress/base-styles": "^6.10.0",
-				"@wordpress/compose": "^7.34.0",
-				"@wordpress/date": "^5.34.0",
-				"@wordpress/deprecated": "^4.34.0",
-				"@wordpress/dom": "^4.34.0",
-				"@wordpress/element": "^6.34.0",
-				"@wordpress/escape-html": "^3.34.0",
-				"@wordpress/hooks": "^4.34.0",
-				"@wordpress/html-entities": "^4.34.0",
-				"@wordpress/i18n": "^6.7.0",
-				"@wordpress/icons": "^11.1.0",
-				"@wordpress/is-shallow-equal": "^5.34.0",
-				"@wordpress/keycodes": "^4.34.0",
-				"@wordpress/primitives": "^4.34.0",
-				"@wordpress/private-apis": "^1.34.0",
-				"@wordpress/rich-text": "^7.34.0",
-				"@wordpress/warning": "^3.34.0",
+				"@wordpress/a11y": "^4.36.0",
+				"@wordpress/base-styles": "^6.12.0",
+				"@wordpress/compose": "^7.36.0",
+				"@wordpress/date": "^5.36.0",
+				"@wordpress/deprecated": "^4.36.0",
+				"@wordpress/dom": "^4.36.0",
+				"@wordpress/element": "^6.36.0",
+				"@wordpress/escape-html": "^3.36.0",
+				"@wordpress/hooks": "^4.36.0",
+				"@wordpress/html-entities": "^4.36.0",
+				"@wordpress/i18n": "^6.9.0",
+				"@wordpress/icons": "^11.3.0",
+				"@wordpress/is-shallow-equal": "^5.36.0",
+				"@wordpress/keycodes": "^4.36.0",
+				"@wordpress/primitives": "^4.36.0",
+				"@wordpress/private-apis": "^1.36.0",
+				"@wordpress/rich-text": "^7.36.0",
+				"@wordpress/warning": "^3.36.0",
 				"change-case": "^4.1.2",
 				"clsx": "^2.1.1",
 				"colord": "^2.7.0",
@@ -11471,14 +11519,14 @@
 			}
 		},
 		"node_modules/@wordpress/media-utils/node_modules/@wordpress/i18n": {
-			"version": "6.7.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.7.0.tgz",
-			"integrity": "sha512-156R15kz17WkFJ0mtoVt9ByFvt4i9zcstFiXC1HjMKr3zV1DZSplvcJeNJTENJBRX8sE+Be0NPevaC8LCodjgw==",
+			"version": "6.12.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.12.0.tgz",
+			"integrity": "sha512-KMleg8p/HtnoX1d/WoRDI51VTZsA4RGNUvBYn+Cc3avaeeNKROb91+viMcOc8NHuLplEzl7zH9/mrOSs9aY3rg==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@tannin/sprintf": "^1.3.2",
-				"@wordpress/hooks": "^4.34.0",
+				"@wordpress/hooks": "^4.39.0",
 				"gettext-parser": "^1.3.1",
 				"memize": "^2.1.0",
 				"tannin": "^1.2.0"
@@ -11492,18 +11540,21 @@
 			}
 		},
 		"node_modules/@wordpress/media-utils/node_modules/@wordpress/icons": {
-			"version": "11.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-11.1.0.tgz",
-			"integrity": "sha512-N61MEoI9dU3fDQu7tdY1/kUSOhERyAnKHcVDWl3KWNFDuNuelnoUCMSckNV4T1Jz/M+2Mkov/J39Mroqo782zQ==",
+			"version": "11.6.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-11.6.0.tgz",
+			"integrity": "sha512-X3Tp3ARJWRokFOTJ1SJQef3J+bykyZHuHL6NSaMnEtbQzs7Tre+3HEghP5S5K/AGnLr+RvpGnwEN0uNy53uIiA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/element": "^6.34.0",
-				"@wordpress/primitives": "^4.34.0"
+				"@wordpress/element": "^6.39.0",
+				"@wordpress/primitives": "^4.39.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
 			}
 		},
 		"node_modules/@wordpress/media-utils/node_modules/gradient-parser": {
@@ -11601,9 +11652,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@wordpress/patterns/node_modules/@wordpress/base-styles": {
-			"version": "6.10.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-6.10.0.tgz",
-			"integrity": "sha512-Dw/1Om7Kv9YXvN6RaSOmzq2id1MrHZ+rUS2uHNkadeF3Jv+W0Zewl9iCBJarB6Nf72GMkktPwpaRrwhc6zPLIg==",
+			"version": "6.15.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-6.15.0.tgz",
+			"integrity": "sha512-AJ569cP6WqG0/RWx+x7MDNFxnCrZ5Pz1dHCLSE+7B0lLMXh3RGC1+Fj0YIZtUQ2ULLf2I3LRn6kuHdwyWNGiNA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -11612,13 +11663,14 @@
 			}
 		},
 		"node_modules/@wordpress/patterns/node_modules/@wordpress/components": {
-			"version": "30.7.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-30.7.0.tgz",
-			"integrity": "sha512-LlXjicK7zXnwmFSTnxByVwL+Muh4QGcqunxlBg3+Ni8yLtQyTKb6yS8wGUCE7USGEMOlEX1NYvp6i3DOZk1tiw==",
+			"version": "30.9.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-30.9.0.tgz",
+			"integrity": "sha512-mx0df0TjChmpCtqQn3iFHphqaLQVNk5Yprs+3NJSfm1kWuZPKfVys6AtmhfBgXs/VrrJk34Z+1N+nqXovHuXnw==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@ariakit/react": "^0.4.15",
+				"@date-fns/utc": "^2.1.1",
 				"@emotion/cache": "^11.7.1",
 				"@emotion/css": "^11.7.1",
 				"@emotion/react": "^11.7.1",
@@ -11629,24 +11681,24 @@
 				"@types/gradient-parser": "1.1.0",
 				"@types/highlight-words-core": "1.2.1",
 				"@use-gesture/react": "^10.3.1",
-				"@wordpress/a11y": "^4.34.0",
-				"@wordpress/base-styles": "^6.10.0",
-				"@wordpress/compose": "^7.34.0",
-				"@wordpress/date": "^5.34.0",
-				"@wordpress/deprecated": "^4.34.0",
-				"@wordpress/dom": "^4.34.0",
-				"@wordpress/element": "^6.34.0",
-				"@wordpress/escape-html": "^3.34.0",
-				"@wordpress/hooks": "^4.34.0",
-				"@wordpress/html-entities": "^4.34.0",
-				"@wordpress/i18n": "^6.7.0",
-				"@wordpress/icons": "^11.1.0",
-				"@wordpress/is-shallow-equal": "^5.34.0",
-				"@wordpress/keycodes": "^4.34.0",
-				"@wordpress/primitives": "^4.34.0",
-				"@wordpress/private-apis": "^1.34.0",
-				"@wordpress/rich-text": "^7.34.0",
-				"@wordpress/warning": "^3.34.0",
+				"@wordpress/a11y": "^4.36.0",
+				"@wordpress/base-styles": "^6.12.0",
+				"@wordpress/compose": "^7.36.0",
+				"@wordpress/date": "^5.36.0",
+				"@wordpress/deprecated": "^4.36.0",
+				"@wordpress/dom": "^4.36.0",
+				"@wordpress/element": "^6.36.0",
+				"@wordpress/escape-html": "^3.36.0",
+				"@wordpress/hooks": "^4.36.0",
+				"@wordpress/html-entities": "^4.36.0",
+				"@wordpress/i18n": "^6.9.0",
+				"@wordpress/icons": "^11.3.0",
+				"@wordpress/is-shallow-equal": "^5.36.0",
+				"@wordpress/keycodes": "^4.36.0",
+				"@wordpress/primitives": "^4.36.0",
+				"@wordpress/private-apis": "^1.36.0",
+				"@wordpress/rich-text": "^7.36.0",
+				"@wordpress/warning": "^3.36.0",
 				"change-case": "^4.1.2",
 				"clsx": "^2.1.1",
 				"colord": "^2.7.0",
@@ -11675,14 +11727,14 @@
 			}
 		},
 		"node_modules/@wordpress/patterns/node_modules/@wordpress/i18n": {
-			"version": "6.7.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.7.0.tgz",
-			"integrity": "sha512-156R15kz17WkFJ0mtoVt9ByFvt4i9zcstFiXC1HjMKr3zV1DZSplvcJeNJTENJBRX8sE+Be0NPevaC8LCodjgw==",
+			"version": "6.12.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.12.0.tgz",
+			"integrity": "sha512-KMleg8p/HtnoX1d/WoRDI51VTZsA4RGNUvBYn+Cc3avaeeNKROb91+viMcOc8NHuLplEzl7zH9/mrOSs9aY3rg==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@tannin/sprintf": "^1.3.2",
-				"@wordpress/hooks": "^4.34.0",
+				"@wordpress/hooks": "^4.39.0",
 				"gettext-parser": "^1.3.1",
 				"memize": "^2.1.0",
 				"tannin": "^1.2.0"
@@ -11696,18 +11748,21 @@
 			}
 		},
 		"node_modules/@wordpress/patterns/node_modules/@wordpress/icons": {
-			"version": "11.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-11.1.0.tgz",
-			"integrity": "sha512-N61MEoI9dU3fDQu7tdY1/kUSOhERyAnKHcVDWl3KWNFDuNuelnoUCMSckNV4T1Jz/M+2Mkov/J39Mroqo782zQ==",
+			"version": "11.6.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-11.6.0.tgz",
+			"integrity": "sha512-X3Tp3ARJWRokFOTJ1SJQef3J+bykyZHuHL6NSaMnEtbQzs7Tre+3HEghP5S5K/AGnLr+RvpGnwEN0uNy53uIiA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/element": "^6.34.0",
-				"@wordpress/primitives": "^4.34.0"
+				"@wordpress/element": "^6.39.0",
+				"@wordpress/primitives": "^4.39.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
 			}
 		},
 		"node_modules/@wordpress/patterns/node_modules/gradient-parser": {
@@ -11766,9 +11821,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@wordpress/plugins/node_modules/@wordpress/base-styles": {
-			"version": "6.10.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-6.10.0.tgz",
-			"integrity": "sha512-Dw/1Om7Kv9YXvN6RaSOmzq2id1MrHZ+rUS2uHNkadeF3Jv+W0Zewl9iCBJarB6Nf72GMkktPwpaRrwhc6zPLIg==",
+			"version": "6.15.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-6.15.0.tgz",
+			"integrity": "sha512-AJ569cP6WqG0/RWx+x7MDNFxnCrZ5Pz1dHCLSE+7B0lLMXh3RGC1+Fj0YIZtUQ2ULLf2I3LRn6kuHdwyWNGiNA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -11777,13 +11832,14 @@
 			}
 		},
 		"node_modules/@wordpress/plugins/node_modules/@wordpress/components": {
-			"version": "30.7.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-30.7.0.tgz",
-			"integrity": "sha512-LlXjicK7zXnwmFSTnxByVwL+Muh4QGcqunxlBg3+Ni8yLtQyTKb6yS8wGUCE7USGEMOlEX1NYvp6i3DOZk1tiw==",
+			"version": "30.9.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-30.9.0.tgz",
+			"integrity": "sha512-mx0df0TjChmpCtqQn3iFHphqaLQVNk5Yprs+3NJSfm1kWuZPKfVys6AtmhfBgXs/VrrJk34Z+1N+nqXovHuXnw==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@ariakit/react": "^0.4.15",
+				"@date-fns/utc": "^2.1.1",
 				"@emotion/cache": "^11.7.1",
 				"@emotion/css": "^11.7.1",
 				"@emotion/react": "^11.7.1",
@@ -11794,24 +11850,24 @@
 				"@types/gradient-parser": "1.1.0",
 				"@types/highlight-words-core": "1.2.1",
 				"@use-gesture/react": "^10.3.1",
-				"@wordpress/a11y": "^4.34.0",
-				"@wordpress/base-styles": "^6.10.0",
-				"@wordpress/compose": "^7.34.0",
-				"@wordpress/date": "^5.34.0",
-				"@wordpress/deprecated": "^4.34.0",
-				"@wordpress/dom": "^4.34.0",
-				"@wordpress/element": "^6.34.0",
-				"@wordpress/escape-html": "^3.34.0",
-				"@wordpress/hooks": "^4.34.0",
-				"@wordpress/html-entities": "^4.34.0",
-				"@wordpress/i18n": "^6.7.0",
-				"@wordpress/icons": "^11.1.0",
-				"@wordpress/is-shallow-equal": "^5.34.0",
-				"@wordpress/keycodes": "^4.34.0",
-				"@wordpress/primitives": "^4.34.0",
-				"@wordpress/private-apis": "^1.34.0",
-				"@wordpress/rich-text": "^7.34.0",
-				"@wordpress/warning": "^3.34.0",
+				"@wordpress/a11y": "^4.36.0",
+				"@wordpress/base-styles": "^6.12.0",
+				"@wordpress/compose": "^7.36.0",
+				"@wordpress/date": "^5.36.0",
+				"@wordpress/deprecated": "^4.36.0",
+				"@wordpress/dom": "^4.36.0",
+				"@wordpress/element": "^6.36.0",
+				"@wordpress/escape-html": "^3.36.0",
+				"@wordpress/hooks": "^4.36.0",
+				"@wordpress/html-entities": "^4.36.0",
+				"@wordpress/i18n": "^6.9.0",
+				"@wordpress/icons": "^11.3.0",
+				"@wordpress/is-shallow-equal": "^5.36.0",
+				"@wordpress/keycodes": "^4.36.0",
+				"@wordpress/primitives": "^4.36.0",
+				"@wordpress/private-apis": "^1.36.0",
+				"@wordpress/rich-text": "^7.36.0",
+				"@wordpress/warning": "^3.36.0",
 				"change-case": "^4.1.2",
 				"clsx": "^2.1.1",
 				"colord": "^2.7.0",
@@ -11840,14 +11896,14 @@
 			}
 		},
 		"node_modules/@wordpress/plugins/node_modules/@wordpress/i18n": {
-			"version": "6.7.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.7.0.tgz",
-			"integrity": "sha512-156R15kz17WkFJ0mtoVt9ByFvt4i9zcstFiXC1HjMKr3zV1DZSplvcJeNJTENJBRX8sE+Be0NPevaC8LCodjgw==",
+			"version": "6.12.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.12.0.tgz",
+			"integrity": "sha512-KMleg8p/HtnoX1d/WoRDI51VTZsA4RGNUvBYn+Cc3avaeeNKROb91+viMcOc8NHuLplEzl7zH9/mrOSs9aY3rg==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@tannin/sprintf": "^1.3.2",
-				"@wordpress/hooks": "^4.34.0",
+				"@wordpress/hooks": "^4.39.0",
 				"gettext-parser": "^1.3.1",
 				"memize": "^2.1.0",
 				"tannin": "^1.2.0"
@@ -11861,18 +11917,21 @@
 			}
 		},
 		"node_modules/@wordpress/plugins/node_modules/@wordpress/icons": {
-			"version": "11.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-11.1.0.tgz",
-			"integrity": "sha512-N61MEoI9dU3fDQu7tdY1/kUSOhERyAnKHcVDWl3KWNFDuNuelnoUCMSckNV4T1Jz/M+2Mkov/J39Mroqo782zQ==",
+			"version": "11.6.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-11.6.0.tgz",
+			"integrity": "sha512-X3Tp3ARJWRokFOTJ1SJQef3J+bykyZHuHL6NSaMnEtbQzs7Tre+3HEghP5S5K/AGnLr+RvpGnwEN0uNy53uIiA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/element": "^6.34.0",
-				"@wordpress/primitives": "^4.34.0"
+				"@wordpress/element": "^6.39.0",
+				"@wordpress/primitives": "^4.39.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
 			}
 		},
 		"node_modules/@wordpress/plugins/node_modules/gradient-parser": {
@@ -11964,9 +12023,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@wordpress/preferences/node_modules/@wordpress/base-styles": {
-			"version": "6.10.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-6.10.0.tgz",
-			"integrity": "sha512-Dw/1Om7Kv9YXvN6RaSOmzq2id1MrHZ+rUS2uHNkadeF3Jv+W0Zewl9iCBJarB6Nf72GMkktPwpaRrwhc6zPLIg==",
+			"version": "6.15.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-6.15.0.tgz",
+			"integrity": "sha512-AJ569cP6WqG0/RWx+x7MDNFxnCrZ5Pz1dHCLSE+7B0lLMXh3RGC1+Fj0YIZtUQ2ULLf2I3LRn6kuHdwyWNGiNA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -11975,13 +12034,14 @@
 			}
 		},
 		"node_modules/@wordpress/preferences/node_modules/@wordpress/components": {
-			"version": "30.7.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-30.7.0.tgz",
-			"integrity": "sha512-LlXjicK7zXnwmFSTnxByVwL+Muh4QGcqunxlBg3+Ni8yLtQyTKb6yS8wGUCE7USGEMOlEX1NYvp6i3DOZk1tiw==",
+			"version": "30.9.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-30.9.0.tgz",
+			"integrity": "sha512-mx0df0TjChmpCtqQn3iFHphqaLQVNk5Yprs+3NJSfm1kWuZPKfVys6AtmhfBgXs/VrrJk34Z+1N+nqXovHuXnw==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@ariakit/react": "^0.4.15",
+				"@date-fns/utc": "^2.1.1",
 				"@emotion/cache": "^11.7.1",
 				"@emotion/css": "^11.7.1",
 				"@emotion/react": "^11.7.1",
@@ -11992,24 +12052,24 @@
 				"@types/gradient-parser": "1.1.0",
 				"@types/highlight-words-core": "1.2.1",
 				"@use-gesture/react": "^10.3.1",
-				"@wordpress/a11y": "^4.34.0",
-				"@wordpress/base-styles": "^6.10.0",
-				"@wordpress/compose": "^7.34.0",
-				"@wordpress/date": "^5.34.0",
-				"@wordpress/deprecated": "^4.34.0",
-				"@wordpress/dom": "^4.34.0",
-				"@wordpress/element": "^6.34.0",
-				"@wordpress/escape-html": "^3.34.0",
-				"@wordpress/hooks": "^4.34.0",
-				"@wordpress/html-entities": "^4.34.0",
-				"@wordpress/i18n": "^6.7.0",
-				"@wordpress/icons": "^11.1.0",
-				"@wordpress/is-shallow-equal": "^5.34.0",
-				"@wordpress/keycodes": "^4.34.0",
-				"@wordpress/primitives": "^4.34.0",
-				"@wordpress/private-apis": "^1.34.0",
-				"@wordpress/rich-text": "^7.34.0",
-				"@wordpress/warning": "^3.34.0",
+				"@wordpress/a11y": "^4.36.0",
+				"@wordpress/base-styles": "^6.12.0",
+				"@wordpress/compose": "^7.36.0",
+				"@wordpress/date": "^5.36.0",
+				"@wordpress/deprecated": "^4.36.0",
+				"@wordpress/dom": "^4.36.0",
+				"@wordpress/element": "^6.36.0",
+				"@wordpress/escape-html": "^3.36.0",
+				"@wordpress/hooks": "^4.36.0",
+				"@wordpress/html-entities": "^4.36.0",
+				"@wordpress/i18n": "^6.9.0",
+				"@wordpress/icons": "^11.3.0",
+				"@wordpress/is-shallow-equal": "^5.36.0",
+				"@wordpress/keycodes": "^4.36.0",
+				"@wordpress/primitives": "^4.36.0",
+				"@wordpress/private-apis": "^1.36.0",
+				"@wordpress/rich-text": "^7.36.0",
+				"@wordpress/warning": "^3.36.0",
 				"change-case": "^4.1.2",
 				"clsx": "^2.1.1",
 				"colord": "^2.7.0",
@@ -12038,14 +12098,14 @@
 			}
 		},
 		"node_modules/@wordpress/preferences/node_modules/@wordpress/i18n": {
-			"version": "6.7.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.7.0.tgz",
-			"integrity": "sha512-156R15kz17WkFJ0mtoVt9ByFvt4i9zcstFiXC1HjMKr3zV1DZSplvcJeNJTENJBRX8sE+Be0NPevaC8LCodjgw==",
+			"version": "6.12.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.12.0.tgz",
+			"integrity": "sha512-KMleg8p/HtnoX1d/WoRDI51VTZsA4RGNUvBYn+Cc3avaeeNKROb91+viMcOc8NHuLplEzl7zH9/mrOSs9aY3rg==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@tannin/sprintf": "^1.3.2",
-				"@wordpress/hooks": "^4.34.0",
+				"@wordpress/hooks": "^4.39.0",
 				"gettext-parser": "^1.3.1",
 				"memize": "^2.1.0",
 				"tannin": "^1.2.0"
@@ -12059,18 +12119,21 @@
 			}
 		},
 		"node_modules/@wordpress/preferences/node_modules/@wordpress/icons": {
-			"version": "11.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-11.1.0.tgz",
-			"integrity": "sha512-N61MEoI9dU3fDQu7tdY1/kUSOhERyAnKHcVDWl3KWNFDuNuelnoUCMSckNV4T1Jz/M+2Mkov/J39Mroqo782zQ==",
+			"version": "11.6.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-11.6.0.tgz",
+			"integrity": "sha512-X3Tp3ARJWRokFOTJ1SJQef3J+bykyZHuHL6NSaMnEtbQzs7Tre+3HEghP5S5K/AGnLr+RvpGnwEN0uNy53uIiA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/element": "^6.34.0",
-				"@wordpress/primitives": "^4.34.0"
+				"@wordpress/element": "^6.39.0",
+				"@wordpress/primitives": "^4.39.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
 			}
 		},
 		"node_modules/@wordpress/preferences/node_modules/gradient-parser": {
@@ -12097,12 +12160,12 @@
 			}
 		},
 		"node_modules/@wordpress/primitives": {
-			"version": "4.34.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.34.0.tgz",
-			"integrity": "sha512-6M/xFse9Da6oC+EZKGGOVCvbX/f5OOw539lyhugnS0sQ+NIWNvvwDh6VW1bCaWQ6uaZDUYbbQeD6Ax97NQuV+w==",
+			"version": "4.39.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.39.0.tgz",
+			"integrity": "sha512-RV9s+KzyuS8p0YKczLecmhFAtOHIWkCToHyDSmRf8N3XOy4id/T0+B5SJ2nMZJleG1oYINf5lrVcccqP2VmFJg==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/element": "^6.34.0",
+				"@wordpress/element": "^6.39.0",
 				"clsx": "^2.1.1"
 			},
 			"engines": {
@@ -12114,9 +12177,9 @@
 			}
 		},
 		"node_modules/@wordpress/priority-queue": {
-			"version": "3.34.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.34.0.tgz",
-			"integrity": "sha512-6qxUP36bvSTvKkxoOhfSPmMZbSt4eCt5diQEugW9LXCuHA6lfWQ2sh1tWWzKpLD9zQCzeYIeVqA1jYHjbO929Q==",
+			"version": "3.39.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.39.0.tgz",
+			"integrity": "sha512-IyiB5y55dIYJZnC5Vl3v2cKuRDR1hYSEA++fijpD4AJZTu+2bhtdN9PnmFE9T25WGzWqnfJEdBSHPglby9MhRA==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"requestidlecallback": "^0.3.0"
@@ -12127,9 +12190,9 @@
 			}
 		},
 		"node_modules/@wordpress/private-apis": {
-			"version": "1.34.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.34.0.tgz",
-			"integrity": "sha512-6AgwgkVZOlXu6kJpQrAtC5WiRfUfxCu/oOKMeN3m8YddJTKj8eRNO7hHfQa0TCOZi7dEEtnnmrREMb0EFIzmPQ==",
+			"version": "1.39.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.39.0.tgz",
+			"integrity": "sha512-ssMAzKtjPV/T1IEFWNSVeaecKG3mhRHYHPMy2Ajh7V8RpOCyYBOZ48kZGyOwd25uzQX5k634tmfW27qJ/SMVQA==",
 			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",
@@ -12137,9 +12200,9 @@
 			}
 		},
 		"node_modules/@wordpress/redux-routine": {
-			"version": "5.34.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.34.0.tgz",
-			"integrity": "sha512-OYODJsho0wwCGrzEutelzBQpWHDS0quwJPGqx4TIWgoBnQtObcPyeqXDMGDJXfAFYP1KT3iE7hsU280EASxpng==",
+			"version": "5.39.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.39.0.tgz",
+			"integrity": "sha512-XvAn9I/rfVWpv9KSKLc24mYqfVHJ4o9PiwcHQb6FyJyeVvCbrHpTFN1iAaXSsBSTCs6mMVKNuZFZv7Sg7c++bg==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"is-plain-object": "^5.0.0",
@@ -12205,9 +12268,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/base-styles": {
-			"version": "6.10.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-6.10.0.tgz",
-			"integrity": "sha512-Dw/1Om7Kv9YXvN6RaSOmzq2id1MrHZ+rUS2uHNkadeF3Jv+W0Zewl9iCBJarB6Nf72GMkktPwpaRrwhc6zPLIg==",
+			"version": "6.15.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-6.15.0.tgz",
+			"integrity": "sha512-AJ569cP6WqG0/RWx+x7MDNFxnCrZ5Pz1dHCLSE+7B0lLMXh3RGC1+Fj0YIZtUQ2ULLf2I3LRn6kuHdwyWNGiNA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -12216,13 +12279,14 @@
 			}
 		},
 		"node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/components": {
-			"version": "30.7.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-30.7.0.tgz",
-			"integrity": "sha512-LlXjicK7zXnwmFSTnxByVwL+Muh4QGcqunxlBg3+Ni8yLtQyTKb6yS8wGUCE7USGEMOlEX1NYvp6i3DOZk1tiw==",
+			"version": "30.9.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-30.9.0.tgz",
+			"integrity": "sha512-mx0df0TjChmpCtqQn3iFHphqaLQVNk5Yprs+3NJSfm1kWuZPKfVys6AtmhfBgXs/VrrJk34Z+1N+nqXovHuXnw==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@ariakit/react": "^0.4.15",
+				"@date-fns/utc": "^2.1.1",
 				"@emotion/cache": "^11.7.1",
 				"@emotion/css": "^11.7.1",
 				"@emotion/react": "^11.7.1",
@@ -12233,24 +12297,24 @@
 				"@types/gradient-parser": "1.1.0",
 				"@types/highlight-words-core": "1.2.1",
 				"@use-gesture/react": "^10.3.1",
-				"@wordpress/a11y": "^4.34.0",
-				"@wordpress/base-styles": "^6.10.0",
-				"@wordpress/compose": "^7.34.0",
-				"@wordpress/date": "^5.34.0",
-				"@wordpress/deprecated": "^4.34.0",
-				"@wordpress/dom": "^4.34.0",
-				"@wordpress/element": "^6.34.0",
-				"@wordpress/escape-html": "^3.34.0",
-				"@wordpress/hooks": "^4.34.0",
-				"@wordpress/html-entities": "^4.34.0",
-				"@wordpress/i18n": "^6.7.0",
-				"@wordpress/icons": "^11.1.0",
-				"@wordpress/is-shallow-equal": "^5.34.0",
-				"@wordpress/keycodes": "^4.34.0",
-				"@wordpress/primitives": "^4.34.0",
-				"@wordpress/private-apis": "^1.34.0",
-				"@wordpress/rich-text": "^7.34.0",
-				"@wordpress/warning": "^3.34.0",
+				"@wordpress/a11y": "^4.36.0",
+				"@wordpress/base-styles": "^6.12.0",
+				"@wordpress/compose": "^7.36.0",
+				"@wordpress/date": "^5.36.0",
+				"@wordpress/deprecated": "^4.36.0",
+				"@wordpress/dom": "^4.36.0",
+				"@wordpress/element": "^6.36.0",
+				"@wordpress/escape-html": "^3.36.0",
+				"@wordpress/hooks": "^4.36.0",
+				"@wordpress/html-entities": "^4.36.0",
+				"@wordpress/i18n": "^6.9.0",
+				"@wordpress/icons": "^11.3.0",
+				"@wordpress/is-shallow-equal": "^5.36.0",
+				"@wordpress/keycodes": "^4.36.0",
+				"@wordpress/primitives": "^4.36.0",
+				"@wordpress/private-apis": "^1.36.0",
+				"@wordpress/rich-text": "^7.36.0",
+				"@wordpress/warning": "^3.36.0",
 				"change-case": "^4.1.2",
 				"clsx": "^2.1.1",
 				"colord": "^2.7.0",
@@ -12279,14 +12343,14 @@
 			}
 		},
 		"node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/i18n": {
-			"version": "6.7.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.7.0.tgz",
-			"integrity": "sha512-156R15kz17WkFJ0mtoVt9ByFvt4i9zcstFiXC1HjMKr3zV1DZSplvcJeNJTENJBRX8sE+Be0NPevaC8LCodjgw==",
+			"version": "6.12.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.12.0.tgz",
+			"integrity": "sha512-KMleg8p/HtnoX1d/WoRDI51VTZsA4RGNUvBYn+Cc3avaeeNKROb91+viMcOc8NHuLplEzl7zH9/mrOSs9aY3rg==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@tannin/sprintf": "^1.3.2",
-				"@wordpress/hooks": "^4.34.0",
+				"@wordpress/hooks": "^4.39.0",
 				"gettext-parser": "^1.3.1",
 				"memize": "^2.1.0",
 				"tannin": "^1.2.0"
@@ -12300,18 +12364,21 @@
 			}
 		},
 		"node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/icons": {
-			"version": "11.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-11.1.0.tgz",
-			"integrity": "sha512-N61MEoI9dU3fDQu7tdY1/kUSOhERyAnKHcVDWl3KWNFDuNuelnoUCMSckNV4T1Jz/M+2Mkov/J39Mroqo782zQ==",
+			"version": "11.6.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-11.6.0.tgz",
+			"integrity": "sha512-X3Tp3ARJWRokFOTJ1SJQef3J+bykyZHuHL6NSaMnEtbQzs7Tre+3HEghP5S5K/AGnLr+RvpGnwEN0uNy53uIiA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/element": "^6.34.0",
-				"@wordpress/primitives": "^4.34.0"
+				"@wordpress/element": "^6.39.0",
+				"@wordpress/primitives": "^4.39.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
 			}
 		},
 		"node_modules/@wordpress/reusable-blocks/node_modules/gradient-parser": {
@@ -12324,19 +12391,20 @@
 			}
 		},
 		"node_modules/@wordpress/rich-text": {
-			"version": "7.34.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-7.34.0.tgz",
-			"integrity": "sha512-zlzrxCFrUjG4wBrEhK7CNXc8vk5Ynq5GE/BC4dXJtk+/EgFNaFtZmusJdHnJSJx46WPeBcDjZk4W7ozAbXzaiA==",
+			"version": "7.39.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-7.39.0.tgz",
+			"integrity": "sha512-4wpQyyaZ9vmInRk0oiBpPFmLtGn6w+ejrQvaCeDeOAeA+IYdEvrTMEbGp7NhYZ9llZvEqEQ8/yNcoAczE4DLSg==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/a11y": "^4.34.0",
-				"@wordpress/compose": "^7.34.0",
-				"@wordpress/data": "^10.34.0",
-				"@wordpress/deprecated": "^4.34.0",
-				"@wordpress/element": "^6.34.0",
-				"@wordpress/escape-html": "^3.34.0",
-				"@wordpress/i18n": "^6.7.0",
-				"@wordpress/keycodes": "^4.34.0",
+				"@wordpress/a11y": "^4.39.0",
+				"@wordpress/compose": "^7.39.0",
+				"@wordpress/data": "^10.39.0",
+				"@wordpress/deprecated": "^4.39.0",
+				"@wordpress/dom": "^4.39.0",
+				"@wordpress/element": "^6.39.0",
+				"@wordpress/escape-html": "^3.39.0",
+				"@wordpress/i18n": "^6.12.0",
+				"@wordpress/keycodes": "^4.39.0",
 				"colord": "2.9.3",
 				"memize": "^2.1.0"
 			},
@@ -12349,13 +12417,13 @@
 			}
 		},
 		"node_modules/@wordpress/rich-text/node_modules/@wordpress/i18n": {
-			"version": "6.7.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.7.0.tgz",
-			"integrity": "sha512-156R15kz17WkFJ0mtoVt9ByFvt4i9zcstFiXC1HjMKr3zV1DZSplvcJeNJTENJBRX8sE+Be0NPevaC8LCodjgw==",
+			"version": "6.12.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.12.0.tgz",
+			"integrity": "sha512-KMleg8p/HtnoX1d/WoRDI51VTZsA4RGNUvBYn+Cc3avaeeNKROb91+viMcOc8NHuLplEzl7zH9/mrOSs9aY3rg==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@tannin/sprintf": "^1.3.2",
-				"@wordpress/hooks": "^4.34.0",
+				"@wordpress/hooks": "^4.39.0",
 				"gettext-parser": "^1.3.1",
 				"memize": "^2.1.0",
 				"tannin": "^1.2.0"
@@ -12595,9 +12663,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@wordpress/server-side-render/node_modules/@wordpress/base-styles": {
-			"version": "6.10.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-6.10.0.tgz",
-			"integrity": "sha512-Dw/1Om7Kv9YXvN6RaSOmzq2id1MrHZ+rUS2uHNkadeF3Jv+W0Zewl9iCBJarB6Nf72GMkktPwpaRrwhc6zPLIg==",
+			"version": "6.15.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-6.15.0.tgz",
+			"integrity": "sha512-AJ569cP6WqG0/RWx+x7MDNFxnCrZ5Pz1dHCLSE+7B0lLMXh3RGC1+Fj0YIZtUQ2ULLf2I3LRn6kuHdwyWNGiNA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -12606,13 +12674,14 @@
 			}
 		},
 		"node_modules/@wordpress/server-side-render/node_modules/@wordpress/components": {
-			"version": "30.7.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-30.7.0.tgz",
-			"integrity": "sha512-LlXjicK7zXnwmFSTnxByVwL+Muh4QGcqunxlBg3+Ni8yLtQyTKb6yS8wGUCE7USGEMOlEX1NYvp6i3DOZk1tiw==",
+			"version": "30.9.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-30.9.0.tgz",
+			"integrity": "sha512-mx0df0TjChmpCtqQn3iFHphqaLQVNk5Yprs+3NJSfm1kWuZPKfVys6AtmhfBgXs/VrrJk34Z+1N+nqXovHuXnw==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@ariakit/react": "^0.4.15",
+				"@date-fns/utc": "^2.1.1",
 				"@emotion/cache": "^11.7.1",
 				"@emotion/css": "^11.7.1",
 				"@emotion/react": "^11.7.1",
@@ -12623,24 +12692,24 @@
 				"@types/gradient-parser": "1.1.0",
 				"@types/highlight-words-core": "1.2.1",
 				"@use-gesture/react": "^10.3.1",
-				"@wordpress/a11y": "^4.34.0",
-				"@wordpress/base-styles": "^6.10.0",
-				"@wordpress/compose": "^7.34.0",
-				"@wordpress/date": "^5.34.0",
-				"@wordpress/deprecated": "^4.34.0",
-				"@wordpress/dom": "^4.34.0",
-				"@wordpress/element": "^6.34.0",
-				"@wordpress/escape-html": "^3.34.0",
-				"@wordpress/hooks": "^4.34.0",
-				"@wordpress/html-entities": "^4.34.0",
-				"@wordpress/i18n": "^6.7.0",
-				"@wordpress/icons": "^11.1.0",
-				"@wordpress/is-shallow-equal": "^5.34.0",
-				"@wordpress/keycodes": "^4.34.0",
-				"@wordpress/primitives": "^4.34.0",
-				"@wordpress/private-apis": "^1.34.0",
-				"@wordpress/rich-text": "^7.34.0",
-				"@wordpress/warning": "^3.34.0",
+				"@wordpress/a11y": "^4.36.0",
+				"@wordpress/base-styles": "^6.12.0",
+				"@wordpress/compose": "^7.36.0",
+				"@wordpress/date": "^5.36.0",
+				"@wordpress/deprecated": "^4.36.0",
+				"@wordpress/dom": "^4.36.0",
+				"@wordpress/element": "^6.36.0",
+				"@wordpress/escape-html": "^3.36.0",
+				"@wordpress/hooks": "^4.36.0",
+				"@wordpress/html-entities": "^4.36.0",
+				"@wordpress/i18n": "^6.9.0",
+				"@wordpress/icons": "^11.3.0",
+				"@wordpress/is-shallow-equal": "^5.36.0",
+				"@wordpress/keycodes": "^4.36.0",
+				"@wordpress/primitives": "^4.36.0",
+				"@wordpress/private-apis": "^1.36.0",
+				"@wordpress/rich-text": "^7.36.0",
+				"@wordpress/warning": "^3.36.0",
 				"change-case": "^4.1.2",
 				"clsx": "^2.1.1",
 				"colord": "^2.7.0",
@@ -12669,14 +12738,14 @@
 			}
 		},
 		"node_modules/@wordpress/server-side-render/node_modules/@wordpress/i18n": {
-			"version": "6.7.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.7.0.tgz",
-			"integrity": "sha512-156R15kz17WkFJ0mtoVt9ByFvt4i9zcstFiXC1HjMKr3zV1DZSplvcJeNJTENJBRX8sE+Be0NPevaC8LCodjgw==",
+			"version": "6.12.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.12.0.tgz",
+			"integrity": "sha512-KMleg8p/HtnoX1d/WoRDI51VTZsA4RGNUvBYn+Cc3avaeeNKROb91+viMcOc8NHuLplEzl7zH9/mrOSs9aY3rg==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@tannin/sprintf": "^1.3.2",
-				"@wordpress/hooks": "^4.34.0",
+				"@wordpress/hooks": "^4.39.0",
 				"gettext-parser": "^1.3.1",
 				"memize": "^2.1.0",
 				"tannin": "^1.2.0"
@@ -12690,18 +12759,21 @@
 			}
 		},
 		"node_modules/@wordpress/server-side-render/node_modules/@wordpress/icons": {
-			"version": "11.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-11.1.0.tgz",
-			"integrity": "sha512-N61MEoI9dU3fDQu7tdY1/kUSOhERyAnKHcVDWl3KWNFDuNuelnoUCMSckNV4T1Jz/M+2Mkov/J39Mroqo782zQ==",
+			"version": "11.6.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-11.6.0.tgz",
+			"integrity": "sha512-X3Tp3ARJWRokFOTJ1SJQef3J+bykyZHuHL6NSaMnEtbQzs7Tre+3HEghP5S5K/AGnLr+RvpGnwEN0uNy53uIiA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/element": "^6.34.0",
-				"@wordpress/primitives": "^4.34.0"
+				"@wordpress/element": "^6.39.0",
+				"@wordpress/primitives": "^4.39.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
 			}
 		},
 		"node_modules/@wordpress/server-side-render/node_modules/gradient-parser": {
@@ -12796,12 +12868,12 @@
 			}
 		},
 		"node_modules/@wordpress/undo-manager": {
-			"version": "1.34.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-1.34.0.tgz",
-			"integrity": "sha512-NQ/LGpaFoEYCKA0Uyg7RO04wx1MF27Jdv2S2tS81sFUO2/L0FJKyW1AQptx7SGEMIxgH9Sn4XIOdsQmLE4nGww==",
+			"version": "1.39.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-1.39.0.tgz",
+			"integrity": "sha512-LcCqVZk3K6tltAuUB1gXyo7lAbS48WP/RsRLrm4GBchY+kQwUT+kme30zCrRfsEJJaYCtfcGo1POIgda/HwHpw==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/is-shallow-equal": "^5.34.0"
+				"@wordpress/is-shallow-equal": "^5.39.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -12890,9 +12962,9 @@
 			}
 		},
 		"node_modules/@wordpress/warning": {
-			"version": "3.34.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.34.0.tgz",
-			"integrity": "sha512-WemuVXjaekzCDsWbDPj/RZSy44mIjPIy35DaoJgfLcgkXMH2GRBRSomhZMkWyGatD39vdXm0nqe95LsLDqrwCg==",
+			"version": "3.39.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.39.0.tgz",
+			"integrity": "sha512-NV2WoU4XxTqZU/3k2D5m5cHIw/uM2dlDgW5u1U5fmFIYLGg43WWMlSHQEu6F4tm7fqFt7k4qwT/FymucqHYp7Q==",
 			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",
@@ -12951,9 +13023,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@wordpress/widgets/node_modules/@wordpress/base-styles": {
-			"version": "6.10.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-6.10.0.tgz",
-			"integrity": "sha512-Dw/1Om7Kv9YXvN6RaSOmzq2id1MrHZ+rUS2uHNkadeF3Jv+W0Zewl9iCBJarB6Nf72GMkktPwpaRrwhc6zPLIg==",
+			"version": "6.15.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-6.15.0.tgz",
+			"integrity": "sha512-AJ569cP6WqG0/RWx+x7MDNFxnCrZ5Pz1dHCLSE+7B0lLMXh3RGC1+Fj0YIZtUQ2ULLf2I3LRn6kuHdwyWNGiNA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -12962,13 +13034,14 @@
 			}
 		},
 		"node_modules/@wordpress/widgets/node_modules/@wordpress/components": {
-			"version": "30.7.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-30.7.0.tgz",
-			"integrity": "sha512-LlXjicK7zXnwmFSTnxByVwL+Muh4QGcqunxlBg3+Ni8yLtQyTKb6yS8wGUCE7USGEMOlEX1NYvp6i3DOZk1tiw==",
+			"version": "30.9.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-30.9.0.tgz",
+			"integrity": "sha512-mx0df0TjChmpCtqQn3iFHphqaLQVNk5Yprs+3NJSfm1kWuZPKfVys6AtmhfBgXs/VrrJk34Z+1N+nqXovHuXnw==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@ariakit/react": "^0.4.15",
+				"@date-fns/utc": "^2.1.1",
 				"@emotion/cache": "^11.7.1",
 				"@emotion/css": "^11.7.1",
 				"@emotion/react": "^11.7.1",
@@ -12979,24 +13052,24 @@
 				"@types/gradient-parser": "1.1.0",
 				"@types/highlight-words-core": "1.2.1",
 				"@use-gesture/react": "^10.3.1",
-				"@wordpress/a11y": "^4.34.0",
-				"@wordpress/base-styles": "^6.10.0",
-				"@wordpress/compose": "^7.34.0",
-				"@wordpress/date": "^5.34.0",
-				"@wordpress/deprecated": "^4.34.0",
-				"@wordpress/dom": "^4.34.0",
-				"@wordpress/element": "^6.34.0",
-				"@wordpress/escape-html": "^3.34.0",
-				"@wordpress/hooks": "^4.34.0",
-				"@wordpress/html-entities": "^4.34.0",
-				"@wordpress/i18n": "^6.7.0",
-				"@wordpress/icons": "^11.1.0",
-				"@wordpress/is-shallow-equal": "^5.34.0",
-				"@wordpress/keycodes": "^4.34.0",
-				"@wordpress/primitives": "^4.34.0",
-				"@wordpress/private-apis": "^1.34.0",
-				"@wordpress/rich-text": "^7.34.0",
-				"@wordpress/warning": "^3.34.0",
+				"@wordpress/a11y": "^4.36.0",
+				"@wordpress/base-styles": "^6.12.0",
+				"@wordpress/compose": "^7.36.0",
+				"@wordpress/date": "^5.36.0",
+				"@wordpress/deprecated": "^4.36.0",
+				"@wordpress/dom": "^4.36.0",
+				"@wordpress/element": "^6.36.0",
+				"@wordpress/escape-html": "^3.36.0",
+				"@wordpress/hooks": "^4.36.0",
+				"@wordpress/html-entities": "^4.36.0",
+				"@wordpress/i18n": "^6.9.0",
+				"@wordpress/icons": "^11.3.0",
+				"@wordpress/is-shallow-equal": "^5.36.0",
+				"@wordpress/keycodes": "^4.36.0",
+				"@wordpress/primitives": "^4.36.0",
+				"@wordpress/private-apis": "^1.36.0",
+				"@wordpress/rich-text": "^7.36.0",
+				"@wordpress/warning": "^3.36.0",
 				"change-case": "^4.1.2",
 				"clsx": "^2.1.1",
 				"colord": "^2.7.0",
@@ -13025,14 +13098,14 @@
 			}
 		},
 		"node_modules/@wordpress/widgets/node_modules/@wordpress/i18n": {
-			"version": "6.7.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.7.0.tgz",
-			"integrity": "sha512-156R15kz17WkFJ0mtoVt9ByFvt4i9zcstFiXC1HjMKr3zV1DZSplvcJeNJTENJBRX8sE+Be0NPevaC8LCodjgw==",
+			"version": "6.12.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.12.0.tgz",
+			"integrity": "sha512-KMleg8p/HtnoX1d/WoRDI51VTZsA4RGNUvBYn+Cc3avaeeNKROb91+viMcOc8NHuLplEzl7zH9/mrOSs9aY3rg==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@tannin/sprintf": "^1.3.2",
-				"@wordpress/hooks": "^4.34.0",
+				"@wordpress/hooks": "^4.39.0",
 				"gettext-parser": "^1.3.1",
 				"memize": "^2.1.0",
 				"tannin": "^1.2.0"
@@ -13046,18 +13119,21 @@
 			}
 		},
 		"node_modules/@wordpress/widgets/node_modules/@wordpress/icons": {
-			"version": "11.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-11.1.0.tgz",
-			"integrity": "sha512-N61MEoI9dU3fDQu7tdY1/kUSOhERyAnKHcVDWl3KWNFDuNuelnoUCMSckNV4T1Jz/M+2Mkov/J39Mroqo782zQ==",
+			"version": "11.6.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-11.6.0.tgz",
+			"integrity": "sha512-X3Tp3ARJWRokFOTJ1SJQef3J+bykyZHuHL6NSaMnEtbQzs7Tre+3HEghP5S5K/AGnLr+RvpGnwEN0uNy53uIiA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/element": "^6.34.0",
-				"@wordpress/primitives": "^4.34.0"
+				"@wordpress/element": "^6.39.0",
+				"@wordpress/primitives": "^4.39.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
 			}
 		},
 		"node_modules/@wordpress/widgets/node_modules/gradient-parser": {
@@ -16119,9 +16195,9 @@
 			"license": "MIT"
 		},
 		"node_modules/csstype": {
-			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-			"integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+			"version": "3.2.3",
+			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+			"integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
 			"license": "MIT"
 		},
 		"node_modules/cwd": {
@@ -25371,9 +25447,9 @@
 			}
 		},
 		"node_modules/newspack-scripts/node_modules/@wordpress/base-styles": {
-			"version": "6.10.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-6.10.0.tgz",
-			"integrity": "sha512-Dw/1Om7Kv9YXvN6RaSOmzq2id1MrHZ+rUS2uHNkadeF3Jv+W0Zewl9iCBJarB6Nf72GMkktPwpaRrwhc6zPLIg==",
+			"version": "6.15.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-6.15.0.tgz",
+			"integrity": "sha512-AJ569cP6WqG0/RWx+x7MDNFxnCrZ5Pz1dHCLSE+7B0lLMXh3RGC1+Fj0YIZtUQ2ULLf2I3LRn6kuHdwyWNGiNA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -25382,13 +25458,14 @@
 			}
 		},
 		"node_modules/newspack-scripts/node_modules/@wordpress/components": {
-			"version": "30.7.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-30.7.0.tgz",
-			"integrity": "sha512-LlXjicK7zXnwmFSTnxByVwL+Muh4QGcqunxlBg3+Ni8yLtQyTKb6yS8wGUCE7USGEMOlEX1NYvp6i3DOZk1tiw==",
+			"version": "30.9.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-30.9.0.tgz",
+			"integrity": "sha512-mx0df0TjChmpCtqQn3iFHphqaLQVNk5Yprs+3NJSfm1kWuZPKfVys6AtmhfBgXs/VrrJk34Z+1N+nqXovHuXnw==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@ariakit/react": "^0.4.15",
+				"@date-fns/utc": "^2.1.1",
 				"@emotion/cache": "^11.7.1",
 				"@emotion/css": "^11.7.1",
 				"@emotion/react": "^11.7.1",
@@ -25399,24 +25476,24 @@
 				"@types/gradient-parser": "1.1.0",
 				"@types/highlight-words-core": "1.2.1",
 				"@use-gesture/react": "^10.3.1",
-				"@wordpress/a11y": "^4.34.0",
-				"@wordpress/base-styles": "^6.10.0",
-				"@wordpress/compose": "^7.34.0",
-				"@wordpress/date": "^5.34.0",
-				"@wordpress/deprecated": "^4.34.0",
-				"@wordpress/dom": "^4.34.0",
-				"@wordpress/element": "^6.34.0",
-				"@wordpress/escape-html": "^3.34.0",
-				"@wordpress/hooks": "^4.34.0",
-				"@wordpress/html-entities": "^4.34.0",
-				"@wordpress/i18n": "^6.7.0",
-				"@wordpress/icons": "^11.1.0",
-				"@wordpress/is-shallow-equal": "^5.34.0",
-				"@wordpress/keycodes": "^4.34.0",
-				"@wordpress/primitives": "^4.34.0",
-				"@wordpress/private-apis": "^1.34.0",
-				"@wordpress/rich-text": "^7.34.0",
-				"@wordpress/warning": "^3.34.0",
+				"@wordpress/a11y": "^4.36.0",
+				"@wordpress/base-styles": "^6.12.0",
+				"@wordpress/compose": "^7.36.0",
+				"@wordpress/date": "^5.36.0",
+				"@wordpress/deprecated": "^4.36.0",
+				"@wordpress/dom": "^4.36.0",
+				"@wordpress/element": "^6.36.0",
+				"@wordpress/escape-html": "^3.36.0",
+				"@wordpress/hooks": "^4.36.0",
+				"@wordpress/html-entities": "^4.36.0",
+				"@wordpress/i18n": "^6.9.0",
+				"@wordpress/icons": "^11.3.0",
+				"@wordpress/is-shallow-equal": "^5.36.0",
+				"@wordpress/keycodes": "^4.36.0",
+				"@wordpress/primitives": "^4.36.0",
+				"@wordpress/private-apis": "^1.36.0",
+				"@wordpress/rich-text": "^7.36.0",
+				"@wordpress/warning": "^3.36.0",
 				"change-case": "^4.1.2",
 				"clsx": "^2.1.1",
 				"colord": "^2.7.0",
@@ -25445,14 +25522,14 @@
 			}
 		},
 		"node_modules/newspack-scripts/node_modules/@wordpress/i18n": {
-			"version": "6.7.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.7.0.tgz",
-			"integrity": "sha512-156R15kz17WkFJ0mtoVt9ByFvt4i9zcstFiXC1HjMKr3zV1DZSplvcJeNJTENJBRX8sE+Be0NPevaC8LCodjgw==",
+			"version": "6.12.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.12.0.tgz",
+			"integrity": "sha512-KMleg8p/HtnoX1d/WoRDI51VTZsA4RGNUvBYn+Cc3avaeeNKROb91+viMcOc8NHuLplEzl7zH9/mrOSs9aY3rg==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@tannin/sprintf": "^1.3.2",
-				"@wordpress/hooks": "^4.34.0",
+				"@wordpress/hooks": "^4.39.0",
 				"gettext-parser": "^1.3.1",
 				"memize": "^2.1.0",
 				"tannin": "^1.2.0"
@@ -25466,18 +25543,21 @@
 			}
 		},
 		"node_modules/newspack-scripts/node_modules/@wordpress/icons": {
-			"version": "11.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-11.1.0.tgz",
-			"integrity": "sha512-N61MEoI9dU3fDQu7tdY1/kUSOhERyAnKHcVDWl3KWNFDuNuelnoUCMSckNV4T1Jz/M+2Mkov/J39Mroqo782zQ==",
+			"version": "11.6.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-11.6.0.tgz",
+			"integrity": "sha512-X3Tp3ARJWRokFOTJ1SJQef3J+bykyZHuHL6NSaMnEtbQzs7Tre+3HEghP5S5K/AGnLr+RvpGnwEN0uNy53uIiA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/element": "^6.34.0",
-				"@wordpress/primitives": "^4.34.0"
+				"@wordpress/element": "^6.39.0",
+				"@wordpress/primitives": "^4.39.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
 			}
 		},
 		"node_modules/newspack-scripts/node_modules/gradient-parser": {

--- a/src/editor/AdvancedSidebar.js
+++ b/src/editor/AdvancedSidebar.js
@@ -6,53 +6,52 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Fragment } from '@wordpress/element';
-import { BaseControl } from '@wordpress/components';
+import { TextControl } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
-import { CategoryAutocomplete, TextControl } from 'newspack-components';
+import { CategoryAutocomplete } from 'newspack-components';
 
 const AdvancedSidebar = ( { onMetaFieldChange, excluded_categories = [], excluded_tags = [], additional_classes = '' } ) => {
 	return (
-		<Fragment>
-			<BaseControl>
-				<TextControl
-					label={ __( 'Additional CSS class(es)', 'newspack-popups' ) }
-					help={ __( 'Separate multiple classes with spaces.', 'newspack-popups' ) }
-					value={ additional_classes }
-					onChange={ value =>
-						onMetaFieldChange( {
-							additional_classes: value,
-						} )
-					}
-				/>
-				<hr />
-				<CategoryAutocomplete
-					label={ __( 'Excluded Categories', 'newspack-popups' ) }
-					description={ __( 'The prompt will not be shown on posts that have any these categories.', 'newspack-popups' ) }
-					value={ excluded_categories }
-					onChange={ tokens =>
-						onMetaFieldChange( {
-							excluded_categories: tokens.map( token => parseInt( token.id ) ),
-						} )
-					}
-				/>
-				<hr />
-				<CategoryAutocomplete
-					label={ __( 'Excluded Tags', 'newspack-popups' ) }
-					description={ __( 'The prompt will not be shown on posts that have any these tags.', 'newspack-popups' ) }
-					taxonomy="tags"
-					value={ excluded_tags }
-					onChange={ tokens =>
-						onMetaFieldChange( {
-							excluded_tags: tokens.map( token => parseInt( token.id ) ),
-						} )
-					}
-				/>
-			</BaseControl>
-		</Fragment>
+		<>
+			<TextControl
+				__next40pxDefaultSize
+				label={ __( 'Additional CSS class(es)', 'newspack-popups' ) }
+				help={ __( 'Separate multiple classes with spaces.', 'newspack-popups' ) }
+				value={ additional_classes }
+				onChange={ value =>
+					onMetaFieldChange( {
+						additional_classes: value,
+					} )
+				}
+			/>
+			<CategoryAutocomplete
+				__next40pxDefaultSize
+				label={ __( 'Excluded Categories', 'newspack-popups' ) }
+				description={ __( 'The prompt will not be shown on posts that have any these categories.', 'newspack-popups' ) }
+				value={ excluded_categories }
+				onChange={ tokens =>
+					onMetaFieldChange( {
+						excluded_categories: tokens.map( token => parseInt( token.id ) ),
+					} )
+				}
+			/>
+			<div style={ { paddingTop: '16px' } } />
+			<CategoryAutocomplete
+				__next40pxDefaultSize
+				label={ __( 'Excluded Tags', 'newspack-popups' ) }
+				description={ __( 'The prompt will not be shown on posts that have any these tags.', 'newspack-popups' ) }
+				taxonomy="tags"
+				value={ excluded_tags }
+				onChange={ tokens =>
+					onMetaFieldChange( {
+						excluded_tags: tokens.map( token => parseInt( token.id ) ),
+					} )
+				}
+			/>
+		</>
 	);
 };
 

--- a/src/editor/DocumentSidebarWithTabs.js
+++ b/src/editor/DocumentSidebarWithTabs.js
@@ -1,0 +1,43 @@
+/**
+ * Single document panel with Settings and Styles tabs.
+ * Panels with group="styles" render under the Styles tab; others under Settings.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { cog, styles } from '@wordpress/icons';
+import { TabPanel, PanelBody } from '@wordpress/components';
+
+const NEWSPACK_POPUPS_TABS_CLASS = 'newspack-popups__tabs';
+
+const DocumentSidebarWithTabs = ( { panels } ) => {
+	const settingsPanels = panels.filter( p => p.group !== 'styles' );
+	const stylesPanels = panels.filter( p => p.group === 'styles' );
+
+	return (
+		<TabPanel
+			className={ NEWSPACK_POPUPS_TABS_CLASS }
+			tabs={ [
+				{ name: 'settings', title: __( 'Settings', 'newspack-popups' ), icon: cog, className: 'newspack-popups__tab-settings' },
+				{ name: 'styles', title: __( 'Styles', 'newspack-popups' ), icon: styles, className: 'newspack-popups__tab-styles' },
+			] }
+		>
+			{ tab => {
+				const items = tab.name === 'settings' ? settingsPanels : stylesPanels;
+				return (
+					<div className={ `${ NEWSPACK_POPUPS_TABS_CLASS }__tab-content` }>
+						{ items.map( ( { name, title, Component, initialOpen = true } ) => (
+							<PanelBody key={ name } title={ title } initialOpen={ initialOpen }>
+								<Component />
+							</PanelBody>
+						) ) }
+					</div>
+				);
+			} }
+		</TabPanel>
+	);
+};
+
+export default DocumentSidebarWithTabs;

--- a/src/editor/FrequencySidebar.js
+++ b/src/editor/FrequencySidebar.js
@@ -123,20 +123,20 @@ const FrequencySidebar = ( {
 					/>
 				</>
 			) }
-			<div style={ { marginTop: '16px', marginBottom: '-12px' } }>
-				<TextControl
-					__next40pxDefaultSize
-					__nextNoMarginBottom
-					label={ __( 'UTM Suppression', 'newspack-popups' ) }
-					help={ __(
-						'Readers arriving at the site via URLs with this utm_source parameter will never be shown the prompt.',
-						'newspack-popups'
-					) }
-					value={ utm_suppression }
-					placeholder={ __( 'utm_campaign_name', 'newspack-popups' ) }
-					onChange={ value => onMetaFieldChange( { utm_suppression: value } ) }
-				/>
-			</div>
+			<div style={ { paddingTop: '8px' } } />
+			<TextControl
+				__next40pxDefaultSize
+				__nextNoMarginBottom
+				label={ __( 'UTM Suppression', 'newspack-popups' ) }
+				help={ __(
+					'Readers arriving at the site via URLs with this utm_source parameter will never be shown the prompt.',
+					'newspack-popups'
+				) }
+				value={ utm_suppression }
+				placeholder={ __( 'utm_campaign_name', 'newspack-popups' ) }
+				onChange={ value => onMetaFieldChange( { utm_suppression: value } ) }
+			/>
+			<div style={ { marginBottom: '-12px' } } />
 		</>
 	);
 };

--- a/src/editor/FrequencySidebar.js
+++ b/src/editor/FrequencySidebar.js
@@ -6,7 +6,6 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Fragment } from '@wordpress/element';
 import {
 	SelectControl,
 	TextControl,
@@ -36,9 +35,10 @@ const FrequencySidebar = ( {
 	utm_suppression,
 } ) => {
 	return (
-		<Fragment>
+		<>
 			<SelectControl
-				label={ __( 'Frequency' ) }
+				__next40pxDefaultSize
+				label={ __( 'Frequency', 'newspack-popups' ) }
 				value={ frequency }
 				onChange={ value => {
 					const metaToUpdate = {
@@ -101,6 +101,7 @@ const FrequencySidebar = ( {
 					/>
 					{ 0 < frequency_max && (
 						<NumberControl
+							__next40pxDefaultSize
 							className="newspack-popups__frequency-number-control"
 							disabled={ 0 === frequency_max }
 							label={ __( 'Max number of displays', 'newspack-popups' ) }
@@ -110,6 +111,7 @@ const FrequencySidebar = ( {
 						/>
 					) }
 					<SelectControl
+						__next40pxDefaultSize
 						label={ __( 'Reset counter per:', 'newspack-popups' ) }
 						value={ frequency_reset }
 						options={ [
@@ -121,15 +123,21 @@ const FrequencySidebar = ( {
 					/>
 				</>
 			) }
-			<hr />
-			<TextControl
-				label={ __( 'UTM Suppression' ) }
-				help={ __( 'Readers arriving at the site via URLs with this utm_source parameter will never be shown the prompt.' ) }
-				value={ utm_suppression }
-				placeholder={ __( 'utm_campaign_name', 'newspack' ) }
-				onChange={ value => onMetaFieldChange( { utm_suppression: value } ) }
-			/>
-		</Fragment>
+			<div style={ { marginTop: '16px', marginBottom: '-12px' } }>
+				<TextControl
+					__next40pxDefaultSize
+					__nextNoMarginBottom
+					label={ __( 'UTM Suppression', 'newspack-popups' ) }
+					help={ __(
+						'Readers arriving at the site via URLs with this utm_source parameter will never be shown the prompt.',
+						'newspack-popups'
+					) }
+					value={ utm_suppression }
+					placeholder={ __( 'utm_campaign_name', 'newspack-popups' ) }
+					onChange={ value => onMetaFieldChange( { utm_suppression: value } ) }
+				/>
+			</div>
+		</>
 	);
 };
 

--- a/src/editor/PositionPlacementControl.js
+++ b/src/editor/PositionPlacementControl.js
@@ -81,8 +81,18 @@ const PositionPlacementControl = ( { layout, label, help, onChange, size, ...pro
 			  ];
 	return (
 		<div className={ classnames( 'newspack-popups-css-grid-selector', 'size-' + size ) }>
-			<p className="components-base-control__label">{ label }</p>
-			<ButtonGroup aria-label={ __( 'Select Position', 'newspack-popups' ) } { ...props }>
+			<p
+				className="components-base-control__label"
+				style={ {
+					fontSize: '11px',
+					fontWeight: 500,
+					lineHeight: 1.4,
+					textTransform: 'uppercase',
+				} }
+			>
+				{ label }
+			</p>
+			<ButtonGroup aria-label={ __( 'Select position', 'newspack-popups' ) } { ...props }>
 				{ layoutOptions.map( ( { label: layoutLabel, value }, index ) => {
 					return (
 						<Tooltip text={ layoutLabel } key={ `grid-tooltip-${ index }` }>

--- a/src/editor/PostTypesPanel.js
+++ b/src/editor/PostTypesPanel.js
@@ -6,7 +6,7 @@ import { without } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { PanelRow, CheckboxControl } from '@wordpress/components';
+import { CheckboxControl } from '@wordpress/components';
 
 const PostTypesPanel = ( { post_types = [], onMetaFieldChange } ) => {
 	const availablePostTypes = [
@@ -16,17 +16,16 @@ const PostTypesPanel = ( { post_types = [], onMetaFieldChange } ) => {
 	];
 
 	return availablePostTypes.map( ( { name, label } ) => (
-		<PanelRow key={ name }>
-			<CheckboxControl
-				label={ label }
-				checked={ post_types.indexOf( name ) > -1 }
-				onChange={ isIncluded => {
-					onMetaFieldChange( {
-						post_types: isIncluded ? [ ...post_types, name ] : without( post_types, name ),
-					} );
-				} }
-			/>
-		</PanelRow>
+		<CheckboxControl
+			key={ name }
+			label={ label }
+			checked={ post_types.indexOf( name ) > -1 }
+			onChange={ isIncluded => {
+				onMetaFieldChange( {
+					post_types: isIncluded ? [ ...post_types, name ] : without( post_types, name ),
+				} );
+			} }
+		/>
 	) );
 };
 

--- a/src/editor/Sidebar.js
+++ b/src/editor/Sidebar.js
@@ -7,7 +7,18 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Fragment } from '@wordpress/element';
-import { RadioControl, RangeControl, SelectControl, ToggleControl, CheckboxControl } from '@wordpress/components';
+import {
+	/* eslint-disable @wordpress/no-unsafe-wp-apis */
+	__experimentalToggleGroupControl as ToggleGroupControl,
+	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
+	__experimentalToggleGroupControlOptionIcon as ToggleGroupControlOptionIcon,
+	/* eslint-enable @wordpress/no-unsafe-wp-apis */
+	RangeControl,
+	SelectControl,
+	ToggleControl,
+	CheckboxControl,
+} from '@wordpress/components';
+import { stretchFullWidth } from '@wordpress/icons';
 
 /**
  * External dependencies
@@ -34,6 +45,8 @@ const Sidebar = props => {
 		isOverlay,
 		archive_page_types = [],
 	} = props;
+	const overlayTriggerType = 'time' === trigger_type || 'scroll' === trigger_type ? trigger_type : 'time';
+	const inlineTriggerType = 'blocks_count' === trigger_type || 'scroll' === trigger_type ? trigger_type : 'scroll';
 	const updatePlacement = value => {
 		onMetaFieldChange( { placement: value } );
 	};
@@ -60,31 +73,41 @@ const Sidebar = props => {
 		}
 	};
 	const customPlacements = window.newspack_popups_data?.custom_placements || {};
-	const popupSizeOptions = window.newspack_popups_data?.popup_size_options || {};
+	const popupSizeOptions = window.newspack_popups_data?.popup_size_options || [];
 	const availableArchivePageTypes = window.newspack_popups_data?.available_archive_page_types || [];
 
 	const helpMessage = getPlacementHelpMessage( props );
 
 	return (
 		<>
-			<RadioControl
+			<ToggleGroupControl
+				__next40pxDefaultSize
 				className="newspack-popups__prompt-type-control"
+				isBlock
 				label={ __( 'Prompt type', 'newspack-popups' ) }
-				selected={ isOverlay ? 'center' : 'inline' }
-				options={ [
-					{ label: __( 'Inline', 'newspack-popups' ), value: 'inline' },
-					{ label: __( 'Overlay', 'newspack-popups' ), value: 'center' },
-				] }
+				value={ isOverlay ? 'center' : 'inline' }
 				onChange={ updatePlacement }
-			/>
+			>
+				<ToggleGroupControlOption label={ __( 'Inline', 'newspack-popups' ) } value="inline" />
+				<ToggleGroupControlOption label={ __( 'Overlay', 'newspack-popups' ) } value="center" />
+			</ToggleGroupControl>
 			{ isOverlay ? (
 				<>
-					<SelectControl
+					<ToggleGroupControl
+						__next40pxDefaultSize
+						isBlock
 						label={ __( 'Size', 'newspack-popups' ) }
 						value={ overlay_size }
 						onChange={ updateSize }
-						options={ popupSizeOptions }
-					/>
+					>
+						{ popupSizeOptions.map( ( { value, label, shortname } ) =>
+							value === 'full-width' ? (
+								<ToggleGroupControlOptionIcon key={ value } icon={ stretchFullWidth } label={ label } value={ value } />
+							) : (
+								<ToggleGroupControlOption key={ value } aria-label={ label } label={ shortname } value={ value } />
+							)
+						) }
+					</ToggleGroupControl>
 					<PositionPlacementControl
 						layout={ placement }
 						label={ __( 'Position', 'newspack-popups' ) }
@@ -96,6 +119,7 @@ const Sidebar = props => {
 				</>
 			) : (
 				<SelectControl
+					__next40pxDefaultSize
 					label={ __( 'Placement' ) }
 					help={ helpMessage }
 					value={ placement }
@@ -116,18 +140,20 @@ const Sidebar = props => {
 
 			{ isOverlay && (
 				<>
-					<SelectControl
+					<ToggleGroupControl
+						__next40pxDefaultSize
+						isBlock
 						label={ __( 'Trigger', 'newspack-popups' ) }
 						help={ __( 'The event to trigger the prompt.', 'newspack-popups' ) }
-						value={ trigger_type }
-						options={ [
-							{ label: __( 'Timer', 'newspack-popups' ), value: 'time' },
-							{ label: __( 'Scroll Progress', 'newspack-popups' ), value: 'scroll' },
-						] }
+						value={ overlayTriggerType }
 						onChange={ value => onMetaFieldChange( { trigger_type: value } ) }
-					/>
-					{ 'scroll' === trigger_type ? (
+					>
+						<ToggleGroupControlOption label={ __( 'Timer', 'newspack-popups' ) } value="time" />
+						<ToggleGroupControlOption label={ __( 'Scroll Progress', 'newspack-popups' ) } value="scroll" />
+					</ToggleGroupControl>
+					{ 'scroll' === overlayTriggerType ? (
 						<RangeControl
+							__next40pxDefaultSize
 							label={ __( 'Scroll Progress (percent)', 'newspack-popups' ) }
 							value={ trigger_scroll_progress }
 							onChange={ value => onMetaFieldChange( { trigger_scroll_progress: value } ) }
@@ -136,6 +162,7 @@ const Sidebar = props => {
 						/>
 					) : (
 						<RangeControl
+							__next40pxDefaultSize
 							label={ __( 'Delay (seconds)', 'newspack-popups' ) }
 							value={ trigger_delay }
 							onChange={ value => onMetaFieldChange( { trigger_delay: value } ) }
@@ -147,18 +174,20 @@ const Sidebar = props => {
 			) }
 			{ placement === 'inline' && (
 				<>
-					<SelectControl
+					<ToggleGroupControl
+						__next40pxDefaultSize
+						isBlock
 						label={ __( 'Insertion position', 'newspack-popups' ) }
 						help={ __( 'The position at which to insert the prompt.', 'newspack-popups' ) }
-						value={ trigger_type }
-						options={ [
-							{ label: __( 'Percentage', 'newspack-popups' ), value: 'scroll' },
-							{ label: __( 'Blocks Count', 'newspack-popups' ), value: 'blocks_count' },
-						] }
+						value={ inlineTriggerType }
 						onChange={ value => onMetaFieldChange( { trigger_type: value } ) }
-					/>
-					{ 'blocks_count' === trigger_type ? (
+					>
+						<ToggleGroupControlOption label={ __( 'Percentage', 'newspack-popups' ) } value="scroll" />
+						<ToggleGroupControlOption label={ __( 'Blocks Count', 'newspack-popups' ) } value="blocks_count" />
+					</ToggleGroupControl>
+					{ 'blocks_count' === inlineTriggerType ? (
 						<RangeControl
+							__next40pxDefaultSize
 							label={ __( 'Number of blocks before the prompt', 'newspack-popups' ) }
 							value={ trigger_blocks_count }
 							onChange={ value => onMetaFieldChange( { trigger_blocks_count: value } ) }
@@ -166,6 +195,7 @@ const Sidebar = props => {
 						/>
 					) : (
 						<RangeControl
+							__next40pxDefaultSize
 							label={ __( 'Approximate Position (in percent)', 'newspack-popups' ) }
 							value={ trigger_scroll_progress }
 							onChange={ value => onMetaFieldChange( { trigger_scroll_progress: value } ) }
@@ -178,6 +208,7 @@ const Sidebar = props => {
 			{ placement === 'archives' && (
 				<Fragment>
 					<RangeControl
+						__next40pxDefaultSize
 						label={ __( 'Number of articles before prompt', 'newspack-popups' ) }
 						value={ archive_insertion_posts_count }
 						onChange={ value => onMetaFieldChange( { archive_insertion_posts_count: value } ) }
@@ -186,7 +217,12 @@ const Sidebar = props => {
 					/>
 
 					<div className="newspack-popups__prompt-type-control">
-						<legend className="components-base-control__legend">{ __( 'Archive Page Types', 'newspack-popups' ) }</legend>
+						<p
+							className="components-base-control__label"
+							style={ { fontSize: '11px', fontWeight: 500, lineHeight: 1.4, textTransform: 'uppercase' } }
+						>
+							{ __( 'Archive Page Types', 'newspack-popups' ) }
+						</p>
 						{ availableArchivePageTypes.map( ( { name, label } ) => (
 							<CheckboxControl
 								key={ name }

--- a/src/editor/Sidebar.js
+++ b/src/editor/Sidebar.js
@@ -11,14 +11,12 @@ import {
 	/* eslint-disable @wordpress/no-unsafe-wp-apis */
 	__experimentalToggleGroupControl as ToggleGroupControl,
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
-	__experimentalToggleGroupControlOptionIcon as ToggleGroupControlOptionIcon,
 	/* eslint-enable @wordpress/no-unsafe-wp-apis */
 	RangeControl,
 	SelectControl,
 	ToggleControl,
 	CheckboxControl,
 } from '@wordpress/components';
-import { stretchFullWidth } from '@wordpress/icons';
 
 /**
  * External dependencies
@@ -82,9 +80,13 @@ const Sidebar = props => {
 		<>
 			<ToggleGroupControl
 				__next40pxDefaultSize
-				className="newspack-popups__prompt-type-control"
 				isBlock
 				label={ __( 'Prompt type', 'newspack-popups' ) }
+				help={
+					isOverlay
+						? __( 'Overlay prompts appear over the page content as a popup.', 'newspack-popups' )
+						: __( 'Inline prompts are shown according to the selected placement.', 'newspack-popups' )
+				}
 				value={ isOverlay ? 'center' : 'inline' }
 				onChange={ updatePlacement }
 			>
@@ -99,14 +101,11 @@ const Sidebar = props => {
 						label={ __( 'Size', 'newspack-popups' ) }
 						value={ overlay_size }
 						onChange={ updateSize }
+						help={ popupSizeOptions.find( ( { value } ) => value === overlay_size )?.help }
 					>
-						{ popupSizeOptions.map( ( { value, label, shortname } ) =>
-							value === 'full-width' ? (
-								<ToggleGroupControlOptionIcon key={ value } icon={ stretchFullWidth } label={ label } value={ value } />
-							) : (
-								<ToggleGroupControlOption key={ value } aria-label={ label } label={ shortname } value={ value } />
-							)
-						) }
+						{ popupSizeOptions.map( ( { value, label, shortname } ) => (
+							<ToggleGroupControlOption key={ value } aria-label={ label } label={ shortname || label } value={ value } />
+						) ) }
 					</ToggleGroupControl>
 					<PositionPlacementControl
 						layout={ placement }

--- a/src/editor/index.js
+++ b/src/editor/index.js
@@ -11,10 +11,9 @@ import { __ } from '@wordpress/i18n';
 import { compose } from '@wordpress/compose';
 import { withSelect, withDispatch, useSelect, useDispatch } from '@wordpress/data';
 import { registerPlugin } from '@wordpress/plugins';
-import { PluginDocumentSettingPanel, PluginPostStatusInfo } from '@wordpress/edit-post';
 import { ExternalLink, Flex } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
-import { store as editorStore } from '@wordpress/editor';
+import { PluginDocumentSettingPanel, PluginPostStatusInfo, store as editorStore } from '@wordpress/editor';
 import { useEffect } from '@wordpress/element';
 
 /**

--- a/src/editor/index.js
+++ b/src/editor/index.js
@@ -25,6 +25,7 @@ import StylesSidebar from './StylesSidebar';
 import FrequencySidebar from './FrequencySidebar';
 import ColorsSidebar from './ColorsSidebar';
 import AdvancedSidebar from './AdvancedSidebar';
+import DocumentSidebarWithTabs from './DocumentSidebarWithTabs';
 import Preview from './Preview';
 import Duplicate from './Duplicate';
 import EditorAdditions from './EditorAdditions';
@@ -64,58 +65,24 @@ const PostTypesPanelWithData = connectData( PostTypesPanel );
 const ExpirationPanelWithData = connectData( ExpirationPanel );
 const AdvancedSidebarWithData = connectData( AdvancedSidebar );
 
-// Register components.
-registerPlugin( 'newspack-popups-styles', {
-	render: () => (
-		<PluginDocumentSettingPanel name="popup-styles-panel" title={ __( 'Styles', 'newspack-popups' ) }>
-			<StylesSidebarWithData />
-		</PluginDocumentSettingPanel>
-	),
-	icon: null,
-} );
+// Panels with group="styles" appear under the Styles tab; others under Settings.
+const promptPanels = [
+	{ name: 'settings', title: __( 'Settings', 'newspack-popups' ), Component: SidebarWithData },
+	...( window?.newspack_popups_data?.segmentation_enabled
+		? [ { name: 'frequency', title: __( 'Frequency', 'newspack-popups' ), Component: FrequencySidebarWithData } ]
+		: [] ),
+	{ name: 'expiration', title: __( 'Expiration', 'newspack-popups' ), Component: ExpirationPanelWithData, initialOpen: false },
+	{ name: 'post-types', title: __( 'Post types', 'newspack-popups' ), Component: PostTypesPanelWithData, initialOpen: false },
+	{ name: 'advanced', title: __( 'Advanced', 'newspack-popups' ), Component: AdvancedSidebarWithData, initialOpen: false },
+	{ name: 'styles', title: __( 'Styles', 'newspack-popups' ), Component: StylesSidebarWithData, group: 'styles' },
+	{ name: 'colors', title: __( 'Color', 'newspack-popups' ), Component: ColorsSidebarWithData, group: 'styles' },
+];
 
+// Register single document panel with Settings and Styles tabs at the top.
 registerPlugin( 'newspack-popups', {
 	render: () => (
-		<PluginDocumentSettingPanel name="popup-settings-panel" title={ __( 'Settings', 'newspack-popups' ) }>
-			<SidebarWithData />
-		</PluginDocumentSettingPanel>
-	),
-	icon: null,
-} );
-
-if ( window?.newspack_popups_data?.segmentation_enabled ) {
-	registerPlugin( 'newspack-popups-frequency', {
-		render: () => (
-			<PluginDocumentSettingPanel name="-frequency-panel" title={ __( 'Frequency', 'newspack-popups' ) }>
-				<FrequencySidebarWithData />
-			</PluginDocumentSettingPanel>
-		),
-		icon: null,
-	} );
-}
-
-registerPlugin( 'newspack-popups-colors', {
-	render: () => (
-		<PluginDocumentSettingPanel name="popup-colors-panel" title={ __( 'Color', 'newspack-popups' ) }>
-			<ColorsSidebarWithData />
-		</PluginDocumentSettingPanel>
-	),
-	icon: null,
-} );
-
-registerPlugin( 'newspack-popups-post-types', {
-	render: () => (
-		<PluginDocumentSettingPanel name="post-types-panel" title={ __( 'Post Types', 'newspack-popups' ) }>
-			<PostTypesPanelWithData />
-		</PluginDocumentSettingPanel>
-	),
-	icon: null,
-} );
-
-registerPlugin( 'newspack-popups-expiration', {
-	render: () => (
-		<PluginDocumentSettingPanel name="expiration-panel" title={ __( 'Expiration', 'newspack-popups' ) }>
-			<ExpirationPanelWithData />
+		<PluginDocumentSettingPanel name="popup-prompt-panel" initialOpen={ true }>
+			<DocumentSidebarWithTabs panels={ promptPanels } />
 		</PluginDocumentSettingPanel>
 	),
 	icon: null,
@@ -135,15 +102,6 @@ if ( window.newspack_popups_merge_tags?.tags?.length ) {
 		return <BlockEdit { ...props } />;
 	} );
 }
-
-registerPlugin( 'newspack-popups-advanced', {
-	render: () => (
-		<PluginDocumentSettingPanel name="popup-advanced-panel" title={ __( 'Advanced Settings', 'newspack-popups' ) }>
-			<AdvancedSidebarWithData />
-		</PluginDocumentSettingPanel>
-	),
-	icon: null,
-} );
 
 registerPlugin( 'newspack-popups-editor', {
 	render: EditorAdditions,

--- a/src/editor/style.scss
+++ b/src/editor/style.scss
@@ -24,24 +24,6 @@ $size__large: 1264px;
 		}
 	}
 
-	&__prompt-type-control {
-		margin-bottom: 1rem;
-
-		.components-base-control__label {
-			display: block;
-		}
-
-		.components-radio-control__option {
-			&:first-of-type {
-				margin-right: 1rem;
-			}
-		}
-
-		.components-base-control__legend {
-			padding-bottom: 4px;
-		}
-	}
-
 	&__segmentation-sidebar {
 		.components-form-token-field__help {
 			display: none;

--- a/src/editor/style.scss
+++ b/src/editor/style.scss
@@ -222,3 +222,22 @@ $size__large: 1264px;
 .components-datetime__date h3 {
 	margin: 0;
 }
+
+.newspack-popups__tabs {
+	.components-tab-panel__tabs {
+		margin-bottom: -1px;
+	}
+
+	.components-tab-panel__tabs-item {
+		flex: 1 1 100%;
+	}
+
+	.components-panel__body:has(&) {
+		border: 0;
+		padding: 0;
+
+		&:has(.newspack-popups__tab-styles.is-active) ~ .components-panel__body{
+			display: none;
+		}
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR adds a tab-like navigation, like the Group block for example, where we separate the "Settings" from the "Styles". It's a bit hacky because I couldn't find a way to do it at the document-level what we can easily achieve with the block (and simply add `group="style"` to a panel.

I've also tweaked some settings to use a `ToggleGroupControl` instead of dropdowns.

<img width="560" height="1744" alt="Settings" src="https://github.com/user-attachments/assets/22e8baa2-bb88-4074-8d47-9967e2bb6366" />
<img width="560" height="1194" alt="Styles" src="https://github.com/user-attachments/assets/dffde3ed-568c-439d-a538-aeadf6727ea0" />

### How to test the changes in this Pull Request:

Make sure all the settings etc... still work

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
