### PR TITLE
Fix emoji encoding in DOM::loadHTML

### DIFF
--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -193,7 +193,7 @@ final class Newspack_Popups_Inserter {
 					$classic_content = force_balance_tags( wpautop( $block['innerHTML'] ) ); // Ensure we have paragraph tags and valid HTML.
 					$dom             = new DomDocument();
 					libxml_use_internal_errors( true );
-					$dom->loadHTML( htmlspecialchars_decode( htmlentities( mb_convert_encoding( $classic_content, 'UTF-8', get_bloginfo( 'charset' ) ) ) ) );
+					$dom->loadHTML( '<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />' . htmlspecialchars_decode( htmlentities( mb_convert_encoding( $classic_content, 'UTF-8', get_bloginfo( 'charset' ) ) ) ) );
 					$dom_body = $dom->getElementsByTagName( 'body' );
 					if ( 0 < $dom_body->length ) {
 						$dom_body_elements = $dom_body->item( 0 )->childNodes;

--- a/tests/test-classic-block-encoding.php
+++ b/tests/test-classic-block-encoding.php
@@ -1,0 +1,297 @@
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+/**
+ * Class ClassicBlockEncoding Test.
+ *
+ * Tests that the DOMDocument UTF-8 encoding fix in convert_classic_blocks
+ * correctly preserves multi-byte characters (emojis, CJK, Cyrillic, etc.)
+ * in different content types and charset configurations.
+ *
+ * @package Newspack_Popups
+ */
+
+/**
+ * ClassicBlockEncoding test case.
+ */
+class ClassicBlockEncodingTest extends WP_UnitTestCase {
+
+	/**
+	 * ReflectionMethod to access the private convert_classic_blocks method.
+	 *
+	 * @var ReflectionMethod
+	 */
+	private static $convert_classic_blocks;
+
+	/**
+	 * Set up.
+	 */
+	public function set_up() { // phpcs:ignore Squiz.Commenting.FunctionComment.Missing
+		parent::set_up();
+		if ( ! self::$convert_classic_blocks ) {
+			self::$convert_classic_blocks = new ReflectionMethod( 'Newspack_Popups_Inserter', 'convert_classic_blocks' );
+			self::$convert_classic_blocks->setAccessible( true );
+		}
+	}
+
+	/**
+	 * Lightbulb emoji in <p> survives round-trip; specific hex bytes F0 9F 92 A1 are intact.
+	 */
+	public function test_emoji_survives_classic_block_conversion() {
+		$emoji  = "\xF0\x9F\x92\xA1"; // U+1F4A1 Light Bulb — 4 bytes in UTF-8.
+		$output = $this->convert_to_html( '<p>' . $emoji . '</p>' );
+
+		$this->assertStringContainsString( $emoji, $output, 'Emoji should survive classic block conversion.' );
+		$this->assertTrue( mb_check_encoding( $output, 'UTF-8' ), 'Output should be valid UTF-8.' );
+	}
+
+	/**
+	 * Pure ASCII classic content is unchanged.
+	 */
+	public function test_ascii_content_unchanged() {
+		$output = $this->convert_to_html( '<p>Hello world</p>' );
+
+		$this->assertStringContainsString( 'Hello world', $output );
+		$this->assertTrue( mb_check_encoding( $output, 'UTF-8' ), 'Output should be valid UTF-8.' );
+	}
+
+	/**
+	 * Single emoji in paragraph is preserved.
+	 */
+	public function test_single_emoji_preserved() {
+		$output = $this->convert_to_html( '<p>Great idea 💡 let us try</p>' );
+
+		$this->assertStringContainsString( '💡', $output, 'Emoji should be preserved.' );
+		$this->assertStringContainsString( 'Great idea', $output, 'Text before emoji should be preserved.' );
+		$this->assertStringContainsString( 'let us try', $output, 'Text after emoji should be preserved.' );
+	}
+
+	/**
+	 * Multiple emojis including are preserved, including flag sequence, skin-tone modifier, and ZWJ compound.
+	 */
+	public function test_multiple_emojis_preserved() {
+		$output = $this->convert_to_html( '<p>🎉🔥💡👍🏽🇺🇸👨‍👩‍👧‍👦</p>' );
+
+		$this->assertStringContainsString( '🎉', $output, 'Party emoji should be preserved.' );
+		$this->assertStringContainsString( '🔥', $output, 'Fire emoji should be preserved.' );
+		$this->assertStringContainsString( '💡', $output, 'Lightbulb emoji should be preserved.' );
+		$this->assertStringContainsString( '👍🏽', $output, 'Skin-tone emoji should be preserved.' );
+		$this->assertStringContainsString( '🇺🇸', $output, 'Flag emoji should be preserved.' );
+		$this->assertStringContainsString( '👨‍👩‍👧‍👦', $output, 'ZWJ compound emoji should be preserved.' );
+	}
+
+	/**
+	 * Accented Latin characters (café, résumé, naïve) are preserved.
+	 */
+	public function test_accented_characters_preserved() {
+		$output = $this->convert_to_html( '<p>News café résumé naïve</p>' );
+
+		$this->assertStringContainsString( 'News', $output, 'News should be preserved.' );
+		$this->assertStringContainsString( 'café', $output, 'café should be preserved.' );
+		$this->assertStringContainsString( 'résumé', $output, 'résumé should be preserved.' );
+		$this->assertStringContainsString( 'naïve', $output, 'naïve should be preserved.' );
+	}
+
+	/**
+	 * CJK (Chinese, Japanese, Korean) characters are preserved.
+	 */
+	public function test_cjk_characters_preserved() {
+		$output = $this->convert_to_html( '<p>我喜欢新闻 ; 私はニュースが大好きです</p>' );
+
+		$this->assertStringContainsString( '我喜欢新闻', $output, 'Chinese characters should be preserved.' );
+		$this->assertStringContainsString( '私はニュースが大好きです', $output, 'Japanese characters should be preserved.' );
+	}
+
+	/**
+	 * Non-Latin scripts (Cyrillic, Arabic, Greek, Thai, Hebrew) are preserved.
+	 */
+	public function test_non_latin_scripts_preserved() {
+		$output = $this->convert_to_html( '<p>News Новости أخبار Νέα ข่าว חֲדָשׁוֹת</p>' );
+
+		$this->assertStringContainsString( 'News', $output, 'News should be preserved.' );
+		$this->assertStringContainsString( 'Новости', $output, 'Cyrillic should be preserved.' );
+		$this->assertStringContainsString( 'أخبار', $output, 'Arabic should be preserved.' );
+		$this->assertStringContainsString( 'Νέα', $output, 'Greek should be preserved.' );
+		$this->assertStringContainsString( 'ข่าว', $output, 'Thai should be preserved.' );
+		$this->assertStringContainsString( 'חֲדָשׁוֹת', $output, 'Hebrew should be preserved.' );
+	}
+
+	/**
+	 * Mixed content with all scripts and emojis in a single block is preserved.
+	 */
+	public function test_mixed_content_all_scripts() {
+		$output = $this->convert_to_html( '<p>News café 💡 我喜欢新闻 私はニュースが大好きです Новости أخبار Νέα ข่าว חֲדָשׁוֹת ♠★</p>' );
+
+		$this->assertStringContainsString( 'News', $output, 'News characters should be preserved.' );
+		$this->assertStringContainsString( 'café', $output, 'Accented characters should be preserved.' );
+		$this->assertStringContainsString( '💡', $output, 'Emoji should be preserved.' );
+		$this->assertStringContainsString( '我喜欢新闻', $output, 'CJK should be preserved.' );
+		$this->assertStringContainsString( '私はニュースが大好きです', $output, 'Japanese should be preserved.' );
+		$this->assertStringContainsString( 'Новости', $output, 'Cyrillic should be preserved.' );
+		$this->assertStringContainsString( 'أخبار', $output, 'Arabic should be preserved.' );
+		$this->assertStringContainsString( 'Νέα', $output, 'Greek should be preserved.' );
+		$this->assertStringContainsString( 'ข่าว', $output, 'Thai should be preserved.' );
+		$this->assertStringContainsString( 'חֲדָשׁוֹת', $output, 'Hebrew should be preserved.' );
+		$this->assertStringContainsString( '♠★', $output, 'Card suit and star symbols should be preserved.' );
+	}
+
+	/**
+	 * Nested HTML structures (links, strong, em) with emoji in content are preserved.
+	 */
+	public function test_nested_html_with_emoji() {
+		$output = $this->convert_to_html( '<p><strong>Bold 💡</strong> and <em>italic 🎉</em></p>' );
+
+		$this->assertStringContainsString( '💡', $output, 'Emoji in <strong> should be preserved.' );
+		$this->assertStringContainsString( '🎉', $output, 'Emoji in <em> should be preserved.' );
+		$this->assertStringContainsString( '<strong>', $output, 'Strong tag should survive DOMDocument.' );
+		$this->assertStringContainsString( '<em>', $output, 'Em tag should survive DOMDocument.' );
+
+		$link_output = $this->convert_to_html( '<p><a href="https://example.com">Click 💡 here</a></p>' );
+
+		$this->assertStringContainsString( '💡', $link_output, 'Emoji in link text should be preserved.' );
+		$this->assertStringContainsString( 'href="https://example.com"', $link_output, 'Link href should survive DOMDocument.' );
+	}
+
+	/**
+	 * <h2> with emoji is still correctly classified as core/heading by the block-name regex.
+	 */
+	public function test_heading_with_emoji_classified_correctly() {
+		$blocks = $this->convert( '<h2>Section 💡 Title</h2>' );
+
+		$this->assertNotEmpty( $blocks, 'Should produce at least one block.' );
+
+		$heading_found = false;
+		foreach ( $blocks as $block ) {
+			if ( 'core/heading' === $block['blockName'] ) {
+				$heading_found = true;
+				$this->assertStringContainsString( '💡', $block['innerHTML'], 'Emoji should be preserved in heading innerHTML.' );
+				$this->assertStringContainsString( 'Section', $block['innerHTML'], 'Text before emoji should be preserved.' );
+				$this->assertStringContainsString( 'Title', $block['innerHTML'], 'Text after emoji should be preserved.' );
+			}
+		}
+		$this->assertTrue( $heading_found, 'Heading with emoji should be classified as core/heading.' );
+	}
+
+	/**
+	 * The UTF-8 meta tag used internally does not leak into any output block innerHTML.
+	 */
+	public function test_meta_tag_not_leaked_to_output() {
+		$test_inputs = [
+			'<p>Content 💡 with emoji</p>',
+			'<p>café résumé</p>',
+			'<h2>Heading 🎉</h2>',
+			'<p>你好世界</p>',
+		];
+
+		foreach ( $test_inputs as $input ) {
+			$blocks = $this->convert( $input );
+			foreach ( $blocks as $block ) {
+				$this->assertStringNotContainsString(
+					'<meta',
+					$block['innerHTML'],
+					'Meta tag should not appear in output block innerHTML for input: ' . $input
+				);
+			}
+		}
+	}
+
+	/**
+	 * HTML numeric entities for emojis (&#x1f4a1;) as produced by wp_encode_emoji() survive the conversion.
+	 */
+	public function test_entity_encoded_emoji_preserved() {
+		$output = $this->convert_to_html( '<p>&#x1f4a1; idea</p>' );
+
+		// DOMDocument resolves numeric entities to actual characters when the charset is declared.
+		// The emoji should appear as the rendered character or remain as a numeric entity.
+		$has_emoji  = false !== strpos( $output, "\xF0\x9F\x92\xA1" );
+		$has_entity = false !== strpos( $output, '&#x1f4a1;' ) || false !== strpos( $output, '&#128161;' );
+		$this->assertTrue(
+			$has_emoji || $has_entity,
+			'Entity-encoded emoji should survive as rendered character or numeric entity.'
+		);
+		$this->assertStringContainsString( 'idea', $output, 'Surrounding text should be preserved.' );
+	}
+
+	/**
+	 * With blog_charset mocked to ISO-8859-1, latin1 accented bytes (\xE9 = é)
+	 * are correctly converted to valid UTF-8 in the output.
+	 */
+	public function test_latin1_charset_accented_content() {
+		update_option( 'blog_charset', 'ISO-8859-1' );
+
+		// \xE9 is "é" in ISO-8859-1.
+		$output = $this->convert_to_html( "<p>caf\xE9 r\xE9sum\xE9</p>" );
+
+		$this->assertTrue( mb_check_encoding( $output, 'UTF-8' ), 'Output should be valid UTF-8 after latin1 conversion.' );
+		$this->assertStringContainsString( 'café', $output, 'Accented character should be correctly converted from latin1 to UTF-8.' );
+		$this->assertStringContainsString( 'résumé', $output, 'Multiple accented characters should be converted.' );
+	}
+
+	/**
+	 * End-to-end: classic content with emoji passed through the public
+	 * insert_popups_in_post_content method with a popup; emoji is preserved in the output.
+	 */
+	public function test_insert_popups_preserves_emoji_in_classic_content() {
+		$classic_content = "First paragraph with 💡 emoji\n<h2>A heading</h2>\nSecond paragraph";
+		$popups          = [ self::create_test_popup( '0' ) ];
+
+		$result = Newspack_Popups_Inserter::insert_popups_in_post_content( $classic_content, $popups );
+
+		$this->assertStringContainsString( '💡', $result, 'Emoji should be preserved through the full public API pipeline.' );
+		$this->assertStringNotContainsString( '<meta', $result, 'Meta tag should not leak into the final serialized output.' );
+	}
+
+	/**
+	 * Create a classic (freeform) block array as produced by parse_blocks().
+	 *
+	 * @param string $html The raw HTML content.
+	 * @return array Block array.
+	 */
+	private static function make_classic_block( $html ) {
+		return [
+			'blockName'    => null,
+			'attrs'        => [],
+			'innerBlocks'  => [],
+			'innerHTML'    => $html,
+			'innerContent' => [ $html ],
+		];
+	}
+
+	/**
+	 * Run convert_classic_blocks via Reflection and return the resulting blocks.
+	 *
+	 * @param string $html Classic block HTML content.
+	 * @return array Array of converted block arrays.
+	 */
+	private function convert( $html ) {
+		return self::$convert_classic_blocks->invoke( null, [ self::make_classic_block( $html ) ] );
+	}
+
+	/**
+	 * Get the combined innerHTML from all blocks returned by convert_classic_blocks.
+	 *
+	 * @param string $html Classic block HTML content.
+	 * @return string Combined innerHTML.
+	 */
+	private function convert_to_html( $html ) {
+		$blocks = $this->convert( $html );
+		return implode( '', array_column( $blocks, 'innerHTML' ) );
+	}
+
+	/**
+	 * Create an inline popup configuration for integration tests.
+	 *
+	 * @param string $scroll_pct Scroll percentage for placement.
+	 * @return array Popup config.
+	 */
+	private static function create_test_popup( $scroll_pct = '0' ) {
+		return [
+			'id'      => wp_rand(),
+			'content' => 'Popup content.',
+			'options' => [
+				'placement'               => 'inline',
+				'trigger_type'            => 'scroll',
+				'trigger_scroll_progress' => $scroll_pct,
+				'trigger_blocks_count'    => '0',
+			],
+		];
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

## Fix emoji corruption in classic editor content when prompts are active

### Problem

Posts written with the classic editor, with no Gutenberg block markers like `<!-- wp:paragraph -->`, presently display garbled emoji characters on the frontend when the Newspack Campaigns `newspack-popups` plugin is active and inline or overlay prompts are configured. For example, the emoji `💡` (U+1F4A1, Light Bulb) renders as `ð¡` instead.

The `post_title` is unaffected, only display of emojis in `post_content` is corrupted.

### The root cause

The plugin's `the_content` filter `Newspack_Popups_Inserter::insert_popups_in_content()` registered in `includes/class-newspack-popups-inserter.php`:
```php
add_filter( 'the_content', [ $this, 'insert_popups_in_content' ], 1 );
```

parses post content into blocks and when the content has no Gutenberg block comments and it routes it through `Newspack_Popups_Inserter::convert_classic_blocks()`. That method uses PHP's `DOMDocument` to split freeform HTML into individual block structures:

```php
$dom->loadHTML(
    htmlspecialchars_decode(
        htmlentities(
            mb_convert_encoding( $classic_content, 'UTF-8', get_bloginfo( 'charset' ) )
        )
    )
);
```

This here was causing an unintentional encoding defect, but just for raw HTML where no Gutenberg syntax is used, because `DOMDocument::loadHTML()` was getting called without declaring the charset, which caused corruption of emojis in the post content output.

The `htmlentities()` with `htmlspecialchars_decode()` pattern used here is a known workaround to preserve HTML structure when feeding content to `DOMDocument`. It works by converting HTML-specific characters like `<`, `>`, `&`, `"` to entities, then reverses only those so that the markup survives.

However emoji characters do not have named HTML entities, e.g. emoji `💡` has no `&bulb;` or similar named entity. So `htmlentities()` used to leave it as raw UTF-8 bytes -- `F0 9F 92 A1`. These raw bytes then reach `DOMDocument::loadHTML()` which defaults to ISO-8859-1 (Latin-1) when no charset is declared. And so the 4-byte UTF-8 sequence gets misinterpreted as 4 separate Latin-1 characters:

| UTF-8 byte | Latin-1 interpretation | Displayed as |
|------------|----------------------|--------------|
| `F0`       | U+00F0     | `ð`            |
| `9F`       | U+009F     | control char, invisible |
| `92`       | U+0092     | control char, invisible |
| `A1`       | U+00A1      | `¡`            |

When `DomDocument::saveHTML()` outputs these, it re-encodes each Latin-1 character back to UTF-8, producing 8 bytes `C3 B0 C2 9F C2 92 C2 A1` instead of the original 4. The browser renders this double-encoded sequence as `ð¡`.

### Fix

Prepended a `<meta>` charset declaration to the HTML string before passing it to `loadHTML()`:

```php
$dom->loadHTML(
    '<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />'
    . htmlspecialchars_decode(
        htmlentities(
            mb_convert_encoding( $classic_content, 'UTF-8', get_bloginfo( 'charset' ) )
        )
    )
);
```

The `<meta>` tag tells the HTML parser to treat the input stream as UTF-8, so multi-byte characters (including 4-byte emoji) are correctly preserved through the `loadHTML()` into `saveHTML()` procdessing.

The `<meta>` tag itself does not appear in the output because `saveHTML()` is called on individual child nodes of `<body>`, not on the full document.

This technique here is a standard approach recommended in PHP documentation and in community to handle UTF-8 with `DOMDocument::loadHTML()`, see sources:

- [https://www.php.net/manual/en/domdocument.loadhtml.php#52251](https://www.php.net/manual/en/domdocument.loadhtml.php#52251), `17` upvotes — *"Pay attention when loading html that has a different charset than iso-8859-1. [...] make sure you have a meta tag in the html's head section: `<meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>`"*, by "bigtree"
- [https://www.php.net/manual/en/domdocument.loadhtml.php#118834](https://www.php.net/manual/en/domdocument.loadhtml.php#118834), `7` upvotes — *"the HTML4-like version will work: `<meta http-equiv="Content-Type" content="text/html; charset=utf-8">`"*, by "fr at felix-riesterer.de"
- [https://www.php.net/manual/en/domdocument.loadhtml.php#78243](https://www.php.net/manual/en/domdocument.loadhtml.php#78243), `4` upvotes — *"to help loadHTML() process utf file correctly, the meta tag should come first, before any utf string appear"*, by "xuanbn"

### Why this affected some sites but not others?

The corruption requires **two conditions to be true at the same time**:

1. **The post content must be raw HTML.** Posts written with the Gutenberg block editor with block comment markers are recognized by recognizes WP's `parse_blocks()` which returns typed blocks (e.g., `blockName: 'core/paragraph'`). These blocks bypass `convert_classic_blocks()` entirely and they are never fed to `DOMDocument`. For posts written with in raw HTML like `<p>💡</p>`, `parse_blocks()` returns these as freeform blocks (`blockName: null`) which do go through the `DOMDocument` processing path.

2. **There must be active inline or overlay prompts configured.** The `insert_popups_in_post_content()` function which calls `convert_classic_blocks()` is only used when there are prompts to insert. If no prompts match the current page, the filter returns untouched content.

This issue was encountered by LE on an already Newspackified Staging site, which had campaign popups set up earlier in the process, and also had raw HTML legacy content that was migrated. This is not a typical launch and migration workflow, and usually Campaigns get set up later in the launch process. Additionally, since Campaigns have evolved and became smarter and are able to parse raw HTML to display inline CTAs, the Newspack Content Converter usage is no longer needed as much as earlier, which is leaving us with more raw HTML in migrated historic content than previously.

### How the root cause was identified

The issue was noted during a Publisher migration which had early Newspacification completed with active inline prompts already created. A post used the emoji `💡` (U+1F4A1) in raw HTML content and did not display correctly -- `💡` displayed as `ð¡`.

I took the content through each step of the plugin's encoding chain logging hex bytes at every stage:

1. `mb_convert_encoding` — UTF-8 to UTF-8 is a no-op. Emoji bytes `f09f92a1` pass through unchanged.
2. `htmlentities` — Converts `<`, `>`, `&`, `"` to named entities. The emoji has no named entity so its raw bytes survive as-is.
4. `htmlspecialchars_decode` — Reverses only the 5 HTML-significant entities. Emoji bytes still intact.
5. `DOMDocument::loadHTML` — Here the corruption occurs. Without a charset declaration, `loadHTML()` defaults to ISO-8859-1. The 4-byte sequence `F0 9F 92 A1` is misread as 4 separate Latin-1 characters, then re-encoded to UTF-8 by `saveHTML()`:

```
- `f09f92a1`, 4 bytes valid emoji
- loadHTML in ISO-8859-1 + saveHTML
- `c3b0 c29f c292 c2a1`, 8 bytes each original byte double-encoded
- browser renders
- `ð (F0→C3B0)  ¡ (A1→C2A1)`, middle bytes are invisible control chars
```

With the fix, the `loadHTML()` now treats the input as UTF-8 and the bytes make the round trip correctly: `f09f92a1` -> `f09f92a1`.

### Unit tests

A new test class `ClassicBlockEncodingTest` was added (`tests/test-classic-block-encoding.php`) with 14 unit tests which use the `convert_classic_blocks()` method, and one integration test through the public `insert_popups_in_post_content()` API.

What these tests cover:
- Emoji processing survives with hex-level byte verification == the original bug scenario
- ASCII-only content unchanged
- Single and multiple emojis
- Accented Latin characters
- Non-Latin scripts Cyrillic, Arabic, Greek, Thai, Hebrew
- Chinese and Japanese characters
- Mixed content combining all of the above in a single block
- Nested HTML structures with emojis
- Heading classification
- Internal `<meta charset>` tag not leaking into any output block
- Entity encoded emoji as produced by `wp_encode_emoji()` on non-utf8mb4 sites
- Latin1 charset scenario -- blog_charset mocked to ISO-8859-1, latin1 byte input correctly converted to valid UTF-8
- E2E -- classic content with emoji processed through `insert_popups_in_post_content()` with an inline popup

## How to test the changes in this PR:

- create a fresh Newspack site with `utf8mb4` encoding
- first activate latest NP Campaigns release, so we can confirm the issue
- create a post A with regular Gutenberg paragraph, with an emoji in title, and one emoji in post content
- confirm both the emojis in title and content display correctly on frontend, because this is block content and there's still no inline campaigns created
- create a post B with some raw HTML content containing an emoji (must be without Gutenberg blocks' comments/syntax), and also put an emoji in the title. You can use phpMyAdmin to edit the `post_content` directly and remove any block comments/syntax, just insert an actual non-encoded emoji there. Also run `wp cache flush` if you've edited the content via phpMyAdmin
- confirm that emojis both in title and content display correctly -- because there's still no inline prompts
- now create a demo campaign and an inline prompt
- confirm that the emoji in post B's post content is now broken, while the emoji in title remains OK
- confirm that the post A still displays correctly
- install and activate this version
- confirm that the emoji in post B's content is now displaying correctly
- run the unit tests and confirm they pass

Regarding sites with other encodings. Newspack sites are either `utf8mb4`, `utf8`, or `latin1`
- `utf8mb4` is fully tested here, which is the WP Cloud default and provides native emoji support by storing the actual 4-byte characters
- `utf8` is not an emoji-compatible encoding anyway, and is very rare on our platform -- our `utf8` sites should be upgraded to `utf8mb4`, so do not bother to test this encoding
- `latin1`, some Newspack sites were migrated from this older standard and still have it, though there's not very many of those at all. If you wish, feel free to test on a `latin1` site too, just note that if you'll be editing the `post_content` via phpMyAdmin, the emoji will be directly encoded in the post_content` column, but all the steps to test remain just the same here as well

### Effect of the fix on different encodings

Here is an overview how this fix affects sites with different encodings. Tested on actual Newspack sites:

| Site charset | Emoji storage | Fix impact on emojis | Fix impact on other chars |
|-------------|--------------|---------------------|--------------------------|
| `utf8mb4` | Raw UTF-8 bytes | **Fixes corruption** | Fixes Chinese symbols, Cyrillic, Arabic, etc. |
| `utf8` (mb3) | HTML entities (`&#x1f4a1;`) | **Zero change** — byte-identical | Fixes Chinese symbols, Cyrillic, Arabic, etc. |
| `latin1` | HTML entities (`&#x1f4a1;`) | **Zero change** — byte-identical | **Zero change** — byte-identical |

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
