### PR TITLE
fix: run do_shortcode on manual, custom placements for the block theme

### DIFF
--- a/src/blocks/custom-placement/view.php
+++ b/src/blocks/custom-placement/view.php
@@ -62,7 +62,8 @@ function render_block( $attributes ) {
 		}
 		foreach ( $prompts as $prompt_id ) {
 			$shortcode = '[newspack-popup id="' . $prompt_id . '"' . $class_names . ']';
-			$content  .= $is_block_theme
+			$render_shortcode = apply_filters( 'newspack_popups_render_custom_placement_shortcode', $is_block_theme, $attributes, $custom_placement_id, $prompt_id );
+			$content  .= $render_shortcode
 				? do_shortcode( $shortcode )
 				: '<!-- wp:shortcode -->' . $shortcode . '<!-- /wp:shortcode -->';
 		}

--- a/src/blocks/custom-placement/view.php
+++ b/src/blocks/custom-placement/view.php
@@ -37,6 +37,7 @@ function render_block( $attributes ) {
 	$class_names         = isset( $attributes['className'] )
 		? ' class="' . esc_attr( $attributes['className'] ) . '"'
 		: '';
+	$in_post_content     = doing_filter( 'the_content' );
 	$is_block_theme      = function_exists( 'wp_is_block_theme' ) && wp_is_block_theme();
 
 	if ( empty( $custom_placement_id ) ) {
@@ -64,7 +65,8 @@ function render_block( $attributes ) {
 		}
 		foreach ( $prompts as $prompt_id ) {
 			$shortcode = '[newspack-popup id="' . $prompt_id . '"' . $class_names . ']';
-			$render_shortcode = apply_filters( 'newspack_popups_render_custom_placement_shortcode', $is_block_theme, $attributes, $custom_placement_id, $prompt_id );
+			$should_render = ! $in_post_content && $is_block_theme;
+			$render_shortcode = apply_filters( 'newspack_popups_render_custom_placement_shortcode', $should_render, $attributes, $custom_placement_id, $prompt_id );
 			$content  .= $render_shortcode
 				? do_shortcode( $shortcode )
 				: '<!-- wp:shortcode -->' . $shortcode . '<!-- /wp:shortcode -->';

--- a/src/blocks/custom-placement/view.php
+++ b/src/blocks/custom-placement/view.php
@@ -34,7 +34,9 @@ function register_block() {
 function render_block( $attributes ) {
 	$content             = '';
 	$custom_placement_id = \Newspack_Popups_Custom_Placements::validate_custom_placement_id( $attributes['customPlacement'] );
-	$class_names         = isset( $attributes['className'] ) ? ' class="' . $attributes['className'] . '"' : '';
+	$class_names         = isset( $attributes['className'] )
+		? ' class="' . esc_attr( $attributes['className'] ) . '"'
+		: '';
 	$is_block_theme      = function_exists( 'wp_is_block_theme' ) && wp_is_block_theme();
 
 	if ( empty( $custom_placement_id ) ) {

--- a/src/blocks/custom-placement/view.php
+++ b/src/blocks/custom-placement/view.php
@@ -35,6 +35,7 @@ function render_block( $attributes ) {
 	$content             = '';
 	$custom_placement_id = \Newspack_Popups_Custom_Placements::validate_custom_placement_id( $attributes['customPlacement'] );
 	$class_names         = isset( $attributes['className'] ) ? ' class="' . $attributes['className'] . '"' : '';
+	$is_block_theme      = function_exists( 'wp_is_block_theme' ) && wp_is_block_theme();
 
 	if ( empty( $custom_placement_id ) ) {
 		return $content;
@@ -60,7 +61,10 @@ function render_block( $attributes ) {
 			$content .= '<!-- Newspack Campaigns: Start custom placement ' . $custom_placement_id . '-->';
 		}
 		foreach ( $prompts as $prompt_id ) {
-			$content .= '<!-- wp:shortcode -->[newspack-popup id="' . $prompt_id . '"' . $class_names . ']<!-- /wp:shortcode -->';
+			$shortcode = '[newspack-popup id="' . $prompt_id . '"' . $class_names . ']';
+			$content  .= $is_block_theme
+				? do_shortcode( $shortcode )
+				: '<!-- wp:shortcode -->' . $shortcode . '<!-- /wp:shortcode -->';
 		}
 		if ( defined( 'WP_NEWSPACK_DEBUG' ) && WP_NEWSPACK_DEBUG ) {
 			$content .= '<!-- Newspack Campaigns: End custom placement ' . $custom_placement_id . '-->';

--- a/src/blocks/single-prompt/view.php
+++ b/src/blocks/single-prompt/view.php
@@ -51,7 +51,8 @@ function render_block( $attributes ) {
 		}
 
 		$shortcode = '[newspack-popup id="' . $prompt_id . '"' . $class_names . ']';
-		$content  .= $is_block_theme
+		$render_shortcode = apply_filters( 'newspack_popups_render_prompt_shortcode', $is_block_theme, $attributes, $prompt_id );
+		$content  .= $render_shortcode
 			? do_shortcode( $shortcode )
 			: '<!-- wp:shortcode -->' . $shortcode . '<!-- /wp:shortcode -->';
 

--- a/src/blocks/single-prompt/view.php
+++ b/src/blocks/single-prompt/view.php
@@ -34,7 +34,9 @@ function register_block() {
 function render_block( $attributes ) {
 	$content     = '';
 	$prompt_id   = $attributes['promptId'];
-	$class_names = isset( $attributes['className'] ) ? ' class="' . $attributes['className'] . '"' : '';
+	$class_names = isset( $attributes['className'] )
+		? ' class="' . esc_attr( $attributes['className'] ) . '"'
+		: '';
 	$is_block_theme = function_exists( 'wp_is_block_theme' ) && wp_is_block_theme();
 
 	if ( empty( $prompt_id ) ) {

--- a/src/blocks/single-prompt/view.php
+++ b/src/blocks/single-prompt/view.php
@@ -35,6 +35,7 @@ function render_block( $attributes ) {
 	$content     = '';
 	$prompt_id   = $attributes['promptId'];
 	$class_names = isset( $attributes['className'] ) ? ' class="' . $attributes['className'] . '"' : '';
+	$is_block_theme = function_exists( 'wp_is_block_theme' ) && wp_is_block_theme();
 
 	if ( empty( $prompt_id ) ) {
 		return $content;
@@ -49,7 +50,10 @@ function render_block( $attributes ) {
 			$content .= '<!-- Newspack Campaigns: Start Prompt ' . $prompt_id . '-->';
 		}
 
-		$content .= '<!-- wp:shortcode -->[newspack-popup id="' . $prompt_id . '"' . $class_names . ']<!-- /wp:shortcode -->';
+		$shortcode = '[newspack-popup id="' . $prompt_id . '"' . $class_names . ']';
+		$content  .= $is_block_theme
+			? do_shortcode( $shortcode )
+			: '<!-- wp:shortcode -->' . $shortcode . '<!-- /wp:shortcode -->';
 
 		if ( defined( 'WP_NEWSPACK_DEBUG' ) && WP_NEWSPACK_DEBUG ) {
 			$content .= '<!-- Newspack Campaigns: End Prompt ' . $prompt_id . '-->';

--- a/src/blocks/single-prompt/view.php
+++ b/src/blocks/single-prompt/view.php
@@ -37,7 +37,8 @@ function render_block( $attributes ) {
 	$class_names = isset( $attributes['className'] )
 		? ' class="' . esc_attr( $attributes['className'] ) . '"'
 		: '';
-	$is_block_theme = function_exists( 'wp_is_block_theme' ) && wp_is_block_theme();
+	$in_post_content = doing_filter( 'the_content' );
+	$is_block_theme  = function_exists( 'wp_is_block_theme' ) && wp_is_block_theme();
 
 	if ( empty( $prompt_id ) ) {
 		return $content;
@@ -53,7 +54,8 @@ function render_block( $attributes ) {
 		}
 
 		$shortcode = '[newspack-popup id="' . $prompt_id . '"' . $class_names . ']';
-		$render_shortcode = apply_filters( 'newspack_popups_render_prompt_shortcode', $is_block_theme, $attributes, $prompt_id );
+		$should_render = ! $in_post_content && $is_block_theme;
+		$render_shortcode = apply_filters( 'newspack_popups_render_prompt_shortcode', $should_render, $attributes, $prompt_id );
 		$content  .= $render_shortcode
 			? do_shortcode( $shortcode )
 			: '<!-- wp:shortcode -->' . $shortcode . '<!-- /wp:shortcode -->';

--- a/tests/test-blocks.php
+++ b/tests/test-blocks.php
@@ -9,11 +9,72 @@
  * Blocks test case.
  */
 class BlocksTest extends WP_UnitTestCase {
+	/**
+	 * Prompt shortcode render filter callback.
+	 *
+	 * @var callable|null
+	 */
+	private $prompt_render_filter = null;
+
+	/**
+	 * Custom placement shortcode render filter callback.
+	 *
+	 * @var callable|null
+	 */
+	private $custom_render_filter = null;
+
 	public function set_up() { // phpcs:ignore Squiz.Commenting.FunctionComment.Missing
+		parent::set_up();
+
 		// Remove any popups (from previous tests).
 		foreach ( Newspack_Popups_Model::retrieve_popups() as $popup ) {
 			wp_delete_post( $popup['id'] );
 		}
+	}
+
+	public function tear_down() { // phpcs:ignore Squiz.Commenting.FunctionComment.Missing
+		if ( $this->prompt_render_filter ) {
+			remove_filter( 'newspack_popups_render_prompt_shortcode', $this->prompt_render_filter );
+		}
+		if ( $this->custom_render_filter ) {
+			remove_filter( 'newspack_popups_render_custom_placement_shortcode', $this->custom_render_filter );
+		}
+		$this->prompt_render_filter = null;
+		$this->custom_render_filter = null;
+
+		wp_reset_postdata();
+		unset( $GLOBALS['post'] );
+		parent::tear_down();
+	}
+
+	/**
+	 * Force shortcode render behavior in tests.
+	 *
+	 * @param bool $prompt_value Render prompt shortcode output.
+	 * @param bool $custom_value Render custom placement shortcode output.
+	 */
+	private function set_shortcode_render_filters( $prompt_value, $custom_value ) {
+		$this->prompt_render_filter = function() use ( $prompt_value ) {
+			return $prompt_value;
+		};
+		$this->custom_render_filter = function() use ( $custom_value ) {
+			return $custom_value;
+		};
+		add_filter( 'newspack_popups_render_prompt_shortcode', $this->prompt_render_filter, 10, 3 );
+		add_filter( 'newspack_popups_render_custom_placement_shortcode', $this->custom_render_filter, 10, 5 );
+	}
+
+	/**
+	 * Create and set a post as the current global post.
+	 *
+	 * @return int Post ID.
+	 */
+	private function set_current_post() {
+		$post_id        = self::factory()->post->create();
+		$post           = get_post( $post_id );
+		$GLOBALS['post'] = $post;
+		setup_postdata( $post );
+		return $post_id;
 	}
 
 	/**
@@ -37,6 +98,8 @@ class BlocksTest extends WP_UnitTestCase {
 	 * Basic Block rendering - Single Prompt block.
 	 */
 	public function test_prompt_block_rendering() {
+		$this->set_shortcode_render_filters( false, false );
+
 		$inline_popup_id       = self::create_popup( [ 'placement' => 'inline' ] );
 		$overlay_popup_id      = self::create_popup( [ 'placement' => 'center' ] );
 		$inline_block_content  = Newspack_Popups\Prompt_Block\render_block( [ 'promptId' => $inline_popup_id ] );
@@ -72,6 +135,8 @@ class BlocksTest extends WP_UnitTestCase {
 	 * Basic Block rendering - Custom Placement block.
 	 */
 	public function test_custom_placement_block_rendering() {
+		$this->set_shortcode_render_filters( false, false );
+
 		$custom_placement_id = 'custom1';
 		$popup_id            = self::create_popup( [ 'placement' => $custom_placement_id ] );
 		$block_content       = Newspack_Popups\Custom_Placement_Block\render_block( [ 'customPlacement' => $custom_placement_id ] );
@@ -100,6 +165,8 @@ class BlocksTest extends WP_UnitTestCase {
 	 * Block rendering with conflicting popups.
 	 */
 	public function test_block_rendering_with_conflict() {
+		$this->set_shortcode_render_filters( false, false );
+
 		$custom_placement_id = 'custom1';
 		$popup_id_first      = self::create_popup( [ 'placement' => $custom_placement_id ] );
 		sleep( 1 ); // Ensure the creation dates are not the same.
@@ -111,5 +178,76 @@ class BlocksTest extends WP_UnitTestCase {
 			'<!-- wp:shortcode -->[newspack-popup id="' . $popup_id_second . '"]<!-- /wp:shortcode --><!-- wp:shortcode -->[newspack-popup id="' . $popup_id_first . '"]<!-- /wp:shortcode -->',
 			'Includes all popup shortcodes in case of a conflict, since the API will decide what to show.'
 		);
+	}
+
+	/**
+	 * Block rendering - Single Prompt block (block themes render shortcode).
+	 */
+	public function test_prompt_block_rendering_block_theme() {
+		$this->set_shortcode_render_filters( true, true );
+		$this->set_current_post();
+
+		$inline_popup_id       = self::create_popup( [ 'placement' => 'inline' ] );
+		$overlay_popup_id      = self::create_popup( [ 'placement' => 'center' ] );
+		$inline_block_content  = Newspack_Popups\Prompt_Block\render_block( [ 'promptId' => $inline_popup_id ] );
+		$overlay_block_content = Newspack_Popups\Prompt_Block\render_block( [ 'promptId' => $overlay_popup_id ] );
+
+		self::assertStringContainsString( '<aside', $inline_block_content, 'Renders inline popup HTML.' );
+		self::assertStringContainsString( 'newspack-popup-container', $inline_block_content, 'Includes popup container markup.' );
+		self::assertStringNotContainsString( '<!-- wp:shortcode -->', $inline_block_content, 'Does not return a shortcode block in block themes.' );
+		self::assertEquals( '', $overlay_block_content, 'Overlay prompt not rendered by the Single Prompt block.' );
+
+		$inline_block_content = Newspack_Popups\Prompt_Block\render_block(
+			[
+				'promptId'  => $inline_popup_id,
+				'className' => 'custom-class',
+			]
+		);
+
+		self::assertStringContainsString( 'class="custom-class"', $inline_block_content, 'Includes custom class on the wrapper element.' );
+	}
+
+	/**
+	 * Block rendering - Custom Placement block (block themes render shortcode).
+	 */
+	public function test_custom_placement_block_rendering_block_theme() {
+		$this->set_shortcode_render_filters( true, true );
+		$this->set_current_post();
+
+		$custom_placement_id = 'custom1';
+		$popup_id            = self::create_popup( [ 'placement' => $custom_placement_id ] );
+		$block_content       = Newspack_Popups\Custom_Placement_Block\render_block( [ 'customPlacement' => $custom_placement_id ] );
+
+		self::assertStringContainsString( '<aside', $block_content, 'Renders popup HTML.' );
+		self::assertStringContainsString( 'newspack-popup-container', $block_content, 'Includes popup container markup.' );
+		self::assertStringNotContainsString( '<!-- wp:shortcode -->', $block_content, 'Does not return a shortcode block in block themes.' );
+
+		$block_content = Newspack_Popups\Custom_Placement_Block\render_block(
+			[
+				'customPlacement' => $custom_placement_id,
+				'className'       => 'custom-class',
+			]
+		);
+
+		self::assertStringContainsString( 'class="custom-class"', $block_content, 'Includes custom class on the wrapper element.' );
+	}
+
+	/**
+	 * Block rendering with conflicting popups (block themes render shortcode).
+	 */
+	public function test_block_rendering_with_conflict_block_theme() {
+		$this->set_shortcode_render_filters( true, true );
+		$this->set_current_post();
+
+		$custom_placement_id = 'custom1';
+		$popup_id_first      = self::create_popup( [ 'placement' => $custom_placement_id ] );
+		sleep( 1 ); // Ensure the creation dates are not the same.
+		$popup_id_second = self::create_popup( [ 'placement' => $custom_placement_id ] );
+		$block_content   = Newspack_Popups\Custom_Placement_Block\render_block( [ 'customPlacement' => $custom_placement_id ] );
+
+		self::assertStringContainsString( 'newspack-popup-container', $block_content, 'Includes popup container markup.' );
+		self::assertStringContainsString( Newspack_Popups_Model::canonize_popup_id( $popup_id_first ), $block_content, 'Includes first popup markup.' );
+		self::assertStringContainsString( Newspack_Popups_Model::canonize_popup_id( $popup_id_second ), $block_content, 'Includes second popup markup.' );
+		self::assertStringNotContainsString( '<!-- wp:shortcode -->', $block_content, 'Does not return shortcode blocks in block themes.' );
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

While Single Prompt and Custom Placements still work in the post/page content using the block theme, it absolutely does not want to do anything with the shortcode these placements use when placed in a template/template part via the site editor. 

This PR adds a check for the block theme and the content, and runs `do_shortcode()` when you're using the block theme and not in the content, rather than inserting the shortcode block code directly. Both Copilot and Cursor suggested using a filter to make it easier to swap between these two "themes" for testing, so I went with that, too 😅 

I think this is kind of a temporary measure; NPPD-1216 proposes some changes to campaigns to make them more "block-like".

Closes NPPD-1212

### How to test the changes in this Pull Request:

1. Set up a couple prompts, one manual and one custom placement.
2. If it's not already running the block theme, switch your site to the block theme. 
3. Edit the Site, and add a Single Placement and Custom Placement block, and add your campaign prompts to them.
4. View on the front-end:

<img width="775" height="298" alt="CleanShot 2026-02-06 at 15 52 23" src="https://github.com/user-attachments/assets/64b8d4b5-0399-4784-8520-f39a0fba3917" />

5. Apply this PR.
6. Refresh the page and confirm you're getting prompts:

<img width="748" height="522" alt="CleanShot 2026-02-06 at 15 51 47" src="https://github.com/user-attachments/assets/d724ab3a-5bde-467b-96c7-767ded4858f7" />

7. Try adding the two manual placements in post/page content, and ensure they still work.
8. Switch to the Classic theme and try adding both placements to the content and widget areas, respectively.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
