### PR TITLE
fix: make sure block supports styles are included inline for the above header placement

### DIFF
--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -55,6 +55,7 @@ final class Newspack_Popups_Inserter {
 		add_action( 'wp_body_open', [ $this, 'insert_before_header' ] );
 		add_action( 'after_archive_post', [ $this, 'insert_inline_prompt_in_archive_pages' ] );
 		add_action( 'wp_before_admin_bar_render', [ $this, 'add_preview_toggle' ] );
+		add_action( 'wp_enqueue_scripts', [ $this, 'prepare_above_header_popup_styles' ], 1 );
 
 		// Always enqueue scripts, since this plugin's scripts are handling pageview sending via GTAG.
 		add_action( 'wp_enqueue_scripts', [ $this, 'enqueue_scripts' ] );
@@ -527,6 +528,79 @@ final class Newspack_Popups_Inserter {
 		foreach ( $popups as $popup ) {
 			echo Newspack_Popups_Model::generate_popup( $popup ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		}
+	}
+
+	/**
+	 * Prepare above-header popup styles early so block layout CSS is printed in the head.
+	 *
+	 * Otherwise, per-block styles like alignment and spacing can be missing.
+	 */
+	public static function prepare_above_header_popup_styles() {
+		static $styles_prepared = false;
+		if ( $styles_prepared ) {
+			return;
+		}
+		if ( ! Newspack_Popups::is_block_theme() ) {
+			return;
+		}
+
+		$before_header_popups = array_filter( self::popups_for_post(), [ 'Newspack_Popups_Model', 'should_be_inserted_above_page_header' ] );
+		if ( empty( $before_header_popups ) ) {
+			return;
+		}
+
+		// Ensure the global styles handle exists before adding inline styles.
+		if ( function_exists( 'wp_enqueue_global_styles' ) ) {
+			wp_enqueue_global_styles();
+		}
+
+		// Get existing block-supports rules so we don't repeat them with the popup's styles.
+		$store              = null;
+		$existing_rule_keys = [];
+		if ( class_exists( '\WP_Style_Engine_CSS_Rules_Store' ) && method_exists( '\WP_Style_Engine_CSS_Rules_Store', 'get_store' ) ) {
+			$store = \WP_Style_Engine_CSS_Rules_Store::get_store( 'block-supports' );
+			if ( $store && method_exists( $store, 'get_all_rules' ) ) {
+				$existing_rule_keys = array_keys( $store->get_all_rules() );
+			}
+		}
+
+		// Temporarily swap the global post with each popup's post ID.
+		global $post;
+		$_post = $post;
+		foreach ( $before_header_popups as $popup ) {
+			$popup_post = \get_post( $popup['id'] );
+			if ( ! $popup_post ) {
+				continue;
+			}
+			$post = $popup_post; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+			setup_postdata( $post );
+			\do_blocks( $popup['content'] );
+		}
+
+		// Loop through the block-supports rules and get only the new rules added when the popups are rendered.
+		$block_supports_css = '';
+		if ( $store && method_exists( $store, 'get_all_rules' ) ) {
+			foreach ( $store->get_all_rules() as $key => $rule ) {
+				if ( in_array( $key, $existing_rule_keys, true ) ) {
+					continue;
+				}
+				if ( is_object( $rule ) && method_exists( $rule, 'get_css' ) ) {
+					$block_supports_css .= $rule->get_css();
+				}
+			}
+		}
+
+		// Print the popup's block-supports CSS inline.
+		if ( '' !== $block_supports_css ) {
+			wp_register_style( 'newspack-popups-block-supports', false, [], filemtime( NEWSPACK_POPUPS_PLUGIN_FILE ) );
+			wp_add_inline_style( 'newspack-popups-block-supports', $block_supports_css );
+			wp_enqueue_style( 'newspack-popups-block-supports' );
+		}
+
+		// Set the global post back to normal.
+		wp_reset_postdata();
+		$post = $_post; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		$styles_prepared = true;
 	}
 
 	/**

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -608,6 +608,7 @@ final class Newspack_Popups_Inserter {
 		}
 
 		// Set the global post back to normal.
+		wp_reset_postdata();
 		$post = $_post; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 		self::$above_header_styles_prepared = true;
 	}

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -55,7 +55,7 @@ final class Newspack_Popups_Inserter {
 		add_action( 'wp_body_open', [ $this, 'insert_before_header' ] );
 		add_action( 'after_archive_post', [ $this, 'insert_inline_prompt_in_archive_pages' ] );
 		add_action( 'wp_before_admin_bar_render', [ $this, 'add_preview_toggle' ] );
-		add_action( 'wp_enqueue_scripts', [ $this, 'prepare_above_header_popup_styles' ], 1 );
+		add_action( 'wp_enqueue_scripts', [ __CLASS__, 'prepare_above_header_popup_styles' ], 1 );
 
 		// Always enqueue scripts, since this plugin's scripts are handling pageview sending via GTAG.
 		add_action( 'wp_enqueue_scripts', [ $this, 'enqueue_scripts' ] );

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -39,6 +39,13 @@ final class Newspack_Popups_Inserter {
 	public static $the_content_has_rendered = false;
 
 	/**
+	 * Whether above-header popup styles have been prepared.
+	 *
+	 * @var boolean
+	 */
+	public static $above_header_styles_prepared = false;
+
+	/**
 	 * Whether we're exporting to Apple News.
 	 *
 	 * @var boolean
@@ -536,8 +543,7 @@ final class Newspack_Popups_Inserter {
 	 * Otherwise, per-block styles like alignment and spacing can be missing.
 	 */
 	public static function prepare_above_header_popup_styles() {
-		static $styles_prepared = false;
-		if ( $styles_prepared ) {
+		if ( self::$above_header_styles_prepared ) {
 			return;
 		}
 		if ( ! Newspack_Popups::is_block_theme() ) {
@@ -578,7 +584,7 @@ final class Newspack_Popups_Inserter {
 			}
 			$post = $popup_post; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 			setup_postdata( $post );
-			\do_blocks( $popup['content'] );
+			Newspack_Popups_Model::get_rendered_popup_body( $popup );
 		}
 
 		// Loop through the block-supports rules and get only the new rules added when the popups are rendered.
@@ -596,15 +602,14 @@ final class Newspack_Popups_Inserter {
 
 		// Print the popup's block-supports CSS inline.
 		if ( '' !== $block_supports_css ) {
-			wp_register_style( 'newspack-popups-block-supports', false, [], filemtime( NEWSPACK_POPUPS_PLUGIN_FILE ) );
+			wp_register_style( 'newspack-popups-block-supports', false, [], null ); // phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion
 			wp_add_inline_style( 'newspack-popups-block-supports', $block_supports_css );
 			wp_enqueue_style( 'newspack-popups-block-supports' );
 		}
 
 		// Set the global post back to normal.
-		wp_reset_postdata();
 		$post = $_post; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-		$styles_prepared = true;
+		self::$above_header_styles_prepared = true;
 	}
 
 	/**

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -563,6 +563,10 @@ final class Newspack_Popups_Inserter {
 				$existing_rule_keys = array_keys( $store->get_all_rules() );
 			}
 		}
+		// If block-supports storage isn't available, skip rendering popups just to collect CSS.
+		if ( ! $store || ! method_exists( $store, 'get_all_rules' ) ) {
+			return;
+		}
 
 		// Temporarily swap the global post with each popup's post ID.
 		global $post;

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -977,6 +977,7 @@ final class Newspack_Popups_Model {
 		$is_newsletter_prompt = self::has_newsletter_prompt( $popup );
 		$classes              = [ 'newspack-popup-container', 'newspack-popup', 'hidden' ];
 		$classes[]            = 'above_header' === $popup['options']['placement'] ? 'newspack-above-header-popup' : null;
+		$classes[]            = 'above_header' === $popup['options']['placement'] && Newspack_Popups::is_block_theme() ? 'is-layout-constrained' : null;
 		$classes[]            = ! self::is_above_header( $popup ) ? 'newspack-inline-popup' : null;
 		$classes[]            = 'publish' !== $popup['status'] ? 'newspack-inactive-popup-status' : null;
 		$classes[]            = $hide_border ? 'newspack-lightbox-no-border' : null;

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -52,6 +52,13 @@ final class Newspack_Popups_Model {
 	protected static $current_popup = null;
 
 	/**
+	 * Cache of rendered popup bodies for the current request.
+	 *
+	 * @var array
+	 */
+	protected static $rendered_popup_bodies = [];
+
+	/**
 	 * Retrieve all Popups (first 100).
 	 *
 	 * @param  boolean $include_unpublished Whether to include unpublished posts.
@@ -961,13 +968,7 @@ final class Newspack_Popups_Model {
 	public static function generate_inline_popup( $popup ) {
 		global $wp;
 
-		$blocks = parse_blocks( $popup['content'] );
-		$body   = '';
-		self::add_form_hooks( $popup );
-		foreach ( $blocks as $block ) {
-			$body .= render_block( $block );
-		}
-		self::remove_form_hooks( $popup );
+		$body = self::get_rendered_popup_body( $popup );
 		do_action( 'newspack_campaigns_after_campaign_render', $popup );
 
 		$element_id           = self::canonize_popup_id( $popup['id'] );
@@ -1052,13 +1053,7 @@ final class Newspack_Popups_Model {
 			return self::generate_inline_popup( $popup );
 		}
 
-		$blocks = parse_blocks( $popup['content'] );
-		$body   = '';
-		self::add_form_hooks( $popup );
-		foreach ( $blocks as $block ) {
-			$body .= render_block( $block );
-		}
-		self::remove_form_hooks( $popup );
+		$body = self::get_rendered_popup_body( $popup );
 		do_action( 'newspack_campaigns_after_campaign_render', $popup );
 
 		$element_id                     = self::canonize_popup_id( $popup['id'] );
@@ -1158,6 +1153,46 @@ final class Newspack_Popups_Model {
 		 * @param string $element_id The popup element ID.
 		 */
 		return apply_filters( 'newspack_popups_popup_content', ob_get_clean(), $popup, $element_id );
+	}
+
+	/**
+	 * Render and memoize a popup body for this request.
+	 *
+	 * @param array $popup Popup data.
+	 * @return string Rendered popup body HTML.
+	 */
+	public static function get_rendered_popup_body( $popup ) {
+		$cache_key = self::get_rendered_popup_cache_key( $popup );
+		if ( isset( self::$rendered_popup_bodies[ $cache_key ] ) ) {
+			return self::$rendered_popup_bodies[ $cache_key ];
+		}
+		if ( empty( $popup['content'] ) ) {
+			self::$rendered_popup_bodies[ $cache_key ] = '';
+			return '';
+		}
+
+		$blocks = parse_blocks( $popup['content'] );
+		$body   = '';
+		self::add_form_hooks( $popup );
+		foreach ( $blocks as $block ) {
+			$body .= render_block( $block );
+		}
+		self::remove_form_hooks( $popup );
+
+		self::$rendered_popup_bodies[ $cache_key ] = $body;
+		return $body;
+	}
+
+	/**
+	 * Build the cache key for a popup body render.
+	 *
+	 * @param array $popup Popup data.
+	 * @return string Cache key.
+	 */
+	private static function get_rendered_popup_cache_key( $popup ) {
+		$popup_id = isset( $popup['id'] ) ? $popup['id'] : 'unknown';
+		$content  = isset( $popup['content'] ) ? $popup['content'] : '';
+		return $popup_id . ':' . md5( $content );
 	}
 
 	/**

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -823,6 +823,15 @@ final class Newspack_Popups {
 	}
 
 	/**
+	 * Check if the current theme is a block theme.
+	 *
+	 * @return bool
+	 */
+	public static function is_block_theme() {
+		return function_exists( 'wp_is_block_theme' ) && wp_is_block_theme();
+	}
+
+	/**
 	 * Is it a preview request – a single popup preview or using "view as" feature.
 	 *
 	 * @return boolean Whether it's a preview request.

--- a/tests/test-insertion.php
+++ b/tests/test-insertion.php
@@ -493,6 +493,9 @@ class InsertionTest extends WP_UnitTestCase_PageWithPopups {
 
 		// Switch to a block theme so that prepare_above_header_popup_styles() proceeds past its is_block_theme() guard.
 		$original_theme = get_stylesheet();
+		if ( ! wp_get_theme( 'twentytwentyfour' )->exists() ) {
+			$this->markTestSkipped( 'The twentytwentyfour theme is not available in this test environment.' );
+		}
 		switch_theme( 'twentytwentyfour' );
 
 		// Reset the guard and deregister any previously enqueued handle so this test runs cleanly.

--- a/tests/test-insertion.php
+++ b/tests/test-insertion.php
@@ -472,4 +472,54 @@ class InsertionTest extends WP_UnitTestCase_PageWithPopups {
 			'Does not include the popup content, since the post tag is excluded on this popup.'
 		);
 	}
+
+	/**
+	 * Test that block-supports CSS for above-header popups is enqueued in wp_head on block themes.
+	 */
+	public function test_above_header_popup_block_supports_css_in_head() {
+		// Remove the default popup.
+		wp_delete_post( self::$popup_id );
+
+		// Use a Group block with flex layout, justifyContent, and padding. The layout block support
+		// generates entries in the block-supports CSS store when this block is rendered.
+		$popup_content = '<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"}}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} --><div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--40)"><!-- wp:paragraph --><p>Above header popup content.</p><!-- /wp:paragraph --></div><!-- /wp:group -->';
+		self::createPopup(
+			$popup_content,
+			[
+				'placement' => 'above_header',
+				'frequency' => 'daily',
+			]
+		);
+
+		// Switch to a block theme so that prepare_above_header_popup_styles() proceeds past its is_block_theme() guard.
+		$original_theme = get_stylesheet();
+		switch_theme( 'twentytwentyfour' );
+
+		// Reset the guard and deregister any previously enqueued handle so this test runs cleanly.
+		Newspack_Popups_Inserter::$above_header_styles_prepared = false;
+		wp_deregister_style( 'newspack-popups-block-supports' );
+
+		// Navigate to a post so popups_for_post() returns results.
+		$post_id = self::factory()->post->create( [ 'post_type' => 'post' ] );
+		self::go_to( get_permalink( $post_id ) );
+		global $wp_query, $post;
+		$wp_query->in_the_loop = true;
+		setup_postdata( $post );
+
+		Newspack_Popups_Inserter::prepare_above_header_popup_styles();
+
+		// Capture wp_head() to assert the inline style was output.
+		ob_start();
+		wp_head();
+		$head_output = ob_get_clean();
+
+		// Restore the original theme.
+		switch_theme( $original_theme );
+
+		self::assertStringContainsString(
+			'newspack-popups-block-supports',
+			$head_output,
+			'wp_head() output contains the newspack-popups-block-supports inline style for above-header popups on block themes.'
+		);
+	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The above-header campaigns were missing block support CSS (like layout, spacing, and alignment styles) when used with the block theme. The styles need to be registered before `wp_head()` fires, but they're not; this PR prerenders above-header popup blocks early enough so we can get the block supports CSS and enqueue it separately.

This issue and fix are similar to https://github.com/Automattic/newspack-plugin/pull/4449, but it would be harder (impossible?) to fix by moving the campaign content, and it's only applied to the block theme. 

Closes NPPD-1199

### How to test the changes in this Pull Request:

1. Switch to a block theme.
2. Set up an above-header campaign with a block that generates CSS, like adding a row block and setting it to spread the inside blocks out. 
3. View on the front end; note that you're losing your row alignment styles (the campaign by default also doesn't have spacing, but that matches with how it works with the classic theme). The blocks also lose their 'content width' -- by default, the block content should be narrower: 632px wide normally, or 1296px wide if you're using a wide block:

In my example, I have a row block set to wide with padding on the top and bottom, and a background set for the entire campaign itself:

<img width="1603" height="280" alt="CleanShot 2026-02-20 at 14 16 28" src="https://github.com/user-attachments/assets/f16e3805-1d36-439a-a87b-7acb52f33647" />

5. Apply this PR.
6. Confirm that your above header campaign's row block now acts like a row block:

<img width="1441" height="286" alt="CleanShot 2026-02-20 at 14 15 50" src="https://github.com/user-attachments/assets/d8d76dd7-5594-44be-964e-eb32460c80dc" />

Smoke testing:
1. Double check that the inline/overlay prompts still enqueue styles and look okay.
2. Try switching to the classic theme and double check the above header, inline, and overlay prompts:


### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
