### PR TITLE
fix: give more specific overlays priority by tweaking DOM order

### DIFF
--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -448,7 +448,7 @@ final class Newspack_Popups_Inserter {
 		}
 
 		// 4. Insert overlay prompts at the top of content.
-		// So's to leave the existing behavior (prepending each overlay) in place,
+		// To leave the existing behavior (prepending each overlay) in place,
 		// we reverse our sorted overlays to ensure the most specific appear
 		// first in the DOM, and get priority for the single available slot.
 		$overlay_popups = array_reverse( self::sort_overlays_by_specificity( $overlay_popups ) );

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -566,8 +566,24 @@ final class Newspack_Popups_Inserter {
 	 */
 	public static function insert_before_header() {
 		$before_header_popups = array_filter( self::popups_for_post(), [ 'Newspack_Popups_Model', 'should_be_inserted_above_page_header' ] );
-		$before_header_popups = self::sort_overlays_by_specificity( array_values( $before_header_popups ) );
-		foreach ( $before_header_popups as $popup ) {
+		// Sort only the overlay subset by specificity — above-header inline prompts are
+		// not subject to the single visible overlay slot constraint and are left in their
+		// original order.
+		$overlay_popups = self::sort_overlays_by_specificity(
+			array_values( array_filter( $before_header_popups, [ 'Newspack_Popups_Model', 'is_overlay' ] ) )
+		);
+		$inline_popups  = array_values(
+			array_filter(
+				$before_header_popups,
+				function( $popup ) {
+					return ! Newspack_Popups_Model::is_overlay( $popup );
+				}
+			)
+		);
+		foreach ( $overlay_popups as $popup ) {
+			echo Newspack_Popups_Model::generate_popup( $popup ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		}
+		foreach ( $inline_popups as $popup ) {
 			echo Newspack_Popups_Model::generate_popup( $popup ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		}
 	}

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -278,8 +278,8 @@ final class Newspack_Popups_Inserter {
 		usort(
 			$overlays,
 			function( $a, $b ) {
-				$a_count = count( $a['segments'] );
-				$b_count = count( $b['segments'] );
+				$a_count = isset( $a['segments'] ) && is_array( $a['segments'] ) ? count( $a['segments'] ) : 0;
+				$b_count = isset( $b['segments'] ) && is_array( $b['segments'] ) ? count( $b['segments'] ) : 0;
 				// Map zero-segment overlays to PHP_INT_MAX so they sort last.
 				$a_key = 0 === $a_count ? PHP_INT_MAX : $a_count;
 				$b_key = 0 === $b_count ? PHP_INT_MAX : $b_count;

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -263,6 +263,33 @@ final class Newspack_Popups_Inserter {
 	}
 
 	/**
+	 * Sort overlay prompts so that segment-assigned ones appear first, ordered by
+	 * ascending segment count (i.e., decreasing specificity). Overlays with no
+	 * segments assigned appear last.
+	 *
+	 * Ensures segment-specific overlays claim the single visible overlay slot before
+	 * unsegmented "show to everyone" overlays, since only one overlay can be displayed
+	 * at a time and the first eligible one in the DOM wins.
+	 *
+	 * @param array $overlays Array of overlay popup objects.
+	 * @return array Sorted array, segment-assigned overlays first by ascending segment count.
+	 */
+	private static function sort_overlays_by_specificity( $overlays ) {
+		usort(
+			$overlays,
+			function( $a, $b ) {
+				$a_count = count( $a['segments'] );
+				$b_count = count( $b['segments'] );
+				// Map zero-segment overlays to PHP_INT_MAX so they sort last.
+				$a_key = 0 === $a_count ? PHP_INT_MAX : $a_count;
+				$b_key = 0 === $b_count ? PHP_INT_MAX : $b_count;
+				return $a_key - $b_key;
+			}
+		);
+		return $overlays;
+	}
+
+	/**
 	 * Insert popups in a post content.
 	 *
 	 * @param string $content The post content.
@@ -421,6 +448,10 @@ final class Newspack_Popups_Inserter {
 		}
 
 		// 4. Insert overlay prompts at the top of content.
+		// So's to leave the existing behavior (prepending each overlay) in place,
+		// we reverse our sorted overlays to ensure the most specific appear
+		// first in the DOM, and get priority for the single available slot.
+		$overlay_popups = array_reverse( self::sort_overlays_by_specificity( $overlay_popups ) );
 		foreach ( $overlay_popups as $overlay_popup ) {
 			$output = '<!-- wp:html -->' . Newspack_Popups_Model::generate_popup( $overlay_popup ) . '<!-- /wp:html -->' . $output;
 		}
@@ -524,6 +555,7 @@ final class Newspack_Popups_Inserter {
 				return Newspack_Popups_Model::should_be_inserted_in_page_content( $popup ) && Newspack_Popups_Model::is_overlay( $popup );
 			}
 		);
+		$popups = self::sort_overlays_by_specificity( array_values( $popups ) );
 		foreach ( $popups as $popup ) {
 			echo Newspack_Popups_Model::generate_popup( $popup ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		}
@@ -534,6 +566,7 @@ final class Newspack_Popups_Inserter {
 	 */
 	public static function insert_before_header() {
 		$before_header_popups = array_filter( self::popups_for_post(), [ 'Newspack_Popups_Model', 'should_be_inserted_above_page_header' ] );
+		$before_header_popups = self::sort_overlays_by_specificity( array_values( $before_header_popups ) );
 		foreach ( $before_header_popups as $popup ) {
 			echo Newspack_Popups_Model::generate_popup( $popup ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		}

--- a/tests/test-overlay-sort.php
+++ b/tests/test-overlay-sort.php
@@ -1,0 +1,130 @@
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+/**
+ * Class OverlaySort Test
+ *
+ * Tests that sort_overlays_by_specificity() orders overlay prompts correctly:
+ * segment-assigned overlays first (ascending by segment count), unsegmented last.
+ *
+ * @package Newspack_Popups
+ */
+
+/**
+ * OverlaySort test case.
+ */
+class OverlaySortTest extends WP_UnitTestCase {
+
+	/**
+	 * Simpler access to the private sort_overlays_by_specificity method.
+	 *
+	 * (See `test-classic-block-encoding.php` too.)
+	 *
+	 * @var ReflectionMethod
+	 */
+	private static $sort_overlays_by_specificity;
+
+	/**
+	 * Set up.
+	 */
+	public function set_up() { // phpcs:ignore Squiz.Commenting.FunctionComment.Missing
+		parent::set_up();
+		if ( ! self::$sort_overlays_by_specificity ) {
+			self::$sort_overlays_by_specificity = new ReflectionMethod( 'Newspack_Popups_Inserter', 'sort_overlays_by_specificity' );
+			self::$sort_overlays_by_specificity->setAccessible( true );
+		}
+	}
+
+	/**
+	 * Mock up the overlay structure.
+	 *
+	 * The only fields sort_overlays_by_specificity() inspects are 'segments' (via count())
+	 * and, to track round-trip ordering of equals, 'id'.
+	 *
+	 * @param int $segment_count Number of segments to assign to the overlay.
+	 * @param int $id            Optional identifier used to verify relative ordering.
+	 * @return array Minimal overlay array.
+	 */
+	private function make_overlay( int $segment_count, int $id = 0 ): array {
+		return [
+			'id'       => $id,
+			'segments' => array_fill( 0, $segment_count, [] ),
+		];
+	}
+
+	/**
+	 * Overlays with zero segments assigned must appear after all segmented overlays.
+	 */
+	public function test_unsegmented_overlays_sort_last() {
+		$overlays = [
+			$this->make_overlay( 0 ),
+			$this->make_overlay( 2 ),
+			$this->make_overlay( 0 ),
+			$this->make_overlay( 1 ),
+		];
+
+		$result = self::$sort_overlays_by_specificity->invoke( null, $overlays );
+
+		// Find the highest index occupied by a segmented overlay and the lowest
+		// index occupied by an unsegmented overlay; the former must be less than
+		// the latter for the sort to be correct.
+		$last_segmented_index    = -1;
+		$first_unsegmented_index = PHP_INT_MAX;
+
+		foreach ( $result as $index => $overlay ) {
+			if ( 0 === count( $overlay['segments'] ) ) {
+				$first_unsegmented_index = min( $first_unsegmented_index, $index );
+			} else {
+				$last_segmented_index = max( $last_segmented_index, $index );
+			}
+		}
+
+		$this->assertGreaterThan(
+			$last_segmented_index,
+			$first_unsegmented_index,
+			'All unsegmented overlays must appear after all segmented overlays.'
+		);
+	}
+
+	/**
+	 * Among overlays with non-zero segment counts, the sort must be ascending by count.
+	 */
+	public function test_segmented_overlays_sorted_by_ascending_count() {
+		$overlays = [
+			$this->make_overlay( 3 ),
+			$this->make_overlay( 1 ),
+			$this->make_overlay( 2 ),
+		];
+
+		$result = self::$sort_overlays_by_specificity->invoke( null, $overlays );
+
+		$counts = array_map( fn( $o ) => count( $o['segments'] ), $result );
+
+		$this->assertSame(
+			[ 1, 2, 3 ],
+			$counts,
+			'Segmented overlays must be sorted in ascending order by segment count.'
+		);
+	}
+
+	/**
+	 * Overlays with identical segment counts must retain their original relative order.
+	 *
+	 * Claude notes that only PHP 8.0+ guarantees a stable sort.
+	 */
+	public function test_equal_segment_count_preserves_relative_order() {
+		$overlays = [
+			$this->make_overlay( 2, 1 ),
+			$this->make_overlay( 2, 2 ),
+			$this->make_overlay( 2, 3 ),
+		];
+
+		$result = self::$sort_overlays_by_specificity->invoke( null, $overlays );
+
+		$ids = array_column( $result, 'id' );
+
+		$this->assertSame(
+			[ 1, 2, 3 ],
+			$ids,
+			'Overlays with equal segment counts must remain in their original relative order.'
+		);
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Addresses [NPPM-2644: General overlay prompts beating more specific ones](https://linear.app/a8c/issue/NPPM-2644/general-overlay-prompts-beating-more-specific-ones).

### How to test the changes in this Pull Request:

1. Set Newspack Campaigns up on your test site.
2. Add a segment you can easily test for (e.g., Not a Subscriber).
3. Add an overlay prompt to your segment.  Every pageview, no cap, will help with testing!
4. Create a new overlay prompt for "Everyone" (no segment).  The order in which these two are created matters, as it factors into their default positions in the page source.
5. In an incognito/otherwise clean browser session, set up the conditions for your segment, and view a page.  This should show you the "Everyone" overlay, and not the one that matches your segment.
6. Apply this PR and then try again in a clean browser session.  You should see the prompt you were expecting for your test segment.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
