### PR TITLE
fix(block-theme): move where above header campaign is inserted

### DIFF
--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -644,7 +644,7 @@ final class Newspack_Popups_Inserter {
 			[ 'Newspack_Popups_Model', 'is_inline' ]
 		);
 		if ( ! empty( $overlay_before_header_popups ) ) {
-			self::sort_overlays_by_specificity( $overlay_before_header_popups );
+			$overlay_before_header_popups = self::sort_overlays_by_specificity( array_values( $overlay_before_header_popups ) );
 		}
 		$popup_markup = '';
 		// Render overlays first, in specificity order.

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -611,7 +611,7 @@ final class Newspack_Popups_Inserter {
 	 */
 	public static function insert_before_header() {
 		// In block themes, prompts are inserted via the header template-part render filter.
-		if ( function_exists( 'wp_is_block_theme' ) && wp_is_block_theme() ) {
+		if ( Newspack_Popups_Model::is_block_theme() ) {
 			return;
 		}
 
@@ -632,7 +632,7 @@ final class Newspack_Popups_Inserter {
 	 * @return string Rendered content with campaign markup prepended when applicable.
 	 */
 	public static function insert_before_header_in_template_part( $block_content, $block, $instance ) {
-		if ( ! function_exists( 'wp_is_block_theme' ) || ! wp_is_block_theme() || is_admin() || self::$header_template_part_has_rendered ) {
+		if ( ! Newspack_Popups_Model::is_block_theme() || is_admin() || self::$header_template_part_has_rendered ) {
 			return $block_content;
 		}
 

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -570,7 +570,40 @@ final class Newspack_Popups_Inserter {
 	}
 
 	/**
-	 * Insert popups markup before header.
+	 * Build combined markup for all above-header prompts: overlays (sorted by specificity)
+	 * first, then inline prompts in their original order.
+	 *
+	 * Both above-header inline prompts and time-triggered overlay prompts are included,
+	 * as both must appear before the header so they are visible without scrolling.
+	 *
+	 * @return string HTML markup, or empty string if there are no above-header prompts.
+	 */
+	private static function get_before_header_markup() {
+		$before_header_popups = array_filter( self::popups_for_post(), [ 'Newspack_Popups_Model', 'should_be_inserted_above_page_header' ] );
+		if ( empty( $before_header_popups ) ) {
+			return '';
+		}
+
+		// Sort only the overlay subset by specificity — above-header inline prompts are
+		// not subject to the single visible overlay slot constraint and are left in their
+		// original order.
+		$overlay_popups = self::sort_overlays_by_specificity(
+			array_values( array_filter( $before_header_popups, [ 'Newspack_Popups_Model', 'is_overlay' ] ) )
+		);
+		$inline_popups  = array_values( array_filter( $before_header_popups, [ 'Newspack_Popups_Model', 'is_inline' ] ) );
+
+		$markup = '';
+		foreach ( $overlay_popups as $popup ) {
+			$markup .= Newspack_Popups_Model::generate_popup( $popup );
+		}
+		foreach ( $inline_popups as $popup ) {
+			$markup .= Newspack_Popups_Model::generate_popup( $popup );
+		}
+		return $markup;
+	}
+
+	/**
+	 * Insert popups markup before header (classic themes via wp_body_open).
 	 */
 	public static function insert_before_header() {
 		if ( self::$before_header_has_rendered ) {
@@ -582,33 +615,13 @@ final class Newspack_Popups_Inserter {
 			return;
 		}
 
-		$before_header_popups = array_filter( self::popups_for_post(), [ 'Newspack_Popups_Model', 'should_be_inserted_above_page_header' ] );
-		if ( empty( $before_header_popups ) ) {
+		$markup = self::get_before_header_markup();
+		if ( empty( $markup ) ) {
 			return;
 		}
 
-		// Sort only the overlay subset by specificity — above-header inline prompts are
-		// not subject to the single visible overlay slot constraint and are left in their
-		// original order.
-		$overlay_popups = self::sort_overlays_by_specificity(
-			array_values( array_filter( $before_header_popups, [ 'Newspack_Popups_Model', 'is_overlay' ] ) )
-		);
-		$inline_popups  = array_values(
-			array_filter(
-				$before_header_popups,
-				function( $popup ) {
-					return ! Newspack_Popups_Model::is_overlay( $popup );
-				}
-			)
-		);
-
 		self::$before_header_has_rendered = true;
-		foreach ( $overlay_popups as $popup ) {
-			echo Newspack_Popups_Model::generate_popup( $popup ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-		}
-		foreach ( $inline_popups as $popup ) {
-			echo Newspack_Popups_Model::generate_popup( $popup ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-		}
+		echo $markup; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
 
 	/**
@@ -624,40 +637,17 @@ final class Newspack_Popups_Inserter {
 			return $block_content;
 		}
 
-		if ( ! self::is_header_template_part_block( $block, $block_content ) ) {
+		if ( ! self::is_header_template_part_block( $block ) ) {
 			return $block_content;
 		}
 
-		$before_header_popups = array_filter( self::popups_for_post(), [ 'Newspack_Popups_Model', 'should_be_inserted_above_page_header' ] );
-		if ( empty( $before_header_popups ) ) {
+		$markup = self::get_before_header_markup();
+		if ( empty( $markup ) ) {
 			return $block_content;
-		}
-
-		$popup_markup = '';
-		// Mirror the overlay/inline ordering used in insert_before_header() for classic themes.
-		$overlay_before_header_popups = array_filter(
-			$before_header_popups,
-			[ 'Newspack_Popups_Model', 'is_overlay' ]
-		);
-		$inline_before_header_popups  = array_filter(
-			$before_header_popups,
-			[ 'Newspack_Popups_Model', 'is_inline' ]
-		);
-		if ( ! empty( $overlay_before_header_popups ) ) {
-			$overlay_before_header_popups = self::sort_overlays_by_specificity( array_values( $overlay_before_header_popups ) );
-		}
-		$popup_markup = '';
-		// Render overlays first, in specificity order.
-		foreach ( $overlay_before_header_popups as $popup ) {
-			$popup_markup .= Newspack_Popups_Model::generate_popup( $popup );
-		}
-		// Then render inline prompts.
-		foreach ( $inline_before_header_popups as $popup ) {
-			$popup_markup .= Newspack_Popups_Model::generate_popup( $popup );
 		}
 
 		self::$before_header_has_rendered = true;
-		return $popup_markup . $block_content;
+		return $markup . $block_content;
 	}
 
 	/**
@@ -666,11 +656,10 @@ final class Newspack_Popups_Inserter {
 	 * Some themes use custom header slugs (for example "header-post"), and in some
 	 * contexts area metadata is missing. Use progressively looser checks.
 	 *
-	 * @param array  $block         Parsed block data.
-	 * @param string $block_content Rendered block content.
+	 * @param array $block Parsed block data.
 	 * @return boolean True if this block is likely a header template part.
 	 */
-	private static function is_header_template_part_block( $block, $block_content ) {
+	private static function is_header_template_part_block( $block ) {
 		if ( empty( $block['blockName'] ) || 'core/template-part' !== $block['blockName'] ) {
 			return false;
 		}

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -640,12 +640,14 @@ final class Newspack_Popups_Inserter {
 			return $block_content;
 		}
 
+		// Set the guard before generating markup to prevent it running again before finishing.
+		self::$header_template_part_has_rendered = true;
+
 		$markup = self::get_before_header_markup();
 		if ( empty( $markup ) ) {
 			return $block_content;
 		}
 
-		self::$header_template_part_has_rendered = true;
 		return $markup . $block_content;
 	}
 

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -50,7 +50,7 @@ final class Newspack_Popups_Inserter {
 	 *
 	 * @var boolean
 	 */
-	private static $before_header_has_rendered = false;
+	private static $header_template_part_has_rendered = false;
 
 	/**
 	 * Constructor.
@@ -570,11 +570,8 @@ final class Newspack_Popups_Inserter {
 	}
 
 	/**
-	 * Build combined markup for all above-header prompts: overlays (sorted by specificity)
+	 * Get the combined markup for all above-header prompts: overlays (sorted by specificity)
 	 * first, then inline prompts in their original order.
-	 *
-	 * Both above-header inline prompts and time-triggered overlay prompts are included,
-	 * as both must appear before the header so they are visible without scrolling.
 	 *
 	 * @return string HTML markup, or empty string if there are no above-header prompts.
 	 */
@@ -590,7 +587,14 @@ final class Newspack_Popups_Inserter {
 		$overlay_popups = self::sort_overlays_by_specificity(
 			array_values( array_filter( $before_header_popups, [ 'Newspack_Popups_Model', 'is_overlay' ] ) )
 		);
-		$inline_popups  = array_values( array_filter( $before_header_popups, [ 'Newspack_Popups_Model', 'is_inline' ] ) );
+		$inline_popups  = array_values(
+			array_filter(
+				$before_header_popups,
+				function( $popup ) {
+					return ! Newspack_Popups_Model::is_overlay( $popup );
+				}
+			)
+		);
 
 		$markup = '';
 		foreach ( $overlay_popups as $popup ) {
@@ -606,10 +610,6 @@ final class Newspack_Popups_Inserter {
 	 * Insert popups markup before header (classic themes via wp_body_open).
 	 */
 	public static function insert_before_header() {
-		if ( self::$before_header_has_rendered ) {
-			return;
-		}
-
 		// In block themes, prompts are inserted via the header template-part render filter.
 		if ( function_exists( 'wp_is_block_theme' ) && wp_is_block_theme() ) {
 			return;
@@ -620,7 +620,6 @@ final class Newspack_Popups_Inserter {
 			return;
 		}
 
-		self::$before_header_has_rendered = true;
 		echo $markup; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
 
@@ -633,7 +632,7 @@ final class Newspack_Popups_Inserter {
 	 * @return string Rendered content with campaign markup prepended when applicable.
 	 */
 	public static function insert_before_header_in_template_part( $block_content, $block, $instance ) {
-		if ( ! function_exists( 'wp_is_block_theme' ) || ! wp_is_block_theme() || is_admin() || self::$before_header_has_rendered ) {
+		if ( ! function_exists( 'wp_is_block_theme' ) || ! wp_is_block_theme() || is_admin() || self::$header_template_part_has_rendered ) {
 			return $block_content;
 		}
 
@@ -646,7 +645,7 @@ final class Newspack_Popups_Inserter {
 			return $block_content;
 		}
 
-		self::$before_header_has_rendered = true;
+		self::$header_template_part_has_rendered = true;
 		return $markup . $block_content;
 	}
 

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -60,7 +60,7 @@ final class Newspack_Popups_Inserter {
 		add_shortcode( 'newspack-popup', [ $this, 'popup_shortcode' ] );
 		add_action( 'after_header', [ $this, 'insert_popups_after_header' ] ); // This is a Newspack theme hook. When used with other themes, popups won't be inserted on archive pages.
 		add_action( 'wp_body_open', [ $this, 'insert_before_header' ] );
-		add_filter( 'render_block_core/template-part', [ $this, 'insert_before_header_in_template_part' ], 10, 3 );
+		add_filter( 'render_block_core/template-part', [ $this, 'insert_before_header_in_template_part' ], 10, 2 );
 		add_action( 'after_archive_post', [ $this, 'insert_inline_prompt_in_archive_pages' ] );
 		add_action( 'wp_before_admin_bar_render', [ $this, 'add_preview_toggle' ] );
 
@@ -626,12 +626,11 @@ final class Newspack_Popups_Inserter {
 	/**
 	 * Insert popups markup before the header template part in block themes.
 	 *
-	 * @param string   $block_content The rendered block content.
-	 * @param array    $block         The full block.
-	 * @param WP_Block $instance      The block instance.
+	 * @param string $block_content The rendered block content.
+	 * @param array  $block         The full block.
 	 * @return string Rendered content with campaign markup prepended when applicable.
 	 */
-	public static function insert_before_header_in_template_part( $block_content, $block, $instance ) {
+	public static function insert_before_header_in_template_part( $block_content, $block ) {
 		if ( ! Newspack_Popups_Model::is_block_theme() || is_admin() || self::$header_template_part_has_rendered ) {
 			return $block_content;
 		}

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -634,7 +634,25 @@ final class Newspack_Popups_Inserter {
 		}
 
 		$popup_markup = '';
-		foreach ( $before_header_popups as $popup ) {
+		// Mirror the overlay/inline ordering used in insert_before_header() for classic themes.
+		$overlay_before_header_popups = array_filter(
+			$before_header_popups,
+			[ 'Newspack_Popups_Model', 'is_overlay' ]
+		);
+		$inline_before_header_popups  = array_filter(
+			$before_header_popups,
+			[ 'Newspack_Popups_Model', 'is_inline' ]
+		);
+		if ( ! empty( $overlay_before_header_popups ) ) {
+			self::sort_overlays_by_specificity( $overlay_before_header_popups );
+		}
+		$popup_markup = '';
+		// Render overlays first, in specificity order.
+		foreach ( $overlay_before_header_popups as $popup ) {
+			$popup_markup .= Newspack_Popups_Model::generate_popup( $popup );
+		}
+		// Then render inline prompts.
+		foreach ( $inline_before_header_popups as $popup ) {
 			$popup_markup .= Newspack_Popups_Model::generate_popup( $popup );
 		}
 

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -46,6 +46,13 @@ final class Newspack_Popups_Inserter {
 	private static $is_apple_news_exporting = false;
 
 	/**
+	 * Whether above-header prompts have already been rendered.
+	 *
+	 * @var boolean
+	 */
+	private static $before_header_has_rendered = false;
+
+	/**
 	 * Constructor.
 	 */
 	public function __construct() {
@@ -53,6 +60,7 @@ final class Newspack_Popups_Inserter {
 		add_shortcode( 'newspack-popup', [ $this, 'popup_shortcode' ] );
 		add_action( 'after_header', [ $this, 'insert_popups_after_header' ] ); // This is a Newspack theme hook. When used with other themes, popups won't be inserted on archive pages.
 		add_action( 'wp_body_open', [ $this, 'insert_before_header' ] );
+		add_filter( 'render_block_core/template-part', [ $this, 'insert_before_header_in_template_part' ], 10, 3 );
 		add_action( 'after_archive_post', [ $this, 'insert_inline_prompt_in_archive_pages' ] );
 		add_action( 'wp_before_admin_bar_render', [ $this, 'add_preview_toggle' ] );
 
@@ -565,7 +573,20 @@ final class Newspack_Popups_Inserter {
 	 * Insert popups markup before header.
 	 */
 	public static function insert_before_header() {
+		if ( self::$before_header_has_rendered ) {
+			return;
+		}
+
+		// In block themes, prompts are inserted via the header template-part render filter.
+		if ( function_exists( 'wp_is_block_theme' ) && wp_is_block_theme() ) {
+			return;
+		}
+
 		$before_header_popups = array_filter( self::popups_for_post(), [ 'Newspack_Popups_Model', 'should_be_inserted_above_page_header' ] );
+		if ( empty( $before_header_popups ) ) {
+			return;
+		}
+
 		// Sort only the overlay subset by specificity — above-header inline prompts are
 		// not subject to the single visible overlay slot constraint and are left in their
 		// original order.
@@ -580,12 +601,75 @@ final class Newspack_Popups_Inserter {
 				}
 			)
 		);
+
+		self::$before_header_has_rendered = true;
 		foreach ( $overlay_popups as $popup ) {
 			echo Newspack_Popups_Model::generate_popup( $popup ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		}
 		foreach ( $inline_popups as $popup ) {
 			echo Newspack_Popups_Model::generate_popup( $popup ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		}
+	}
+
+	/**
+	 * Insert popups markup before the header template part in block themes.
+	 *
+	 * @param string   $block_content The rendered block content.
+	 * @param array    $block         The full block.
+	 * @param WP_Block $instance      The block instance.
+	 * @return string Rendered content with campaign markup prepended when applicable.
+	 */
+	public static function insert_before_header_in_template_part( $block_content, $block, $instance ) {
+		if ( ! function_exists( 'wp_is_block_theme' ) || ! wp_is_block_theme() || is_admin() || self::$before_header_has_rendered ) {
+			return $block_content;
+		}
+
+		if ( ! self::is_header_template_part_block( $block, $block_content ) ) {
+			return $block_content;
+		}
+
+		$before_header_popups = array_filter( self::popups_for_post(), [ 'Newspack_Popups_Model', 'should_be_inserted_above_page_header' ] );
+		if ( empty( $before_header_popups ) ) {
+			return $block_content;
+		}
+
+		$popup_markup = '';
+		foreach ( $before_header_popups as $popup ) {
+			$popup_markup .= Newspack_Popups_Model::generate_popup( $popup );
+		}
+
+		self::$before_header_has_rendered = true;
+		return $popup_markup . $block_content;
+	}
+
+	/**
+	 * Whether a template-part block appears to be a header template part.
+	 *
+	 * Some themes use custom header slugs (for example "header-post"), and in some
+	 * contexts area metadata is missing. Use progressively looser checks.
+	 *
+	 * @param array  $block         Parsed block data.
+	 * @param string $block_content Rendered block content.
+	 * @return boolean True if this block is likely a header template part.
+	 */
+	private static function is_header_template_part_block( $block, $block_content ) {
+		if ( empty( $block['blockName'] ) || 'core/template-part' !== $block['blockName'] ) {
+			return false;
+		}
+
+		$attrs = isset( $block['attrs'] ) ? $block['attrs'] : [];
+
+		// Most reliable signal when present.
+		if ( isset( $attrs['area'] ) && 'header' === $attrs['area'] ) {
+			return true;
+		}
+
+		// Many themes use non-exact slugs such as "header-post" or "site-header".
+		if ( isset( $attrs['slug'] ) && preg_match( '/(^|[-_])header([-_]|$)/', $attrs['slug'] ) ) {
+			return true;
+		}
+
+		return false;
 	}
 
 	/**

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -964,7 +964,7 @@ final class Newspack_Popups_Model {
 	 *
 	 * @return boolean True if the current theme is a block theme.
 	 */
-	private static function is_block_theme() {
+	public static function is_block_theme() {
 		if ( null !== self::$block_theme_override ) {
 			return self::$block_theme_override;
 		}

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -1006,6 +1006,7 @@ final class Newspack_Popups_Model {
 		$is_newsletter_prompt = self::has_newsletter_prompt( $popup );
 		$classes              = [ 'newspack-popup-container', 'newspack-popup', 'hidden' ];
 		$classes[]            = 'above_header' === $popup['options']['placement'] ? 'newspack-above-header-popup' : null;
+		$classes[]            = 'above_header' && self::is_block_theme() ? 'has-global-padding' : null;
 		$classes[]            = ! self::is_above_header( $popup ) ? 'newspack-inline-popup' : null;
 		$classes[]            = 'publish' !== $popup['status'] ? 'newspack-inactive-popup-status' : null;
 		$classes[]            = $hide_border ? 'newspack-lightbox-no-border' : null;

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -1006,7 +1006,7 @@ final class Newspack_Popups_Model {
 		$is_newsletter_prompt = self::has_newsletter_prompt( $popup );
 		$classes              = [ 'newspack-popup-container', 'newspack-popup', 'hidden' ];
 		$classes[]            = 'above_header' === $popup['options']['placement'] ? 'newspack-above-header-popup' : null;
-		$classes[]            = 'above_header' && self::is_block_theme() ? 'has-global-padding' : null;
+		$classes[]            = 'above_header' === $popup['options']['placement'] && self::is_block_theme() ? 'has-global-padding' : null;
 		$classes[]            = ! self::is_above_header( $popup ) ? 'newspack-inline-popup' : null;
 		$classes[]            = 'publish' !== $popup['status'] ? 'newspack-inactive-popup-status' : null;
 		$classes[]            = $hide_border ? 'newspack-lightbox-no-border' : null;

--- a/src/view/style.scss
+++ b/src/view/style.scss
@@ -492,6 +492,11 @@ $width__tablet: 782px;
 	&.hidden {
 		display: none;
 	}
+
+	// Remove space below the above header campaign in block themes.
+	.wp-site-blocks & > * {
+		margin-block-start: 0;
+	}
 }
 
 // This is needed for the scroll-triggered popups to function properly.

--- a/src/view/style.scss
+++ b/src/view/style.scss
@@ -493,7 +493,7 @@ $width__tablet: 782px;
 		display: none;
 	}
 
-	// Remove space below the above header campaign in block themes.
+	// Remove top margin from block immediately following the prompt in block themes.
 	.wp-site-blocks & > * {
 		margin-block-start: 0;
 	}

--- a/src/view/style.scss
+++ b/src/view/style.scss
@@ -494,7 +494,7 @@ $width__tablet: 782px;
 	}
 
 	// Remove top margin from block immediately following the prompt in block themes.
-	.wp-site-blocks & + * {
+	.wp-site-blocks &:not(.hidden) + * {
 		margin-block-start: 0;
 	}
 }

--- a/src/view/style.scss
+++ b/src/view/style.scss
@@ -494,7 +494,7 @@ $width__tablet: 782px;
 	}
 
 	// Remove top margin from block immediately following the prompt in block themes.
-	.wp-site-blocks & > * {
+	.wp-site-blocks & + * {
 		margin-block-start: 0;
 	}
 }

--- a/tests/test-block-theme-header-insertion.php
+++ b/tests/test-block-theme-header-insertion.php
@@ -1,0 +1,205 @@
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+/**
+ * Class Block Theme Header Insertion Test
+ *
+ * @package Newspack_Popups
+ */
+
+/**
+ * Block theme header insertion test case.
+ */
+class BlockThemeHeaderInsertionTest extends WP_UnitTestCase_PageWithPopups {
+	/**
+	 * Original theme stylesheet.
+	 *
+	 * @var string
+	 */
+	private $original_theme_stylesheet;
+
+	/**
+	 * Reflection helper for protected inserter popups cache.
+	 *
+	 * @var ReflectionProperty
+	 */
+	private static $inserter_popups_property;
+
+	/**
+	 * Reflection helper for private before-header render guard.
+	 *
+	 * @var ReflectionProperty
+	 */
+	private static $before_header_has_rendered_property;
+
+
+	/**
+	 * Set up each test.
+	 */
+	public function set_up() { // phpcs:ignore Squiz.Commenting.FunctionComment.Missing
+		parent::set_up();
+
+		$this->original_theme_stylesheet = get_stylesheet();
+		$block_theme_stylesheet          = $this->get_any_block_theme_stylesheet();
+		if ( ! $block_theme_stylesheet ) {
+			$this->markTestSkipped( 'No block theme is available in this test environment.' );
+		}
+		switch_theme( $block_theme_stylesheet );
+
+		if ( ! self::$inserter_popups_property ) {
+			self::$inserter_popups_property = new ReflectionProperty( 'Newspack_Popups_Inserter', 'popups' );
+			self::$inserter_popups_property->setAccessible( true );
+		}
+		if ( ! self::$before_header_has_rendered_property ) {
+			self::$before_header_has_rendered_property = new ReflectionProperty( 'Newspack_Popups_Inserter', 'before_header_has_rendered' );
+			self::$before_header_has_rendered_property->setAccessible( true );
+		}
+		self::$inserter_popups_property->setValue( null, [] );
+		self::$before_header_has_rendered_property->setValue( null, false );
+	}
+
+	/**
+	 * Tear down each test.
+	 */
+	public function tear_down() { // phpcs:ignore Squiz.Commenting.FunctionComment.Missing
+		if ( $this->original_theme_stylesheet ) {
+			switch_theme( $this->original_theme_stylesheet );
+		}
+		if ( self::$inserter_popups_property ) {
+			self::$inserter_popups_property->setValue( null, [] );
+		}
+		if ( self::$before_header_has_rendered_property ) {
+			self::$before_header_has_rendered_property->setValue( null, false );
+		}
+		parent::tear_down();
+	}
+
+	/**
+	 * Find any installed block theme stylesheet slug.
+	 *
+	 * @return string|null Theme stylesheet, or null if unavailable.
+	 */
+	private function get_any_block_theme_stylesheet() {
+		foreach ( wp_get_themes() as $stylesheet => $theme ) {
+			if ( method_exists( $theme, 'is_block_theme' ) && $theme->is_block_theme() ) {
+				return $stylesheet;
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Build a basic header template-part block shape.
+	 *
+	 * @return array
+	 */
+	private function get_header_template_part_block() {
+		return [
+			'blockName' => 'core/template-part',
+			'attrs'     => [
+				'area' => 'header',
+				'slug' => 'header',
+			],
+		];
+	}
+
+	/**
+	 * Prepare inserter cache with popup objects for deterministic tests.
+	 *
+	 * @param array $popups Popup objects.
+	 */
+	private function seed_inserter_popups( $popups ) {
+		self::$inserter_popups_property->setValue( null, $popups );
+		self::$before_header_has_rendered_property->setValue( null, false );
+	}
+
+	/**
+	 * Block themes should prepend the prompt to header template-part render output once.
+	 */
+	public function test_inserts_once_for_header_template_part() {
+		$popup_id = self::createPopup(
+			'Block theme header prompt',
+			[
+				'placement' => 'above_header',
+				'frequency' => 'always',
+			]
+		);
+		$popup    = Newspack_Popups_Model::retrieve_popup_by_id( $popup_id );
+		$this->seed_inserter_popups( [ $popup ] );
+
+		$block_content = '<div class="wp-block-template-part">header content</div>';
+		$block         = $this->get_header_template_part_block();
+
+		$first = Newspack_Popups_Inserter::insert_before_header_in_template_part( $block_content, $block, null );
+		$this->assertStringContainsString( 'Block theme header prompt', $first, 'Header template part is prepended with prompt markup.' );
+		$this->assertStringEndsWith( $block_content, $first, 'Original header template-part output remains after prepended markup.' );
+
+		$second = Newspack_Popups_Inserter::insert_before_header_in_template_part( $block_content, $block, null );
+		$this->assertSame( $block_content, $second, 'Prompt is not inserted again after first render.' );
+	}
+
+	/**
+	 * Non-header template parts should not be modified.
+	 */
+	public function test_does_not_insert_for_non_header_template_part() {
+		$popup_id = self::createPopup(
+			'Should not render here',
+			[
+				'placement' => 'above_header',
+				'frequency' => 'always',
+			]
+		);
+		$popup    = Newspack_Popups_Model::retrieve_popup_by_id( $popup_id );
+		$this->seed_inserter_popups( [ $popup ] );
+
+		$block_content = '<div class="wp-block-template-part">footer content</div>';
+		$block         = [
+			'blockName' => 'core/template-part',
+			'attrs'     => [
+				'area' => 'footer',
+				'slug' => 'footer',
+			],
+		];
+
+		$result = Newspack_Popups_Inserter::insert_before_header_in_template_part( $block_content, $block, null );
+		$this->assertSame( $block_content, $result, 'Only header template-part blocks should be modified.' );
+	}
+
+	/**
+	 * Overlay specificity ordering should be preserved in block theme path.
+	 */
+	public function test_overlay_specificity_order_is_preserved() {
+		$generic_overlay_id = self::createPopup(
+			'Generic overlay',
+			[
+				'placement'    => 'center',
+				'trigger_type' => 'time',
+				'frequency'    => 'always',
+			]
+		);
+		$segment_overlay_id = self::createPopup(
+			'Segment overlay',
+			[
+				'placement'    => 'center',
+				'trigger_type' => 'time',
+				'frequency'    => 'always',
+			]
+		);
+
+		$generic_overlay              = Newspack_Popups_Model::retrieve_popup_by_id( $generic_overlay_id );
+		$segment_specific_overlay     = Newspack_Popups_Model::retrieve_popup_by_id( $segment_overlay_id );
+		$segment_specific_overlay['segments'] = [ [ 'id' => 123 ] ];
+
+		// Seed in reverse order; segment-specific should still render first.
+		$this->seed_inserter_popups( [ $generic_overlay, $segment_specific_overlay ] );
+
+		$block_content = '<div class="wp-block-template-part">header content</div>';
+		$block         = $this->get_header_template_part_block();
+		$result        = Newspack_Popups_Inserter::insert_before_header_in_template_part( $block_content, $block, null );
+
+		$segment_pos = strpos( $result, 'Segment overlay' );
+		$generic_pos = strpos( $result, 'Generic overlay' );
+
+		$this->assertNotFalse( $segment_pos, 'Segment-specific overlay should be rendered.' );
+		$this->assertNotFalse( $generic_pos, 'Generic overlay should be rendered.' );
+		$this->assertLessThan( $generic_pos, $segment_pos, 'Segment-specific overlay should render before generic overlay.' );
+	}
+}

--- a/tests/test-block-theme-header-insertion.php
+++ b/tests/test-block-theme-header-insertion.php
@@ -28,7 +28,7 @@ class BlockThemeHeaderInsertionTest extends WP_UnitTestCase_PageWithPopups {
 	 *
 	 * @var ReflectionProperty
 	 */
-	private static $before_header_has_rendered_property;
+	private static $header_template_part_has_rendered_property;
 
 
 	/**
@@ -48,12 +48,12 @@ class BlockThemeHeaderInsertionTest extends WP_UnitTestCase_PageWithPopups {
 			self::$inserter_popups_property = new ReflectionProperty( 'Newspack_Popups_Inserter', 'popups' );
 			self::$inserter_popups_property->setAccessible( true );
 		}
-		if ( ! self::$before_header_has_rendered_property ) {
-			self::$before_header_has_rendered_property = new ReflectionProperty( 'Newspack_Popups_Inserter', 'before_header_has_rendered' );
-			self::$before_header_has_rendered_property->setAccessible( true );
+		if ( ! self::$header_template_part_has_rendered_property ) {
+			self::$header_template_part_has_rendered_property = new ReflectionProperty( 'Newspack_Popups_Inserter', 'header_template_part_has_rendered' );
+			self::$header_template_part_has_rendered_property->setAccessible( true );
 		}
 		self::$inserter_popups_property->setValue( null, [] );
-		self::$before_header_has_rendered_property->setValue( null, false );
+		self::$header_template_part_has_rendered_property->setValue( null, false );
 	}
 
 	/**
@@ -66,8 +66,8 @@ class BlockThemeHeaderInsertionTest extends WP_UnitTestCase_PageWithPopups {
 		if ( self::$inserter_popups_property ) {
 			self::$inserter_popups_property->setValue( null, [] );
 		}
-		if ( self::$before_header_has_rendered_property ) {
-			self::$before_header_has_rendered_property->setValue( null, false );
+		if ( self::$header_template_part_has_rendered_property ) {
+			self::$header_template_part_has_rendered_property->setValue( null, false );
 		}
 		parent::tear_down();
 	}
@@ -108,7 +108,7 @@ class BlockThemeHeaderInsertionTest extends WP_UnitTestCase_PageWithPopups {
 	 */
 	private function seed_inserter_popups( $popups ) {
 		self::$inserter_popups_property->setValue( null, $popups );
-		self::$before_header_has_rendered_property->setValue( null, false );
+		self::$header_template_part_has_rendered_property->setValue( null, false );
 	}
 
 	/**

--- a/tests/test-block-theme-header-insertion.php
+++ b/tests/test-block-theme-header-insertion.php
@@ -164,6 +164,68 @@ class BlockThemeHeaderInsertionTest extends WP_UnitTestCase_PageWithPopups {
 	}
 
 	/**
+	 * Header-like slug fallback should insert when area is missing.
+	 */
+	public function test_inserts_for_slug_only_header_match() {
+		$popup_id = self::createPopup(
+			'Slug fallback prompt',
+			[
+				'placement' => 'above_header',
+				'frequency' => 'always',
+			]
+		);
+		$popup    = Newspack_Popups_Model::retrieve_popup_by_id( $popup_id );
+		$this->seed_inserter_popups( [ $popup ] );
+
+		$block_content = '<div class="wp-block-template-part">header content</div>';
+		$variants      = [ 'header-post', 'site-header' ];
+
+		foreach ( $variants as $slug ) {
+			self::$header_template_part_has_rendered_property->setValue( null, false );
+
+			$block = [
+				'blockName' => 'core/template-part',
+				'attrs'     => [
+					'slug' => $slug,
+				],
+			];
+
+			$result = Newspack_Popups_Inserter::insert_before_header_in_template_part( $block_content, $block, null );
+			$this->assertStringContainsString(
+				'Slug fallback prompt',
+				$result,
+				sprintf( 'Slug "%s" should match header fallback regex.', $slug )
+			);
+		}
+	}
+
+	/**
+	 * Slugs that merely contain "headers" should not match the header fallback regex.
+	 */
+	public function test_does_not_insert_for_slug_only_non_match() {
+		$popup_id = self::createPopup(
+			'Should not render for headers slug',
+			[
+				'placement' => 'above_header',
+				'frequency' => 'always',
+			]
+		);
+		$popup    = Newspack_Popups_Model::retrieve_popup_by_id( $popup_id );
+		$this->seed_inserter_popups( [ $popup ] );
+
+		$block_content = '<div class="wp-block-template-part">not header content</div>';
+		$block         = [
+			'blockName' => 'core/template-part',
+			'attrs'     => [
+				'slug' => 'my-headers-archive',
+			],
+		];
+
+		$result = Newspack_Popups_Inserter::insert_before_header_in_template_part( $block_content, $block, null );
+		$this->assertSame( $block_content, $result, 'Slug "my-headers-archive" should not match header fallback regex.' );
+	}
+
+	/**
 	 * Overlay specificity ordering should be preserved in block theme path.
 	 */
 	public function test_overlay_specificity_order_is_preserved() {

--- a/tests/test-block-theme-header-insertion.php
+++ b/tests/test-block-theme-header-insertion.php
@@ -128,11 +128,11 @@ class BlockThemeHeaderInsertionTest extends WP_UnitTestCase_PageWithPopups {
 		$block_content = '<div class="wp-block-template-part">header content</div>';
 		$block         = $this->get_header_template_part_block();
 
-		$first = Newspack_Popups_Inserter::insert_before_header_in_template_part( $block_content, $block, null );
+		$first = Newspack_Popups_Inserter::insert_before_header_in_template_part( $block_content, $block );
 		$this->assertStringContainsString( 'Block theme header prompt', $first, 'Header template part is prepended with prompt markup.' );
 		$this->assertStringEndsWith( $block_content, $first, 'Original header template-part output remains after prepended markup.' );
 
-		$second = Newspack_Popups_Inserter::insert_before_header_in_template_part( $block_content, $block, null );
+		$second = Newspack_Popups_Inserter::insert_before_header_in_template_part( $block_content, $block );
 		$this->assertSame( $block_content, $second, 'Prompt is not inserted again after first render.' );
 	}
 
@@ -159,7 +159,7 @@ class BlockThemeHeaderInsertionTest extends WP_UnitTestCase_PageWithPopups {
 			],
 		];
 
-		$result = Newspack_Popups_Inserter::insert_before_header_in_template_part( $block_content, $block, null );
+		$result = Newspack_Popups_Inserter::insert_before_header_in_template_part( $block_content, $block );
 		$this->assertSame( $block_content, $result, 'Only header template-part blocks should be modified.' );
 	}
 
@@ -190,7 +190,7 @@ class BlockThemeHeaderInsertionTest extends WP_UnitTestCase_PageWithPopups {
 				],
 			];
 
-			$result = Newspack_Popups_Inserter::insert_before_header_in_template_part( $block_content, $block, null );
+			$result = Newspack_Popups_Inserter::insert_before_header_in_template_part( $block_content, $block );
 			$this->assertStringContainsString(
 				'Slug fallback prompt',
 				$result,
@@ -221,7 +221,7 @@ class BlockThemeHeaderInsertionTest extends WP_UnitTestCase_PageWithPopups {
 			],
 		];
 
-		$result = Newspack_Popups_Inserter::insert_before_header_in_template_part( $block_content, $block, null );
+		$result = Newspack_Popups_Inserter::insert_before_header_in_template_part( $block_content, $block );
 		$this->assertSame( $block_content, $result, 'Slug "my-headers-archive" should not match header fallback regex.' );
 	}
 
@@ -255,7 +255,7 @@ class BlockThemeHeaderInsertionTest extends WP_UnitTestCase_PageWithPopups {
 
 		$block_content = '<div class="wp-block-template-part">header content</div>';
 		$block         = $this->get_header_template_part_block();
-		$result        = Newspack_Popups_Inserter::insert_before_header_in_template_part( $block_content, $block, null );
+		$result        = Newspack_Popups_Inserter::insert_before_header_in_template_part( $block_content, $block );
 
 		$segment_pos = strpos( $result, 'Segment overlay' );
 		$generic_pos = strpos( $result, 'Generic overlay' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

An alternative approach to https://github.com/Automattic/newspack-popups/pull/1527. 

Out of the box, the above-header campaigns were missing block support CSS (like layout, spacing, and alignment styles) when used with the block theme. The styles need to be registered before `wp_head()` fires, but they're not; this PR moves the insertion point of the above header prompt for the block theme to fix this.

(Unfortunately it moves the prompt _inside_ of the header; if we do end up reworking the prompts to be more block-like themselves like in NPPD-1216, we should be able to use the block hooks API to move this above the header [in theory]).

Closes NPPD-1199

### How to test the changes in this Pull Request:

1. Switch to a block theme.
2. Set up an above-header campaign with a block that generates CSS, like adding a row block and setting it to spread the inside blocks out.
3. View on the front end; note that you're losing your row alignment styles (the campaign by default also doesn't have spacing, but that matches with how it works with the classic theme). The blocks also lose their 'content width' -- by default, the block content should be narrower: 632px wide normally, or 1296px wide if you're using a wide block.

In my example, I have a row block set to wide with padding on the top and bottom, and a background set for the entire campaign itself:

<img width="1597" height="430" alt="CleanShot 2026-03-03 at 17 01 57" src="https://github.com/user-attachments/assets/b4dc99aa-4b77-418f-86bd-34bb1527b270" />

5. Apply this PR.
6. Confirm that your above header campaign's row block now acts like a row block:

<img width="1559" height="427" alt="CleanShot 2026-03-03 at 17 00 39" src="https://github.com/user-attachments/assets/b96043cb-6143-42ef-9b1d-95fa1ecfc32d" />

Smoke testing:

1. Double check that the inline/overlay prompts (both timed and scroll depth) look okay with the same kinds of blocks. 
2. Try switching to the classic theme and double check the above header, inline, and overlay prompts.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
