### PR TITLE
perf: cache popup retrieval and content block parsing

### DIFF
--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -30,6 +30,8 @@ final class Newspack_Popups_Inserter {
 	 */
 	protected static $segments = [];
 
+	const PARSED_BLOCKS_CACHE_EXPIRY = 3600; // 1 hour.
+
 	/**
 	 * Whether we've already inserted prompts into the content.
 	 * If we've already inserted popups into the content, don't try to do it again.
@@ -298,6 +300,30 @@ final class Newspack_Popups_Inserter {
 	}
 
 	/**
+	 * Parse blocks from content, using object cache when available.
+	 *
+	 * Caches the result of parse_blocks() + convert_classic_blocks() keyed
+	 * by the content hash so that repeated processing of the same content
+	 * (across page loads with persistent cache) is avoided.
+	 *
+	 * @param string $content Post content.
+	 * @return array Parsed block array.
+	 */
+	private static function get_parsed_blocks( $content ) {
+		$cache_key = 'parsed_blocks_' . md5( $content );
+		$cached    = wp_cache_get( $cache_key, Newspack_Popups_Model::CACHE_GROUP );
+		if ( false !== $cached ) {
+			return $cached;
+		}
+
+		$parsed_blocks = self::convert_classic_blocks( parse_blocks( $content ) );
+
+		wp_cache_set( $cache_key, $parsed_blocks, Newspack_Popups_Model::CACHE_GROUP, self::PARSED_BLOCKS_CACHE_EXPIRY ); // phpcs:ignore WordPressVIPMinimum.Performance.LowExpiryCacheTime.CacheTimeUndetermined
+
+		return $parsed_blocks;
+	}
+
+	/**
 	 * Insert popups in a post content.
 	 *
 	 * @param string $content The post content.
@@ -309,7 +335,7 @@ final class Newspack_Popups_Inserter {
 		// For these blocks, let's ignore their length for purposes of inserting prompts.
 		$length_ignored_blocks = [ 'jetpack/slideshow', 'newspack-blocks/carousel', 'newspack-popups/single-prompt' ];
 
-		$parsed_blocks = self::convert_classic_blocks( parse_blocks( $content ) );
+		$parsed_blocks = self::get_parsed_blocks( $content );
 
 		// List of blocks that require innerHTML to render content.
 		$blocks_to_skip_empty = [

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -25,6 +25,17 @@ final class Newspack_Popups_Model {
 	 */
 	protected static $inline_placements = [ 'inline', 'above_header', 'archives' ];
 
+	const CACHE_GROUP          = 'newspack_popups';
+	const CACHE_KEY_ELIGIBLE   = 'eligible_popups';
+	const CACHE_EXPIRY_ELIGIBLE = 600; // 10 minutes.
+
+	/**
+	 * Clear the eligible popups cache.
+	 */
+	public static function clear_popup_cache() {
+		wp_cache_delete( self::CACHE_KEY_ELIGIBLE, self::CACHE_GROUP );
+	}
+
 	/**
 	 * List of hooks that can be used to insert hidden inputs in forms that will be rendered inside a popup.
 	 *
@@ -215,7 +226,18 @@ final class Newspack_Popups_Model {
 			self::$overlay_placements,
 			self::$inline_placements
 		);
-		$args             = [
+
+		// Only cache the default frontend query (published, no campaign filter, default placements).
+		$use_cache = ! $include_unpublished && false === $campaign_id && null === $placements;
+
+		if ( $use_cache ) {
+			$cached = wp_cache_get( self::CACHE_KEY_ELIGIBLE, self::CACHE_GROUP );
+			if ( false !== $cached ) {
+				return $cached;
+			}
+		}
+
+		$args = [
 			'post_type'      => Newspack_Popups::NEWSPACK_POPUPS_CPT,
 			'post_status'    => $include_unpublished ? [ 'draft', 'pending', 'future', 'publish' ] : 'publish',
 			'posts_per_page' => 100,
@@ -239,7 +261,13 @@ final class Newspack_Popups_Model {
 			$args['tax_query'] = [ $tax_query ]; // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
 		}
 
-		return self::retrieve_popups_with_query( new WP_Query( $args ) );
+		$result = self::retrieve_popups_with_query( new WP_Query( $args ) );
+
+		if ( $use_cache ) {
+			wp_cache_set( self::CACHE_KEY_ELIGIBLE, $result, self::CACHE_GROUP, self::CACHE_EXPIRY_ELIGIBLE ); // phpcs:ignore WordPressVIPMinimum.Performance.LowExpiryCacheTime.CacheTimeUndetermined
+		}
+
+		return $result;
 	}
 
 	/**

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -94,6 +94,12 @@ final class Newspack_Popups {
 		add_action( 'transition_post_status', [ __CLASS__, 'prevent_default_category_on_publish' ], 10, 3 );
 		add_action( 'transition_post_status', [ __CLASS__, 'store_activation_dates' ], 10, 3 );
 		add_action( 'pre_delete_term', [ __CLASS__, 'prevent_default_category_on_term_delete' ], 10, 2 );
+		add_action( 'save_post_' . self::NEWSPACK_POPUPS_CPT, [ 'Newspack_Popups_Model', 'clear_popup_cache' ] );
+		add_action( 'transition_post_status', [ __CLASS__, 'maybe_clear_popup_cache_on_transition' ], 10, 3 );
+		add_action( 'set_object_terms', [ __CLASS__, 'maybe_clear_popup_cache_on_terms' ], 10, 4 );
+		add_action( 'added_post_meta', [ __CLASS__, 'maybe_clear_popup_cache_on_meta' ], 10, 4 );
+		add_action( 'updated_post_meta', [ __CLASS__, 'maybe_clear_popup_cache_on_meta' ], 10, 4 );
+		add_action( 'deleted_post_meta', [ __CLASS__, 'maybe_clear_popup_cache_on_meta' ], 10, 4 );
 		add_filter( 'show_admin_bar', [ __CLASS__, 'show_admin_bar' ], 10, 2 ); // phpcs:ignore WordPressVIPMinimum.UserExperience.AdminBarRemoval.RemovalDetected
 		add_filter( 'newspack_blocks_should_deduplicate', [ __CLASS__, 'newspack_blocks_should_deduplicate' ], 10, 2 );
 
@@ -1114,6 +1120,47 @@ final class Newspack_Popups {
 		}
 		if ( 'publish' === $old_status && 'publish' !== $new_status ) {
 			update_post_meta( $post->ID, 'deactivation_date', gmdate( 'Y-m-d H:i:s' ) );
+		}
+	}
+
+	/**
+	 * Clear popup cache when a popup's post status changes.
+	 *
+	 * @param string  $new_status New status.
+	 * @param string  $old_status Old status.
+	 * @param WP_Post $post       Post object.
+	 */
+	public static function maybe_clear_popup_cache_on_transition( $new_status, $old_status, $post ) {
+		if ( self::NEWSPACK_POPUPS_CPT === $post->post_type ) {
+			Newspack_Popups_Model::clear_popup_cache();
+		}
+	}
+
+	/**
+	 * Clear popup cache when terms are set on a popup.
+	 *
+	 * @param int    $object_id  Object ID.
+	 * @param array  $terms      Array of term IDs.
+	 * @param array  $tt_ids     Array of term taxonomy IDs.
+	 * @param string $taxonomy   Taxonomy slug.
+	 */
+	public static function maybe_clear_popup_cache_on_terms( $object_id, $terms, $tt_ids, $taxonomy ) {
+		if ( self::NEWSPACK_POPUPS_CPT === get_post_type( $object_id ) ) {
+			Newspack_Popups_Model::clear_popup_cache();
+		}
+	}
+
+	/**
+	 * Clear popup cache when popup meta is updated or deleted.
+	 *
+	 * @param int    $meta_id    Meta ID.
+	 * @param int    $object_id  Post ID.
+	 * @param string $meta_key   Meta key.
+	 * @param mixed  $meta_value Meta value.
+	 */
+	public static function maybe_clear_popup_cache_on_meta( $meta_id, $object_id, $meta_key, $meta_value ) {
+		if ( self::NEWSPACK_POPUPS_CPT === get_post_type( $object_id ) ) {
+			Newspack_Popups_Model::clear_popup_cache();
 		}
 	}
 

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -1159,7 +1159,15 @@ final class Newspack_Popups {
 	 * @param mixed  $meta_value Meta value.
 	 */
 	public static function maybe_clear_popup_cache_on_meta( $meta_id, $object_id, $meta_key, $meta_value ) {
+		static $cache_cleared_for_request = false;
+
+		// Debounce cache clearing so it only happens once per request per popup save.
+		if ( $cache_cleared_for_request ) {
+			return;
+		}
+
 		if ( self::NEWSPACK_POPUPS_CPT === get_post_type( $object_id ) ) {
+			$cache_cleared_for_request = true;
 			Newspack_Popups_Model::clear_popup_cache();
 		}
 	}

--- a/tests/test-popup-cache.php
+++ b/tests/test-popup-cache.php
@@ -1,0 +1,199 @@
+<?php
+/**
+ * Class Popup Cache Test
+ *
+ * @package Newspack_Popups
+ */
+
+/**
+ * Popup cache test case.
+ */
+class PopupCacheTest extends WP_UnitTestCase {
+
+	/**
+	 * Remove all popups between tests.
+	 */
+	public function set_up() {
+		parent::set_up();
+		foreach ( Newspack_Popups_Model::retrieve_popups( true ) as $popup ) {
+			wp_delete_post( $popup['id'] );
+		}
+		Newspack_Popups_Model::clear_popup_cache();
+	}
+
+	/**
+	 * Test that eligible popups are cached on second call.
+	 */
+	public function test_eligible_popups_are_cached() {
+		self::factory()->post->create(
+			[
+				'post_type'   => Newspack_Popups::NEWSPACK_POPUPS_CPT,
+				'post_status' => 'publish',
+			]
+		);
+
+		// First call populates cache.
+		$result1 = Newspack_Popups_Model::retrieve_eligible_popups();
+
+		// Verify cache is populated.
+		$cached = wp_cache_get( Newspack_Popups_Model::CACHE_KEY_ELIGIBLE, Newspack_Popups_Model::CACHE_GROUP );
+		self::assertNotFalse( $cached, 'Cache should be populated after first call.' );
+		self::assertEquals( $result1, $cached, 'Cached value should match first call result.' );
+
+		// Second call should return same result.
+		$result2 = Newspack_Popups_Model::retrieve_eligible_popups();
+		self::assertEquals( $result1, $result2, 'Second call should return cached result.' );
+	}
+
+	/**
+	 * Test that cache is invalidated when a popup is saved.
+	 */
+	public function test_cache_invalidated_on_save() {
+		$popup_id = self::factory()->post->create(
+			[
+				'post_type'   => Newspack_Popups::NEWSPACK_POPUPS_CPT,
+				'post_status' => 'publish',
+			]
+		);
+
+		// Populate cache.
+		Newspack_Popups_Model::retrieve_eligible_popups();
+		self::assertNotFalse(
+			wp_cache_get( Newspack_Popups_Model::CACHE_KEY_ELIGIBLE, Newspack_Popups_Model::CACHE_GROUP ),
+			'Cache should be populated.'
+		);
+
+		// Trigger save.
+		wp_update_post(
+			[
+				'ID'         => $popup_id,
+				'post_title' => 'Updated',
+			]
+		);
+
+		// Cache should be cleared.
+		self::assertFalse(
+			wp_cache_get( Newspack_Popups_Model::CACHE_KEY_ELIGIBLE, Newspack_Popups_Model::CACHE_GROUP ),
+			'Cache should be cleared after popup save.'
+		);
+	}
+
+	/**
+	 * Test that cache is not used for unpublished or campaign-filtered queries.
+	 */
+	public function test_cache_bypassed_for_preview_queries() {
+		self::factory()->post->create(
+			[
+				'post_type'   => Newspack_Popups::NEWSPACK_POPUPS_CPT,
+				'post_status' => 'publish',
+			]
+		);
+
+		// Populate default cache.
+		Newspack_Popups_Model::retrieve_eligible_popups();
+
+		// Call with include_unpublished — should NOT use cache.
+		Newspack_Popups_Model::retrieve_eligible_popups( true );
+
+		// Default cache should still be intact (not overwritten).
+		$cached = wp_cache_get( Newspack_Popups_Model::CACHE_KEY_ELIGIBLE, Newspack_Popups_Model::CACHE_GROUP );
+		self::assertNotFalse( $cached, 'Default cache should not be affected by preview queries.' );
+	}
+
+	/**
+	 * Test that cache is invalidated when popup meta is updated.
+	 */
+	public function test_cache_invalidated_on_meta_update() {
+		$popup_id = self::factory()->post->create(
+			[
+				'post_type'   => Newspack_Popups::NEWSPACK_POPUPS_CPT,
+				'post_status' => 'publish',
+			]
+		);
+
+		// Populate cache.
+		Newspack_Popups_Model::retrieve_eligible_popups();
+
+		// Update placement meta.
+		update_post_meta( $popup_id, 'placement', 'center' );
+
+		// Cache should be cleared.
+		self::assertFalse(
+			wp_cache_get( Newspack_Popups_Model::CACHE_KEY_ELIGIBLE, Newspack_Popups_Model::CACHE_GROUP ),
+			'Cache should be cleared after meta update.'
+		);
+	}
+
+	/**
+	 * Test that cache is invalidated when terms are set on a popup.
+	 */
+	public function test_cache_invalidated_on_term_change() {
+		$popup_id = self::factory()->post->create(
+			[
+				'post_type'   => Newspack_Popups::NEWSPACK_POPUPS_CPT,
+				'post_status' => 'publish',
+			]
+		);
+
+		// Populate cache.
+		Newspack_Popups_Model::retrieve_eligible_popups();
+
+		// Assign a category.
+		$cat_id = self::factory()->category->create();
+		wp_set_object_terms( $popup_id, [ $cat_id ], 'category' );
+
+		// Cache should be cleared.
+		self::assertFalse(
+			wp_cache_get( Newspack_Popups_Model::CACHE_KEY_ELIGIBLE, Newspack_Popups_Model::CACHE_GROUP ),
+			'Cache should be cleared after term assignment.'
+		);
+	}
+
+	/**
+	 * Test that parsed blocks are cached by content hash.
+	 */
+	public function test_parsed_blocks_are_cached() {
+		$content   = '<!-- wp:paragraph --><p>Hello world</p><!-- /wp:paragraph -->';
+		$cache_key = 'parsed_blocks_' . md5( $content );
+
+		// Ensure cache is empty.
+		wp_cache_delete( $cache_key, Newspack_Popups_Model::CACHE_GROUP );
+
+		// Use reflection to call the private method.
+		$method = new ReflectionMethod( 'Newspack_Popups_Inserter', 'get_parsed_blocks' );
+		$method->setAccessible( true );
+
+		$result1 = $method->invoke( null, $content );
+
+		// Cache should now be populated.
+		$cached = wp_cache_get( $cache_key, Newspack_Popups_Model::CACHE_GROUP );
+		self::assertNotFalse( $cached, 'Parsed blocks should be cached.' );
+		self::assertEquals( $result1, $cached, 'Cached parsed blocks should match.' );
+
+		// Second call with same content should return identical result.
+		$result2 = $method->invoke( null, $content );
+		self::assertEquals( $result1, $result2, 'Same content should return same parsed blocks.' );
+	}
+
+	/**
+	 * Test that different content produces different cache entries.
+	 */
+	public function test_parsed_blocks_different_content() {
+		$content_a = '<!-- wp:paragraph --><p>Content A</p><!-- /wp:paragraph -->';
+		$content_b = '<!-- wp:paragraph --><p>Content B</p><!-- /wp:paragraph -->';
+
+		$method = new ReflectionMethod( 'Newspack_Popups_Inserter', 'get_parsed_blocks' );
+		$method->setAccessible( true );
+
+		$result_a = $method->invoke( null, $content_a );
+		$result_b = $method->invoke( null, $content_b );
+
+		self::assertNotEquals( $result_a, $result_b, 'Different content should produce different parsed blocks.' );
+
+		// Each should be independently cached.
+		$cached_a = wp_cache_get( 'parsed_blocks_' . md5( $content_a ), Newspack_Popups_Model::CACHE_GROUP );
+		$cached_b = wp_cache_get( 'parsed_blocks_' . md5( $content_b ), Newspack_Popups_Model::CACHE_GROUP );
+		self::assertEquals( $result_a, $cached_a );
+		self::assertEquals( $result_b, $cached_b );
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Cache the eligible popups query and parsed block content in the WordPress object cache to eliminate redundant, expensive work on every frontend page load.

  - The retrieve_eligible_popups() query is now cached with a 10-minute TTL. Only the default frontend query is cached; preview, unpublished, and campaign-filtered queries bypass the cache.
  - The parse_blocks() + convert_classic_blocks() result (which instantiates DOMDocument for each classic block) is cached keyed by content MD5 hash with a 1-hour TTL, so editing the post automatically invalidates the cache.
  - The popup cache is explicitly invalidated on popup save, status transition, term assignment, and meta add/update/delete.

### Benchmark tests

You can find the benchmark code here: https://gist.github.com/miguelpeixe/96855676cae22b45a4ce2e34c4acd5ee

Run it locally via CLI: `wp eval-file benchmark-cache.php`

| Operation | Metric | Uncached | Cached | Speedup |
|---|---|---|---|---|
| Popup retrieval | avg | 64.88 ms | 0.002 ms | 26,706x |
| Popup retrieval | p50 | 60.24 ms | 0.008 ms | 7,431x |
| Popup retrieval | p95 | 78.12 ms | 0.003 ms | 25,203x |
| Content parsing (4.5KB) | avg | 0.60 ms | 0.018 ms | 33x |
| Content parsing (4.5KB) | p50 | 0.44 ms | 0.014 ms | 31x |
| Content parsing (4.5KB) | p95 | 1.51 ms | 0.045 ms | 34x |
| **Combined savings** | **avg** | | | **~65.5 ms/page** |

### How to test the changes in this Pull Request:

1. Ensure a persistent object cache is active (e.g., Memcached or Redis), or test with the default in-memory cache to verify basic correctness.
2. Create several published prompts with different placements (inline, overlay, above header).
3. Visit a post on the frontend and verify all expected prompts appear correctly.
4. Edit a prompt (change its title, placement, or frequency) and verify the updated prompt appears immediately on the frontend without stale data.
5. Assign a category to a prompt that restricts it to specific posts, and verify it only appears on matching posts.
6. Remove a category assignment from a prompt and verify it now appears on all eligible posts again.
7. Trash a prompt and verify it no longer appears on the frontend.
8. Publish a new prompt and verify it appears on the frontend immediately.
9. Use the "View As" preview feature (campaign-filtered query) and verify that previewing still works correctly and does not pollute the default cache.
10. Verify prompts display correctly on archive pages (after_header hook) and inside the Homepage Posts block.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
