### PR TITLE
fix(segmentation): reject falsy Mailchimp merge field values in donor check

### DIFF
--- a/includes/class-newspack-popups-segmentation.php
+++ b/includes/class-newspack-popups-segmentation.php
@@ -186,6 +186,17 @@ final class Newspack_Popups_Segmentation {
 	}
 
 	/**
+	 * Check if a Mailchimp merge field value should be considered as a positive donor indicator.
+	 *
+	 * @param mixed $field_value The merge field value to check.
+	 * @return bool Whether the value indicates the contact is a donor.
+	 */
+	public static function is_donor_merge_field_value( $field_value ) {
+		$falsy_values = [ 'no', 'none', 'false', '0', '' ];
+		return ! in_array( strtolower( (string) $field_value ), $falsy_values, true );
+	}
+
+	/**
 	 * When a reader logs in and the connected ESP is Mailchimp, check their donation status.
 	 * If they have a non-empty value in a merge field which matches the newspack_popups_mc_donor_merge_field
 	 * setting, then they should be segmented as a donor.
@@ -224,7 +235,7 @@ final class Newspack_Popups_Segmentation {
 			$donor_merge_field = Newspack_Popups_Settings::get_setting( 'newspack_popups_mc_donor_merge_field' );
 
 			foreach ( $merge_fields as $field_name => $field_value ) {
-				if ( false !== strpos( $field_name, $donor_merge_field ) && ! empty( $field_value ) ) {
+				if ( false !== strpos( $field_name, $donor_merge_field ) && self::is_donor_merge_field_value( $field_value ) ) {
 					if ( method_exists( '\Newspack\Logger', 'log' ) ) {
 						\Newspack\Logger::log(
 							sprintf(

--- a/tests/test-segmentation-donor-check.php
+++ b/tests/test-segmentation-donor-check.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * Tests for donor merge field value checking in Newspack_Popups_Segmentation.
+ *
+ * @package Newspack_Popups
+ */
+
+/**
+ * Test the is_donor_merge_field_value method.
+ */
+class SegmentationDonorCheckTest extends WP_UnitTestCase {
+
+	/**
+	 * Values that should be treated as positive donor indicators.
+	 *
+	 * @return array[] Test cases as [ value, description ].
+	 */
+	public function donor_positive_values() {
+		return [
+			'string yes'     => [ 'yes', 'string "yes"' ],
+			'string Yes'     => [ 'Yes', 'string "Yes" (mixed case)' ],
+			'string true'    => [ 'true', 'string "true"' ],
+			'string True'    => [ 'True', 'string "True" (mixed case)' ],
+			'numeric 1'      => [ '1', 'string "1"' ],
+			'integer 1'      => [ 1, 'integer 1' ],
+			'numeric 5'      => [ '5', 'string "5"' ],
+			'date string'    => [ '2024-01-15', 'date string' ],
+			'dollar amount'  => [ '$50.00', 'dollar amount' ],
+			'numeric amount' => [ '50.00', 'numeric amount' ],
+			'arbitrary text' => [ 'monthly', 'arbitrary text value' ],
+			'string donor'   => [ 'donor', 'string "donor"' ],
+			'boolean true'   => [ true, 'boolean true' ],
+		];
+	}
+
+	/**
+	 * Values that should NOT be treated as donor indicators.
+	 *
+	 * @return array[] Test cases as [ value, description ].
+	 */
+	public function donor_negative_values() {
+		return [
+			'empty string' => [ '', 'empty string' ],
+			'string no'    => [ 'no', 'string "no"' ],
+			'string No'    => [ 'No', 'string "No" (mixed case)' ],
+			'string NO'    => [ 'NO', 'string "NO" (uppercase)' ],
+			'string none'  => [ 'none', 'string "none"' ],
+			'string None'  => [ 'None', 'string "None" (mixed case)' ],
+			'string false' => [ 'false', 'string "false"' ],
+			'string False' => [ 'False', 'string "False" (mixed case)' ],
+			'string 0'     => [ '0', 'string "0"' ],
+		];
+	}
+
+	/**
+	 * Values that the OLD behavior (! empty()) would have treated as donor but the NEW
+	 * behavior correctly rejects. These are the cases the change was designed to fix.
+	 *
+	 * @return array[] Test cases as [ value, description ].
+	 */
+	public function donor_previously_false_positive_values() {
+		return [
+			'string no'    => [ 'no', 'string "no"' ],
+			'string No'    => [ 'No', 'string "No" (mixed case)' ],
+			'string none'  => [ 'none', 'string "none"' ],
+			'string None'  => [ 'None', 'string "None" (mixed case)' ],
+			'string false' => [ 'false', 'string "false"' ],
+			'string False' => [ 'False', 'string "False" (mixed case)' ],
+		];
+	}
+
+	/**
+	 * Test that positive values are treated as donor indicators.
+	 *
+	 * @dataProvider donor_positive_values
+	 * @param mixed  $value       The merge field value.
+	 * @param string $description Description of the test case.
+	 */
+	public function test_positive_donor_values( $value, $description ) {
+		self::assertTrue(
+			Newspack_Popups_Segmentation::is_donor_merge_field_value( $value ),
+			"Value $description should be treated as a positive donor indicator."
+		);
+	}
+
+	/**
+	 * Test that negative/falsy values are not treated as donor indicators.
+	 *
+	 * @dataProvider donor_negative_values
+	 * @param mixed  $value       The merge field value.
+	 * @param string $description Description of the test case.
+	 */
+	public function test_negative_donor_values( $value, $description ) {
+		self::assertFalse(
+			Newspack_Popups_Segmentation::is_donor_merge_field_value( $value ),
+			"Value $description should NOT be treated as a donor indicator."
+		);
+	}
+
+	/**
+	 * Test that values which were false positives under old behavior are now rejected.
+	 *
+	 * @dataProvider donor_previously_false_positive_values
+	 * @param mixed  $value       The merge field value.
+	 * @param string $description Description of the test case.
+	 */
+	public function test_previously_false_positive_values_are_now_rejected( $value, $description ) {
+		// These values are non-empty (would pass `! empty()`) but should not indicate a donor.
+		self::assertNotEmpty( $value, "Precondition: $description is non-empty, so old behavior would have flagged it as donor." );
+		self::assertFalse(
+			Newspack_Popups_Segmentation::is_donor_merge_field_value( $value ),
+			"Value $description was a false positive under old behavior and should now be rejected."
+		);
+	}
+}


### PR DESCRIPTION
## Summary

Fixes [NPPM-2698](https://linear.app/a8c/issue/NPPM-2698/wyofile-audience-management-mailchimp-donor-merge-fields)

When a reader logs in with Mailchimp as the ESP, the segmentation code checks their merge fields to determine donor status. Previously, the check used `! empty()`, which treated any non-empty string — including `"no"`, `"none"`, `"false"`, and `"False"` — as a positive donor indicator. Thissome sites to incorrectly mark every Mailchimp subscriber as a donor.

This PR replaces the `! empty()` check with an explicit falsy-value list (`no`, `none`, `false`, `0`, `""`), compared case-insensitively. The logic is extracted into a dedicated `is_donor_merge_field_value()` method with full test coverage.

- Extracts donor value check into `Newspack_Popups_Segmentation::is_donor_merge_field_value()`
- Rejects `"no"`, `"none"`, `"false"`, `"False"`, `"0"`, and `""` as non-donor values
- Adds 28 PHPUnit tests covering positive values, negative values, and previously false-positive cases

## Test plan

* Connect your site with Mailchimp.
* Go to Audience > Campaigns > Settings
* Set up a merge field
* Edit a contact in Mailchimp and edit the value of that merge field there
* Run the tests below logging in as a reader with different values in that merge field
* You can check whether the user was marked as a donor or not using `Newspack\Reader_Data::get_data( $user_id ); ` in the shell. There should be a `is_donor` key.

- [ ] Confirm a Mailchimp contact with a merge field value of `"false"` or `"no"` is **not** marked as a donor
- [ ] Confirm a Mailchimp contact with a merge field value of `"true"`, `"yes"`, a date, or a dollar amount **is** marked as a donor
- [ ] Confirm a Mailchimp contact with an empty merge field value is **not** marked as a donor
- [ ] Run `n test-php --filter SegmentationDonorCheckTest` — all 28 tests should pass