### PR TITLE
fix: update favorite categories matching

### DIFF
--- a/src/criteria/default/favorite-categories.js
+++ b/src/criteria/default/favorite-categories.js
@@ -1,4 +1,0 @@
-import { setMatchingAttribute } from '../utils';
-
-// Use the pre-calculated favorite_categories from the reader data store.
-setMatchingAttribute( 'favorite_categories' );

--- a/src/criteria/default/favorite-categories.js
+++ b/src/criteria/default/favorite-categories.js
@@ -1,36 +1,4 @@
-import { setMatchingFunction } from '../utils';
+import { setMatchingAttribute } from '../utils';
 
-setMatchingFunction( 'favorite_categories', ( config, ras ) => {
-	let match = false;
-	const views = ras.getUniqueActivitiesBy( 'article_view', 'post_id' );
-
-	if ( 1 >= views.length ) {
-		return match;
-	}
-
-	const categories = views.reduce( ( c, v ) => {
-		if ( v.data?.categories?.length ) {
-			c.push( ...v.data.categories );
-		}
-		return c;
-	}, [] );
-	const counts = categories.reduce( ( number, category ) => {
-		number[ category ] = ( number[ category ] || 0 ) + 1;
-		return number;
-	}, {} );
-	const countsArray = Object.entries( counts );
-	countsArray.sort( ( a, b ) => b[ 1 ] - a[ 1 ] );
-
-	if ( ! countsArray || ! countsArray.length ) {
-		return match;
-	}
-
-	// Must have viewed at least 2 categories or 2 posts within the same category in order to rank.
-	if ( ! countsArray[ 1 ] || countsArray[ 0 ][ 1 ] > countsArray[ 1 ][ 1 ] ) {
-		if ( -1 < config.value.indexOf( parseInt( countsArray[ 0 ][ 0 ] ) ) ) {
-			match = true;
-		}
-	}
-
-	return match;
-} );
+// Use the pre-calculated favorite_categories from the reader data store.
+setMatchingAttribute( 'favorite_categories' );

--- a/src/criteria/default/index.js
+++ b/src/criteria/default/index.js
@@ -1,6 +1,5 @@
 import './articles-read';
 import './devices';
-import './favorite-categories';
 import './donation';
 import './newsletter';
 import './user-account';

--- a/src/criteria/default/index.php
+++ b/src/criteria/default/index.php
@@ -26,10 +26,11 @@ $criteria = [
 		'matching_function' => 'range',
 	],
 	'favorite_categories'      => [
-		'name'              => __( 'Favorite Categories', 'newspack-popups' ),
-		'description'       => __( 'Most read categories of reader.', 'newspack-popups' ),
-		'category'          => 'reader_engagement',
-		'matching_function' => 'list__in',
+		'name'               => __( 'Favorite Categories', 'newspack-popups' ),
+		'description'        => __( 'Most read categories of reader.', 'newspack-popups' ),
+		'category'           => 'reader_engagement',
+		'matching_function'  => 'list__in',
+		'matching_attribute' => 'favorite_categories',
 	],
 	'devices'                  => [
 		'name'        => __( 'Devices', 'newspack-popups' ),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Replaces the custom `favorite_categories` matching function with a simple `setMatchingAttribute` call that reads the pre-calculated `favorite_categories` field from the reader data store.

Previously, `favorite-categories.js` contained ~35 lines of on-demand category ranking logic that iterated over article view activities, counted category occurrences, and applied a minimum threshold ("at least 2 categories or 2 posts within the same category"). This is now redundant because [newspack-plugin#4594](https://github.com/Automattic/newspack-plugin/pull/4594) adds a `favorite_categories` field to the reader data store that pre-calculates the top 5 categories by view frequency on every article view.

By removing the custom matching function, the criteria falls back to the PHP-defined `list__in` matching function, which checks if any of the store's `favorite_categories` array values match the segment config values — using loose type comparison to handle number/string coercion between the store (numeric IDs) and segment config (string values).

**Behavior change:** The old logic required at least 2 categories viewed or 2 posts in the same category before matching, and only considered the top 1 category. The new logic uses the pre-calculated top-5 array with no minimum threshold, matching if any of the reader's top 5 categories overlap with the segment's configured categories.

Depends on https://github.com/Automattic/newspack-plugin/pull/4594

### How to test the changes in this Pull Request:

1. Ensure newspack-plugin branch `feat/reader-data/add-engagement-fields` is active
2. Visit several articles across different categories (at least 3-4 articles)
3. Open DevTools → Application → Local Storage and verify `np_reader_1_favorite_categories` contains an array of category IDs
4. Create a campaign/prompt with a segment using the "Favorite Categories" criteria, configured to match one of the categories you viewed
5. Verify the prompt displays correctly for matching categories
6. Verify the prompt does **not** display when configured for a category you haven't viewed
7. Run `npm test` in newspack-popups — all 28 tests should pass

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?