### PR TITLE
fix(inserter): trim leading whitespace before content validation comparison

### DIFF
--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -504,7 +504,7 @@ final class Newspack_Popups_Inserter {
 		}
 
 		$filtered_content = explode( "\n", self::get_validation_content( $content ) );
-		$post_content     = explode( "\n", $post->post_content );
+		$post_content     = explode( "\n", ltrim( $post->post_content ) );
 		if (
 			// If prompts are disabled for this post.
 			self::assess_has_disabled_popups()

--- a/tests/test-insertion.php
+++ b/tests/test-insertion.php
@@ -472,4 +472,23 @@ class InsertionTest extends WP_UnitTestCase_PageWithPopups {
 			'Does not include the popup content, since the post tag is excluded on this popup.'
 		);
 	}
+
+	/**
+	 * Test that inline prompts still render when post_content has leading whitespace.
+	 *
+	 * When post_content begins with newline characters (e.g. from migrations or
+	 * non-editor save flows), the guard clause in insert_popups_in_content() must
+	 * not bail due to a first-line mismatch between the validated and raw content.
+	 */
+	public function test_insertion_with_leading_whitespace_in_post_content() {
+		$post_content_with_leading_newlines = "\n\n<!-- wp:paragraph -->\n<p>Post content.</p>\n<!-- /wp:paragraph -->";
+
+		self::renderPost( '', $post_content_with_leading_newlines );
+
+		self::assertStringContainsString(
+			self::$popup_content,
+			self::$post_content,
+			'Inline prompt renders even when post_content has leading newlines.'
+		);
+	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The guard clause in `insert_popups_in_content()` compares the first line of `get_validation_content($content)` (which `trim()`s its output) against the first line of raw `$post->post_content`. When `post_content` starts with `\n`, `explode("\n", ...)` produces an empty first element on the raw side but not the validated side, causing a mismatch that silently skips all inline prompt insertion. Overlays are unaffected (they render via `wp_body_open`).

Fix: `ltrim()` the raw `post_content` before exploding, matching the behavior of `get_validation_content()`.

Closes [NPPM-2716](https://linear.app/a8c/issue/NPPM-2716).

### How to test the changes in this Pull Request:

1. Create a post with leading `\n` characters in `post_content` (via direct DB write or WP-CLI, not the block editor which normalizes them away)
2. Verify inline prompts render on the post
3. Verify inline prompts still render on normal posts without leading whitespace
4. Verify overlay prompts are unaffected

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

🤖 Generated with [Claude Code](https://claude.com/claude-code)