### PR TITLE
feat: add campaigns to block theme archives

### DIFF
--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -62,7 +62,7 @@ final class Newspack_Popups_Inserter {
 		add_action( 'wp_body_open', [ $this, 'insert_before_header' ] );
 		add_filter( 'render_block_core/template-part', [ $this, 'insert_before_header_in_template_part' ], 10, 2 );
 		add_action( 'after_archive_post', [ $this, 'insert_inline_prompt_in_archive_pages' ] );
-		add_filter( 'render_block', [ $this, 'insert_inline_prompt_in_block_theme_archives' ], 10, 2 );
+		add_filter( 'render_block', [ $this, 'insert_inline_prompt_in_block_theme_archives' ], 10, 3 );
 		add_action( 'wp_before_admin_bar_render', [ $this, 'add_preview_toggle' ] );
 
 		// Always enqueue scripts, since this plugin's scripts are handling pageview sending via GTAG.
@@ -736,19 +736,33 @@ final class Newspack_Popups_Inserter {
 	/**
 	 * Insert inline prompts into a rendered core/post-template block on archive/home pages.
 	 *
-	 * Uses the render_block filter so this works with block themes.
+	 * Uses the render_block filter so this works with block themes. Only targets
+	 * the primary Query Loop (the one that inherits the global/main query) so
+	 * that secondary loops like "featured posts" or "you may also like" don't
+	 * receive prompt injection.
 	 *
-	 * @param string $block_content Rendered block HTML.
-	 * @param array  $block         Block data array, including 'blockName'.
+	 * @param string   $block_content Rendered block HTML.
+	 * @param array    $block         Block data array, including 'blockName'.
+	 * @param WP_Block $instance      The block instance (available since WP 5.9).
 	 * @return string Filtered block HTML.
 	 */
-	public static function insert_inline_prompt_in_block_theme_archives( $block_content, $block ) {
+	public static function insert_inline_prompt_in_block_theme_archives( $block_content, $block, $instance = null ) {
 		if ( 'core/post-template' !== $block['blockName'] ) {
 			return $block_content;
 		}
 
 		if ( ! is_archive() && ! is_home() ) {
 			return $block_content;
+		}
+
+		// Only inject into the Query Loop that inherits the main/global query.
+		// Secondary loops (custom queryId, inherit=false) should not get prompts.
+		if ( $instance instanceof WP_Block ) {
+			$query_context = $instance->context['query'] ?? [];
+			$inherits_main = ! empty( $query_context['inherit'] );
+			if ( ! $inherits_main ) {
+				return $block_content;
+			}
 		}
 
 		$archives_popups = array_filter( self::popups_for_post(), [ 'Newspack_Popups_Model', 'should_be_inserted_in_archive_pages' ] );

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -713,7 +713,7 @@ final class Newspack_Popups_Inserter {
 				|| ( is_post_type_archive() && ! in_array( 'post-type', $popup['options']['archive_page_types'] ) )
 				|| ( is_tax() && ! in_array( 'taxonomy', $popup['options']['archive_page_types'] ) )
 			) {
-				return '';
+				continue;
 			}
 
 			$archive_insertion_posts_count = intval( $popup['options']['archive_insertion_posts_count'] );
@@ -762,12 +762,16 @@ final class Newspack_Popups_Inserter {
 		}
 
 		// $parts[0] is the opening wrapper (e.g. <ul ...>); $parts[1..n] are the post items.
+		// Detect the post item tag from the first item so the campaign wrapper matches:
+		// <li> for list layouts (valid inside <ul>), <div> for grid layouts.
+		preg_match( '/^<(li|div)/', $parts[1], $tag_match );
+		$item_tag   = $tag_match[1] ?? 'li';
 		$post_count = count( $parts ) - 1;
 		$output     = $parts[0];
 
 		for ( $i = 1; $i <= $post_count; $i++ ) {
 			$output .= $parts[ $i ];
-			$output .= self::get_inline_prompt_html_for_archive_pages( $i, 'aside' );
+			$output .= self::get_inline_prompt_html_for_archive_pages( $i, $item_tag );
 		}
 
 		return $output;

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -764,12 +764,25 @@ final class Newspack_Popups_Inserter {
 
 		// $parts[0] is the opening <ul>; $parts[1..n] are the post items.
 		$post_count = count( $parts ) - 1;
-		$output     = $parts[0];
+
+		// The closing </ul> (and any content that follows it) lives in the last part because
+		// preg_split's lookahead puts everything after the final post item there. Strip it off
+		// so that any injected prompt <li> elements are inserted before </ul>, not after it.
+		$trailing = '';
+		$close_ul = strripos( $parts[ $post_count ], '</ul' );
+		if ( false !== $close_ul ) {
+			$trailing            = substr( $parts[ $post_count ], $close_ul );
+			$parts[ $post_count ] = substr( $parts[ $post_count ], 0, $close_ul );
+		}
+
+		$output = $parts[0];
 
 		for ( $i = 1; $i <= $post_count; $i++ ) {
 			$output .= $parts[ $i ];
 			$output .= self::get_inline_prompt_html_for_archive_pages( $i, 'li', $archives_popups );
 		}
+
+		$output .= $trailing;
 
 		return $output;
 	}

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -62,6 +62,7 @@ final class Newspack_Popups_Inserter {
 		add_action( 'wp_body_open', [ $this, 'insert_before_header' ] );
 		add_filter( 'render_block_core/template-part', [ $this, 'insert_before_header_in_template_part' ], 10, 2 );
 		add_action( 'after_archive_post', [ $this, 'insert_inline_prompt_in_archive_pages' ] );
+		add_filter( 'render_block', [ $this, 'insert_inline_prompt_in_block_theme_archives' ], 10, 2 );
 		add_action( 'wp_before_admin_bar_render', [ $this, 'add_preview_toggle' ] );
 
 		// Always enqueue scripts, since this plugin's scripts are handling pageview sending via GTAG.
@@ -687,9 +688,22 @@ final class Newspack_Popups_Inserter {
 	 * @return void
 	 */
 	public static function insert_inline_prompt_in_archive_pages( $post_count ) {
+		echo self::get_inline_prompt_html_for_archive_pages( $post_count ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+	}
+
+	/**
+	 * Get the HTML for an inline prompt on archive pages.
+	 *
+	 * @param integer $post_count  Order of the post in the posts loop.
+	 * @param string  $wrapper     Opening tag (with any attributes) to wrap the prompt in. Defaults to 'article class="entry"' to match classic theme; uses 'aside' for block themes.
+	 * @return string HTML output, or empty string.
+	 */
+	public static function get_inline_prompt_html_for_archive_pages( $post_count, $wrapper = 'article class="entry"' ) {
+		$tag = strtok( $wrapper, ' ' );
 		global $wp_query;
 
 		$archives_popups = array_filter( self::popups_for_post(), [ 'Newspack_Popups_Model', 'should_be_inserted_in_archive_pages' ] );
+		$output          = '';
 		foreach ( $archives_popups as $popup ) {
 			// insert popup only on selected archive page types.
 			if ( is_category() && ! in_array( 'category', $popup['options']['archive_page_types'] )
@@ -699,7 +713,7 @@ final class Newspack_Popups_Inserter {
 				|| ( is_post_type_archive() && ! in_array( 'post-type', $popup['options']['archive_page_types'] ) )
 				|| ( is_tax() && ! in_array( 'taxonomy', $popup['options']['archive_page_types'] ) )
 			) {
-					return;
+				return '';
 			}
 
 			$archive_insertion_posts_count = intval( $popup['options']['archive_insertion_posts_count'] );
@@ -710,10 +724,53 @@ final class Newspack_Popups_Inserter {
 				|| ( $popup['options']['archive_insertion_is_repeating'] && 0 === $post_count % $archive_insertion_posts_count )
 				|| ( $archive_insertion_posts_count >= $wp_query->post_count && $post_count === $wp_query->post_count )
 			) {
-				// Wrapping the popup in an article with `entry` class element to keep the archive page markup.
-				echo '<article class="entry">' . Newspack_Popups_Model::generate_popup( $popup ) . '</article>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				$output .= '<' . $wrapper . '>' . Newspack_Popups_Model::generate_popup( $popup ) . '</' . $tag . '>';
 			}
 		}
+		return $output;
+	}
+
+	/**
+	 * Insert inline prompts into a rendered core/post-template block on archive/home pages.
+	 *
+	 * Uses the render_block filter so this works with block themes.
+	 *
+	 * @param string $block_content Rendered block HTML.
+	 * @param array  $block         Block data array, including 'blockName'.
+	 * @return string Filtered block HTML.
+	 */
+	public static function insert_inline_prompt_in_block_theme_archives( $block_content, $block ) {
+		if ( 'core/post-template' !== $block['blockName'] ) {
+			return $block_content;
+		}
+
+		if ( ! is_archive() && ! is_home() ) {
+			return $block_content;
+		}
+
+		$archives_popups = array_filter( self::popups_for_post(), [ 'Newspack_Popups_Model', 'should_be_inserted_in_archive_pages' ] );
+		if ( empty( $archives_popups ) ) {
+			return $block_content;
+		}
+
+		// Split on each post item boundary. core/post-template wraps each post in <li class="wp-block-post ..."> (list layout) or <div class="wp-block-post ..."> (grid layout).
+		// Use [\s"'] to avoid false matches on child element classes like wp-block-post-title, wp-block-post-excerpt, etc. (which also start with "wp-block-post").
+		$parts = preg_split( '/(?=<(?:li|div)[^>]*\bwp-block-post[\s"\'])/', $block_content );
+
+		if ( ! $parts || count( $parts ) < 2 ) {
+			return $block_content;
+		}
+
+		// $parts[0] is the opening wrapper (e.g. <ul ...>); $parts[1..n] are the post items.
+		$post_count = count( $parts ) - 1;
+		$output     = $parts[0];
+
+		for ( $i = 1; $i <= $post_count; $i++ ) {
+			$output .= $parts[ $i ];
+			$output .= self::get_inline_prompt_html_for_archive_pages( $i, 'aside' );
+		}
+
+		return $output;
 	}
 
 	/**

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -694,16 +694,19 @@ final class Newspack_Popups_Inserter {
 	/**
 	 * Get the HTML for an inline prompt on archive pages.
 	 *
-	 * @param integer $post_count  Order of the post in the posts loop.
-	 * @param string  $wrapper     Opening tag (with any attributes) to wrap the prompt in. Defaults to 'article class="entry"' to match classic theme; uses 'aside' for block themes.
+	 * @param integer $post_count      Order of the post in the posts loop.
+	 * @param string  $wrapper         Opening tag (with any attributes) to wrap the prompt in. Defaults to 'article class="entry"' to match classic theme; pass the post item tag for block themes.
+	 * @param array   $archives_popups Pre-filtered list of archive popups. If null, popups_for_post() is filtered internally.
 	 * @return string HTML output, or empty string.
 	 */
-	public static function get_inline_prompt_html_for_archive_pages( $post_count, $wrapper = 'article class="entry"' ) {
+	public static function get_inline_prompt_html_for_archive_pages( $post_count, $wrapper = 'article class="entry"', $archives_popups = null ) {
 		$tag = strtok( $wrapper, ' ' );
 		global $wp_query;
 
-		$archives_popups = array_filter( self::popups_for_post(), [ 'Newspack_Popups_Model', 'should_be_inserted_in_archive_pages' ] );
-		$output          = '';
+		if ( null === $archives_popups ) {
+			$archives_popups = array_filter( self::popups_for_post(), [ 'Newspack_Popups_Model', 'should_be_inserted_in_archive_pages' ] );
+		}
+		$output = '';
 		foreach ( $archives_popups as $popup ) {
 			// insert popup only on selected archive page types.
 			if ( is_category() && ! in_array( 'category', $popup['options']['archive_page_types'] )
@@ -749,9 +752,6 @@ final class Newspack_Popups_Inserter {
 		}
 
 		$archives_popups = array_filter( self::popups_for_post(), [ 'Newspack_Popups_Model', 'should_be_inserted_in_archive_pages' ] );
-		if ( empty( $archives_popups ) ) {
-			return $block_content;
-		}
 
 		// Split on each post item boundary. core/post-template wraps each post in <li class="wp-block-post ..."> (list layout) or <div class="wp-block-post ..."> (grid layout).
 		// Use [\s"'] to avoid false matches on child element classes like wp-block-post-title, wp-block-post-excerpt, etc. (which also start with "wp-block-post").
@@ -771,7 +771,7 @@ final class Newspack_Popups_Inserter {
 
 		for ( $i = 1; $i <= $post_count; $i++ ) {
 			$output .= $parts[ $i ];
-			$output .= self::get_inline_prompt_html_for_archive_pages( $i, $item_tag );
+			$output .= self::get_inline_prompt_html_for_archive_pages( $i, $item_tag, $archives_popups );
 		}
 
 		return $output;

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -753,25 +753,22 @@ final class Newspack_Popups_Inserter {
 
 		$archives_popups = array_filter( self::popups_for_post(), [ 'Newspack_Popups_Model', 'should_be_inserted_in_archive_pages' ] );
 
-		// Split on each post item boundary. core/post-template wraps each post in <li class="wp-block-post ..."> (list layout) or <div class="wp-block-post ..."> (grid layout).
-		// Use [\s"'] to avoid false matches on child element classes like wp-block-post-title, wp-block-post-excerpt, etc. (which also start with "wp-block-post").
-		$parts = preg_split( '/(?=<(?:li|div)[^>]*\bwp-block-post[\s"\'])/', $block_content );
+		// Split on each post item boundary. core/post-template wraps each post in
+		// <li class="wp-block-post ...">. Use [\s"'] to avoid false matches on child element
+		// classes like wp-block-post-title, wp-block-post-excerpt, etc.
+		$parts = preg_split( '/(?=<li[^>]*\bwp-block-post[\s"\'])/', $block_content );
 
 		if ( ! $parts || count( $parts ) < 2 ) {
 			return $block_content;
 		}
 
-		// $parts[0] is the opening wrapper (e.g. <ul ...>); $parts[1..n] are the post items.
-		// Detect the post item tag from the first item so the campaign wrapper matches:
-		// <li> for list layouts (valid inside <ul>), <div> for grid layouts.
-		preg_match( '/^<(li|div)/', $parts[1], $tag_match );
-		$item_tag   = $tag_match[1] ?? 'li';
+		// $parts[0] is the opening <ul>; $parts[1..n] are the post items.
 		$post_count = count( $parts ) - 1;
 		$output     = $parts[0];
 
 		for ( $i = 1; $i <= $post_count; $i++ ) {
 			$output .= $parts[ $i ];
-			$output .= self::get_inline_prompt_html_for_archive_pages( $i, $item_tag, $archives_popups );
+			$output .= self::get_inline_prompt_html_for_archive_pages( $i, 'li', $archives_popups );
 		}
 
 		return $output;

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -688,19 +688,19 @@ final class Newspack_Popups_Inserter {
 	 * @return void
 	 */
 	public static function insert_inline_prompt_in_archive_pages( $post_count ) {
-		echo self::get_inline_prompt_html_for_archive_pages( $post_count ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		echo self::get_inline_prompt_html_for_archive_pages( $post_count, 'article', null, 'class="entry"' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
 
 	/**
 	 * Get the HTML for an inline prompt on archive pages.
 	 *
 	 * @param integer $post_count      Order of the post in the posts loop.
-	 * @param string  $wrapper         Opening tag (with any attributes) to wrap the prompt in. Defaults to 'article class="entry"' to match classic theme; pass the post item tag for block themes.
+	 * @param string  $tag             Wrapper element tag name. Defaults to 'article'.
 	 * @param array   $archives_popups Pre-filtered list of archive popups. If null, popups_for_post() is filtered internally.
+	 * @param string  $attrs           Optional HTML attributes string for the wrapper element (e.g. 'class="entry"').
 	 * @return string HTML output, or empty string.
 	 */
-	public static function get_inline_prompt_html_for_archive_pages( $post_count, $wrapper = 'article class="entry"', $archives_popups = null ) {
-		$tag = strtok( $wrapper, ' ' );
+	public static function get_inline_prompt_html_for_archive_pages( $post_count, $tag = 'article', $archives_popups = null, $attrs = '' ) {
 		global $wp_query;
 
 		if ( null === $archives_popups ) {
@@ -727,7 +727,8 @@ final class Newspack_Popups_Inserter {
 				|| ( $popup['options']['archive_insertion_is_repeating'] && 0 === $post_count % $archive_insertion_posts_count )
 				|| ( $archive_insertion_posts_count >= $wp_query->post_count && $post_count === $wp_query->post_count )
 			) {
-				$output .= '<' . $wrapper . '>' . Newspack_Popups_Model::generate_popup( $popup ) . '</' . $tag . '>';
+					$open_tag = ! empty( $attrs ) ? $tag . ' ' . $attrs : $tag;
+				$output  .= '<' . $open_tag . '>' . Newspack_Popups_Model::generate_popup( $popup ) . '</' . $tag . '>';
 			}
 		}
 		return $output;

--- a/src/view/style.scss
+++ b/src/view/style.scss
@@ -436,6 +436,12 @@ $width__tablet: 782px;
 	}
 }
 
+// In block theme grid layouts, campaigns should span all columns.
+.wp-block-post-template.wp-block-post-template-is-layout-grid > li:has(.newspack-popup-container) {
+	grid-column: 1/-1;
+	width: 100%;
+}
+
 .newspack-inline-popup {
 	display: block;
 	border: 1px solid rgba(black, 0.2);

--- a/tests/test-insertion.php
+++ b/tests/test-insertion.php
@@ -555,6 +555,41 @@ class InsertionTest extends WP_UnitTestCase_PageWithPopups {
 	}
 
 	/**
+	 * Block theme archive insertion — secondary (non-inherited) Query Loops are skipped.
+	 */
+	public function test_block_theme_archive_insertion_skips_secondary_query_loop() {
+		Newspack_Popups_Model::set_popup_options(
+			self::$popup_id,
+			[
+				'placement'                      => 'archives',
+				'frequency'                      => 'always',
+				'archive_insertion_posts_count'  => 1,
+				'archive_insertion_is_repeating' => false,
+			]
+		);
+
+		$block_content = '<ul class="wp-block-post-template"><li class="wp-block-post post-type-post">Post 1</li></ul>';
+		$block         = [ 'blockName' => 'core/post-template' ];
+
+		$post_ids = self::factory()->post->create_many( 3 );
+		$this->go_to( home_url() );
+		$GLOBALS['post'] = get_post( end( $post_ids ) ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+
+		// Simulate a secondary Query Loop (inherit=false, custom queryId).
+		$instance = new WP_Block(
+			$block,
+			[
+				'query'   => [ 'inherit' => false ],
+				'queryId' => 42,
+			]
+		);
+
+		$result = Newspack_Popups_Inserter::insert_inline_prompt_in_block_theme_archives( $block_content, $block, $instance );
+
+		self::assertSame( $block_content, $result, 'Secondary Query Loop content is returned unchanged.' );
+	}
+
+	/**
 	 * Block theme archive insertion — non-archive page is untouched.
 	 */
 	public function test_block_theme_archive_insertion_skips_non_archive() {

--- a/tests/test-insertion.php
+++ b/tests/test-insertion.php
@@ -521,41 +521,6 @@ class InsertionTest extends WP_UnitTestCase_PageWithPopups {
 	}
 
 	/**
-	 * Block theme archive insertion — grid layout uses div wrapper.
-	 */
-	public function test_block_theme_archive_insertion_grid_layout() {
-		Newspack_Popups_Model::set_popup_options(
-			self::$popup_id,
-			[
-				'placement'                      => 'archives',
-				'frequency'                      => 'always',
-				'archive_insertion_posts_count'  => 1,
-				'archive_insertion_is_repeating' => false,
-			]
-		);
-
-		// Grid layout uses <div> instead of <li> for post items.
-		$block_content = '
-			<div class="wp-block-post-template is-flex-container">
-				<div class="wp-block-post post-type-post">Post 1 content</div>
-				<div class="wp-block-post post-type-post">Post 2 content</div>
-			</div>';
-
-		$block = [ 'blockName' => 'core/post-template' ];
-
-		$post_ids = self::factory()->post->create_many( 5 );
-		$this->go_to( home_url() );
-		$GLOBALS['post'] = get_post( end( $post_ids ) ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-
-		$result = Newspack_Popups_Inserter::insert_inline_prompt_in_block_theme_archives( $block_content, $block );
-
-		// Campaign should be present and wrapped in <div>, not <li>.
-		self::assertStringContainsString( self::$popup_content, $result, 'Campaign HTML is present in grid layout output.' );
-		self::assertMatchesRegularExpression( '/<div>\s*<div[^>]*newspack-popup-container/', $result, 'Campaign is wrapped in a <div> for grid layout.' );
-		self::assertDoesNotMatchRegularExpression( '/<li>\s*<div[^>]*newspack-popup-container/', $result, 'Campaign is not wrapped in a <li> for grid layout.' );
-	}
-
-	/**
 	 * Block theme archive insertion — non-archive page is untouched.
 	 */
 	public function test_block_theme_archive_insertion_skips_non_archive() {

--- a/tests/test-insertion.php
+++ b/tests/test-insertion.php
@@ -521,6 +521,41 @@ class InsertionTest extends WP_UnitTestCase_PageWithPopups {
 	}
 
 	/**
+	 * Block theme archive insertion — grid layout uses div wrapper.
+	 */
+	public function test_block_theme_archive_insertion_grid_layout() {
+		Newspack_Popups_Model::set_popup_options(
+			self::$popup_id,
+			[
+				'placement'                      => 'archives',
+				'frequency'                      => 'always',
+				'archive_insertion_posts_count'  => 1,
+				'archive_insertion_is_repeating' => false,
+			]
+		);
+
+		// Grid layout uses <div> instead of <li> for post items.
+		$block_content = '
+			<div class="wp-block-post-template is-flex-container">
+				<div class="wp-block-post post-type-post">Post 1 content</div>
+				<div class="wp-block-post post-type-post">Post 2 content</div>
+			</div>';
+
+		$block = [ 'blockName' => 'core/post-template' ];
+
+		$post_ids = self::factory()->post->create_many( 5 );
+		$this->go_to( home_url() );
+		$GLOBALS['post'] = get_post( end( $post_ids ) ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+
+		$result = Newspack_Popups_Inserter::insert_inline_prompt_in_block_theme_archives( $block_content, $block );
+
+		// Campaign should be present and wrapped in <div>, not <li>.
+		self::assertStringContainsString( self::$popup_content, $result, 'Campaign HTML is present in grid layout output.' );
+		self::assertMatchesRegularExpression( '/<div>\s*<div[^>]*newspack-popup-container/', $result, 'Campaign is wrapped in a <div> for grid layout.' );
+		self::assertDoesNotMatchRegularExpression( '/<li>\s*<div[^>]*newspack-popup-container/', $result, 'Campaign is not wrapped in a <li> for grid layout.' );
+	}
+
+	/**
 	 * Block theme archive insertion — non-archive page is untouched.
 	 */
 	public function test_block_theme_archive_insertion_skips_non_archive() {

--- a/tests/test-insertion.php
+++ b/tests/test-insertion.php
@@ -629,6 +629,109 @@ class InsertionTest extends WP_UnitTestCase_PageWithPopups {
 	}
 
 	/**
+	 * Block theme archive insertion — end-of-list fallback when post count < trigger count.
+	 *
+	 * The fallback path ($archive_insertion_posts_count >= $wp_query->post_count)
+	 * inserts a prompt at the very end of a short list. Verify that the prompt
+	 * still lands inside the <ul>, not after it.
+	 */
+	public function test_block_theme_archive_insertion_end_of_list_fallback() {
+		Newspack_Popups_Model::set_popup_options(
+			self::$popup_id,
+			[
+				'placement'                      => 'archives',
+				'frequency'                      => 'always',
+				'archive_insertion_posts_count'  => 10,
+				'archive_insertion_is_repeating' => false,
+			]
+		);
+
+		$block_content = '<ul class="wp-block-post-template"><li class="wp-block-post post-type-post">Post 1</li><li class="wp-block-post post-type-post">Post 2</li></ul>';
+		$block         = [ 'blockName' => 'core/post-template' ];
+
+		$post_ids = self::factory()->post->create_many( 2 );
+		$this->go_to( home_url() );
+		$GLOBALS['post'] = get_post( end( $post_ids ) ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+
+		// Force post_count to 2 so the fallback path fires
+		// ($archive_insertion_posts_count >= $wp_query->post_count).
+		global $wp_query;
+		$wp_query->post_count = 2;
+
+		$result = Newspack_Popups_Inserter::insert_inline_prompt_in_block_theme_archives( $block_content, $block );
+
+		$pos_popup    = strpos( $result, self::$popup_content );
+		$pos_close_ul = strpos( $result, '</ul>' );
+
+		self::assertNotFalse( $pos_popup, 'Campaign HTML is present via end-of-list fallback.' );
+		self::assertLessThan( $pos_close_ul, $pos_popup, 'End-of-list prompt appears before </ul>.' );
+	}
+
+	/**
+	 * Archive page type gate uses continue, not return — a skipped prompt does not
+	 * suppress subsequent prompts in the same loop iteration.
+	 */
+	public function test_archive_page_type_skip_does_not_suppress_other_prompts() {
+		$cat_id = self::factory()->term->create(
+			[
+				'name'     => 'News',
+				'taxonomy' => 'category',
+				'slug'     => 'news',
+			]
+		);
+
+		// Prompt A: restricted to 'tag' only — should be skipped on a category archive.
+		$popup_a_content = 'Prompt-A-tag-only';
+		$popup_a_id      = self::createPopup(
+			$popup_a_content,
+			[
+				'placement'                      => 'archives',
+				'frequency'                      => 'always',
+				'archive_insertion_posts_count'  => 1,
+				'archive_insertion_is_repeating' => false,
+				'archive_page_types'             => [ 'tag' ],
+			]
+		);
+
+		// Prompt B: restricted to 'category' — should render on a category archive.
+		$popup_b_content = 'Prompt-B-category';
+		$popup_b_id      = self::createPopup(
+			$popup_b_content,
+			[
+				'placement'                      => 'archives',
+				'frequency'                      => 'always',
+				'archive_insertion_posts_count'  => 1,
+				'archive_insertion_is_repeating' => false,
+				'archive_page_types'             => [ 'category' ],
+			]
+		);
+
+		// Remove the default popup so only A and B are active.
+		wp_delete_post( self::$popup_id );
+
+		$post_ids = self::factory()->post->create_many( 3 );
+		foreach ( $post_ids as $pid ) {
+			wp_set_post_terms( $pid, [ $cat_id ], 'category' );
+		}
+
+		$this->go_to( get_category_link( $cat_id ) );
+		$GLOBALS['post'] = get_post( end( $post_ids ) ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+
+		$output = Newspack_Popups_Inserter::get_inline_prompt_html_for_archive_pages( 1, 'li' );
+
+		self::assertStringNotContainsString(
+			$popup_a_content,
+			$output,
+			'Prompt restricted to tags is skipped on a category archive.'
+		);
+		self::assertStringContainsString(
+			$popup_b_content,
+			$output,
+			'Prompt restricted to categories still renders after a prior prompt was skipped.'
+		);
+	}
+
+	/**
 	 * Test tags exclusion has priority over inclusion.
 	 */
 	public function test_tags_exclusion_priority_over_inclusion() {

--- a/tests/test-insertion.php
+++ b/tests/test-insertion.php
@@ -521,6 +521,40 @@ class InsertionTest extends WP_UnitTestCase_PageWithPopups {
 	}
 
 	/**
+	 * Block theme archive insertion — prompt <li> must stay inside </ul>, not after it.
+	 *
+	 * Regression: preg_split's lookahead left </ul> in the last part, so the injected
+	 * prompt <li> was appended after the closing </ul> tag.
+	 */
+	public function test_block_theme_archive_insertion_prompt_inside_ul() {
+		Newspack_Popups_Model::set_popup_options(
+			self::$popup_id,
+			[
+				'placement'                      => 'archives',
+				'frequency'                      => 'always',
+				'archive_insertion_posts_count'  => 1,
+				'archive_insertion_is_repeating' => true,
+			]
+		);
+
+		$block_content = '<ul class="wp-block-post-template"><li class="wp-block-post post-type-post">Post 1</li><li class="wp-block-post post-type-post">Post 2</li></ul>';
+		$block         = [ 'blockName' => 'core/post-template' ];
+
+		$post_ids = self::factory()->post->create_many( 5 );
+		$this->go_to( home_url() );
+		$GLOBALS['post'] = get_post( end( $post_ids ) ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+
+		$result = Newspack_Popups_Inserter::insert_inline_prompt_in_block_theme_archives( $block_content, $block );
+
+		$pos_close_ul = strpos( $result, '</ul>' );
+		$pos_popup    = strrpos( $result, self::$popup_content );
+
+		self::assertNotFalse( $pos_popup, 'Campaign HTML is present in the output.' );
+		self::assertNotFalse( $pos_close_ul, 'Closing </ul> is present in the output.' );
+		self::assertLessThan( $pos_close_ul, $pos_popup, 'Last campaign insertion appears before </ul>, not after it.' );
+	}
+
+	/**
 	 * Block theme archive insertion — non-archive page is untouched.
 	 */
 	public function test_block_theme_archive_insertion_skips_non_archive() {

--- a/tests/test-insertion.php
+++ b/tests/test-insertion.php
@@ -438,6 +438,128 @@ class InsertionTest extends WP_UnitTestCase_PageWithPopups {
 	}
 
 	/**
+	 * Block theme archive insertion — inserts after Nth post item.
+	 */
+	public function test_block_theme_archive_insertion_basic() {
+		Newspack_Popups_Model::set_popup_options(
+			self::$popup_id,
+			[
+				'placement'                      => 'archives',
+				'frequency'                      => 'always',
+				'archive_insertion_posts_count'  => 2,
+				'archive_insertion_is_repeating' => false,
+			]
+		);
+
+		$block_content = '
+			<ul class="wp-block-post-template">
+				<li class="wp-block-post post-type-post">Post 1 content</li>
+				<li class="wp-block-post post-type-post">Post 2 content</li>
+				<li class="wp-block-post post-type-post">Post 3 content</li>
+			</ul>';
+
+		$block = [ 'blockName' => 'core/post-template' ];
+
+		// Create enough posts so $wp_query->post_count > archive_insertion_posts_count (2),
+		// preventing the end-of-list fallback from firing in unexpected positions.
+		$post_ids = self::factory()->post->create_many( 5 );
+
+		// Navigate to the blog home page (is_home() = true). This avoids any
+		// archive_page_types early-return since is_category() etc. are false on is_home().
+		$this->go_to( home_url() );
+
+		// Set up a post in the global context — simulates the state after the Query Loop
+		// block finishes rendering (global $post = last post in the loop).
+		$GLOBALS['post'] = get_post( end( $post_ids ) ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+
+		$result = Newspack_Popups_Inserter::insert_inline_prompt_in_block_theme_archives( $block_content, $block );
+
+		$pos_post2 = strpos( $result, 'Post 2 content' );
+		$pos_popup = strpos( $result, self::$popup_content );
+		$pos_post3 = strpos( $result, 'Post 3 content' );
+
+		self::assertNotFalse( $pos_popup, 'Campaign HTML is present in the output.' );
+		self::assertGreaterThan( $pos_post2, $pos_popup, 'Campaign appears after post 2.' );
+		self::assertLessThan( $pos_post3, $pos_popup, 'Campaign appears before post 3.' );
+	}
+
+	/**
+	 * Block theme archive insertion — repeating every N posts.
+	 */
+	public function test_block_theme_archive_insertion_repeating() {
+		Newspack_Popups_Model::set_popup_options(
+			self::$popup_id,
+			[
+				'placement'                      => 'archives',
+				'frequency'                      => 'always',
+				'archive_insertion_posts_count'  => 2,
+				'archive_insertion_is_repeating' => true,
+			]
+		);
+
+		$block_content = '
+			<ul class="wp-block-post-template">
+				<li class="wp-block-post post-type-post">Post 1</li>
+				<li class="wp-block-post post-type-post">Post 2</li>
+				<li class="wp-block-post post-type-post">Post 3</li>
+				<li class="wp-block-post post-type-post">Post 4</li>
+			</ul>';
+
+		$block = [ 'blockName' => 'core/post-template' ];
+
+		$post_ids = self::factory()->post->create_many( 5 );
+		$this->go_to( home_url() );
+		$GLOBALS['post'] = get_post( end( $post_ids ) ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+
+		$result = Newspack_Popups_Inserter::insert_inline_prompt_in_block_theme_archives( $block_content, $block );
+
+		self::assertSame(
+			2,
+			substr_count( $result, self::$popup_content ),
+			'Campaign appears twice in repeating mode (after posts 2 and 4).'
+		);
+	}
+
+	/**
+	 * Block theme archive insertion — non-archive page is untouched.
+	 */
+	public function test_block_theme_archive_insertion_skips_non_archive() {
+		Newspack_Popups_Model::set_popup_options(
+			self::$popup_id,
+			[
+				'placement'                      => 'archives',
+				'frequency'                      => 'always',
+				'archive_insertion_posts_count'  => 1,
+				'archive_insertion_is_repeating' => false,
+			]
+		);
+
+		$block_content = '<ul class="wp-block-post-template"><li class="wp-block-post">Post 1</li></ul>';
+		$block         = [ 'blockName' => 'core/post-template' ];
+
+		$post_id = self::factory()->post->create();
+		$this->go_to( get_permalink( $post_id ) );
+
+		$result = Newspack_Popups_Inserter::insert_inline_prompt_in_block_theme_archives( $block_content, $block );
+
+		self::assertSame( $block_content, $result, 'Block content is unchanged on a single post page.' );
+	}
+
+	/**
+	 * Block theme archive insertion — non-post-template block is untouched.
+	 */
+	public function test_block_theme_archive_insertion_skips_other_blocks() {
+		$block_content = '<p>Some paragraph</p>';
+		$block         = [ 'blockName' => 'core/paragraph' ];
+
+		$this->go_to( home_url() );
+
+		$result = Newspack_Popups_Inserter::insert_inline_prompt_in_block_theme_archives( $block_content, $block );
+
+		self::assertSame( $block_content, $result, 'Non-post-template block content is returned unchanged.' );
+	}
+
+	/**
 	 * Test tags exclusion has priority over inclusion.
 	 */
 	public function test_tags_exclusion_priority_over_inclusion() {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds support for the campaigns in the block theme, both the popup ones (which are inserted in the classic theme using a custom hook), and inline between archive posts. 

**Edited to add:**
This PR also addresses an issue unrelated to block themes: The `archive_page_types` gate in `insert_inline_prompt_in_archive_pages` previously used `return`, which stopped running through all remaining prompts once one was skipped. This has been switched to `continue` in this PR, so each prompt is evaluated independently. This will change how this works for Classic themes, too: if multiple archive prompts have different page type restrictions, they will now each be evaluated rather than the first skip aborting the entire loop.

Closes NPPD-1125

### How to test the changes in this Pull Request:

1. On a site running the block theme, set up a few different campaign prompts: an inline one for archives that will show after every X posts, and one that will show as a popup.
2. View your archive page; ensure the prompts display as expected.
3. For the inline prompt, try changing the settings: have it not repeat, change the conditions of the archive it should show on, etc. Test as you change things and make sure it's acting as expected.
4. Try changing the archive to use a grid layout; confirm that the campaign spans the whole available width (possibly breaking the grid, depending where the campaign is inserted).
5. Switch to the Classic theme and smoke test campaigns in archives, just in case. Note that the prompt doesn't span the full width of the grid there - the block theme uses a widely used block so it made sense to me to add the CSS to the plugin, but the Classic theme is quite custom. I think it'd make more sense to add the CSS there.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
