### PR TITLE
fix(reader-data): allow is_donor to be writeable on donor landing page

### DIFF
--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -69,7 +69,7 @@ final class Newspack_Popups_Inserter {
 		add_action( 'apple_news_do_fetch_exporter', [ __CLASS__, 'apple_news_do_fetch_exporter' ] );
 		add_filter( 'newspack_popups_assess_has_disabled_popups', [ __CLASS__, 'disable_prompts' ] );
 
-		// Allow read-only reader data keys to be writeable in certain conditions.
+		// Allow read-only reader data keys to be writable in certain conditions.
 		add_filter( 'newspack_reader_data_read_only_keys', [ __CLASS__, 'set_reader_data_read_only_keys' ] );
 
 		// These hooks are fired before and after rendering posts in the Homepage Posts block.

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -69,6 +69,9 @@ final class Newspack_Popups_Inserter {
 		add_action( 'apple_news_do_fetch_exporter', [ __CLASS__, 'apple_news_do_fetch_exporter' ] );
 		add_filter( 'newspack_popups_assess_has_disabled_popups', [ __CLASS__, 'disable_prompts' ] );
 
+		// Allow read-only reader data keys to be writeable in certain conditions.
+		add_filter( 'newspack_reader_data_read_only_keys', [ __CLASS__, 'set_reader_data_read_only_keys' ] );
+
 		// These hooks are fired before and after rendering posts in the Homepage Posts block.
 		// By removing the the_content filter before rendering, we avoid incorrectly injecting popup content into excerpts in the block.
 		add_action(
@@ -889,6 +892,24 @@ final class Newspack_Popups_Inserter {
 
 		// Enqueue Jetpack contact form styles if any active popups contain contact forms.
 		self::maybe_enqueue_contact_form_styles();
+	}
+
+	/**
+	 * Allow read-only reader data keys to be writeable in certain conditions.
+	 *
+	 * @param string[] $keys Read-only reader data keys.
+	 * @return string[] Read-only reader data keys.
+	 */
+	public static function set_reader_data_read_only_keys( $keys ) {
+		if ( is_admin() || ! is_page() ) {
+			return $keys;
+		}
+
+		// Allow is_donor to be writeable on the donor landing page only.
+		if ( get_the_ID() === (int) Newspack_Popups_Settings::donor_landing_page() ) {
+			$keys = array_values( array_diff( $keys, [ 'is_donor' ] ) );
+		}
+		return $keys;
 	}
 
 	/**

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -895,7 +895,7 @@ final class Newspack_Popups_Inserter {
 	}
 
 	/**
-	 * Allow read-only reader data keys to be writeable in certain conditions.
+	 * Allow read-only reader data keys to be writable in certain conditions.
 	 *
 	 * @param string[] $keys Read-only reader data keys.
 	 * @return string[] Read-only reader data keys.
@@ -910,7 +910,7 @@ final class Newspack_Popups_Inserter {
 			return $keys;
 		}
 
-		// Allow is_donor to be writeable on the donor landing page only.
+		// Allow is_donor to be writable on the donor landing page only.
 		if ( get_queried_object_id() === $donor_landing_page_id ) {
 			$keys = array_values( array_diff( $keys, [ 'is_donor' ] ) );
 		}

--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -905,8 +905,13 @@ final class Newspack_Popups_Inserter {
 			return $keys;
 		}
 
+		$donor_landing_page_id = absint( Newspack_Popups_Settings::donor_landing_page() );
+		if ( ! $donor_landing_page_id ) {
+			return $keys;
+		}
+
 		// Allow is_donor to be writeable on the donor landing page only.
-		if ( get_the_ID() === (int) Newspack_Popups_Settings::donor_landing_page() ) {
+		if ( get_queried_object_id() === $donor_landing_page_id ) {
 			$keys = array_values( array_diff( $keys, [ 'is_donor' ] ) );
 		}
 		return $keys;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a regression introduced by the read-only reader data keys defined in https://github.com/Automattic/newspack-plugin/pull/4532. The donor landing page fails to set `is_donor` due to enforcement of this key as read-only.

The fix makes use of the `newspack_reader_data_read_only_keys` filter to remove `is_donor` from the list of read-only keys, only when on the donor landing page as defined by `Newspack_Popups_Settings`. This allows the value to be written in the specific scenario where a reader lands on the donor landing page.

### How to test the changes in this Pull Request:

1. In WP admin, visit **Audience > Campaigns > Settings** and choose a page for the "Donor landing page" option, then save. This defines the page that readers will be redirected to after a successful off-site donation transaction.

<img width="1012" height="295" alt="Screenshot 2026-04-07 at 11 25 24 AM" src="https://github.com/user-attachments/assets/0884bed9-5133-4028-8c9b-94913898c969" />

2. While on `trunk`, visit the donor landing page as an anonymous reader. In the JS console, observe an error: `Uncaught Error: Key 'is_donor' is read-only.` In Dev Tools > localStorage, also observe that the `np_reader_1_is_donor` value has not been set.
3. Check out this branch and refresh the donor landing page in the anonymous reader session. This time confirm there's no JS console error, and confirm in localStorage that the `np_reader_1_is_donor` value has been set to `true`.
4. Visit any other page in the same reader session. In the JS console, paste: `window.newspackReaderActivation.store.set( 'is_donor', false );` and confirm that it throws the read-only error: `Uncaught Error: Key 'is_donor' is read-only.`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
