### PR TITLE
fix: ensure background colour, size work in iframed editor (NEWS-1707)

### DIFF
--- a/src/editor/EditorAdditions.js
+++ b/src/editor/EditorAdditions.js
@@ -6,25 +6,62 @@
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
-import { useEffect } from '@wordpress/element';
+import { useEffect, useRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
-import { isOverlayPlacement, updateEditorColors } from './utils';
+import { getEditorDocument, isOverlayPlacement, updateEditorColors } from './utils';
 
 const EditorAdditions = () => {
 	const meta = useSelect( select => select( 'core/editor' ).getEditedPostAttribute( 'meta' ) );
 	const { background_color, overlay_size, placement } = meta;
 
-	// Update editor colors to match popup colors.
+	// Keep a ref so the mount effect always has the current background color.
+	const backgroundColorRef = useRef( background_color );
+	useEffect( () => {
+		backgroundColorRef.current = background_color;
+	}, [ background_color ] );
+
+	// Update editor colors when the color picker changes.
 	useEffect( () => {
 		updateEditorColors( background_color );
 	}, [ background_color ] );
 
+	// Apply the initial color once the editor canvas is ready. In WP 7.0+ the
+	// canvas is an iframe that may not be loaded when the component first mounts,
+	// so the color-picker effect above fires before the elements exist.
+	useEffect( () => {
+		const applyColors = () => updateEditorColors( backgroundColorRef.current );
+
+		// TODO: Remove this when WP 6.9 is no longer supported, and the iframe is always used for the editor.
+		if ( getEditorDocument().querySelector( '.editor-styles-wrapper' ) ) {
+			applyColors();
+			return;
+		}
+
+		const iframe = document.querySelector( 'iframe[name="editor-canvas"]' );
+		if ( iframe ) {
+			// Iframe exists but may not have finished loading.
+			iframe.addEventListener( 'load', applyColors );
+			return () => iframe.removeEventListener( 'load', applyColors );
+		}
+
+		// Iframe hasn't been inserted yet — watch for it.
+		const observer = new MutationObserver( () => {
+			const newIframe = document.querySelector( 'iframe[name="editor-canvas"]' );
+			if ( newIframe ) {
+				observer.disconnect();
+				newIframe.addEventListener( 'load', applyColors );
+			}
+		} );
+		observer.observe( document.body, { childList: true, subtree: true } );
+		return () => observer.disconnect();
+	}, [] ); // eslint-disable-line react-hooks/exhaustive-deps
+
 	// Setting editor size as per the popup size.
 	useEffect( () => {
-		const blockEditor = document.querySelector( '.block-editor-block-list__layout' );
+		const blockEditor = getEditorDocument().querySelector( '.block-editor-block-list__layout' );
 		if ( blockEditor ) {
 			blockEditor.classList.forEach( className => {
 				if ( className.startsWith( 'is-size-' ) ) {

--- a/src/editor/EditorAdditions.js
+++ b/src/editor/EditorAdditions.js
@@ -42,36 +42,60 @@ const EditorAdditions = () => {
 
 		const iframe = document.querySelector( 'iframe[name="editor-canvas"]' );
 		if ( iframe ) {
-			// Iframe exists but may not have finished loading.
-			iframe.addEventListener( 'load', applyColors );
+			if ( iframe.contentDocument?.readyState === 'complete' ) {
+				// Iframe is already loaded — apply immediately.
+				applyColors();
+				return;
+			}
+			// Iframe exists but hasn't finished loading.
+			iframe.addEventListener( 'load', applyColors, { once: true } );
 			return () => iframe.removeEventListener( 'load', applyColors );
 		}
 
 		// Iframe hasn't been inserted yet — watch for it.
+		let capturedIframe = null;
 		const observer = new MutationObserver( () => {
 			const newIframe = document.querySelector( 'iframe[name="editor-canvas"]' );
 			if ( newIframe ) {
 				observer.disconnect();
-				newIframe.addEventListener( 'load', applyColors );
+				capturedIframe = newIframe;
+				newIframe.addEventListener( 'load', applyColors, { once: true } );
 			}
 		} );
 		observer.observe( document.body, { childList: true, subtree: true } );
-		return () => observer.disconnect();
+		return () => {
+			observer.disconnect();
+			if ( capturedIframe ) {
+				capturedIframe.removeEventListener( 'load', applyColors );
+			}
+		};
 	}, [] ); // eslint-disable-line react-hooks/exhaustive-deps
 
 	// Setting editor size as per the popup size.
 	useEffect( () => {
-		const blockEditor = getEditorDocument().querySelector( '.block-editor-block-list__layout' );
-		if ( blockEditor ) {
-			blockEditor.classList.forEach( className => {
-				if ( className.startsWith( 'is-size-' ) ) {
-					blockEditor.classList.remove( className );
-				}
-			} );
+		const applySize = () => {
+			const blockEditor = getEditorDocument().querySelector( '.block-editor-block-list__layout' );
+			if ( blockEditor ) {
+				blockEditor.classList.forEach( className => {
+					if ( className.startsWith( 'is-size-' ) ) {
+						blockEditor.classList.remove( className );
+					}
+				} );
 
-			if ( isOverlayPlacement( placement ) ) {
-				blockEditor.classList.add( `is-size-${ overlay_size }` );
+				if ( isOverlayPlacement( placement ) ) {
+					blockEditor.classList.add( `is-size-${ overlay_size }` );
+				}
 			}
+		};
+
+		applySize();
+
+		// In WP 7.0+, the block list lives inside the editor iframe and may not
+		// exist yet on the first run. Reapply when the iframe finishes loading.
+		const iframe = document.querySelector( 'iframe[name="editor-canvas"]' );
+		if ( iframe && iframe.contentDocument?.readyState !== 'complete' ) {
+			iframe.addEventListener( 'load', applySize, { once: true } );
+			return () => iframe.removeEventListener( 'load', applySize );
 		}
 	}, [ overlay_size, placement ] );
 	return null;

--- a/src/editor/EditorAdditions.js
+++ b/src/editor/EditorAdditions.js
@@ -31,6 +31,8 @@ const EditorAdditions = () => {
 	// Apply the initial color once the editor canvas is ready. In WP 7.0+ the
 	// canvas is an iframe that may not be loaded when the component first mounts,
 	// so the color-picker effect above fires before the elements exist.
+	// Deps are intentionally empty so the readiness listener isn't re-registered
+	// on every colour change — the ref above captures the latest value.
 	useEffect( () => {
 		return whenEditorReady( () => updateEditorColors( backgroundColorRef.current ) );
 	}, [] ); // eslint-disable-line react-hooks/exhaustive-deps

--- a/src/editor/EditorAdditions.js
+++ b/src/editor/EditorAdditions.js
@@ -11,7 +11,7 @@ import { useEffect, useRef } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { getEditorDocument, isOverlayPlacement, updateEditorColors } from './utils';
+import { getEditorDocument, isOverlayPlacement, updateEditorColors, whenEditorReady } from './utils';
 
 const EditorAdditions = () => {
 	const meta = useSelect( select => select( 'core/editor' ).getEditedPostAttribute( 'meta' ) );
@@ -32,43 +32,7 @@ const EditorAdditions = () => {
 	// canvas is an iframe that may not be loaded when the component first mounts,
 	// so the color-picker effect above fires before the elements exist.
 	useEffect( () => {
-		const applyColors = () => updateEditorColors( backgroundColorRef.current );
-
-		// TODO: Remove this when WP 6.9 is no longer supported, and the iframe is always used for the editor.
-		if ( getEditorDocument().querySelector( '.editor-styles-wrapper' ) ) {
-			applyColors();
-			return;
-		}
-
-		const iframe = document.querySelector( 'iframe[name="editor-canvas"]' );
-		if ( iframe ) {
-			if ( iframe.contentDocument?.readyState === 'complete' ) {
-				// Iframe is already loaded — apply immediately.
-				applyColors();
-				return;
-			}
-			// Iframe exists but hasn't finished loading.
-			iframe.addEventListener( 'load', applyColors, { once: true } );
-			return () => iframe.removeEventListener( 'load', applyColors );
-		}
-
-		// Iframe hasn't been inserted yet — watch for it.
-		let capturedIframe = null;
-		const observer = new MutationObserver( () => {
-			const newIframe = document.querySelector( 'iframe[name="editor-canvas"]' );
-			if ( newIframe ) {
-				observer.disconnect();
-				capturedIframe = newIframe;
-				newIframe.addEventListener( 'load', applyColors, { once: true } );
-			}
-		} );
-		observer.observe( document.body, { childList: true, subtree: true } );
-		return () => {
-			observer.disconnect();
-			if ( capturedIframe ) {
-				capturedIframe.removeEventListener( 'load', applyColors );
-			}
-		};
+		return whenEditorReady( () => updateEditorColors( backgroundColorRef.current ) );
 	}, [] ); // eslint-disable-line react-hooks/exhaustive-deps
 
 	// Setting editor size as per the popup size.
@@ -87,16 +51,7 @@ const EditorAdditions = () => {
 				}
 			}
 		};
-
-		applySize();
-
-		// In WP 7.0+, the block list lives inside the editor iframe and may not
-		// exist yet on the first run. Reapply when the iframe finishes loading.
-		const iframe = document.querySelector( 'iframe[name="editor-canvas"]' );
-		if ( iframe && iframe.contentDocument?.readyState !== 'complete' ) {
-			iframe.addEventListener( 'load', applySize, { once: true } );
-			return () => iframe.removeEventListener( 'load', applySize );
-		}
+		return whenEditorReady( applySize );
 	}, [ overlay_size, placement ] );
 	return null;
 };

--- a/src/editor/utils.js
+++ b/src/editor/utils.js
@@ -93,6 +93,8 @@ const hexToRGB = hex =>
 		.match( /.{2}/g )
 		.map( x => parseInt( x, 16 ) );
 
+const EDITOR_CANVAS_SELECTOR = 'iframe[name="editor-canvas"]';
+
 /**
  * Get the document context for the block editor. In WordPress 7.0+, the editor
  * canvas is rendered inside an iframe, so querySelector on the parent document
@@ -105,7 +107,7 @@ const hexToRGB = hex =>
  * @return {Document} The editor's document context.
  */
 export const getEditorDocument = () => {
-	const iframe = document.querySelector( 'iframe[name="editor-canvas"]' );
+	const iframe = document.querySelector( EDITOR_CANVAS_SELECTOR );
 	return iframe?.contentDocument ?? document; // TODO: Remove `?? document` fallback when WP 6.9 support is dropped.
 };
 
@@ -135,7 +137,7 @@ export const getEditorDocument = () => {
  * @return {Function} Cleanup function that removes any pending listeners/observers.
  */
 export const whenEditorReady = callback => {
-	const iframe = document.querySelector( 'iframe[name="editor-canvas"]' );
+	const iframe = document.querySelector( EDITOR_CANVAS_SELECTOR );
 	if ( iframe ) {
 		// Case 1: iframe exists and is fully loaded.
 		if ( iframe.contentDocument?.readyState === 'complete' ) {
@@ -156,7 +158,7 @@ export const whenEditorReady = callback => {
 	// Case 3: iframe hasn't been inserted yet — watch for it.
 	let capturedIframe = null;
 	const observer = new MutationObserver( () => {
-		const newIframe = document.querySelector( 'iframe[name="editor-canvas"]' );
+		const newIframe = document.querySelector( EDITOR_CANVAS_SELECTOR );
 		if ( newIframe ) {
 			observer.disconnect();
 			capturedIframe = newIframe;

--- a/src/editor/utils.js
+++ b/src/editor/utils.js
@@ -96,7 +96,8 @@ const hexToRGB = hex =>
 /**
  * Get the document context for the block editor. In WordPress 7.0+, the editor
  * canvas is rendered inside an iframe, so querySelector on the parent document
- * will not find editor elements. Fall back to the parent document for older versions.
+ * will not find editor elements. Falls back to the parent document for older
+ * versions, or when the iframe's contentDocument is not yet available (null).
  *
  * TODO: Once WP 6.9 is no longer supported, this can be simplified to always
  * return the iframe's contentDocument.
@@ -105,7 +106,7 @@ const hexToRGB = hex =>
  */
 export const getEditorDocument = () => {
 	const iframe = document.querySelector( 'iframe[name="editor-canvas"]' );
-	return iframe ? iframe.contentDocument : document; // TODO: Remove `: document` fallback when WP 6.9 support is dropped.
+	return iframe?.contentDocument ?? document; // TODO: Remove `?? document` fallback when WP 6.9 support is dropped.
 };
 
 /**

--- a/src/editor/utils.js
+++ b/src/editor/utils.js
@@ -121,6 +121,13 @@ export const getEditorDocument = () => {
  * 3. Editor-canvas iframe has not been inserted yet — observes the DOM for its
  *    insertion, then waits for its load event.
  *
+ * Limitation: only fires once per call. If Gutenberg later unmounts and
+ * remounts the canvas iframe (e.g. toggling code-editor or fullscreen), the
+ * new iframe won't get the callback applied — EditorAdditions stays mounted
+ * as a top-level slot fill, so its effects don't re-run on swap. In practice
+ * the dependent effects in EditorAdditions reapply the glue whenever
+ * `background_color`, `overlay_size`, or `placement` change.
+ *
  * TODO: Once WP 6.9 is no longer supported this can be simplified to cases 2/3
  * only (the iframe is always used for the editor canvas).
  *

--- a/src/editor/utils.js
+++ b/src/editor/utils.js
@@ -110,6 +110,61 @@ export const getEditorDocument = () => {
 };
 
 /**
+ * Calls `callback` once the editor canvas is available and returns a cleanup
+ * function suitable for use as a useEffect return value. Handles three cases:
+ *
+ * 1. Editor already rendered (WP 6.9 non-iframe, or iframe already loaded) —
+ *    calls the callback immediately.
+ * 2. Editor-canvas iframe exists but has not finished loading — waits for the
+ *    load event, then calls the callback.
+ * 3. Editor-canvas iframe has not been inserted yet — observes the DOM for its
+ *    insertion, then waits for its load event.
+ *
+ * TODO: Once WP 6.9 is no longer supported this can be simplified to cases 2/3
+ * only (the iframe is always used for the editor canvas).
+ *
+ * @param {Function} callback Function to invoke when the editor canvas is ready.
+ * @return {Function} Cleanup function that removes any pending listeners/observers.
+ */
+export const whenEditorReady = callback => {
+	// Case 1: editor already rendered (.editor-styles-wrapper present in current doc).
+	if ( getEditorDocument().querySelector( '.editor-styles-wrapper' ) ) {
+		callback();
+		return () => {};
+	}
+
+	const iframe = document.querySelector( 'iframe[name="editor-canvas"]' );
+	if ( iframe ) {
+		if ( iframe.contentDocument?.readyState === 'complete' ) {
+			// Case 1b: iframe exists and is fully loaded.
+			callback();
+			return () => {};
+		}
+		// Case 2: iframe exists but hasn't finished loading.
+		iframe.addEventListener( 'load', callback, { once: true } );
+		return () => iframe.removeEventListener( 'load', callback );
+	}
+
+	// Case 3: iframe hasn't been inserted yet — watch for it.
+	let capturedIframe = null;
+	const observer = new MutationObserver( () => {
+		const newIframe = document.querySelector( 'iframe[name="editor-canvas"]' );
+		if ( newIframe ) {
+			observer.disconnect();
+			capturedIframe = newIframe;
+			newIframe.addEventListener( 'load', callback, { once: true } );
+		}
+	} );
+	observer.observe( document.body, { childList: true, subtree: true } );
+	return () => {
+		observer.disconnect();
+		if ( capturedIframe ) {
+			capturedIframe.removeEventListener( 'load', callback );
+		}
+	};
+};
+
+/**
  * Set the background color meta field.
  * Based on https://github.com/Automattic/newspack-theme/blob/trunk/newspack-theme/inc/template-functions.php#L401-L431
  *

--- a/src/editor/utils.js
+++ b/src/editor/utils.js
@@ -113,8 +113,9 @@ export const getEditorDocument = () => {
  * Calls `callback` once the editor canvas is available and returns a cleanup
  * function suitable for use as a useEffect return value. Handles three cases:
  *
- * 1. Editor already rendered (WP 6.9 non-iframe, or iframe already loaded) —
- *    calls the callback immediately.
+ * 1. Editor-canvas iframe exists and is fully loaded, or (WP 6.9 fallback) the
+ *    non-iframe editor is already rendered in the parent document — calls the
+ *    callback immediately.
  * 2. Editor-canvas iframe exists but has not finished loading — waits for the
  *    load event, then calls the callback.
  * 3. Editor-canvas iframe has not been inserted yet — observes the DOM for its
@@ -127,22 +128,22 @@ export const getEditorDocument = () => {
  * @return {Function} Cleanup function that removes any pending listeners/observers.
  */
 export const whenEditorReady = callback => {
-	// Case 1: editor already rendered (.editor-styles-wrapper present in current doc).
-	if ( getEditorDocument().querySelector( '.editor-styles-wrapper' ) ) {
-		callback();
-		return () => {};
-	}
-
 	const iframe = document.querySelector( 'iframe[name="editor-canvas"]' );
 	if ( iframe ) {
+		// Case 1: iframe exists and is fully loaded.
 		if ( iframe.contentDocument?.readyState === 'complete' ) {
-			// Case 1b: iframe exists and is fully loaded.
 			callback();
 			return () => {};
 		}
 		// Case 2: iframe exists but hasn't finished loading.
 		iframe.addEventListener( 'load', callback, { once: true } );
 		return () => iframe.removeEventListener( 'load', callback );
+	}
+
+	// WP 6.9 fallback: no iframe, editor renders directly in the parent document.
+	if ( document.querySelector( '.editor-styles-wrapper' ) ) {
+		callback();
+		return () => {};
 	}
 
 	// Case 3: iframe hasn't been inserted yet — watch for it.

--- a/src/editor/utils.js
+++ b/src/editor/utils.js
@@ -94,6 +94,21 @@ const hexToRGB = hex =>
 		.map( x => parseInt( x, 16 ) );
 
 /**
+ * Get the document context for the block editor. In WordPress 7.0+, the editor
+ * canvas is rendered inside an iframe, so querySelector on the parent document
+ * will not find editor elements. Fall back to the parent document for older versions.
+ *
+ * TODO: Once WP 6.9 is no longer supported, this can be simplified to always
+ * return the iframe's contentDocument.
+ *
+ * @return {Document} The editor's document context.
+ */
+export const getEditorDocument = () => {
+	const iframe = document.querySelector( 'iframe[name="editor-canvas"]' );
+	return iframe ? iframe.contentDocument : document; // TODO: Remove `: document` fallback when WP 6.9 support is dropped.
+};
+
+/**
  * Set the background color meta field.
  * Based on https://github.com/Automattic/newspack-theme/blob/trunk/newspack-theme/inc/template-functions.php#L401-L431
  *
@@ -120,8 +135,9 @@ export const updateEditorColors = backgroundColor => {
 
 	const foregroundColor = contrastRatio > 5 ? blackColor : whiteColor;
 
-	const editorStylesEl = document.querySelector( '.editor-styles-wrapper' );
-	const editorPostTitleEl = document.querySelector( '.wp-block.editor-post-title__block .editor-post-title__input' );
+	const editorDoc = getEditorDocument();
+	const editorStylesEl = editorDoc.querySelector( '.editor-styles-wrapper' );
+	const editorPostTitleEl = editorDoc.querySelector( '.wp-block.editor-post-title__block .editor-post-title__input' );
 	if ( editorStylesEl ) {
 		editorStylesEl.style.backgroundColor = backgroundColor;
 		editorStylesEl.style.color = foregroundColor;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

In WP 7.0, the background colour and prompt size previews stopped working for due to the editor always being iframed. This PR should get it working for WP 7.0, while keeping it functional for WP 6.9 for now. 

Closes NEWS-1707

### How to test the changes in this Pull Request:

1. On a site running the latest WP 7.0 RC, create a prompt. Change the background colour; note it doesn't work. Do the same width the size.
2. Apply this PR and run `npm run build`.
3. Repeat step 1; confirm the colour and size changes now works. 
4. Try saving your changes, and navigating away from the editor. Ensure that your changes are still applied. 
5. Repeat steps 3 and 4 on a site running WP 6.9, and ensure that these options still work as expected there, too.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
