### PR TITLE
perf: Memoize is_user_admin, is_preview_request and viewing_as_spec per request

### DIFF
--- a/includes/class-newspack-popups-view-as.php
+++ b/includes/class-newspack-popups-view-as.php
@@ -37,12 +37,20 @@ final class Newspack_Popups_View_As {
 	 * @return string "View as" specification.
 	 */
 	public static function viewing_as_spec() {
+		static $result = null;
+		if ( null !== $result ) {
+			return $result;
+		}
 		if ( ! Newspack_Popups::is_user_admin() ) {
-			return false;
+			$result = false;
+			return $result;
 		}
 		if ( isset( $_GET['view_as'] ) && $_GET['view_as'] ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-			return sanitize_text_field( $_GET['view_as'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$result = sanitize_text_field( $_GET['view_as'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			return $result;
 		}
+		$result = false;
+		return $result;
 	}
 
 	/**

--- a/includes/class-newspack-popups-view-as.php
+++ b/includes/class-newspack-popups-view-as.php
@@ -34,23 +34,31 @@ final class Newspack_Popups_View_As {
 	/**
 	 * Get the "view as" feature specification.
 	 *
-	 * @return string "View as" specification.
+	 * @return string|false "View as" specification, or false if not applicable.
 	 */
 	public static function viewing_as_spec() {
-		static $result = null;
-		if ( null !== $result ) {
-			return $result;
+		static $cache = [];
+		$raw_view_as = isset( $_GET['view_as'] ) ? $_GET['view_as'] : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+
+		// Key on the current user ID and the raw view_as value, so a cached
+		// result from an earlier user/query context (e.g. after
+		// wp_set_current_user() or go_to() in tests) can't leak into a later
+		// call within the same PHP process.
+		$key = get_current_user_id() . ':' . $raw_view_as;
+		if ( array_key_exists( $key, $cache ) ) {
+			return $cache[ $key ];
 		}
+
 		if ( ! Newspack_Popups::is_user_admin() ) {
-			$result = false;
-			return $result;
+			$cache[ $key ] = false;
+			return false;
 		}
-		if ( isset( $_GET['view_as'] ) && $_GET['view_as'] ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-			$result = sanitize_text_field( $_GET['view_as'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			return $result;
+		if ( $raw_view_as ) {
+			$cache[ $key ] = sanitize_text_field( $raw_view_as );
+			return $cache[ $key ];
 		}
-		$result = false;
-		return $result;
+		$cache[ $key ] = false;
+		return false;
 	}
 
 	/**

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -826,15 +826,20 @@ final class Newspack_Popups {
 	}
 
 	/**
-	 * Is it a preview request – a single popup preview or using "view as" feature.
+	 * Is it a preview request ? a single popup preview or using "view as" feature.
 	 *
 	 * @return boolean Whether it's a preview request.
 	 */
 	public static function is_preview_request() {
+		static $result = null;
+		if ( null !== $result ) {
+			return $result;
+		}
 		$is_customizer_preview = is_customize_preview();
 		// Used by the Newspack Plugin's Campaigns Wizard.
 		$is_view_as_preview = false != Newspack_Popups_View_As::viewing_as_spec();
-		return ! empty( self::previewed_popup_id() ) || ! empty( self::preset_popup_id() ) || $is_view_as_preview || $is_customizer_preview;
+		$result = ! empty( self::previewed_popup_id() ) || ! empty( self::preset_popup_id() ) || $is_view_as_preview || $is_customizer_preview;
+		return $result;
 	}
 
 	/**
@@ -963,6 +968,10 @@ final class Newspack_Popups {
 	 * will not be fired for them.
 	 */
 	public static function is_user_admin() {
+		static $result = null;
+		if ( null !== $result ) {
+			return $result;
+		}
 		/**
 		 * Filter to allow other plugins to decide which capability should be checked
 		 * to determine whether a user's activity should be tracked via Google Analytics.
@@ -971,7 +980,8 @@ final class Newspack_Popups {
 		 * @return string Filtered capability string.
 		 */
 		$capability = apply_filters( 'newspack_popups_admin_user_capability', 'edit_others_pages' );
-		return is_user_logged_in() && current_user_can( $capability );
+		$result     = is_user_logged_in() && current_user_can( $capability );
+		return $result;
 	}
 
 	/**

--- a/includes/class-newspack-popups.php
+++ b/includes/class-newspack-popups.php
@@ -826,20 +826,28 @@ final class Newspack_Popups {
 	}
 
 	/**
-	 * Is it a preview request ? a single popup preview or using "view as" feature.
+	 * Is it a preview request? A single popup preview or using the "view as" feature.
 	 *
 	 * @return boolean Whether it's a preview request.
 	 */
 	public static function is_preview_request() {
-		static $result = null;
-		if ( null !== $result ) {
-			return $result;
-		}
-		$is_customizer_preview = is_customize_preview();
+		static $cache = [];
+		$previewed_popup_id = self::previewed_popup_id();
+		$preset_popup_id    = self::preset_popup_id();
 		// Used by the Newspack Plugin's Campaigns Wizard.
-		$is_view_as_preview = false != Newspack_Popups_View_As::viewing_as_spec();
-		$result = ! empty( self::previewed_popup_id() ) || ! empty( self::preset_popup_id() ) || $is_view_as_preview || $is_customizer_preview;
-		return $result;
+		$is_view_as_preview    = false != Newspack_Popups_View_As::viewing_as_spec();
+		$is_customizer_preview = is_customize_preview();
+
+		// Key on every input the result depends on, so cached user/query-param
+		// context from an earlier simulated request (e.g. PHPUnit's go_to())
+		// can't leak into a later one within the same PHP process.
+		$key = implode( ':', [ $previewed_popup_id, $preset_popup_id, $is_view_as_preview ? '1' : '0', $is_customizer_preview ? '1' : '0' ] );
+		if ( array_key_exists( $key, $cache ) ) {
+			return $cache[ $key ];
+		}
+
+		$cache[ $key ] = ! empty( $previewed_popup_id ) || ! empty( $preset_popup_id ) || $is_view_as_preview || $is_customizer_preview;
+		return $cache[ $key ];
 	}
 
 	/**
@@ -968,9 +976,12 @@ final class Newspack_Popups {
 	 * will not be fired for them.
 	 */
 	public static function is_user_admin() {
-		static $result = null;
-		if ( null !== $result ) {
-			return $result;
+		static $cache = [];
+		// Key on the current user ID so a cached result from an earlier user
+		// (e.g. after wp_set_current_user() in tests) can't leak into a later check.
+		$user_id = get_current_user_id();
+		if ( array_key_exists( $user_id, $cache ) ) {
+			return $cache[ $user_id ];
 		}
 		/**
 		 * Filter to allow other plugins to decide which capability should be checked
@@ -979,9 +990,9 @@ final class Newspack_Popups {
 		 * @param string $capability Capability to check. Default: edit_others_pages.
 		 * @return string Filtered capability string.
 		 */
-		$capability = apply_filters( 'newspack_popups_admin_user_capability', 'edit_others_pages' );
-		$result     = is_user_logged_in() && current_user_can( $capability );
-		return $result;
+		$capability        = apply_filters( 'newspack_popups_admin_user_capability', 'edit_others_pages' );
+		$cache[ $user_id ] = is_user_logged_in() && current_user_can( $capability );
+		return $cache[ $user_id ];
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

## Summary                                                           

  - Memoize `Newspack_Popups::is_user_admin()`, `Newspack_Popups::is_preview_request()` and `Newspack_Popups_View_As::viewing_as_spec()` using static variables so each method computes its result only
   once per request.
                                                                                                                                                                                                       
  ## Problem                                                           

  On archive pages with many posts, these methods are called repeatedly per popup x post combination:                                                                                                  
   
  | Method | Calls per request | Cost |                                                                                                                                                                
  |---|---|---|                                                        
  | `is_user_admin()` | 132 | 1.6ms |                                                                                                                                                                  
  | `is_preview_request()` | 120 | 3.5ms |                             
  | `viewing_as_spec()` | 132 | 2.4ms |                                                                                                                                                                
   
  The call chain is:                                                                                                                                                                                   
  assess_taxonomy_filter (96x) -> is_preview_request -> viewing_as_spec -> is_user_admin
  show_admin_bar (22x)         -> is_preview_request -> viewing_as_spec -> is_user_admin                                                                                                                  
  parse_view_as (12x)          -> viewing_as_spec -> is_user_admin       
                                                                                                                                                                                                       
  `is_user_admin()` calls `apply_filters()` + `current_user_can()` every time. `is_preview_request()` calls `is_customize_preview()`, `previewed_popup_id()`, `preset_popup_id()` and
  `viewing_as_spec()` every time. None of these results can change within a single HTTP request.                                                                                                       
                                                                       
  On a test archive page with 48 posts and ~91 evaluated popups, the total overhead is ~5ms. The cost scales linearly with post count x popup count.                                                   
                                                                       
  ## Fix                                                                                                                                                                                               
                                                                       
  Add `static $result` memoization to all three methods. The first call computes the result; subsequent calls return the cached value immediately.                                                     
                                                                       
  This pattern is safe because:                                                                                                                                                                        
  - User capabilities don't change within a request                    
  - `$_GET['view_as']` is constant within a request                                                                                                                                                    
  - `previewed_popup_id()` / `preset_popup_id()` read from `$_GET` which is constant
  - `is_customize_preview()` is constant within a request                                                                                                                                              
                                                                                                                                                                                                       
  ## Test plan                                                                                                                                                                                         
                                                                                                                                                                                                       
  - [ ] Verify prompts display correctly on archive pages (logged out)                                                                                                                                 
  - [ ] Verify prompts display correctly for admin users (logged in)
  - [ ] Verify "View As" feature still works (`?view_as=...` parameter)                                                                                                                                
  - [ ] Verify single popup preview still works                                                                                                                                                        
  - [ ] Verify Customizer preview still works

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
