### PR TITLE
fix: handle invalid post id in retrieve_preview_popup

### DIFF
--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -125,7 +125,7 @@ final class Newspack_Popups_Inserter {
 		// Get the previewed popup and return early.
 		if ( Newspack_Popups::previewed_popup_id() ) {
 			$preview_popup = Newspack_Popups_Model::retrieve_preview_popup( Newspack_Popups::previewed_popup_id() );
-			return [ $preview_popup ];
+			return $preview_popup ? [ $preview_popup ] : [];
 		}
 		if ( Newspack_Popups::preset_popup_id() ) {
 			$preset_popup = Newspack_Popups_Presets::retrieve_preset_popup( Newspack_Popups::preset_popup_id() );

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -287,12 +287,15 @@ final class Newspack_Popups_Model {
 	 * Retrieve popup preview CPT post.
 	 *
 	 * @param string $post_id Post id.
-	 * @return object Popup object.
+	 * @return object|null Popup object, or null if the post id does not resolve to a post.
 	 */
 	public static function retrieve_preview_popup( $post_id ) {
 		// Up-to-date post data is stored in an autosave.
 		$autosave    = wp_get_post_autosave( $post_id );
 		$post_object = $autosave ? $autosave : get_post( $post_id );
+		if ( ! $post_object ) {
+			return null;
+		}
 		// Setting proper id for correct API calls.
 		$post_object->ID = $post_id;
 
@@ -1094,7 +1097,10 @@ final class Newspack_Popups_Model {
 
 		// If previewing a single prompt, override saved settings with preview settings. Allow manual and custom placement prompts to be displayed as usual.
 		if ( $previewed_popup_id && ( ! $is_manual_or_custom_placement || $popup['id'] === $previewed_popup_id ) ) {
-			$popup = self::retrieve_preview_popup( $previewed_popup_id );
+			$preview_popup = self::retrieve_preview_popup( $previewed_popup_id );
+			if ( $preview_popup ) {
+				$popup = $preview_popup;
+			}
 		}
 		if ( Newspack_Popups::preset_popup_id() ) {
 			$popup = Newspack_Popups_Presets::retrieve_preset_popup( Newspack_Popups::preset_popup_id() );

--- a/includes/class-newspack-popups-model.php
+++ b/includes/class-newspack-popups-model.php
@@ -286,8 +286,8 @@ final class Newspack_Popups_Model {
 	/**
 	 * Retrieve popup preview CPT post.
 	 *
-	 * @param string $post_id Post id.
-	 * @return object|null Popup object, or null if the post id does not resolve to a post.
+	 * @param int|string $post_id Post id. Often a query-parameter string.
+	 * @return array|null Popup object array, or null if the post id does not resolve to a post.
 	 */
 	public static function retrieve_preview_popup( $post_id ) {
 		// Up-to-date post data is stored in an autosave.

--- a/tests/test-model.php
+++ b/tests/test-model.php
@@ -238,6 +238,24 @@ class ModelTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests retrieve_preview_popup with a post id that does not resolve to a post.
+	 *
+	 * Production sites get hit with bot traffic carrying garbage `pp` query params,
+	 * which previously fataled at `$post_object->ID = $post_id` when both
+	 * wp_get_post_autosave() and get_post() returned null.
+	 */
+	public function test_retrieve_preview_popup_with_invalid_id() {
+		self::assertNull(
+			Newspack_Popups_Model::retrieve_preview_popup( 'definitely-not-a-post-id' ),
+			'Invalid preview ids return null instead of fataling.'
+		);
+		self::assertNull(
+			Newspack_Popups_Model::retrieve_preview_popup( 999999999 ),
+			'Numeric ids that do not match any post return null.'
+		);
+	}
+
+	/**
 	 * Tests fetching default settings.
 	 */
 	public function test_settings() {

--- a/tests/test-model.php
+++ b/tests/test-model.php
@@ -256,6 +256,23 @@ class ModelTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that an invalid `pp` query param does not produce a popup list with null entries,
+	 * which would cascade to "Trying to access array offset on null" warnings downstream.
+	 */
+	public function test_popups_for_post_with_invalid_preview_id() {
+		$_GET['pp'] = 'definitely-not-a-post-id';
+		try {
+			self::assertSame(
+				[],
+				Newspack_Popups_Inserter::popups_for_post(),
+				'Invalid preview ids result in an empty popup list, not [ null ].'
+			);
+		} finally {
+			unset( $_GET['pp'] );
+		}
+	}
+
+	/**
 	 * Tests fetching default settings.
 	 */
 	public function test_settings() {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Production fatals from `class-newspack-popups-model.php:297`:

```
PHP Fatal error: Uncaught Error: Attempt to assign property "ID" on null
in includes/class-newspack-popups-model.php:297
Stack trace:
#0 .../class-newspack-popups-inserter.php(126): Newspack_Popups_Model::retrieve_preview_popup('turn01')
#1 .../class-newspack-popups-inserter.php(579): Newspack_Popups_Inserter::popups_for_post()
#2 .../class-newspack-popups-inserter.php(618): Newspack_Popups_Inserter::get_before_header_markup()
...
#10 .../themes/newspack-theme/header.php(23): do_action('wp_body_open')
#11 .../themes/newspack-theme/404.php(10): get_header()
```

`retrieve_preview_popup` does:

```php
$autosave    = wp_get_post_autosave( $post_id );
$post_object = $autosave ? $autosave : get_post( $post_id );
$post_object->ID = $post_id;  // ← fatal when both lookups returned null
```

Trigger in production is bot traffic hitting 404 pages with garbage `?pp=...` query params (the trace shows `'turn01'`).

This PR:

- `retrieve_preview_popup` returns `null` when the post id does not resolve to any post.
- `generate_popup` only swaps the resolved `$popup` for the preview when `retrieve_preview_popup` actually returned something, so we don't replace a valid popup with `null` downstream.

### How to test the changes in this Pull Request:

1. Apply the patch on a site with the Newspack theme and at least one published prompt.
2. Hit a 404 URL with a garbage preview id, e.g. `https://<site>/no-such-page/?pp=turn01`.
3. Confirm the page renders the 404 normally and no PHP fatal is logged. Repeat with `?pp=999999999`.
4. Run `phpunit tests/test-model.php` (or the full suite) and confirm `ModelTest::test_retrieve_preview_popup_with_invalid_id` passes.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?