### PR TITLE
fix: cache empty popups_for_post() results

### DIFF
--- a/includes/class-newspack-popups-inserter.php
+++ b/includes/class-newspack-popups-inserter.php
@@ -17,11 +17,13 @@ final class Newspack_Popups_Inserter {
 	const ADMIN_SCRIPT_HANDLE = 'newspack-popups-admin-bar';
 
 	/**
-	 * The popup objects to display.
+	 * The popup objects to display, memoized per request.
+	 * Null means "not yet computed" for this request; an empty array is a
+	 * valid, cacheable result (no popups eligible for the current post).
 	 *
-	 * @var array
+	 * @var array|null
 	 */
-	protected static $popups = [];
+	protected static $popups = null;
 
 	/**
 	 * Segments for displayed popups.
@@ -118,7 +120,7 @@ final class Newspack_Popups_Inserter {
 	 * @return array Popup objects.
 	 */
 	public static function popups_for_post() {
-		if ( ! empty( self::$popups ) ) {
+		if ( null !== self::$popups ) {
 			return self::$popups;
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

## Problem

`Newspack_Popups_Inserter::popups_for_post()` memoizes its result in `self::$popups`, guarded by:

```php
protected static $popups = [];

public static function popups_for_post() {
	if ( ! empty( self::$popups ) ) {
		return self::$popups;
	}
	...
	self::$popups = $popups_to_display; // may be []
	return $popups_to_display;
}
```

`empty( [] )` is always `true`, so whenever no campaign is eligible for the current request, the cache is written but never read back as a hit. Every subsequent call in the same request re-runs `assess_has_disabled_popups()`, `parse_view_as()`, `Newspack_Popups_Model::retrieve_eligible_popups()` (a `WP_Query`) and a `should_display()` pass over every campaign.

`popups_for_post()` is called from `insert_popups_in_content()`, `insert_popups_after_header()`, `insert_before_header()` and `insert_inline_prompt_in_archive_pages()`, so on an archive page this repeats **once per post** instead of once per request. On a site where no campaigns match the request context (e.g. all campaigns are scoped to a segment/view that excludes the current visitor), this turns into 40-50+ redundant query + evaluation passes on a single archive page load.

## Fix

Use `null` instead of `[]` as the "not yet computed" sentinel, since an empty array is a legitimate, cacheable result:

```php
protected static $popups = null;

public static function popups_for_post() {
	if ( null !== self::$popups ) {
		return self::$popups;
	}
	...
}
```

No other change in behavior: the `IS_TEST_ENV` branch already skips writing the cache, so tests are unaffected either way, and nothing else reads `Newspack_Popups_Inserter::$popups` directly (the data-api class has its own unrelated `$popups` property).

## Test plan

- [x] `php -l` on the changed file
- [ ] Verify prompts still render on posts/pages that have eligible campaigns
- [ ] Verify archive pages with zero eligible campaigns no longer re-run `retrieve_eligible_popups()` per post (checked via query count / profiling)